### PR TITLE
Use launcher to run queries through a running extension socket

### DIFF
--- a/cmd/launcher/README.md
+++ b/cmd/launcher/README.md
@@ -39,6 +39,83 @@ You can also define the enroll secret via a file path (`--enroll_secret_path`) o
 
 You may need to define the `--insecure` and/or `--insecure_grpc` flag depending on your server configurations.
 
+### Running an extension socket
+
+To run a launcher-powered extension socket, run `launcher socket` and the path of the socket will be printed to stdout:
+
+```
+./build/launcher socket
+/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/osquery.sock
+^C
+exiting...
+```
+
+To run the socket at a defined path, use the `--path` flag:
+
+```
+./build/launcher socket --path=/tmp/sock
+/tmp/sock
+```
+
+### Querying an extension socket
+
+To run queries against an existing extension socket, use `launcher query`. You must define the socket path via the `--socket` flag. Query JSON can be provided via stdin or a file specified via the `--queries` flag. Consider an example querying the socket via queries defined in a file:
+
+```
+$ cat queries.json
+{
+  "queries": {
+    "apps": "select name, path from apps limit 2",
+    "hostname": "select hostname from system_info"
+  }
+}
+$ ./build/launcher query --socket=/tmp/osquery.sock --queries=./queries.json
+{
+    "results": {
+        "apps": [
+            {
+                "name": "1Password 6.app",
+                "path": "/Applications/1Password 6.app"
+            },
+            {
+                "name": "2BUA8C4S2C.com.agilebits.onepassword4-helper.app",
+                "path": "/Applications/1Password 6.app/Contents/Library/LoginItems/2BUA8C4S2C.com.agilebits.onepassword4-helper.app"
+            }
+        ],
+        "hostname": [
+            {
+                "hostname": "marpaia"
+            }
+        ]
+    }
+}
+```
+
+Now consider an example using stdin:
+
+```
+$ cat queries.json | ./build/launcher query --socket=/tmp/osquery.sock
+{
+    "results": {
+        "apps": [
+            {
+                "name": "1Password 6.app",
+                "path": "/Applications/1Password 6.app"
+            },
+            {
+                "name": "2BUA8C4S2C.com.agilebits.onepassword4-helper.app",
+                "path": "/Applications/1Password 6.app/Contents/Library/LoginItems/2BUA8C4S2C.com.agilebits.onepassword4-helper.app"
+            }
+        ],
+        "hostname": [
+            {
+                "hostname": "marpaia"
+            }
+        ]
+    }
+}
+```
+
 ## Examples
 
 ### Connecting to Fleet

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -83,7 +83,7 @@ func runQuery(args []string) error {
 		return err
 	}
 
-	queries := queryFile{}
+	var queries queryFile
 
 	if _, err := os.Stat(*flQueries); err == nil {
 		data, err := ioutil.ReadFile(*flQueries)
@@ -137,7 +137,7 @@ func runQuery(args []string) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "    ")
 	if err := enc.Encode(results); err != nil {
-		panic(err)
+		return errors.Wrap(err, "encoding JSON query results")
 	}
 
 	return nil

