### PR TITLE
packaging-builder: accept actual grpc hostname

### DIFF
--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -540,7 +540,7 @@ func grpcServerForHostname(hostname string) string {
 		return "localhost:8082"
 	case "master.cloud.kolide.net":
 		return "master-grpc.cloud.kolide.net:443"
-	case "kolide.co", "kolide.com":
+	case "kolide.co", "kolide.com", "launcher.kolide.com:443":
 		return "launcher.kolide.com:443"
 	default:
 		if strings.Contains(hostname, ":") {


### PR DESCRIPTION
When building a package, we special case a few hostnames to create  the desired folder structure. This ensures that if the real hostname is passed to `package-builder --hostname=`, we don't accidentally build a package with unintended folder names. 