### PR TITLE
Accept PR range and tenant number as flags

### DIFF
--- a/cmd/package-builder/README.md
+++ b/cmd/package-builder/README.md
@@ -60,7 +60,9 @@ To use the tool to generate Kolide internal development packages, run:
 
 ```
 ./build/package-builder dev --debug \
-  --mac_package_signing_key="Developer ID Installer: Acme Inc (ABCDEF123456)"
+  --mac_package_signing_key="Developer ID Installer: Acme Inc (ABCDEF123456)" \
+	--pr_start=600 \
+	--pr_end=750
 ```
 
 ### Production Packages


### PR DESCRIPTION
This PR adds three flags to `package-builder dev`:

- `--pr_start`: the number of the cloud PR to start generating packages at (required)
- `--pr_end`: the number of the cloud PR to stop generating packages at (required)
- `--number_of_tenants`: the number of tenants to generate packages for (default: 3)