### PR TITLE
allow specifying package version

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -131,7 +131,8 @@ func runMake(args []string) error {
 		}
 	}
 
-	paths, err := packaging.CreatePackages(osqueryVersion, *flHostname, *flEnrollSecret, macPackageSigningKey, *flInsecure, *flInsecureGrpc, *flAutoupdate, *flUpdateChannel, *flIdentifier, *flOmitSecret, *flSystemd, *flCertPins, *flRootPEM)
+	currentVersion := version.Version().Version
+	paths, err := packaging.CreatePackages(currentVersion, osqueryVersion, *flHostname, *flEnrollSecret, macPackageSigningKey, *flInsecure, *flInsecureGrpc, *flAutoupdate, *flUpdateChannel, *flIdentifier, *flOmitSecret, *flSystemd, *flCertPins, *flRootPEM)
 	if err != nil {
 		return errors.Wrap(err, "could not generate packages")
 	}


### PR DESCRIPTION
The library methods implicitly used the binary build tags, which are never the correct version unless the package-builder utility is building the actual binary.