### PR TITLE
package-builder tool for creating enroll secrets

### DIFF
--- a/tools/packaging/kolide.go
+++ b/tools/packaging/kolide.go
@@ -15,7 +15,7 @@ import (
 // CreateKolidePackages will create a launcher macOS package. The output paths
 // of the packages are returned and an error if the operation was not successful.
 func CreateKolidePackages(uploadRoot, osqueryVersion, hostname, tenant string, pemKey []byte, macPackageSigningKey string) (*PackagePaths, error) {
-	secret, err := enrollSecret(tenant, pemKey)
+	secret, err := EnrollSecret(tenant, pemKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create enrollment secret")
 	}
@@ -84,9 +84,9 @@ func TenantName(id int) string {
 	return m.string()
 }
 
-// enrollSecret will generate an enrollment secret for a tenant given a valid
+// EnrollSecret will generate an enrollment secret for a tenant given a valid
 // signing key
-func enrollSecret(tenantName string, pemKey []byte) (string, error) {
+func EnrollSecret(tenantName string, pemKey []byte) (string, error) {
 	fingerPrint := fmt.Sprintf("% x", md5.Sum([]byte(pemKey)))
 	fingerPrint = strings.Replace(fingerPrint, " ", ":", 15)
 


### PR DESCRIPTION
```
$ ./build/package-builder enroll-secret --help
USAGE
  package-builder enroll-secret [flags]

FLAGS
  -enroll_secret_signing_key   the path to the PEM key which is used to sign the enrollment secret JWT token
  -tenant                      the tenant name to generate a secret for (example: dababi)

$ ./build/package-builder enroll-secret --tenant dadada
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZW5hbnQiOiJkYWRhZGEiLCJraWQiOiJiYTo5NjphMDo0YjpmZDo0OTpjMDoxODo2YzpkNDo3Yzo3Njo1ODpkZTpmMDpmZSJ9.sYn9dTU6xrE90pHQmPjtiVbxFBXA0F3vwl6xBSdj4jSlTEiWjRQszPeAZjMqqjZ3oGATXslvwu7jBWMMlfq7uudN3Pqf1OD5iFTuYS2Y52MDvgiikGIeqgT9MnuEm86zL5HfmZeDy6PUt6QNBqIxOKTHHnR_VONNlAo9TkRWs9OA9YNxqCvft8jBpfOZ5cw-Y3R133mYGIEUCclyhzGRgtht8hA8me1mh0IvVDytpM476nThK2Mbv_9DBf56dzJ-YT_JfENK6CcQIGAl6G6jLnl_HvLkCyOnPiIC0a7o_7CiNI3hxvhfDwiL5ybo9mMw6cnRURfh_SDuSlW2qNvM0Q
$
```