### PR TITLE
Improvements to clean_host.sh script

### DIFF
--- a/tools/packaging/clean_host.sh
+++ b/tools/packaging/clean_host.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root:"
+   echo "  sudo $0"
+   exit 1
+fi
+
+countLaunchersQuery="select count(name) as launchers from launchd where name = 'com.kolide.launcher.plist';"
+launchersInstalled=`osqueryi "${countLaunchersQuery}" --line | awk {'print $3'}`
+
+if [[ $launchersInstalled -ne 1 ]]; then
+  echo "Found $launchersInstalled running launcher instance, but was expecting 1"
+  echo "Exiting..."
+  exit 1
+fi
+
 /bin/launchctl stop /Library/LaunchDaemons/com.kolide.launcher.plist
 /bin/launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
 sleep 3
@@ -8,3 +23,5 @@ rm -f /Library/LaunchDaemons/com.kolide.launcher.plist
 rm -rf /usr/local/kolide
 rm -rf /var/kolide
 rm -rf /var/log/kolide
+
+echo "One launcher instance cleaned"


### PR DESCRIPTION
See the following command-line interface via the following interaction:

```
$ ./tools/packaging/clean_host.sh
This script must be run as root:
  sudo ./tools/packaging/clean_host.sh

$ sudo ./tools/packaging/clean_host.sh
Found 0 running launcher instance, but was expecting 1
Exiting...

$ sudo installer -pkg ~/Downloads/signed_production_launcher_package.pkg -target /
installer: Package name is signed_production_launcher_package
installer: Upgrading at base path /
installer: The upgrade was successful.

$ sudo ./tools/packaging/clean_host.sh
One launcher instance cleaned

$
```