### PR TITLE
make osquery extension log to stderr instead of stdout

### DIFF
--- a/cmd/osquery-extension/osquery-extension.go
+++ b/cmd/osquery-extension/osquery-extension.go
@@ -14,7 +14,7 @@ func main() {
 	flag.Bool("verbose", false, "")
 	flag.Parse()
 
-	fmt.Printf("%+v", os.Args)
+	fmt.Fprintf(os.Stderr, "%+v", os.Args)
 
 	sig := make(chan os.Signal)
 	signal.Notify(sig, os.Interrupt)


### PR DESCRIPTION
The existing implementation would create a single line in the stdout logs.