### PR TITLE
Add request UUIDs for debugging purposes

### DIFF
--- a/service/logging.go
+++ b/service/logging.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/service/uuid"
 	"github.com/kolide/osquery-go/plugin/distributed"
 	"github.com/kolide/osquery-go/plugin/logger"
 )
@@ -24,8 +25,10 @@ type logmw struct {
 
 func (mw logmw) RequestEnrollment(ctx context.Context, enrollSecret, hostIdentifier string) (errcode string, reauth bool, err error) {
 	defer func(begin time.Time) {
+		uuid, _ := uuid.FromContext(ctx)
 		level.Debug(mw.logger).Log(
 			"method", "RequestEnrollment",
+			"uuid", uuid,
 			"enrollSecret", enrollSecret,
 			"hostIdentifier", hostIdentifier,
 			"errcode", errcode,
@@ -39,25 +42,29 @@ func (mw logmw) RequestEnrollment(ctx context.Context, enrollSecret, hostIdentif
 	return
 }
 
-func (mw logmw) RequestConfig(ctx context.Context, nodeKey string) (errcode string, reauth bool, err error) {
+func (mw logmw) RequestConfig(ctx context.Context, nodeKey string) (config string, reauth bool, err error) {
 	defer func(begin time.Time) {
+		uuid, _ := uuid.FromContext(ctx)
 		level.Debug(mw.logger).Log(
 			"method", "RequestConfig",
-			"errcode", errcode,
+			"uuid", uuid,
+			"config", config,
 			"reauth", reauth,
 			"err", err,
 			"took", time.Since(begin),
 		)
 	}(time.Now())
 
-	errcode, reauth, err = mw.next.RequestConfig(ctx, nodeKey)
+	config, reauth, err = mw.next.RequestConfig(ctx, nodeKey)
 	return
 }
 
 func (mw logmw) PublishLogs(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (message, errcode string, reauth bool, err error) {
 	defer func(begin time.Time) {
+		uuid, _ := uuid.FromContext(ctx)
 		level.Debug(mw.logger).Log(
 			"method", "PublishLogs",
+			"uuid", uuid,
 			"logType", logType,
 			"log_count", len(logs),
 			"message", message,
@@ -75,8 +82,10 @@ func (mw logmw) PublishLogs(ctx context.Context, nodeKey string, logType logger.
 func (mw logmw) RequestQueries(ctx context.Context, nodeKey string) (res *distributed.GetQueriesResult, reauth bool, err error) {
 	defer func(begin time.Time) {
 		resJSON, _ := json.Marshal(res)
+		uuid, _ := uuid.FromContext(ctx)
 		level.Debug(mw.logger).Log(
 			"method", "RequestQueries",
+			"uuid", uuid,
 			"res", string(resJSON),
 			"reauth", reauth,
 			"err", err,
@@ -91,8 +100,10 @@ func (mw logmw) RequestQueries(ctx context.Context, nodeKey string) (res *distri
 func (mw logmw) PublishResults(ctx context.Context, nodeKey string, results []distributed.Result) (message, errcode string, reauth bool, err error) {
 	defer func(begin time.Time) {
 		resJSON, _ := json.Marshal(results)
+		uuid, _ := uuid.FromContext(ctx)
 		level.Debug(mw.logger).Log(
 			"method", "PublishResults",
+			"uuid", uuid,
 			"results", string(resJSON),
 			"message", message,
 			"errcode", errcode,

--- a/service/uuid.go
+++ b/service/uuid.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+
+	goog_uuid "github.com/google/uuid"
+	"github.com/kolide/launcher/service/uuid"
+	"github.com/kolide/osquery-go/plugin/distributed"
+	"github.com/kolide/osquery-go/plugin/logger"
+)
+
+func uuidMiddleware(next KolideService) KolideService {
+	return uuidmw{next}
+}
+
+type uuidmw struct {
+	next KolideService
+}
+
+func makeUUID() string {
+	uuid, err := goog_uuid.NewRandom()
+	if err != nil {
+		return ""
+	}
+
+	return uuid.String()
+}
+
+func (mw uuidmw) RequestEnrollment(ctx context.Context, enrollSecret, hostIdentifier string) (errcode string, reauth bool, err error) {
+	ctx = uuid.NewContext(ctx, makeUUID())
+	return mw.next.RequestEnrollment(ctx, enrollSecret, hostIdentifier)
+}
+
+func (mw uuidmw) RequestConfig(ctx context.Context, nodeKey string) (errcode string, reauth bool, err error) {
+	ctx = uuid.NewContext(ctx, makeUUID())
+	return mw.next.RequestConfig(ctx, nodeKey)
+}
+
+func (mw uuidmw) PublishLogs(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (message, errcode string, reauth bool, err error) {
+	ctx = uuid.NewContext(ctx, makeUUID())
+	return mw.next.PublishLogs(ctx, nodeKey, logType, logs)
+}
+
+func (mw uuidmw) RequestQueries(ctx context.Context, nodeKey string) (res *distributed.GetQueriesResult, reauth bool, err error) {
+	ctx = uuid.NewContext(ctx, makeUUID())
+	return mw.next.RequestQueries(ctx, nodeKey)
+}
+
+func (mw uuidmw) PublishResults(ctx context.Context, nodeKey string, results []distributed.Result) (message, errcode string, reauth bool, err error) {
+	ctx = uuid.NewContext(ctx, makeUUID())
+	return mw.next.PublishResults(ctx, nodeKey, results)
+}

--- a/service/uuid/context.go
+++ b/service/uuid/context.go
@@ -1,0 +1,19 @@
+package uuid
+
+import "context"
+
+// Use a private type to prevent name collisions with other packages
+type key string
+
+const uuidKey key = "UUID"
+
+// NewContext creates a new context with the UUID set to the provided value
+func NewContext(ctx context.Context, uuid string) context.Context {
+	return context.WithValue(ctx, uuidKey, uuid)
+}
+
+// FromContext returns the UUID value stored in ctx, if any.
+func FromContext(ctx context.Context) (string, bool) {
+	uuid, ok := ctx.Value(uuidKey).(string)
+	return uuid, ok
+}


### PR DESCRIPTION
These UUIDs will be logged in debug logging mode, and sent with the gRPC
request metadata.