### PR TITLE
add pathstate to launchd template

### DIFF
--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -453,7 +453,13 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>
-        <true/>
+        <dict>
+            <key>PathState</key>
+            <dict>
+                <key>{{.SecretPath}}</key>
+                <true/>
+            </dict>
+        </dict>
         <key>ThrottleInterval</key>
         <integer>60</integer>
         <key>ProgramArguments</key>

--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -465,10 +465,14 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
         <key>ProgramArguments</key>
         <array>
             <string>{{.LauncherPath}}</string>
-            <string>--debug</string>{{if .InsecureGrpc}}
-            <string>--insecure_grpc</string>{{end}}{{if .Insecure}}
-            <string>--insecure</string>{{end}}{{if .Autoupdate}}
-            <string>--autoupdate</string>{{end}}
+            {{if .InsecureGrpc}}
+            <string>--insecure_grpc</string>
+			{{end}}
+			{{if .Insecure}}
+            <string>--insecure</string>{{end}}
+			{{if .Autoupdate}}
+            <string>--autoupdate</string>
+			{{end}}
         </array>
         <key>StandardErrorPath</key>
         <string>{{.LogDirectory}}/launcher-stderr.log</string>

--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -450,8 +450,6 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
             <key>KOLIDE_LAUNCHER_UPDATE_CHANNEL</key>
             <string>{{.UpdateChannel}}</string>{{end}}
         </dict>
-        <key>RunAtLoad</key>
-        <true/>
         <key>KeepAlive</key>
         <dict>
             <key>PathState</key>


### PR DESCRIPTION
Keeps the launchd process up only if the enroll secret is present.

Closes #199