### PR TITLE
Remove insecure TLS since TLS can be disabled

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -378,9 +378,6 @@ func main() {
 			control.WithLogger(logger),
 			control.WithGetShellsInterval(opts.getShellsInterval),
 		}
-		if opts.insecureTLS {
-			controlOpts = append(controlOpts, control.WithInsecureSkipVerify())
-		}
 		if opts.disableControlTLS {
 			controlOpts = append(controlOpts, control.WithDisableTLS())
 		}

--- a/pkg/control/option.go
+++ b/pkg/control/option.go
@@ -1,8 +1,6 @@
 package control
 
 import (
-	"crypto/tls"
-	"net/http"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -13,17 +11,6 @@ type Option func(*Client)
 func WithLogger(logger log.Logger) Option {
 	return func(c *Client) {
 		c.logger = logger
-	}
-}
-
-func WithInsecureSkipVerify() Option {
-	return func(c *Client) {
-		c.client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}
-		c.insecure = true
 	}
 }
 

--- a/pkg/control/shells.go
+++ b/pkg/control/shells.go
@@ -111,7 +111,7 @@ func (c *Client) connectToShell(ctx context.Context, path string, session map[st
 	}
 
 	wsPath := path + "/" + room
-	client, err := wsrelay.NewClient(c.addr, wsPath, c.disableTLS, c.insecure)
+	client, err := wsrelay.NewClient(c.addr, wsPath, c.disableTLS)
 	if err != nil {
 		level.Info(c.logger).Log(
 			"msg", "error creating client",

--- a/pkg/wsrelay/client.go
+++ b/pkg/wsrelay/client.go
@@ -1,7 +1,6 @@
 package wsrelay
 
 import (
-	"crypto/tls"
 	"net/url"
 
 	"github.com/gorilla/websocket"
@@ -15,7 +14,7 @@ type Client struct {
 
 // NewClient creates a new websocket client that can be interrupted
 // via SIGINT
-func NewClient(brokerAddr, path string, disableTLS bool, insecure bool) (*Client, error) {
+func NewClient(brokerAddr, path string, disableTLS bool) (*Client, error) {
 	// determine the scheme
 	scheme := "wss"
 	if disableTLS {
@@ -30,8 +29,7 @@ func NewClient(brokerAddr, path string, disableTLS bool, insecure bool) (*Client
 	}
 
 	// connect to the websocket at the given URL
-	dialer := websocket.Dialer{TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}}
-	conn, resp, err := dialer.Dial(u.String(), nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 
 	if err != nil {
 		if err == websocket.ErrBadHandshake {


### PR DESCRIPTION
This was a part of my other PR but I pulled it out to tidy it up. 

I don't think we need this anymore since we can just disable TLS for development. The flag remains since the TLS osquery stuff uses it.