### PR TITLE
Shard root directory by hostname

### DIFF
--- a/tools/packaging/clean_host.sh
+++ b/tools/packaging/clean_host.sh
@@ -1,27 +1,76 @@
 #!/bin/bash
 
-if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root:"
-   echo "  sudo $0"
-   exit 1
-fi
+for i in "$@"
+do
+case $i in
+    -h | --help)
+    usage
+    exit 0
+    ;;
+    --remove-db)
+    REMOVE_DATABASE=1
+    shift
+    ;;
+    *)
+    ;;
+esac
+done
 
-countLaunchersQuery="select count(name) as launchers from launchd where name = 'com.kolide.launcher.plist';"
-launchersInstalled=`osqueryi "${countLaunchersQuery}" --line | awk '{print $3}'`
 
-if [[ $launchersInstalled -ne 1 ]]; then
-  echo "Found $launchersInstalled running launcher instance, but was expecting 1"
-  echo "Exiting..."
-  exit 1
-fi
+function usage() {
+    echo "Clean launcher instances from your host"
+    echo ""
+    echo "sudo $0 [args]"
+    echo ""
+    echo "  Arguments:"
+    echo "    -h --help     Print help text"
+    echo "    --remove-db   Remove database files"
+    echo ""
+}
 
-/bin/launchctl stop /Library/LaunchDaemons/com.kolide.launcher.plist
-/bin/launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
-sleep 3
-rm -rf /etc/kolide
-rm -f /Library/LaunchDaemons/com.kolide.launcher.plist
-rm -rf /usr/local/kolide
-rm -rf /var/kolide
-rm -rf /var/log/kolide
+function ensureMacos() {
+  if [[ `uname` != 'Darwin' ]]; then
+    echo "This script must be run on macOS:"
+    echo "  sudo $0 --help"
+    exit 1
+  fi
+}
 
-echo "One launcher instance cleaned"
+function ensureRoot() {
+  if [[ $EUID != 0 ]]; then
+     echo "This script must be run as root:"
+     echo "  sudo $0 --help"
+     exit 1
+  fi
+}
+
+function main() {
+  ensureMacos
+  ensureRoot
+
+  countLaunchersQuery="select count(name) as launchers from launchd where name = 'com.kolide.launcher.plist';"
+  launchersInstalled=`osqueryi "${countLaunchersQuery}" --line | awk '{print $3}'`
+
+  if [[ $launchersInstalled -ne 1 ]]; then
+    echo "Found $launchersInstalled running launcher instance, but was expecting 1"
+    echo "Exiting..."
+    exit 1
+  fi
+
+  /bin/launchctl stop /Library/LaunchDaemons/com.kolide.launcher.plist
+  /bin/launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
+  sleep 3
+
+  rm -rf /etc/kolide
+  rm -f /Library/LaunchDaemons/com.kolide.launcher.plist
+  rm -rf /usr/local/kolide
+  rm -rf /var/log/kolide
+
+  if [[ $REMOVE_DATABASE ]]; then
+    rm -rf /var/kolide
+  fi
+
+  echo "One launcher instance cleaned"
+}
+
+main


### PR DESCRIPTION
As described by #77, this PR created a subdirectory of `/var/kolide` for each hostname so that state is not trampled or conflated when using packages to connect to different server instances.

This PR also removes the `rm -rf /var/kolide` line from the `clean_host.sh` script and abstracts that capability behind a `clean_host.sh --remove-db` flag.

Consider the files installed by a package:

```
$ ./tools/packaging/extract_mac_pkg.sh ./launcher.pkg
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/etc
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/etc/kolide
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/etc/kolide/secret
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/Library
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/Library/LaunchDaemons
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/Library/LaunchDaemons/com.kolide.launcher.plist
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local/kolide
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local/kolide/bin
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local/kolide/bin/launcher
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local/kolide/bin/osquery-extension.ext
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/usr/local/kolide/bin/osqueryd
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/var
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/var/kolide
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/var/kolide/localhost-5000
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/var/log
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/tmp.CmMvBfws/package/var/log/kolide
```

Notice that `/var/kolide/localhost-5000` is created by the package.

Now, consider the content of the LaunchDaemon

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>Label</key>
        <string>com.kolide.launcher</string>
        <key>EnvironmentVariables</key>
        <dict>
            <key>KOLIDE_LAUNCHER_ROOT_DIRECTORY</key>
            <string>/var/kolide/localhost-5000</string>
            <key>KOLIDE_LAUNCHER_KOLIDE_URL</key>
            <string>localhost:8082</string>
            <key>KOLIDE_LAUNCHER_ENROLL_SECRET_PATH</key>
            <string>/etc/kolide/secret</string>
        </dict>
        <key>RunAtLoad</key>
        <true/>
        <key>KeepAlive</key>
        <true/>
        <key>ThrottleInterval</key>
        <integer>60</integer>
        <key>ProgramArguments</key>
        <array>
            <string>/usr/local/kolide/bin/launcher</string>
            <string>--insecure_grpc</string>
        </array>
        <key>StandardErrorPath</key>
        <string>/var/log/kolide/launcher-stderr.log</string>
        <key>StandardOutPath</key>
        <string>/var/log/kolide/launcher-stdout.log</string>
    </dict>
</plist>
```

Notice that `/var/kolide/localhost-5000` is used as the root directory.

After installing the package, note the content of `/var/kolide/localhost-5000`:

```
$ ls -l /var/kolide/localhost-5000
total 4112
-rw-------  1 root  wheel  2097152 Aug 22 10:54 launcher.db
-rw-r--r--  1 root  wheel       43 Aug 22 10:52 osquery.autoload
drwx------  8 root  wheel      272 Aug 22 10:53 osquery.db
-rw-r--r--  1 root  wheel        5 Aug 22 10:52 osquery.pid
srwxr-xr-x  1 root  wheel        0 Aug 22 10:52 osquery.sock
srwxr-xr-x  1 root  wheel        0 Aug 22 10:52 osquery.sock.52006
```