### PR TITLE
Add the '--utc' flag to the default osquery startup options

### DIFF
--- a/osquery/runtime.go
+++ b/osquery/runtime.go
@@ -136,6 +136,7 @@ func createOsquerydCommand(osquerydBinary string, paths *osqueryFilePaths, confi
 		"--host_identifier=uuid",
 		"--force=true",
 		"--disable_watchdog",
+		"--utc",
 	)
 	if stdout != nil {
 		cmd.Stdout = stdout


### PR DESCRIPTION
This flag converts all unix time to utc. Fixes #272 