### PR TITLE
Allow systemd to start launcher

### DIFF
--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -57,13 +57,11 @@ func createLinuxPackages(osqueryVersion, hostname, secret string, insecure, inse
 	rootDirectory := filepath.Join("/var", identifier, sanitizeHostname(hostname))
 	binaryDirectory := filepath.Join("/usr/local", identifier, "bin")
 	configurationDirectory := filepath.Join("/etc", identifier)
-	logDirectory := filepath.Join("/var/log", identifier)
 	systemdDirectory := "/etc/systemd/system"
 	pathsToCreate := []string{
 		rootDirectory,
 		binaryDirectory,
 		configurationDirectory,
-		logDirectory,
 		systemdDirectory,
 	}
 


### PR DESCRIPTION
This change creates a systemd unit file for the launcher. When the DEB or RPM package is installed a post install script will also enable and start the launcher service so it runs and starts up again through system reboots.

Tested on CentOS 7 and Ubuntu 16