### PR TITLE
Fix opening PTY for daemon, fix error unmarshal for getShells 

### DIFF
--- a/pkg/control/shells.go
+++ b/pkg/control/shells.go
@@ -18,7 +18,7 @@ type getShellsRequest struct {
 
 type getShellsResponse struct {
 	Sessions    []map[string]string `json:"sessions"`
-	Err         error               `json:"error,omitempty"`
+	Err         string              `json:"error,omitempty"`
 	NodeInvalid bool                `json:"node_invalid,omitempty"`
 }
 
@@ -72,7 +72,7 @@ func (c *Client) getShells(ctx context.Context) {
 		return
 	}
 
-	if responseBody.Err != nil {
+	if responseBody.Err != "" {
 		level.Info(c.logger).Log(
 			"msg", "response body contained error",
 			"err", responseBody.Err,

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -715,7 +715,7 @@ func renderLaunchDaemon(w io.Writer, options *launchDaemonTemplateOptions) error
             <string>--control</string>
 			{{end}}
 			{{if .DisableControlTLS}}
-						<string>--disable_control_tls</string>
+            <string>--disable_control_tls</string>
 			{{end}}
         </array>
         <key>StandardErrorPath</key>


### PR DESCRIPTION
This changes how the PTY is opened. Luckily, we didn't have to fork and change the underlying lib as we originally discussed. They expose a way to do what `pty.Run` does in the library already.

Also, this adjusts error unmarshaling from the JSON in the getShells response.