### PR TITLE
Initial Launcher CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ Osquery has a very extensible plugin architecture that allow it to be heavily cu
 
 An implementation of the gRPC server is included with the [Kolide Fleet](https://github.com/kolide/fleet) osquery fleet manager. Kolide Fleet implements both the gRPC server as well as the legacy TLS server API, so it presents an easy migration path for existing TLS API users.
 
-### Easy Packaging and Deployment Tooling
-
-
-Deploying osquery and configuring it to communicate with a management server can be complicated, especially if you have to make customized deployment packages. The Launcher includes a tool called `package-builder` which you can use to create Launcher packages for your organization.
-
-Take the headache out of deploying osquery and check out the [documentation](./cmd/package-builder/README.md).
-
 ### Kolide's Best Practices
 
 Osquery allows you to ask a lot of great questions, but sometimes it's hard to know exactly which questions you should ask and what queries will expose the answers. The Launcher includes a table called `kolide_best_practices` which aggregates useful information in an easy "compliant" vs "not compliant" interface. Consider the following queries:
@@ -48,3 +41,15 @@ The following best practices, and many more, are included:
 - Is the firewall enabled?
 - Are [Remote Apple Events](https://support.apple.com/kb/PH18721?locale=en_US) disabled?
 - Is Internet Sharing disabled?
+
+### Reduced Configuration Surface
+
+The osqueryd binary was designed to be very configurable, which allows it to be used in very different environments. The Launcher wraps osqueryd configuration and exposes very high-level options that allow you to easily connect osquery to a server that is compliant with the [gRPC specification](https://github.com/kolide/agent-api/blob/master/agent_api.proto) (such as [Kolide Fleet](https://github.com/kolide/fleet)).
+
+To learn about The Launcher's command-line interface, see the Launcher [documentation](./cmd/launcher/README.md).
+
+### Easy Packaging and Deployment Tooling
+
+Deploying osquery and configuring it to communicate with a management server can be complicated, especially if you have to make customized deployment packages. The Launcher includes a tool called `package-builder` which you can use to create Launcher packages for your organization.
+
+Take the headache out of deploying osquery and check out the [documentation](./cmd/package-builder/README.md).

--- a/cmd/launcher/README.md
+++ b/cmd/launcher/README.md
@@ -1,0 +1,65 @@
+# The Osquery Launcher
+
+## Building the tool
+
+From the root of the repository, run the following:
+
+```
+make deps
+make launcher
+./build/launcher --help
+```
+
+To install the launcher binaries to `$GOPATH/bin`, run the following:
+
+```
+make deps
+make install
+```
+
+You *could* run `go get github.com/kolide/launcher/cmd/...` to install the binaries but it is not recommended because the binaries will not be built with version information when you run `launcher --version`.
+
+## General Usage
+
+To use The Launcher to easily connect osquery to a server that is compliant with the [gRPC specification](https://github.com/kolide/agent-api/blob/master/agent_api.proto), invoke the binary with just a few flags:
+
+- `--hostname`: the hostname of the gRPC server for your environment
+- `--root_directory`: the location of the local database, pidfiles, etc.
+- `--enroll_secret`: the enroll secret that is used in your environment
+
+```
+./build/launcher \
+  --hostname=fleet.acme.net:443 \
+  --root_directory=/var/kolide-fleet \
+  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5
+```
+
+You can also define the enroll secret via a file path (`--enroll_secret_path`) or an environment variable (`KOLIDE_LAUNCHER_ENROLL_SECRET`). See `launcher --help` for more information.
+
+You may need to define the `--insecure` and/or `--insecure_grpc` flag depending on your server configurations.
+
+## Examples
+
+### Connecting to Fleet
+
+Let's say that you have [Kolide Fleet](https://github.com/kolide/fleet) running at https://fleet.acme.org, you could simply run the following to connect The Launcher to Fleet (assuming you replace the enroll secret with the correct string):
+
+```
+launcher \
+  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5 \
+  --hostname=fleet.acme.org:443 \
+  --root_directory=/var/acme/fleet
+```
+
+If you're running Fleet on the default development location (https://localhost:8080), you can connect a launcher via:
+
+```
+mkdir /tmp/fleet-launcher
+launcher \
+  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5 \
+  --hostname=fleet.acme.org:443 \
+  --root_directory=/tmp/fleet-launcher \
+  --insecure
+```
+
+Note the `--insecure` flag.


### PR DESCRIPTION
# The Osquery Launcher

## Building the tool

From the root of the repository, run the following:

```
make deps
make launcher
./build/launcher --help
```

To install the launcher binaries to `$GOPATH/bin`, run the following:

```
make deps
make install
```

You *could* run `go get github.com/kolide/launcher/cmd/...` to install the binaries but it is not recommended because the binaries will not be built with version information when you run `launcher --version`.

## General Usage

To use The Launcher to easily connect osquery to a server that is compliant with the [gRPC specification](https://github.com/kolide/agent-api/blob/master/agent_api.proto), invoke the binary with just a few flags:

- `--hostname`: the hostname of the gRPC server for your environment
- `--root_directory`: the location of the local database, pidfiles, etc.
- `--enroll_secret`: the enroll secret you generated above for your environment

```
./build/launcher \
  --hostname=fleet.acme.net:443 \
  --root_directory=/var/kolide-fleet \
  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5
```

You can also define the enroll secret via a file path (`--enroll_secret_path`) or an environment variable (`KOLIDE_LAUNCHER_ENROLL_SECRET`). See `launcher --help` for more information.

You may need to define the `--insecure` and/or `--insecure_grpc` flag depending on your server configurations.

## Examples

### Connecting to Fleet

Let's say that you have [Kolide Fleet](https://github.com/kolide/fleet) running at https://fleet.acme.org, you could simply run the following to connect The Launcher to Fleet (assuming you replace the enroll secret with the correct string):

```
launcher \
  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5 \
  --hostname=fleet.acme.org:443 \
  --root_directory=/var/acme/fleet
```

If you're running Fleet on the default development location (https://localhost:8080), you can connect a launcher via:

```
mkdir /tmp/fleet-launcher
launcher \
  --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5 \
  --hostname=fleet.acme.org:443 \
  --root_directory=/tmp/fleet-launcher \
  --insecure
```

Note the `--insecure` flag.