### PR TITLE
Increase timeout to open osquery extension socket

### DIFF
--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -270,7 +270,7 @@ func (r *Runner) Healthy() error {
 
 // How long to wait before erroring because we cannot open the osquery
 // extension socket.
-const socketOpenTimeout = 5 * time.Second
+const socketOpenTimeout = 10 * time.Second
 
 // How often to try to open the osquery extension socket
 const socketOpenInterval = 200 * time.Millisecond


### PR DESCRIPTION
Occasionally during tests the 5s timeout would expire. Bumping to 10s still
seems like a reasonable limit, and may prevent startup from failing under
unusual circumstances.