### PR TITLE
Add uninstalling.md with Debian dpkg instructions

### DIFF
--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -14,14 +14,10 @@ To remove `launcher` and **preserve** configuration files execute `sudo dpkg --r
 
 To remove `launcher` and **remove** configuration files exeute `sudo dpkg --purge launcher`.
 
-`dpkg --purge` will not delete directories which are not empty. As a result you will likely see the following warning: 
+`dpkg --purge` will not delete directories which are not empty. As a result you might see a warning which looks like: 
 
 ```
-dpkg: warning: while removing launcher, directory '/usr/local/kolide/bin' not empty so not removed
-dpkg: warning: while removing launcher, directory '/var/kolide/dichiye.launcher.kolide.com-443' not empty so not removed
+dpkg: warning: while removing launcher, directory '/foo/bar/kolide/bin' not empty so not removed
+dpkg: warning: while removing launcher, directory '/dir/kolide/' not empty so not removed
 ```
-
-To remove these leftover directories execute:
-- `sudo rm -rf /usr/local/kolide`
-- `sudo rm -rf /var/kolide`
-
+The left over directories mentioned in the `dpkg` warning can be removed with `sudo rm -rf`

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -6,18 +6,33 @@
 
 #### Installed via `dpkg`
 
-These instructions cover uninstalling if you installed the offical package `kolide-osquery-launcher.deb` via `dpkg -i`.
+These instructions cover uninstalling a Launcher package (ie: `kolide-osquery-launcher.deb`) via `dpkg -i`.
 
-To list packages installed via `dpkg` execute `dpkg --list`. The Osquery Launcher is called `launcher`, executing `dpkg --list | grep 'launcher'` will show the relevant entry.
+To list packages installed via `dpkg` run the following:
 
-To remove `launcher` and **preserve** configuration files execute `sudo dpkg --remove launcher`. 
+```
+dpkg --list
+```
 
-To remove `launcher` and **remove** configuration files exeute `sudo dpkg --purge launcher`.
+The Osquery Launcher is called `launcher`, executing `dpkg --list | grep 'launcher'` will show the relevant entry.
+
+To remove `launcher` and **preserve** configuration files, run the following:
+
+```
+sudo dpkg --remove launcher
+```
+
+To remove `launcher` and **remove** configuration files, run the following:
+
+```
+sudo dpkg --purge launcher
+```
 
 `dpkg --purge` will not delete directories which are not empty. As a result you might see a warning which looks like: 
 
 ```
-dpkg: warning: while removing launcher, directory '/foo/bar/kolide/bin' not empty so not removed
-dpkg: warning: while removing launcher, directory '/dir/kolide/' not empty so not removed
+dpkg: warning: while removing launcher, directory '/usr/local/kolide/bin' not empty so not removed
+dpkg: warning: while removing launcher, directory '/var/kolide/launcher.example.org-443' not empty so not removed
 ```
-The left over directories mentioned in the `dpkg` warning can be removed with `sudo rm -rf`
+
+Based on the configurations used when the Launcher package was created, the specific paths printed may look slightly different. In any case, these left over directories mentioned in the `dpkg` warning can be removed with `sudo rm -rf`.

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -1,0 +1,27 @@
+# Uninstalling Osquery Launcher
+
+## Linux
+
+### Debian
+
+#### Installed via `dpkg`
+
+These instructions cover uninstalling if you installed the offical package `kolide-osquery-launcher.deb` via `dpkg -i`.
+
+To list packages installed via `dpkg` execute `dpkg --list`. The Osquery Launcher is called `launcher`, executing `dpkg --list | grep 'launcher'` will show the relevant entry.
+
+To remove `launcher` and **preserve** configuration files execute `sudo dpkg --remove launcher`. 
+
+To remove `launcher` and **remove** configuration files exeute `sudo dpkg --purge launcher`.
+
+`dpkg --purge` will not delete directories which are not empty. As a result you will likely see the following warning: 
+
+```
+dpkg: warning: while removing launcher, directory '/usr/local/kolide/bin' not empty so not removed
+dpkg: warning: while removing launcher, directory '/var/kolide/dichiye.launcher.kolide.com-443' not empty so not removed
+```
+
+To remove these leftover directories execute:
+- `sudo rm -rf /usr/local/kolide`
+- `sudo rm -rf /var/kolide`
+


### PR DESCRIPTION
Addresses part of #243. 

Creates `docs/uninstalling.md`. 

Documents how to uninstall `launcher` if installed using the `kolide-osquery-launcher.deb` via  `dpkg` on Debian. 
