### PR TITLE
kill process group without calling getpgid

### DIFF
--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -630,9 +630,6 @@ func (o *OsqueryInstance) Query(query string) ([]map[string]string, error) {
 
 // kill process group kills a process and all its children.
 func killProcessGroup(cmd *exec.Cmd) error {
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err == nil {
-		return syscall.Kill(-pgid, 15)
-	}
-	return errors.Wrap(err, "get PGID")
+	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	return errors.Wrapf(err, "kill process group %s", cmd.Process.Pid)
 }

--- a/osquery/runtime_test.go
+++ b/osquery/runtime_test.go
@@ -140,23 +140,14 @@ func TestSimplePath(t *testing.T) {
 
 func TestRestart(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
-
-	require.NoError(t, buildOsqueryExtensionInBinDir(getBinDir(t)))
-	runner, err := LaunchInstance(WithRootDirectory(rootDirectory))
-	require.NoError(t, err)
-
-	waitHealthy(t, runner)
+	runner, _, teardown := setupOsqueryInstanceForTests(t)
+	defer teardown()
 
 	require.NoError(t, runner.Restart())
 	waitHealthy(t, runner)
 
 	require.NoError(t, runner.Restart())
 	waitHealthy(t, runner)
-
-	require.NoError(t, runner.Shutdown())
 }
 
 func TestOsqueryDies(t *testing.T) {


### PR DESCRIPTION
If the original exec process is dead, then syscall.Getpgid fails and syscall.Kill is never called.
Updated the method to just call syscall.Kill directly.

Closes #229