### PR TITLE
Add disable tls flag to --dev_help

### DIFF
--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -322,6 +322,7 @@ func developerUsage() {
 	printOpt("update_channel")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("control_get_shells_interval")
+	printOpt("disable_control_tls")
 	fmt.Fprintf(os.Stderr, "\n")
 	usageFooter()
 }


### PR DESCRIPTION
This prints out the flag in the developer usage help