### PR TITLE
Osquery runtime process recovery bugs

### DIFF
--- a/osquery/runtime_test.go
+++ b/osquery/runtime_test.go
@@ -145,3 +145,26 @@ func TestRestart(t *testing.T) {
 
 	require.NoError(t, instance.Kill())
 }
+
+func TestRecover(t *testing.T) {
+	rootDirectory, rmRootDirectory, err := osqueryTempDir()
+	require.NoError(t, err)
+	defer rmRootDirectory()
+
+	// this could be `defer falsifyOsArgs(rootDirectory)()` but this may be more clear
+	cancelFunc := falsifyOsArgs(rootDirectory)
+	defer cancelFunc()
+
+	require.NoError(t, buildOsqueryExtensionInTempDir(rootDirectory))
+	instance, err := LaunchOsqueryInstance(WithRootDirectory(rootDirectory))
+	require.NoError(t, err)
+
+	require.NoError(t, instance.Recover(errors.New("fabricated in a test")))
+	require.NoError(t, instance.Recover(errors.New("fabricated in a test")))
+
+	healthy, err := instance.Healthy()
+	require.NoError(t, err)
+	require.True(t, healthy)
+
+	require.NoError(t, instance.Kill())
+}


### PR DESCRIPTION
This PR fixes two bugs:

- The `Recover` function used `o.cmd.ProcessState.Exited()` to see if the process was dead, but `o.cmd.ProcessState` is `nil` until the process exits, so calling `Recover()` on a healthy instance would cause a nil pointer dereference.
- The recovery process intends to check if the extension manager server is alive and, if so, shut it down cleanly. The actual implementation was only shutting down the extension manager server if it was NOT healthy, which doesn't really make any sense at all.