### PR TITLE
Adding restart to launcher systemd unit file

### DIFF
--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -414,6 +414,8 @@ ExecStart={{.LauncherPath}} \
 --autoupdate \
 --update_channel={{.UpdateChannel}} \{{end}}
 --osqueryd_path={{.OsquerydPath}}
+Restart=on-failure
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target`

--- a/tools/packaging/packaging.go
+++ b/tools/packaging/packaging.go
@@ -135,7 +135,7 @@ func CreateLinuxPackages(osqueryVersion, hostname, secret string, insecure, inse
 set -e
 systemctl daemon-reload
 systemctl enable launcher
-systemctl start launcher`
+systemctl restart launcher`
 
 	systemdLauncherInstallerFile, err := os.Create(
 		filepath.Join(packageRoot, binaryDirectory, "launcher-systemd-installer"),


### PR DESCRIPTION
Built new package and verified systemd unit file text was accurate. This will allow the launcher to overcome an intermittent issue noticed with systemd-resolved when first starting and throwing a "connection refused" error upon trying to resolve a domain by simply retrying after a few seconds. 