### PR TITLE
Launcher Info Table: kolide_launcher_info

### DIFF
--- a/osquery/launcher_info.go
+++ b/osquery/launcher_info.go
@@ -1,0 +1,38 @@
+package osquery
+
+import (
+	"context"
+
+	"github.com/kolide/kit/version"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+)
+
+func LauncherInfo(client *osquery.ExtensionManagerClient) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("version"),
+		table.TextColumn("go_version"),
+		table.TextColumn("branch"),
+		table.TextColumn("revision"),
+		table.TextColumn("build_date"),
+		table.TextColumn("build_user"),
+	}
+	return table.NewPlugin("kolide_launcher_info", columns, generateLauncherInfo(client))
+}
+
+func generateLauncherInfo(client *osquery.ExtensionManagerClient) table.GenerateFunc {
+	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		results := []map[string]string{
+			map[string]string{
+				"version":    version.Version().Version,
+				"go_version": version.Version().GoVersion,
+				"branch":     version.Version().Branch,
+				"revision":   version.Version().Revision,
+				"build_date": version.Version().BuildDate,
+				"build_user": version.Version().BuildUser,
+			},
+		}
+
+		return results, nil
+	}
+}

--- a/osquery/platform_tables.go
+++ b/osquery/platform_tables.go
@@ -9,6 +9,7 @@ import (
 
 func platformTables(client *osquery.ExtensionManagerClient) []*table.Plugin {
 	return []*table.Plugin{
+		LauncherInfo(client),
 		BestPractices(client),
 		EmailAddresses(client),
 	}

--- a/osquery/platform_tables_darwin.go
+++ b/osquery/platform_tables_darwin.go
@@ -9,6 +9,7 @@ import (
 
 func platformTables(client *osquery.ExtensionManagerClient) []*table.Plugin {
 	return []*table.Plugin{
+		LauncherInfo(client),
 		BestPractices(client),
 		EmailAddresses(client),
 		Spotlight(),


### PR DESCRIPTION
This PR introduces a new table: `kolide_launcher_info`

![screen shot 2017-09-05 at 12 00 02 pm](https://user-images.githubusercontent.com/927168/30075341-f6b9985a-9231-11e7-839e-3821e98171b8.png)
