### PR TITLE
support HTTP as an alternate transport

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,6 +84,18 @@
   version = "0.2"
 
 [[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
+  version = "v1.6.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/kolide/kit"
   packages = ["env","fs","testutil","version"]
@@ -111,7 +123,7 @@
   branch = "master"
   name = "github.com/miekg/pkcs11"
   packages = ["."]
-  revision = "b0a4dd3f1df2065883a1a0a9045fb893319d3c67"
+  revision = "694c80ab67e3b197690c5ba8a11f0ecdf7a90c93"
 
 [[projects]]
   branch = "master"
@@ -147,13 +159,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ssh/terminal"]
-  revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
+  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
+  revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
   branch = "master"
@@ -165,13 +177,13 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "665f6529cca930e27b831a0d1dafffbe1c172924"
+  revision = "8b4580aae2a0dd0c231a45d3ccb8434ff533b840"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "88f656faf3f37f690df1a32515b479415e1a6769"
+  revision = "75cc3cad82b5f47d3fb229ddda8c5167da14f294"
 
 [[projects]]
   branch = "master"
@@ -183,17 +195,17 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "11c7f9e547da6db876260ce49ea7536985904c9b"
+  revision = "7f0da29060c682909f650ad8ed4e515bd74fa12a"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
-  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
-  version = "v1.7.2"
+  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "5a9f7b402fe85096d2e1d0383435ee1876e863d0"
+  version = "v1.8.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c50edc0a6c9e71c0b2cb3544ab9cb477dcc569f0432be4cbd546f31fbcfe0e7c"
+  inputs-digest = "6c5c7adf0481977012bcc2518a9f8ca53fbb71f496392d1fa2fe6e432607dffb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -55,7 +55,7 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["endpoint","log","log/level","transport/grpc"]
+  packages = ["endpoint","log","log/level","transport/grpc","transport/http"]
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
@@ -68,14 +68,14 @@
 [[projects]]
   name = "github.com/go-stack/stack"
   packages = ["."]
-  revision = "817915b46b97fd7bb80e8ab6b69f01a53ac3eebf"
-  version = "v1.6.0"
+  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
+  version = "v1.7.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -93,13 +93,13 @@
   branch = "master"
   name = "github.com/kolide/osquery-go"
   packages = [".","gen/osquery","gen/osquery/mock","plugin/config","plugin/distributed","plugin/logger","plugin/table","transport"]
-  revision = "03a792fcca9a86c9a717109c2ad8763d0759105b"
+  revision = "77394894ef63b4ea25e1c0c4f8a8b3d1919e1aa6"
 
 [[projects]]
   branch = "master"
   name = "github.com/kolide/updater"
   packages = ["tuf"]
-  revision = "ec5168a7b81bf57730f1a16fb6c36f9374f0874a"
+  revision = "2d06c5fa40b21b6828539994b5b5414714ee2973"
 
 [[projects]]
   branch = "master"
@@ -111,7 +111,7 @@
   branch = "master"
   name = "github.com/miekg/pkcs11"
   packages = ["."]
-  revision = "eda1d775a087f2a96fec7c7876ea94dea43e6027"
+  revision = "b0a4dd3f1df2065883a1a0a9045fb893319d3c67"
 
 [[projects]]
   branch = "master"
@@ -147,31 +147,31 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ssh/terminal"]
-  revision = "541b9d50ad47e36efd8fb423e938e59ff1691f68"
+  revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "aabf50738bcdd9b207582cbe796b59ed65d56680"
+  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  revision = "8e0aa688b654ef28caa72506fa5ec8dba9fc7690"
+  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "8dbc5d05d6edcc104950cc299a1ce6641235bc86"
+  revision = "665f6529cca930e27b831a0d1dafffbe1c172924"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "c01e4764d870b77f8abe5096ee19ad20d80e8075"
+  revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   branch = "master"
@@ -183,17 +183,17 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "f676e0f3ac6395ff1a529ae59a6670878a8371a6"
+  revision = "11c7f9e547da6db876260ce49ea7536985904c9b"
 
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
-  revision = "f7bf885db0b7479a537ec317c6e48ce53145f3db"
-  version = "v1.7.0"
+  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
+  version = "v1.7.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1c1aaef7211b2a2a41be582cbe36547df6ef364b5f2e13aeaeb54bd1ff9c8ed8"
+  inputs-digest = "c50edc0a6c9e71c0b2cb3544ab9cb477dcc569f0432be4cbd546f31fbcfe0e7c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,7 @@
 
 [[constraint]]
   name = "github.com/kolide/osquery-go"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/kolide/updater"

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -27,6 +27,7 @@ type options struct {
 	debug              bool
 	insecureTLS        bool
 	insecureGRPC       bool
+	transportHTTP      bool
 	notaryServerURL    string
 	mirrorServerURL    string
 	autoupdateInterval time.Duration
@@ -113,6 +114,12 @@ func parseOptions() (*options, error) {
 			"Dial GRPC without a TLS config (default: false)",
 		)
 
+		flHTTPTransport = flag.Bool(
+			"transport_http",
+			env.Bool("KOLIDE_LAUNCHER_TRANSPORT_HTTP", false),
+			"Use HTTP Transport instead of gRPC (default: false)",
+		)
+
 		// Version command: launcher --version
 		flVersion = flag.Bool(
 			"version",
@@ -174,6 +181,7 @@ func parseOptions() (*options, error) {
 		debug:              *flDebug,
 		insecureTLS:        *flInsecureTLS,
 		insecureGRPC:       *flInsecureGRPC,
+		transportHTTP:      *flHTTPTransport,
 		notaryServerURL:    *flNotaryServerURL,
 		mirrorServerURL:    *flMirrorURL,
 		autoupdateInterval: *flAutoupdateInterval,
@@ -213,6 +221,7 @@ func shortUsage() {
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("autoupdate")
 	fmt.Fprintf(os.Stderr, "\n")
+	printOpt("transport_http")
 	printOpt("version")
 	fmt.Fprintf(os.Stderr, "\n")
 	fmt.Fprintf(os.Stderr, "  All options can be set as environment variables using the following convention:\n")

--- a/osquery/extension.go
+++ b/osquery/extension.go
@@ -3,6 +3,7 @@ package osquery
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"time"
 
@@ -551,7 +552,10 @@ func (e *Extension) LogString(ctx context.Context, typ logger.LogType, logText s
 
 // GetQueries will request the distributed queries to execute from the server.
 func (e *Extension) GetQueries(ctx context.Context) (*distributed.GetQueriesResult, error) {
-	return e.getQueriesWithReenroll(ctx, true)
+	q, err := e.getQueriesWithReenroll(ctx, true)
+	// TODO remove
+	fmt.Println(q.Queries)
+	return q, err
 }
 
 // Helper to allow for a single attempt at re-enrollment

--- a/service/client.go
+++ b/service/client.go
@@ -21,15 +21,17 @@ type KolideClient struct {
 }
 
 type enrollmentRequest struct {
-	EnrollSecret   string
-	HostIdentifier string
+	EnrollSecret   string `json:"enroll_secret"`
+	HostIdentifier string `json:"host_identifier"`
 }
 
 type enrollmentResponse struct {
-	NodeKey     string
-	NodeInvalid bool
-	Err         error
+	NodeKey     string `json:"node_key"`
+	NodeInvalid bool   `json:"node_invalid"`
+	Err         error  `json:"err,omitempty"`
 }
+
+func (r enrollmentResponse) error() error { return r.Err }
 
 // requestTimeout is duration after which the request is cancelled.
 const requestTimeout = 60 * time.Second
@@ -49,14 +51,16 @@ func (e KolideClient) RequestEnrollment(ctx context.Context, enrollSecret, hostI
 }
 
 type agentAPIRequest struct {
-	NodeKey string
+	NodeKey string `json:"node_key"`
 }
 
 type configResponse struct {
-	ConfigJSONBlob string
-	NodeInvalid    bool
-	Err            error
+	ConfigJSONBlob string `json:"config_json_blob"`
+	NodeInvalid    bool   `json:"node_invalid"`
+	Err            error  `json:"err,omitempty"`
 }
+
+func (r configResponse) error() error { return r.Err }
 
 // RequestConfig implements KolideService.RequestConfig.
 func (e KolideClient) RequestConfig(ctx context.Context, nodeKey string) (string, bool, error) {
@@ -72,17 +76,19 @@ func (e KolideClient) RequestConfig(ctx context.Context, nodeKey string) (string
 }
 
 type logCollection struct {
-	NodeKey string
-	LogType logger.LogType
-	Logs    []string
+	NodeKey string         `json:"node_key"`
+	LogType logger.LogType `json:"log_type"`
+	Logs    []string       `json:"logs"`
 }
 
 type agentAPIResponse struct {
-	Message     string
-	ErrorCode   string
-	NodeInvalid bool
-	Err         error
+	Message     string `json:"message"`
+	ErrorCode   string `json:"error_code"`
+	NodeInvalid bool   `json:"node_invalid"`
+	Err         error  `json:"err,omitempty"`
 }
+
+func (r agentAPIResponse) error() error { return r.Err }
 
 // PublishLogs implements KolideService.PublishLogs
 func (e KolideClient) PublishLogs(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
@@ -98,10 +104,12 @@ func (e KolideClient) PublishLogs(ctx context.Context, nodeKey string, logType l
 }
 
 type queryCollection struct {
-	Queries     distributed.GetQueriesResult
-	NodeInvalid bool
-	Err         error
+	Queries     distributed.GetQueriesResult `json:"queries"`
+	NodeInvalid bool                         `json:"node_invalid"`
+	Err         error                        `json:"err,omitempty"`
 }
+
+func (r queryCollection) error() error { return r.Err }
 
 // RequestQueries implements KolideService.RequestQueries
 func (e KolideClient) RequestQueries(ctx context.Context, nodeKey string) (*distributed.GetQueriesResult, bool, error) {
@@ -117,8 +125,8 @@ func (e KolideClient) RequestQueries(ctx context.Context, nodeKey string) (*dist
 }
 
 type resultCollection struct {
-	NodeKey string
-	Results []distributed.Result
+	NodeKey string               `json:"node_key"`
+	Results []distributed.Result `json:"results"`
 }
 
 // PublishResults implements KolideService.PublishResults
@@ -148,8 +156,8 @@ func (e KolideClient) CheckHealth(ctx context.Context) (int32, error) {
 }
 
 type healthcheckResponse struct {
-	Status int32
-	Err    error
+	Status int32 `json:"status"`
+	Err    error `json:"err,omitempty"`
 }
 
 func makeRequestEnrollmentEndpoint(svc KolideService) endpoint.Endpoint {

--- a/service/client_http.go
+++ b/service/client_http.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/go-kit/kit/log"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/kolide/launcher/service/uuid"
+)
+
+func attachUUIDHeaderHTTP() httptransport.ClientOption {
+	return httptransport.ClientBefore(
+		func(ctx context.Context, r *http.Request) context.Context {
+			uuid, _ := uuid.FromContext(ctx)
+			return httptransport.SetRequestHeader("uuid", uuid)(ctx, r)
+		},
+	)
+}
+
+// NewHTTPClient creates an HTTP Client that implements the Launcher endpoints.
+func NewHTTPClient(instance string, logger log.Logger) (KolideService, error) {
+	u, err := url.Parse(instance)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []httptransport.ClientOption{
+		attachUUIDHeaderHTTP(),
+	}
+
+	requestEnrollmentEndpoint := httptransport.NewClient(
+		"POST",
+		copyURL(u, "/api/v1/launcher/enroll"),
+		httptransport.EncodeJSONRequest,
+		decodeHTTPEnrollmentResponse,
+		opts...,
+	).Endpoint()
+
+	requestConfigEndpoint := httptransport.NewClient(
+		"POST",
+		copyURL(u, "/api/v1/launcher/config"),
+		httptransport.EncodeJSONRequest,
+		decodeHTTPConfigResponse,
+		opts...,
+	).Endpoint()
+
+	publishLogsEndpoint := httptransport.NewClient(
+		"POST",
+		copyURL(u, "/api/v1/launcher/log"),
+		httptransport.EncodeJSONRequest,
+		decodeLauncherResponse,
+		opts...,
+	).Endpoint()
+
+	requestQueriesEndpoint := httptransport.NewClient(
+		"POST",
+		copyURL(u, "/api/v1/launcher/distributed/read"),
+		httptransport.EncodeJSONRequest,
+		decodeHTTPQueryCollectionResponse,
+		opts...,
+	).Endpoint()
+
+	publishResultsEndpoint := httptransport.NewClient(
+		"POST",
+		copyURL(u, "/api/v1/launcher/distributed/write"),
+		httptransport.EncodeJSONRequest,
+		decodeLauncherResponse,
+		opts...,
+	).Endpoint()
+
+	var client KolideService = KolideClient{
+		RequestEnrollmentEndpoint: requestEnrollmentEndpoint,
+		RequestConfigEndpoint:     requestConfigEndpoint,
+		PublishLogsEndpoint:       publishLogsEndpoint,
+		RequestQueriesEndpoint:    requestQueriesEndpoint,
+		PublishResultsEndpoint:    publishResultsEndpoint,
+	}
+
+	client = LoggingMiddleware(logger)(client)
+	client = uuidMiddleware(client)
+
+	return client, nil
+
+}
+
+func copyURL(base *url.URL, path string) *url.URL {
+	next := *base
+	next.Path = path
+	return &next
+}

--- a/service/server_http.go
+++ b/service/server_http.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+)
+
+func NewHTTPHandler(e KolideClient, logger log.Logger) http.Handler {
+	opts := []kithttp.ServerOption{
+		kithttp.ServerBefore(kithttp.PopulateRequestContext),
+		kithttp.ServerErrorLogger(logger),
+		kithttp.ServerErrorEncoder(encodeError),
+	}
+
+	newServer := func(e endpoint.Endpoint, decodeFn kithttp.DecodeRequestFunc) http.Handler {
+		return kithttp.NewServer(e, decodeFn, encodeResponse, opts...)
+	}
+
+	enrollHandler := newServer(
+		e.RequestEnrollmentEndpoint,
+		decodeHTTPEnrollmentRequest,
+	)
+
+	configHandler := newServer(
+		e.RequestConfigEndpoint,
+		decodeHTTPLauncherRequest,
+	)
+
+	logHandler := newServer(
+		e.PublishLogsEndpoint,
+		decodeHTTPLogCollectionRequest,
+	)
+
+	queriesHandler := newServer(
+		e.RequestQueriesEndpoint,
+		decodeHTTPLauncherRequest,
+	)
+
+	resultsHandler := newServer(
+		e.PublishResultsEndpoint,
+		decodeHTTPResultCollectionRequest,
+	)
+
+	r := mux.NewRouter()
+	r.Handle("/api/v1/launcher/enroll", enrollHandler).
+		Methods("POST").
+		Name("enroll_launcher")
+
+	r.Handle("/api/v1/launcher/config", configHandler).
+		Methods("POST").
+		Name("launcher_config")
+
+	r.Handle("/api/v1/launcher/log", logHandler).
+		Methods("POST").
+		Name("launcher_log")
+
+	r.Handle("/api/v1/launcher/distributed/read", queriesHandler).
+		Methods("POST").
+		Name("launcher_request_queries")
+
+	r.Handle("/api/v1/launcher/distributed/write", resultsHandler).
+		Methods("POST").
+		Name("launcher_write_query_results")
+
+	return r
+}
+
+// erroer interface is implemented by response structs to encode business logic errors
+type errorer interface {
+	error() error
+}
+
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	if e, ok := response.(errorer); ok && e.error() != nil {
+		encodeError(ctx, e.error(), w)
+		return nil
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(response)
+}
+
+func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	w.WriteHeader(http.StatusInternalServerError)
+	enc.Encode(map[string]interface{}{
+		"error": err.Error(),
+	})
+}

--- a/service/transport_http.go
+++ b/service/transport_http.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func decodeHTTPEnrollmentRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req enrollmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(err, "decode enrollment request")
+	}
+	return req, nil
+}
+
+func decodeHTTPLauncherRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req agentAPIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(err, "decode agent_api request")
+	}
+	return req, nil
+}
+
+func decodeHTTPLogCollectionRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req logCollection
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(err, "decode log collection request")
+	}
+	return req, nil
+}
+
+func decodeHTTPEnrollmentResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, errorDecoder(r)
+	}
+	var resp enrollmentResponse
+	err := json.NewDecoder(r.Body).Decode(&resp)
+	return resp, errors.Wrap(err, "decode enrollment response")
+}
+
+func decodeHTTPConfigResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, errorDecoder(r)
+	}
+	var resp configResponse
+	err := json.NewDecoder(r.Body).Decode(&resp)
+	return resp, errors.Wrap(err, "decode config response")
+}
+
+func decodeHTTPQueryCollectionResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, errorDecoder(r)
+	}
+	var resp queryCollection
+	err := json.NewDecoder(r.Body).Decode(&resp)
+	return resp, errors.Wrap(err, "decode query collection response")
+}
+
+func decodeLauncherResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, errorDecoder(r)
+	}
+	var resp agentAPIResponse
+	err := json.NewDecoder(r.Body).Decode(&resp)
+	return resp, errors.Wrap(err, "decode agent_api response")
+}
+
+func errorDecoder(r *http.Response) error {
+	var w errorWrapper
+	if err := json.NewDecoder(r.Body).Decode(&w); err != nil {
+		return err
+	}
+	return errors.New(w.Error)
+}
+
+type errorWrapper struct {
+	Error string `json:"error"`
+}

--- a/service/transport_http.go
+++ b/service/transport_http.go
@@ -32,6 +32,14 @@ func decodeHTTPLogCollectionRequest(ctx context.Context, r *http.Request) (inter
 	return req, nil
 }
 
+func decodeHTTPResultCollectionRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req resultCollection
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(err, "decode result collection request")
+	}
+	return req, nil
+}
+
 func decodeHTTPEnrollmentResponse(_ context.Context, r *http.Response) (interface{}, error) {
 	if r.StatusCode != http.StatusOK {
 		return nil, errorDecoder(r)


### PR DESCRIPTION
WIP. This PR will implement HTTP as a transport for all the launcher endpoints, ensuring that users with restrictive loadbalancers can fallback to a working configuration. 

For #197 