### PR TITLE
regression: re-add osquery_version to enrollment details

### DIFF
--- a/osquery/extension.go
+++ b/osquery/extension.go
@@ -699,6 +699,9 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	if val, ok := resp[0]["os_platform_like"]; ok {
 		details.OSPlatformLike = val
 	}
+	if val, ok := resp[0]["osquery_version"]; ok {
+		details.OsqueryVersion = val
+	}
 	if val, ok := resp[0]["hardware_model"]; ok {
 		details.HardwareModel = val
 	}


### PR DESCRIPTION
- what?
  - adds back in the osquery_version key to the enrollment details we send on host enrollment

- why?
  - when re-organizing the fields alphabetically, i lost this step in the func
  - surrounded by red and green, nobody caught it