### PR TITLE
add gcp pkgbuild

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /builder/prepare_workspace.inc
+prepare_workspace || exit
+make deps
+make xp

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,0 +1,12 @@
+steps:
+    - name: 'gcr.io/cloud-builders/go'
+      entrypoint: 'sh'
+      args: ['-c', '/workspace/build.sh']
+      env: ['PROJECT_ROOT=github.com/kolide/launcher']
+
+    - name: 'gcr.io/cloud-builders/gsutil'
+      entrypoint: 'bash'
+      args:
+      - '-c'
+      - '/workspace/tarbin.sh'
+

--- a/simulator/testdata/bad_symlink/symlink.yaml
+++ b/simulator/testdata/bad_symlink/symlink.yaml
@@ -1,1 +1,0 @@
-foo/bar/bing/bang/boom

--- a/tarbin.sh
+++ b/tarbin.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+version="$(git rev-parse --short HEAD)"
+tar -czf latest.tar.gz build/darwin build/linux
+gsutil cp latest.tar.gz "gs://kolide-build-cache/launcher/latest.tar.gz"
+gsutil cp latest.tar.gz "gs://kolide-build-cache/launcher/${version}.tar.gz"


### PR DESCRIPTION
Not intending to merge but putting it up for discussion. 

The idea behind this is that the cloudbuild steps below can be used to build the binary then tar it to a storage bucket. 

Once that is done, a second build job can be triggered to create mac or linux packages based on the binary. See https://github.com/kolide/gcp-pkgbuild for the mac package part. 

```
steps:
    - name: 'gcr.io/cloud-builders/go'
      entrypoint: 'sh'
      args: ['-c', '/workspace/build.sh']
      env: ['PROJECT_ROOT=github.com/kolide/launcher']

    - name: 'gcr.io/cloud-builders/gsutil'
      entrypoint: 'bash'
      args:
      - '-c'
      - '/workspace/tarbin.sh'

     # a third step here could kick off the package build
     # or the pkgbuild steps could be copy pasted into here
     # or something could watch the bucket.  
```