### PR TITLE
Launcher restart sometimes fails on autoupdate.

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -170,6 +170,28 @@ func insecureHTTPClient() *http.Client {
 	}
 }
 
+// We have to find the instance of osqueryd and send it an interrupt so it
+// shuts down it's extensions which are child processes of osqueryd. If we
+// don't do this the extension continues to run and osqueryd thinks we're trying
+// to register a duplicate extension and start up of new launcher process fails.
+func shutdownOsQuery(rootdir string) error {
+	pidFilePath := filepath.Join(rootdir, "osquery.pid")
+	sPid, err := ioutil.ReadFile(pidFilePath)
+	if err != nil {
+		return errors.Wrap(err, "finding osquery pid")
+	}
+	pid, err := strconv.Atoi(string(sPid))
+	if err != nil {
+		return errors.Wrap(err, "converting pid to int")
+	}
+	sigTerm := syscall.Signal(15)
+	if err := syscall.Kill(pid, sigTerm); err != nil {
+		return errors.Wrap(err, "killing osqueryd")
+	}
+	time.Sleep(5 * time.Second)
+	return nil
+}
+
 func enableAutoUpdate(
 	notaryURL, mirrorURL, binaryPath, rootdir string,
 	autoupdateInterval time.Duration,
@@ -209,30 +231,12 @@ func enableAutoUpdate(
 
 	// call this method to restart the launcher when autoupdate completes.
 	launcherFinalizer := func() error {
-		// We have to find the instance of osqueryd and send it an interrupt so it
-		// shuts down it's extensions which are child processes of osqueryd. If we
-		// don't do this the extension continues to run and osqueryd thinks we're trying
-		// to register a duplicate extension and start up of new launcher process fails.
-		pidFilePath := filepath.Join(rootdir, "osquery.pid")
-		sPid, err := ioutil.ReadFile(pidFilePath)
-		if err != nil {
-			return errors.Wrap(err, "finding osquery pid")
-		}
-		pid, err := strconv.Atoi(string(sPid))
-		if err != nil {
-			return errors.Wrap(err, "converting pid")
-		}
-		p, err := os.FindProcess(pid)
-		if err != nil {
-			return errors.Wrap(err, "finding pid")
-		}
-		// TODO: Interrupt doesn't work on Windows?
-		err = p.Signal(os.Interrupt)
-		if err != nil {
-			return errors.Wrap(err, "signal osqueryd failed")
-		}
-		if _, err = p.Wait(); err != nil {
-			return errors.Wrap(err, "shutdown osqueryd fails")
+
+		if err = shutdownOsQuery(rootdir); err != nil {
+			level.Warn(logger).Log(
+				"method", "launcherFinalizer",
+				"err", err,
+			)
 		}
 		// replace launcher
 		if err = syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {


### PR DESCRIPTION
Fixes problem with hanging extension. Osquery extension is not shut down properly because it's a child process of osqueryd which is a child process of launcher .


 ```                                                                                                           
W0918 10:21:30.004748 84549632 interface.cpp:117] Refusing to register duplicate extension kolide                                                                                                                                                                                          
[osquery extension: /Users/jam/code/go/src/github.com/kolide/launcher/build/osquery-extension.ext --socket ../launcher-artifacts/osquery.sock --timeout 3 --interval 3]E0918 10:21:34.544639 3475305408 init.cpp:568] Cannot activate kolide_grpc config plugin: Unknown registry plugin: k
olide_grpc                         
```