### PR TITLE
set the distributed interval flag

### DIFF
--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -117,6 +117,7 @@ func createOsquerydCommand(osquerydBinary string, paths *osqueryFilePaths, confi
 		fmt.Sprintf("--logger_plugin=%s", loggerPlugin),
 		fmt.Sprintf("--distributed_plugin=%s", distributedPlugin),
 		"--disable_distributed=false",
+		"--distributed_interval=3",
 		"--pack_delimiter=:",
 		"--config_refresh=10",
 		"--host_identifier=uuid",


### PR DESCRIPTION
We were previously not defining this, so it defaulted to 60 seconds. This PR lowers it to 3 seconds. Note that this is 3 seconds between the osqueryd process communicating with the launcher distributed read extension plugin. Further optimization can exist in the gRPC plugin.