### PR TITLE
Add the debug flag to the execution of launcher

### DIFF
--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -351,6 +351,7 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
         <key>ProgramArguments</key>
         <array>
             <string>{{.LauncherPath}}</string>
+            <string>--debug</string>
             {{if .InsecureGrpc}}<string>--insecure_grpc</string>{{end}}
             {{if .Insecure}}<string>--insecure</string>{{end}}
         </array>


### PR DESCRIPTION
Plist from `./build/package-builder make --identifier=kolide --hostname=localhost:8080 --enroll_secret=1234`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>Label</key>
        <string>com.kolide.launcher</string>
        <key>EnvironmentVariables</key>
        <dict>
            <key>KOLIDE_LAUNCHER_ROOT_DIRECTORY</key>
            <string>/var/kolide/localhost-8080</string>
            <key>KOLIDE_LAUNCHER_HOSTNAME</key>
            <string>localhost:8080</string>
            <key>KOLIDE_LAUNCHER_ENROLL_SECRET_PATH</key>
            <string>/etc/kolide/secret</string>
            <key>KOLIDE_LAUNCHER_OSQUERYD_PATH</key>
            <string>/usr/local/kolide/bin/osqueryd</string>
        </dict>
        <key>RunAtLoad</key>
        <true/>
        <key>KeepAlive</key>
        <true/>
        <key>ThrottleInterval</key>
        <integer>60</integer>
        <key>ProgramArguments</key>
        <array>
            <string>/usr/local/kolide/bin/launcher</string>
            <string>--debug</string>
        </array>
        <key>StandardErrorPath</key>
        <string>/var/log/kolide/launcher-stderr.log</string>
        <key>StandardOutPath</key>
        <string>/var/log/kolide/launcher-stdout.log</string>
    </dict>
</plist>
```