### PR TITLE
Add proxy configuration when downloading TUF metadata

### DIFF
--- a/tools/notary/generate_tuf.go
+++ b/tools/notary/generate_tuf.go
@@ -66,7 +66,9 @@ func bootstrapFromNotary(notaryConfigDir, localRepo, gun string) error {
 		notaryConfigDir,
 		data.GUN(gun),
 		conf.RemoteServer.URL,
-		&http.Transport{},
+		&http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 		passwordRetriever,
 		trustpinning.TrustPinConfig{},
 	)


### PR DESCRIPTION
Add `Proxy: http.ProxyFromEnvironment` to fix #285