### PR TITLE
launcher: add tls config to grpc.Dial

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -51,6 +51,7 @@ type options struct {
 	enrollSecretPath   string
 	autoupdateInterval time.Duration
 	insecureTLS        bool
+	insecureGRPC       bool
 	printVersion       bool
 	debug              bool
 }
@@ -74,6 +75,11 @@ func parseOptions() (*options, error) {
 			"insecure",
 			false,
 			"do not verify TLS certs for outgoing connections",
+		)
+		flInsecureGRPC = flag.Bool(
+			"insecure_grpc",
+			false,
+			"dial GRPC without a TLS config",
 		)
 		flOsquerydPath = flag.String(
 			"osqueryd_path",
@@ -129,6 +135,7 @@ func parseOptions() (*options, error) {
 		enrollSecretPath:   *flEnrollSecretPath,
 		debug:              *flDebug,
 		insecureTLS:        *flInsecureTLS,
+		insecureGRPC:       *flInsecureGRPC,
 		autoupdateInterval: *flAutoupdateInterval,
 	}
 
@@ -234,6 +241,42 @@ func logFatal(logger log.Logger, args ...interface{}) {
 	os.Exit(1)
 }
 
+// dialGRPC creates a grpc client connection.
+func dialGRPC(
+	serverURL string,
+	insecureTLS bool,
+	insecureGRPC bool,
+	logger log.Logger,
+) (*grpc.ClientConn, error) {
+	level.Info(logger).Log(
+		"msg", "dialing grpc server",
+		"server", serverURL,
+		"tls_secure", insecureTLS == false,
+		"grpc_secure", insecureGRPC == false,
+	)
+	grpcOpts := []grpc.DialOption{
+		grpc.WithTimeout(time.Second),
+	}
+	if insecureGRPC {
+		grpcOpts = append(grpcOpts, grpc.WithInsecure())
+	} else {
+		host, _, err := net.SplitHostPort(serverURL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "split grpc server host and port: %s", serverURL)
+		}
+		creds := credentials.NewTLS(&tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: insecureTLS,
+		})
+		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(creds))
+	}
+	conn, err := grpc.Dial(
+		serverURL,
+		grpcOpts...,
+	)
+	return conn, err
+}
+
 func main() {
 	logger := log.NewJSONLogger(os.Stderr)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
@@ -275,28 +318,7 @@ func main() {
 	}
 	defer db.Close()
 
-	level.Info(logger).Log(
-		"msg", "dialing grpc server",
-		"server", opts.kolideServerURL,
-		"credentials", opts.insecureTLS == true,
-	)
-	grpcOpts := []grpc.DialOption{
-		grpc.WithTimeout(time.Second),
-	}
-	if opts.insecureTLS {
-		grpcOpts = append(grpcOpts, grpc.WithInsecure())
-	} else {
-		host, _, err := net.SplitHostPort(opts.kolideServerURL)
-		if err != nil {
-			logFatal(logger, "err", errors.Wrap(err, "split grpc server host and port"))
-		}
-		creds := credentials.NewTLS(&tls.Config{ServerName: host})
-		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(creds))
-	}
-	conn, err := grpc.Dial(
-		opts.kolideServerURL,
-		grpcOpts...,
-	)
+	conn, err := dialGRPC(opts.kolideServerURL, opts.insecureTLS, opts.insecureGRPC, logger)
 	if err != nil {
 		logFatal(logger, "err", errors.Wrap(err, "dialing grpc server"))
 	}


### PR DESCRIPTION
Updates the launcher to dial the grpc server with a TLS config.

Example: 
```
./build/launcher -kolide_url=398.cloud.kolide.net:443 -enroll_secret=foobar
```