--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -36,6 +36,7 @@ type osqueryOptions struct {
 	// options included by the caller of LaunchOsqueryInstance
 	binaryPath            string
 	rootDirectory         string
+	extensionSocketPath   string
 	configPluginFlag      string
 	loggerPluginFlag      string
 	distributedPluginFlag string
@@ -79,7 +80,7 @@ type osqueryFilePaths struct {
 // In return, a structure of paths is returned that can be used to launch an
 // osqueryd instance. An error may be returned if the supplied parameters are
 // unacceptable.
-func calculateOsqueryPaths(rootDir string) (*osqueryFilePaths, error) {
+func calculateOsqueryPaths(rootDir, extensionSocketPath string) (*osqueryFilePaths, error) {
 	// Determine the path to the extension
 	exPath, err := os.Executable()
 	if err != nil {
@@ -92,6 +93,11 @@ func calculateOsqueryPaths(rootDir string) (*osqueryFilePaths, error) {
 		} else {
 			return nil, errors.Wrapf(err, "could not stat extension path")
 		}
+	}
+
+	// Determine the path to the extension socket
+	if extensionSocketPath == "" {
+		extensionSocketPath = filepath.Join(rootDir, "osquery.sock")
 	}
 
 	// Write the autoload file
@@ -398,7 +404,7 @@ func (r *Runner) launchOsqueryInstance() error {
 
 	// Based on the root directory, calculate the file names of all of the
 	// required osquery artifact files.
-	paths, err := calculateOsqueryPaths(o.opts.rootDirectory)
+	paths, err := calculateOsqueryPaths(o.opts.rootDirectory, o.opts.extensionSocketPath)
 	if err != nil {
 		return errors.Wrap(err, "could not calculate osquery file paths")
 	}

--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -195,6 +195,15 @@ func WithRootDirectory(path string) OsqueryInstanceOption {
 	}
 }
 
+// WithExtensionSocketPath is a functional option which allows the user to
+// define the path of the extension socket path that osqueryd will open to
+// communicate with other processes.
+func WithExtensionSocketPath(path string) OsqueryInstanceOption {
+	return func(i *OsqueryInstance) {
+		i.opts.extensionSocketPath = path
+	}
+}
+
 // WithConfigPluginFlag is a functional option which allows the user to define
 // which config plugin osqueryd should use to retrieve the config. If this is not
 // defined, it is assumed that no configuration is needed and a no-op config

--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -111,7 +111,7 @@ func calculateOsqueryPaths(rootDir, extensionSocketPath string) (*osqueryFilePat
 		databasePath:          filepath.Join(rootDir, "osquery.db"),
 		extensionPath:         extensionPath,
 		extensionAutoloadPath: extensionAutoloadPath,
-		extensionSocketPath:   filepath.Join(rootDir, "osquery.sock"),
+		extensionSocketPath:   extensionSocketPath,
 	}, nil
 }
 

--- a/osquery/runtime_test.go
+++ b/osquery/runtime_test.go
@@ -36,7 +36,7 @@ func TestCalculateOsqueryPaths(t *testing.T) {
 	fakeExtensionPath := filepath.Join(binDir, "osquery-extension.ext")
 	require.NoError(t, ioutil.WriteFile(fakeExtensionPath, []byte("#!/bin/bash\nsleep infinity"), 0755))
 
-	paths, err := calculateOsqueryPaths(binDir)
+	paths, err := calculateOsqueryPaths(binDir, "")
 	require.NoError(t, err)
 
 	// ensure that all of our resulting artifact files are in the rootDir that we


### PR DESCRIPTION
## Running the socket

```
$ ./build/launcher socket
/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/osquery.sock
^C
exiting...
```

## Running the socket at a defined path

```
$ ./build/launcher socket --path=/tmp/sock
/tmp/sock
^C
exiting...
$
```

## Querying the socket via stdin

```
$ cat queries.json
{
  "queries": {
    "apps": "select name, path from apps limit 2",
    "hostname": "select hostname from system_info"
  }
}
$ cat queries.json | ./build/launcher query --socket=/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/osquery.sock
{
    "results": {
        "apps": [
            {
                "name": "1Password 6.app",
                "path": "/Applications/1Password 6.app"
            },
            {
                "name": "2BUA8C4S2C.com.agilebits.onepassword4-helper.app",
                "path": "/Applications/1Password 6.app/Contents/Library/LoginItems/2BUA8C4S2C.com.agilebits.onepassword4-helper.app"
            }
        ],
        "hostname": [
            {
                "hostname": "marpaia"
            }
        ]
    }
}
```

## Querying the socket via queries defined in a file

```
$ ./build/launcher query --socket=/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/osquery.sock --queries=./queries.json
{
    "results": {
        "apps": [
            {
                "name": "1Password 6.app",
                "path": "/Applications/1Password 6.app"
            },
            {
                "name": "2BUA8C4S2C.com.agilebits.onepassword4-helper.app",
                "path": "/Applications/1Password 6.app/Contents/Library/LoginItems/2BUA8C4S2C.com.agilebits.onepassword4-helper.app"
            }
        ],
        "hostname": [
            {
                "hostname": "marpaia"
            }
        ]
    }
}
```

## Usage

```
$ ./build/launcher socket --help
  Usage:
    launcher socket

  Flags:
    --path /var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/osquery.sock  The path to the socket

$ ./build/launcher query --help
  Usage:
    launcher query

  Flags:
    --queries   A file containing queries to run
    --socket    The path to the socket

$
```

close #239 