### PR TITLE
Handle users who have not set GOPATH

### DIFF
--- a/osquery/runtime_test.go
+++ b/osquery/runtime_test.go
@@ -79,7 +79,10 @@ func buildOsqueryExtensionInTempDir(rootDirectory string) error {
 
 	goPath := os.Getenv("GOPATH")
 	if goPath == "" {
-		return errors.New("GOPATH is not set")
+		goPath = filepath.Join(os.Getenv("HOME"), "go")
+		if stat, err := os.Stat(goPath); err != nil || !stat.IsDir() {
+			return errors.New("GOPATH is not set and default doesn't exist")
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
If `$GOPATH` is not set, use `$HOME/go` if it exists.

close #31 