### PR TITLE
Reduce shell check interval, increase error reporting

### DIFF
--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -36,10 +36,7 @@ func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *op
 			return nil
 		},
 		Interrupt: func(err error) {
-			if err != nil {
-				level.Info(logger).Log("err", err)
-			}
-			level.Info(logger).Log("msg", "control interrupted")
+			level.Info(logger).Log("msg", "control interrupted", "err", err)
 			controlClient.Stop()
 		},
 	}, nil

--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -36,6 +36,9 @@ func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *op
 			return nil
 		},
 		Interrupt: func(err error) {
+			if err != nil {
+				level.Info(logger).Log("err", err)
+			}
 			level.Info(logger).Log("msg", "control interrupted")
 			controlClient.Stop()
 		},

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -131,6 +131,9 @@ func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.
 			return nil
 		},
 		Interrupt: func(err error) {
+			if err != nil {
+				level.Info(logger).Log("err", err)
+			}
 			level.Info(logger).Log("msg", "extension interrupted")
 			grpcConn.Close()
 			ext.Shutdown()

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -131,10 +131,7 @@ func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.
 			return nil
 		},
 		Interrupt: func(err error) {
-			if err != nil {
-				level.Info(logger).Log("err", err)
-			}
-			level.Info(logger).Log("msg", "extension interrupted")
+			level.Info(logger).Log("msg", "extension interrupted", "err", err)
 			grpcConn.Close()
 			ext.Shutdown()
 			if runner != nil {

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -348,6 +348,9 @@ func main() {
 		level.Info(logger).Log("msg", "beginnning shutdown")
 		return nil
 	}, func(err error) {
+		if err != nil {
+			level.Info(logger).Log("err", err)
+		}
 		level.Info(logger).Log("msg", "signal notifier interrupted")
 		// cancel the context to allow for graceful termination.
 		cancel()

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -77,7 +77,7 @@ func parseOptions() (*options, error) {
 		)
 		flGetShellsInterval = flag.Duration(
 			"control_get_shells_interval",
-			env.Duration("KOLIDE_CONTROL_GET_SHELLS_INTERVAL", time.Minute),
+			env.Duration("KOLIDE_CONTROL_GET_SHELLS_INTERVAL", 3*time.Second),
 			"The interval at which the get shells request will be made",
 		)
 

--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -71,10 +71,7 @@ func createUpdater(
 			return nil
 		},
 		Interrupt: func(err error) {
-			if err != nil {
-				level.Info(logger).Log("err", err)
-			}
-			level.Info(logger).Log("msg", "updater interrupted")
+			level.Info(logger).Log("msg", "updater interrupted", "err", err)
 			if stop != nil {
 				stop()
 			}

--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -71,6 +71,9 @@ func createUpdater(
 			return nil
 		},
 		Interrupt: func(err error) {
+			if err != nil {
+				level.Info(logger).Log("err", err)
+			}
 			level.Info(logger).Log("msg", "updater interrupted")
 			if stop != nil {
 				stop()

--- a/pkg/control/shells.go
+++ b/pkg/control/shells.go
@@ -138,9 +138,15 @@ func (c *Client) connectToShell(ctx context.Context, path string, session map[st
 		webtty.WithLogger(c.logger),
 		webtty.WithKeepAliveDeadline(),
 	)
+	if err != nil {
+		level.Info(c.logger).Log(
+			"msg", "error creating TTY",
+			"err", err,
+		)
+	}
 	if err := TTY.Run(ctx); err != nil {
 		level.Info(c.logger).Log(
-			"msg", "error creating web TTY",
+			"msg", "error running TTY",
 			"err", err,
 		)
 		return

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -715,7 +715,7 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
             <string>--control</string>
 			{{end}}
 			{{if .DisableControlTLS}}
-						<string>--disable_control_tls</string>
+            <string>--disable_control_tls</string>
 			{{end}}
         </array>
         <key>StandardErrorPath</key>


### PR DESCRIPTION
The default shell interval was too long and would often close due to timeout before even connecting. Also there were a few spots we forgot to log errors.