### PR TITLE
Kill osqueryd spawned children during restart

### DIFF
--- a/osquery/runtime_test.go
+++ b/osquery/runtime_test.go
@@ -111,7 +111,7 @@ func TestBadBinaryPath(t *testing.T) {
 // fatals the test
 func waitHealthy(t *testing.T, runner *Runner) {
 	testutil.FatalAfterFunc(t, 30*time.Second, func() {
-		for runner.Healthy() != nil {
+		for err := runner.Healthy(); err != nil; {
 			time.Sleep(500 * time.Millisecond)
 		}
 	})
@@ -167,7 +167,8 @@ func TestOsqueryDies(t *testing.T) {
 
 	// Simulate the osquery process unexpectedly dying
 	runner.instanceLock.Lock()
-	require.NoError(t, runner.instance.cmd.Process.Kill())
+	require.NoError(t, killProcessGroup(runner.instance.cmd))
+	runner.instance.errgroup.Wait()
 	runner.instanceLock.Unlock()
 
 	waitHealthy(t, runner)


### PR DESCRIPTION
    fix osquery restart process

    cmd.Process.Kill() only kills the child process, but not those spawned by osqueryd.
    When Restart() was called, osqueryd would die, but the extension process would remain, causing
    a new osqueryd process to not start again. Killing the whole process group fixes the error.

    Fixed the wait_healty test helper, which was shadowing the error and terminating early.
    Added errgroup.Wait() in the restart method to wait for the old osquery extension to die.

Closes #221 

Used https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for reference. 