### PR TITLE
Add macOS uninstall instructions

### DIFF
--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -44,16 +44,26 @@ Based on the configurations used when the Launcher package was created, the spec
 Directories:
 - `$HOME/Applications/Kolide.app`
 - `$HOME/Library/Application Support/Kolide`
+- `/usr/local/kolide`
+- `/var/kolide`
+- `/etc/kolide`
+
+Files:
+- `/Library/LaunchDaemons/com.kolide.launcher.plist`
 
 To remove the `.app` bundle, run the following:
 
 ```
-rm -r `$HOME/Applications/Kolide.app`
+rm -r $HOME/Applications/Kolide.app
 ```
 
 To remove the preferences, cache and other supporting files, run the following:
 
 ```
-rm -r `$HOME/Library/Application Support/Kolide`
+rm -r $HOME/Library/Application Support/Kolide
+rm -r /usr/local/kolide
+rm -r /var/kolide
+rm -r /etc/kolide
+rm  /Library/LaunchDaemons/com.kolide.launcher.plist
 ```
 

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -53,11 +53,11 @@ Files:
 To remove the binaries and other supporting files, run the following:
 
 ```
+sudo launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
+sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 sudo rm -r /usr/local/kolide
 sudo rm -r /var/kolide
 sudo rm -r /etc/kolide
-sudo launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
-sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 ```
 
 ### App (`kolide-desktop-app.pkg`)

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -36,3 +36,24 @@ dpkg: warning: while removing launcher, directory '/var/kolide/launcher.example.
 ```
 
 Based on the configurations used when the Launcher package was created, the specific paths printed may look slightly different. In any case, these left over directories mentioned in the `dpkg` warning can be removed with `sudo rm -rf`.
+
+## macOS
+
+### Launcher (`kolide-osquery-launcher.pkg`)
+
+Directories:
+- `$HOME/Applications/Kolide.app`
+- `$HOME/Library/Application Support/Kolide`
+
+To remove the `.app` bundle, run the following:
+
+```
+rm -r `$HOME/Applications/Kolide.app`
+```
+
+To remove the preferences, cache and other supporting files, run the following:
+
+```
+rm -r `$HOME/Library/Application Support/Kolide`
+```
+

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -42,8 +42,28 @@ Based on the configurations used when the Launcher package was created, the spec
 ### Launcher (`kolide-osquery-launcher.pkg`)
 
 Directories:
+
+- `/usr/local/kolide`
+- `/var/kolide`
+- `/etc/kolide`
+
+Files:
+- `/Library/LaunchDaemons/com.kolide.launcher.plist`
+
+To remove the binaries and other supporting files, run the following:
+
+```
+sudo rm -r /usr/local/kolide
+sudo rm -r /var/kolide
+sudo rm -r /etc/kolide
+sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
+```
+
+### App (`kolide-desktop-app.pkg`)
+
+Directories:
 - `$HOME/Applications/Kolide.app`
-- `$HOME/Library/Application Support/Kolide`
+- `"$HOME/Library/Application Support/Kolide"`
 - `/usr/local/kolide`
 - `/var/kolide`
 - `/etc/kolide`
@@ -61,9 +81,8 @@ To remove the preferences, cache and other supporting files, run the following:
 
 ```
 rm -r $HOME/Library/Application Support/Kolide
-rm -r /usr/local/kolide
-rm -r /var/kolide
-rm -r /etc/kolide
-rm  /Library/LaunchDaemons/com.kolide.launcher.plist
+sudo rm -r /usr/local/kolide
+sudo rm -r /var/kolide
+sudo rm -r /etc/kolide
+sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 ```
-

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -56,6 +56,7 @@ To remove the binaries and other supporting files, run the following:
 sudo rm -r /usr/local/kolide
 sudo rm -r /var/kolide
 sudo rm -r /etc/kolide
+sudo launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
 sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 ```
 
@@ -81,5 +82,6 @@ To remove the preferences, cache and other supporting files, run the following:
 ```
 sudo rm -r "$HOME/Library/Application Support/Kolide"
 sudo rm -r /usr/local/kolide
+sudo launchctl unload /Library/LaunchDaemons/com.kolide.launcher.plist
 sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 ```

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -65,8 +65,7 @@ Directories:
 - `$HOME/Applications/Kolide.app`
 - `"$HOME/Library/Application Support/Kolide"`
 - `/usr/local/kolide`
-- `/var/kolide`
-- `/etc/kolide`
+
 
 Files:
 - `/Library/LaunchDaemons/com.kolide.launcher.plist`
@@ -74,15 +73,13 @@ Files:
 To remove the `.app` bundle, run the following:
 
 ```
-rm -r $HOME/Applications/Kolide.app
+sudo rm -r /Applications/Kolide.app
 ```
 
 To remove the preferences, cache and other supporting files, run the following:
 
 ```
-rm -r $HOME/Library/Application Support/Kolide
+sudo rm -r "$HOME/Library/Application Support/Kolide"
 sudo rm -r /usr/local/kolide
-sudo rm -r /var/kolide
-sudo rm -r /etc/kolide
 sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 ```


### PR DESCRIPTION
I've run `sudo find / -name 'Kolide'` on my system, with the Kolide launcher installed, the only two directories which are present appear to be:
- `$HOME/Applications/Kolide.app`
- `$HOME/Library/Application Support/Kolide`

`rm -r`ing both of these directories constitutes a successful uninstall as far as I can tell.