### PR TITLE
add mdm profile info table

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -91,8 +91,14 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/groob/plist"
+  packages = ["."]
+  revision = "63337f8a3d790883921bfaa0d54fd16d0baba0e0"
+
+[[projects]]
+  branch = "master"
   name = "github.com/kolide/kit"
-  packages = ["env","fs","testutil","version"]
+  packages = ["env","fs","logutil","testutil","version"]
   revision = "566c8f56a6ff7daba204818fbab0f2cb854b3310"
 
 [[projects]]
@@ -206,6 +212,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ac70924b5d0ae7a7fa29944cb7e9ce29a259639cf625ee387080aa332b2c0016"
+  inputs-digest = "c0db9c24953f899c2d13f2557389a680202dfccf193b4dfa736efdb641b33b8b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/osquery/mdm.go
+++ b/osquery/mdm.go
@@ -1,0 +1,113 @@
+package osquery
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+
+	"github.com/go-kit/kit/log"
+	"github.com/groob/plist"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+func MDMInfo(logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("enrolled"),
+		table.TextColumn("server_url"),
+		table.TextColumn("checkin_url"),
+		table.IntegerColumn("access_rights"),
+		table.TextColumn("install_date"),
+		table.TextColumn("payload_identifier"),
+		table.TextColumn("topic"),
+		table.TextColumn("sign_message"),
+		table.TextColumn("identity_certificate_uuid"),
+		table.TextColumn("has_scep_payload"),
+	}
+	return table.NewPlugin("kolide_mdm_info", columns, generateMDMInfo)
+}
+
+func generateMDMInfo(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	profiles, err := getMDMProfile()
+	if err != nil {
+		return nil, err
+	}
+
+	var enrollProfileItems []profileItem
+	var results []map[string]string
+	var mdmResults map[string]string
+	for _, payload := range profiles.ComputerLevel {
+		for _, item := range payload.ProfileItems {
+			if item.PayloadContent == nil {
+				continue
+			}
+			if item.PayloadType == "com.apple.mdm" {
+				enrollProfile := item.PayloadContent
+				enrollProfileItems = payload.ProfileItems
+				mdmResults = map[string]string{
+					"enrolled":                  "true",
+					"server_url":                enrollProfile.ServerURL,
+					"checkin_url":               enrollProfile.CheckInURL,
+					"access_rights":             strconv.Itoa(enrollProfile.AccessRights),
+					"install_date":              payload.ProfileInstallDate,
+					"payload_identifier":        payload.ProfileIdentifier,
+					"sign_message":              strconv.FormatBool(enrollProfile.SignMessage),
+					"topic":                     enrollProfile.Topic,
+					"identity_certificate_uuid": enrollProfile.IdentityCertificateUUID,
+				}
+				break
+			}
+		}
+	}
+	if len(enrollProfileItems) != 0 {
+		for _, item := range enrollProfileItems {
+			if item.PayloadType == "com.apple.security.scep" {
+				mdmResults["has_scep_payload"] = "true"
+			}
+		}
+		results = append(results, mdmResults)
+	} else {
+		results = []map[string]string{map[string]string{"enrolled": "false"}}
+	}
+	return results, nil
+}
+
+func getMDMProfile() (*profilesOutput, error) {
+	cmd := exec.Command("/usr/bin/profiles", "-L", "-o", "stdout-xml")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrap(err, "calling /usr/bin/profiles to get MDM profile payload")
+	}
+
+	var profiles profilesOutput
+	if err := plist.Unmarshal(out, &profiles); err != nil {
+		return nil, errors.Wrap(err, "unmarshal profiles output")
+	}
+
+	return &profiles, nil
+}
+
+type profilesOutput struct {
+	ComputerLevel []profilePayload `plist:"_computerlevel"`
+}
+
+type profilePayload struct {
+	ProfileIdentifier  string
+	ProfileInstallDate string
+	ProfileItems       []profileItem
+}
+
+type profileItem struct {
+	PayloadContent *payloadContent
+	PayloadType    string
+}
+
+type payloadContent struct {
+	AccessRights            int
+	CheckInURL              string
+	ServerURL               string
+	ServerCapabilities      []string
+	Topic                   string
+	IdentityCertificateUUID string
+	SignMessage             bool
+}

--- a/osquery/platform_tables_darwin.go
+++ b/osquery/platform_tables_darwin.go
@@ -17,6 +17,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		Spotlight(),
 		munki.MunkiReport(client, logger),
 		munki.ManagedInstalls(client, logger),
+		MDMInfo(logger),
 		KolideVulnerabilities(client, logger),
 	}
 }


### PR DESCRIPTION
excuse the exec jank, https://github.com/facebook/osquery/issues/1666#issuecomment-160812564

```
osquery> select * from kolide_mdm_info;
                 enrolled = true
               server_url = https://dev.micromdm.io/mdm/connect
              checkin_url = https://dev.micromdm.io/mdm/checkin
            access_rights = 8191
             install_date = 2017-12-01 22:53:00 +0000
       payload_identifier = com.github.micromdm.micromdm.enroll
                    topic = com.apple.mgmt.External.50C91AEB-9506-484C-A83A-86CBDE06A95F
             sign_message = true
identity_certificate_uuid = f8f9b353-393a-45eb-b70d-51c64910e943
         has_scep_payload = true
```