### PR TITLE
make binary-bundle: generate distributable binaries for the launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,16 @@ push-containers: $(CONTAINERS)
 	for container in $(CONTAINERS); do \
 		gcloud docker -- push gcr.io/kolide-ose-testing/$${container}-launcher; \
 	done
+
+binary-bundle: xp
+	rm -rf build/binary-bundle
+	mkdir -p build/binary-bundle/linux
+	mkdir -p build/binary-bundle/darwin
+	cp build/linux/launcher build/binary-bundle/linux/launcher
+	cp build/linux/osquery-extension.ext build/binary-bundle/linux/osquery-extension.ext
+	go run ./tools/download-osquery.go --platform=linux --output=build/binary-bundle/linux/osqueryd
+	cp build/darwin/launcher build/binary-bundle/darwin/launcher
+	cp build/darwin/osquery-extension.ext build/binary-bundle/darwin/osquery-extension.ext
+	go run ./tools/download-osquery.go --platform=darwin --output=build/binary-bundle/darwin/osqueryd
+	cd build/binary-bundle && zip -r "launcher_${VERSION}.zip" linux/ darwin/
+	cp build/binary-bundle/launcher_${VERSION}.zip build/binary-bundle/launcher_latest.zip

--- a/tools/download-osquery.go
+++ b/tools/download-osquery.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kolide/kit/env"
+	"github.com/kolide/kit/fs"
+	"github.com/kolide/launcher/tools/packaging"
+)
+
+func main() {
+	var (
+		flVersion  = flag.String("version", env.String("VERSION", "stable"), "the osqueryd version to download")
+		flPlatform = flag.String("platform", env.String("PLATFORM", ""), "the platform to download osqueryd for (ie: darwin, linux)")
+		flOutput   = flag.String("output", env.String("OUTPUT", ""), "the path where the binary should be output")
+	)
+	flag.Parse()
+
+	if *flPlatform == "" {
+		fmt.Println("The --platform option must be defined")
+		os.Exit(1)
+	}
+
+	path, err := packaging.FetchOsquerydBinary(*flVersion, *flPlatform)
+	if err != nil {
+		fmt.Println("An error occurred fetching the osqueryd binary: ", err)
+		os.Exit(1)
+	}
+
+	if *flOutput != "" {
+		if err := fs.CopyFile(path, *flOutput); err != nil {
+			fmt.Printf("Couldn't copy file to %s: %s", *flOutput, err)
+			os.Exit(1)
+		}
+		fmt.Println(*flOutput)
+	} else {
+		fmt.Println(path)
+	}
+}


### PR DESCRIPTION
This adds a similar utility to what we have with fleet (https://dl.kolide.com/bin/fleet_latest.zip) to launcher so that we can similarly publish binaries on https://dl.kolide.com