### PR TITLE
initial munki tables

### DIFF
--- a/osquery/munki_darwin.go
+++ b/osquery/munki_darwin.go
@@ -44,7 +44,6 @@ func (m *MunkiInfo) ManagedInstalls(client *osquery.ExtensionManagerClient, logg
 }
 
 func (m *MunkiInfo) generateMunkiInstalls(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-
 	if err := m.loadReport(); err != nil {
 		return nil, err
 	}
@@ -67,15 +66,8 @@ func (m *MunkiInfo) generateMunkiReport(ctx context.Context, queryContext table.
 		return nil, err
 	}
 
-	var errors string
-	if len(m.report.Errors) != 0 {
-		errors = strings.Join(m.report.Errors, ";")
-	}
-
-	var warnings string
-	if len(m.report.Warnings) != 0 {
-		warnings = strings.Join(m.report.Warnings, ";")
-	}
+	errors := strings.Join(m.report.Errors, ";")
+	warnings := strings.Join(m.report.Warnings, ";")
 
 	results := []map[string]string{
 		map[string]string{

--- a/osquery/munki_darwin.go
+++ b/osquery/munki_darwin.go
@@ -1,0 +1,127 @@
+// +build darwin
+
+package osquery
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/groob/plist"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+type MunkiInfo struct {
+	report *munkiReport
+}
+
+func (m *MunkiInfo) MunkiReport(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("version"),
+		table.TextColumn("start_time"),
+		table.TextColumn("end_time"),
+		table.TextColumn("success"),
+		table.TextColumn("errors"),
+		table.TextColumn("warnings"),
+		table.TextColumn("console_user"),
+		table.TextColumn("manifest_name"),
+	}
+	return table.NewPlugin("kolide_munki_report", columns, m.generateMunkiReport)
+}
+
+func (m *MunkiInfo) ManagedInstalls(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("installed_version"),
+		table.TextColumn("installed"),
+		table.TextColumn("name"),
+		table.TextColumn("end_time"),
+	}
+	return table.NewPlugin("kolide_munki_installs", columns, m.generateMunkiInstalls)
+}
+
+func (m *MunkiInfo) generateMunkiInstalls(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+
+	if err := m.loadReport(); err != nil {
+		return nil, err
+	}
+	var results []map[string]string
+
+	for _, install := range m.report.ManagedInstalls {
+		results = append(results, map[string]string{
+			"installed_version": install.InstalledVersion,
+			"installed":         fmt.Sprintf("%v", install.Installed),
+			"name":              install.Name,
+			"end_time":          m.report.EndTime,
+		})
+	}
+
+	return results, nil
+}
+
+func (m *MunkiInfo) generateMunkiReport(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	if err := m.loadReport(); err != nil {
+		return nil, err
+	}
+
+	var errors string
+	if len(m.report.Errors) != 0 {
+		errors = strings.Join(m.report.Errors, ";")
+	}
+
+	var warnings string
+	if len(m.report.Warnings) != 0 {
+		warnings = strings.Join(m.report.Warnings, ";")
+	}
+
+	results := []map[string]string{
+		map[string]string{
+			"start_time":    m.report.StartTime,
+			"end_time":      m.report.EndTime,
+			"console_user":  m.report.ConsoleUser,
+			"version":       m.report.ManagedInstallVersion,
+			"success":       fmt.Sprintf("%v", len(m.report.Errors) == 0),
+			"errors":        errors,
+			"warnings":      warnings,
+			"manifest_name": m.report.ManifestName,
+		},
+	}
+
+	return results, nil
+}
+
+type munkiReport struct {
+	ConsoleUser           string
+	StartTime             string
+	EndTime               string
+	Errors                []string
+	Warnings              []string
+	ManagedInstallVersion string
+	ManifestName          string
+	ManagedInstalls       []managedInstall
+}
+
+type managedInstall struct {
+	Installed        bool   `plist:"installed"`
+	InstalledVersion string `plist:"installed_version"`
+	Name             string `plist:"name"`
+}
+
+func (m *MunkiInfo) loadReport() error {
+	const reportPath = "/Library/Managed Installs/ManagedInstallReport.plist"
+	file, err := os.Open(reportPath)
+	if err != nil {
+		return errors.Wrap(err, "open ManagedInstallReport file")
+	}
+	defer file.Close()
+
+	var report munkiReport
+	if err := plist.NewDecoder(file).Decode(&report); err != nil {
+		return errors.Wrap(err, "decode ManagedInstallReport plist")
+	}
+	m.report = &report
+	return nil
+}

--- a/osquery/platform_tables_darwin.go
+++ b/osquery/platform_tables_darwin.go
@@ -9,11 +9,14 @@ import (
 )
 
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) []*table.Plugin {
+	munki := new(MunkiInfo)
 	return []*table.Plugin{
 		LauncherInfo(client),
 		BestPractices(client),
 		EmailAddresses(client),
 		Spotlight(),
+		munki.MunkiReport(client, logger),
+		munki.ManagedInstalls(client, logger),
 		KolideVulnerabilities(client, logger),
 	}
 }


### PR DESCRIPTION
```
I'm sure I'm missing some stuff, but this is great to have. 
osquery> select * from kolide_munki_report;
+------------+---------------------------+---------------------------+---------+--------------------------------------------------+----------+--------------+---------------+
| version    | start_time                | end_time                  | success | errors                                           | warnings | console_user | manifest_name |
+------------+---------------------------+---------------------------+---------+--------------------------------------------------+----------+--------------+---------------+
| 3.0.0.3333 | 2017-11-30 19:46:13 +0000 | 2017-11-30 19:46:15 +0000 | false   | No default Software Update CatalogURL for: 10.13 |          | victor       | site_default  |
+------------+---------------------------+---------------------------+---------+--------------------------------------------------+----------+--------------+---------------+
osquery> select * from kolide_munki_installs;
+-------------------+-----------+---------------------+---------------------------+
| installed_version | installed | name                | end_time                  |
+-------------------+-----------+---------------------+---------------------------+
| 2.0.0             | true      | yo                  | 2017-11-30 19:46:15 +0000 |
| 5.1.0             | true      | kolide-corp-osquery | 2017-11-30 19:46:15 +0000 |
| 0.2.1-15-g50e9947 | true      | launcher            | 2017-11-30 19:46:15 +0000 |
+-------------------+-----------+---------------------+---------------------------+
```