### PR TITLE
Rename spotlight table to kolide_spotlight

### DIFF
--- a/osquery/mdfind.go
+++ b/osquery/mdfind.go
@@ -22,7 +22,7 @@ func Spotlight() *table.Plugin {
 		table.TextColumn("query"),
 		table.TextColumn("path"),
 	}
-	return table.NewPlugin("spotlight", columns, generateSpotlight)
+	return table.NewPlugin("kolide_spotlight", columns, generateSpotlight)
 }
 
 func generateSpotlight(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {


### PR DESCRIPTION
We settled on all launcher provided tables being prefixed with `kolide_`, so this adds that for the (currently unused) `spotlight` table (now: `kolide_spotlight`).