### PR TITLE
Rename flags in package-builder to match launcher and osquery

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -99,17 +99,17 @@ func parseOptions() (*options, error) {
 		flKolideServerURL = flag.String(
 			"hostname",
 			env.String("KOLIDE_LAUNCHER_HOSTNAME", ""),
-			"Hostname of the Kolide server to communicate with",
+			"Hostname of the remote server to communicate with",
 		)
 		flEnrollSecret = flag.String(
 			"enroll_secret",
 			env.String("KOLIDE_LAUNCHER_ENROLL_SECRET", ""),
-			"Enroll secret to authenticate with the Kolide server",
+			"The enrollment secret used to authenticate with the server",
 		)
 		flEnrollSecretPath = flag.String(
 			"enroll_secret_path",
 			env.String("KOLIDE_LAUNCHER_ENROLL_SECRET_PATH", ""),
-			"Path to a file containing the enroll secret to authenticate with the Kolide server",
+			"Path to a file containing the enrollment secret",
 		)
 		flMirrorURL = flag.String(
 			"mirror_url",

--- a/cmd/package-builder/README.md
+++ b/cmd/package-builder/README.md
@@ -14,10 +14,10 @@ make package-builder
 
 ### Creating a set of packages
 
-Assuming you have built the `package-builder` tool and the `launcher` binaries via `make package-builder`, you can create a set of launcher packages by using the `package-builder make` command. The only required parameter is `--hostname`. If you don't define an enrollment secret via `--enrollment_secret`, then a blank enrollment secret will be used when connecting to the gRPC server defined by the supplied hostname.
+Assuming you have built the `package-builder` tool and the `launcher` binaries via `make package-builder`, you can create a set of launcher packages by using the `package-builder make` command. The only required parameter is `--hostname`. If you don't define an enrollment secret via `--enroll_secret`, then a blank enrollment secret will be used when connecting to the gRPC server defined by the supplied hostname.
 
 ```
-./build/package-builder make --hostname=grpc.launcher.acme.biz:443 --enrollment_secret=foobar123
+./build/package-builder make --hostname=grpc.launcher.acme.biz:443 --enroll_secret=foobar123
 ```
 
 If you'd like to customize the keys that are used to sign the enrollment secret and macOS package, consider the following usage:
@@ -25,19 +25,19 @@ If you'd like to customize the keys that are used to sign the enrollment secret 
 ```
 ./build/package-builder make \
   --hostname=localhost:8082 \
-  --enrollment_secret=foobar123 \
+  --enroll_secret=foobar123 \
   --osquery_version=stable \
   --mac_package_signing_key="Developer ID Installer: Acme Inc (ABCDEF123456)"
 ```
 
-The macOS package will install a LaunchDaemon that will connect the launcher to the server specified by the `--hostname` flag, using an enrollment secret specified by the `--enrollment_secret` flag. The Linux packages will currently lay down the launcher and osquery binaries as well as the enrollment secret specified by the `--enrollment_secret` flag.
+The macOS package will install a LaunchDaemon that will connect the launcher to the server specified by the `--hostname` flag, using an enrollment secret specified by the `--enroll_secret` flag. The Linux packages will currently lay down the launcher and osquery binaries as well as the enrollment secret specified by the `--enroll_secret` flag.
 
 If you would like the resultant launcher binary to be invoked with the `--insecure` or `--insecure_grpc` flags, include them with the invocation of `package-builder`:
 
 ```
 ./build/package-builder make \
   --hostname=localhost:8082 \
-  --enrollment_secret=foobar123 \
+  --enroll_secret=foobar123 \
   --insecure \
   --insecure_grpc
 ```
@@ -69,6 +69,6 @@ To use the tool to generate Kolide production packages, run:
 
 ```
 ./build/package-builder prod --debug \
-  --enrollment_secret_signing_key=/path/to/key.pem \
+  --enroll_secret_signing_key=/path/to/key.pem \
   --mac_package_signing_key="Developer ID Installer: Acme Inc (ABCDEF123456)"
 ```

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -40,9 +40,9 @@ func runMake(args []string) error {
 			env.String("OSQUERY_VERSION", ""),
 			"the osquery version to include in the resultant packages",
 		)
-		flEnrollmentSecret = flagset.String(
-			"enrollment_secret",
-			env.String("ENROLLMENT_SECRET_SIGNING_KEY", ""),
+		flEnrollSecret = flagset.String(
+			"enroll_secret",
+			env.String("ENROLL_SECRET", ""),
 			"the string to be used as the server enrollment secret",
 		)
 		flMacPackageSigningKey = flagset.String(
@@ -90,7 +90,7 @@ func runMake(args []string) error {
 	macPackageSigningKey := *flMacPackageSigningKey
 	_ = macPackageSigningKey
 
-	paths, err := packaging.CreatePackages(osqueryVersion, *flHostname, *flEnrollmentSecret, macPackageSigningKey, *flInsecure, *flInsecureGrpc)
+	paths, err := packaging.CreatePackages(osqueryVersion, *flHostname, *flEnrollSecret, macPackageSigningKey, *flInsecure, *flInsecureGrpc)
 	if err != nil {
 		return errors.Wrap(err, "could not generate packages")
 	}
@@ -117,9 +117,9 @@ func runDev(args []string) error {
 			env.String("OSQUERY_VERSION", ""),
 			"the osquery version to include in the resultant packages",
 		)
-		flEnrollmentSecretSigningKeyPath = flagset.String(
-			"enrollment_secret_signing_key",
-			env.String("ENROLLMENT_SECRET_SIGNING_KEY", ""),
+		flEnrollSecretSigningKeyPath = flagset.String(
+			"enroll_secret_signing_key",
+			env.String("enroll_secret_signing_key", ""),
 			"the path to the PEM key which is used to sign the enrollment secret JWT token",
 		)
 		flMacPackageSigningKey = flagset.String(
@@ -149,19 +149,19 @@ func runDev(args []string) error {
 		osqueryVersion = "stable"
 	}
 
-	enrollmentSecretSigningKeyPath := *flEnrollmentSecretSigningKeyPath
-	if enrollmentSecretSigningKeyPath == "" {
-		enrollmentSecretSigningKeyPath = filepath.Join(packaging.LauncherSource(), "/tools/packaging/example_rsa.pem")
+	enrollSecretSigningKeyPath := *flEnrollSecretSigningKeyPath
+	if enrollSecretSigningKeyPath == "" {
+		enrollSecretSigningKeyPath = filepath.Join(packaging.LauncherSource(), "/tools/packaging/example_rsa.pem")
 	}
 
-	if _, err := os.Stat(enrollmentSecretSigningKeyPath); err != nil {
+	if _, err := os.Stat(enrollSecretSigningKeyPath); err != nil {
 		if os.IsNotExist(err) {
 			return errors.Wrap(err, "key file doesn't exist")
 		} else {
 			return errors.Wrap(err, "could not stat key file")
 		}
 	}
-	pemKey, err := ioutil.ReadFile(enrollmentSecretSigningKeyPath)
+	pemKey, err := ioutil.ReadFile(enrollSecretSigningKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "could not read the supplied key file")
 	}
@@ -272,9 +272,9 @@ func runProd(args []string) error {
 			env.String("OSQUERY_VERSION", ""),
 			"the osquery version to include in the resultant packages",
 		)
-		flEnrollmentSecretSigningKeyPath = flagset.String(
-			"enrollment_secret_signing_key",
-			env.String("ENROLLMENT_SECRET_SIGNING_KEY", ""),
+		flEnrollSecretSigningKeyPath = flagset.String(
+			"enroll_secret_signing_key",
+			env.String("enroll_secret_signing_key", ""),
 			"the path to the PEM key which is used to sign the enrollment secret JWT token",
 		)
 		flMacPackageSigningKey = flagset.String(
@@ -304,19 +304,19 @@ func runProd(args []string) error {
 		osqueryVersion = "stable"
 	}
 
-	enrollmentSecretSigningKeyPath := *flEnrollmentSecretSigningKeyPath
-	if enrollmentSecretSigningKeyPath == "" {
-		enrollmentSecretSigningKeyPath = filepath.Join(packaging.LauncherSource(), "/tools/packaging/example_rsa.pem")
+	enrollSecretSigningKeyPath := *flEnrollSecretSigningKeyPath
+	if enrollSecretSigningKeyPath == "" {
+		enrollSecretSigningKeyPath = filepath.Join(packaging.LauncherSource(), "/tools/packaging/example_rsa.pem")
 	}
 
-	if _, err := os.Stat(enrollmentSecretSigningKeyPath); err != nil {
+	if _, err := os.Stat(enrollSecretSigningKeyPath); err != nil {
 		if os.IsNotExist(err) {
 			return errors.Wrap(err, "key file doesn't exist")
 		} else {
 			return errors.Wrap(err, "could not stat key file")
 		}
 	}
-	pemKey, err := ioutil.ReadFile(enrollmentSecretSigningKeyPath)
+	pemKey, err := ioutil.ReadFile(enrollSecretSigningKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "could not read the supplied key file")
 	}


### PR DESCRIPTION
Launcher and Osquery itself both use the pattern of calling enrollment secret flags `--enroll_secret`, so this PR updates the package builder tool to use the same format. Also included in this PR are some minor updates to the help text of some launcher flags.