### PR TITLE
Fix - MacOS distribution package

### DIFF
--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -514,7 +514,7 @@ func CreateMacPackage(
 
 	distributionFileName := "distribution.xml"
 	distributionFilePath := filepath.Join(outputPathDir, distributionFileName)
-  distributionFile, err := os.Create(distributionFilePath)
+	distributionFile, err := os.Create(distributionFilePath)
 	distrOutputFile := fmt.Sprintf("launcher-darwin-%s-distribution.pkg", packageVersion)
 	distrOutputPath := filepath.Join(outputPathDir, distrOutputFile)
 	distributionOpts := &distributionTemplateOptions{
@@ -547,7 +547,7 @@ func CreateMacPackage(
 		distrOutputPath,
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "could not add the distribution file")
+		return "", errors.Wrap(err, "could not produce a macOS distribution package")
 	}
 
 	return distrOutputPath, nil
@@ -780,6 +780,12 @@ sleep 5
 	return t.ExecuteTemplate(w, "postinstall", options)
 }
 
+// productbuild runs the following productbuild command:
+//   productbuild \
+//     --distribution ${distributionFile} \
+//     --package-path ${packageFile} \
+//     [--sign ${macPackageSigningKey}] \
+//     ${outputPath}
 func productbuild(packageDir, distributionFile, packageFile, macPackageSigningKey, outputPath string) error {
 	args := []string{
 		"--distribution", distributionFile,
@@ -791,7 +797,6 @@ func productbuild(packageDir, distributionFile, packageFile, macPackageSigningKe
 	}
 
 	args = append(args, outputPath)
-  fmt.Printf("productbuild %s", args)
 	cmd := exec.Command("productbuild", args...)
 	cmd.Dir = packageDir
 	stderr := new(bytes.Buffer)

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -520,6 +520,7 @@ func CreateMacPackage(
 	distributionOpts := &distributionTemplateOptions{
 		PackageVersion:    packageVersion,
 		PackageFileName:   outputFile,
+		Identifier:        identifier,
 	}
 	if err := renderDistributionFile(distributionFile, distributionOpts); err != nil {
 		return "", errors.Wrap(err, "could not render distribution file to disk")
@@ -843,6 +844,7 @@ func pkgbuild(packageRoot, scriptsRoot, identifier, version, macPackageSigningKe
 type distributionTemplateOptions struct {
 	PackageVersion    string
 	PackageFileName   string
+	Identifier        string
 }
 
 // renderDistributionFile renders a distribution file to add to launcher's template.
@@ -850,18 +852,18 @@ func renderDistributionFile(w io.Writer, options *distributionTemplateOptions) e
 	distributionTemplate :=
 		`<?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
-    <pkg-ref id="com.launcher.launcher"/>
+    <pkg-ref id="com.{{.Identifier}}.launcher"/>
     <options customize="never" require-scripts="false"/>
     <choices-outline>
         <line choice="default">
-            <line choice="com.launcher.launcher"/>
+            <line choice="com.{{.Identifier}}.launcher"/>
         </line>
     </choices-outline>
     <choice id="default"/>
-    <choice id="com.launcher.launcher" visible="false">
-        <pkg-ref id="com.launcher.launcher"/>
+    <choice id="com.{{.Identifier}}.launcher" visible="false">
+        <pkg-ref id="com.{{.Identifier}}.launcher"/>
     </choice>
-    <pkg-ref id="com.launcher.launcher" version="{{.PackageVersion}}" onConclusion="none">{{.PackageFileName}}</pkg-ref>
+    <pkg-ref id="com.{{.Identifier}}.launcher" version="{{.PackageVersion}}" onConclusion="none">{{.PackageFileName}}</pkg-ref>
 </installer-gui-script>`
 	t, err := template.New("Distribution").Parse(distributionTemplate)
 	if err != nil {


### PR DESCRIPTION
Some MDMs (like SimpleMDM) require the OSX package (`.pkg`) to contain a "distribution" file, and therefore require the command `productbuild` to be run after `pkgbuild` in order for the package to be accepted by SimpleMDM.

I was unsure whether it would be better to output both versions (with and without the distribution file), the choice is done at the line 553, but could be modified to include both.

I can confirm it works and gets distributed and installed fine with SimpleMDM, but it would be a good idea to also check with other MDMs.