### PR TITLE
fix restart and shutdown options for osquery runner

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -9,6 +9,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/kit/actor"
 	kolidelog "github.com/kolide/launcher/pkg/log"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/kolide/launcher/pkg/osquery/runtime"
@@ -20,15 +21,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// extension is the osquery extension and osquery runtime
-type extension struct {
-	*runtime.Runner
-	Execute   func() error
-	Interrupt func(err error)
-}
-
 // TODO: the extension, runtime, and client are all kind of entangled here. Untangle the underlying libraries and separate into units
-func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.DB, logger log.Logger, opts *options) (*extension, error) {
+func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.DB, logger log.Logger, opts *options) (
+	*actor.Actor,
+	func() error, // restart osqueryd runner
+	func() error, // shutdown osqueryd runner
+	error,
+) {
 	// read the enroll secret, if either it or the path has been specified
 	var enrollSecret string
 	if opts.enrollSecret != "" {
@@ -36,7 +35,7 @@ func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.
 	} else if opts.enrollSecretPath != "" {
 		content, err := ioutil.ReadFile(opts.enrollSecretPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not read enroll_secret_path: %s", opts.enrollSecretPath)
+			return nil, nil, nil, errors.Wrapf(err, "could not read enroll_secret_path: %s", opts.enrollSecretPath)
 		}
 		enrollSecret = string(bytes.TrimSpace(content))
 	}
@@ -47,17 +46,17 @@ func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.
 		rootPool = x509.NewCertPool()
 		pemContents, err := ioutil.ReadFile(opts.rootPEM)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading root certs PEM at path: %s", opts.rootPEM)
+			return nil, nil, nil, errors.Wrapf(err, "reading root certs PEM at path: %s", opts.rootPEM)
 		}
 		if ok := rootPool.AppendCertsFromPEM(pemContents); !ok {
-			return nil, errors.Errorf("found no valid certs in PEM at path: %s", opts.rootPEM)
+			return nil, nil, nil, errors.Errorf("found no valid certs in PEM at path: %s", opts.rootPEM)
 		}
 	}
 
 	// connect to the grpc server
 	grpcConn, err := service.DialGRPC(opts.kolideServerURL, opts.insecureTLS, opts.insecureGRPC, opts.certPins, rootPool, logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "dialing grpc server")
+		return nil, nil, nil, errors.Wrap(err, "dialing grpc server")
 	}
 
 	// create the client of the grpc service
@@ -73,90 +72,71 @@ func createExtensionRuntime(ctx context.Context, rootDirectory string, db *bolt.
 	// create the extension
 	ext, err := osquery.NewExtension(launcherClient, db, extOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "starting grpc extension")
+		return nil, nil, nil, errors.Wrap(err, "starting grpc extension")
 	}
 
 	// create the logging adapter for osquery
 	osqueryLogger := &kolidelog.OsqueryLogAdapter{Logger: level.Debug(log.With(logger, "component", "osquery"))}
 
-	// initialize a var for the runner here, so we can start it in execute
-	// and still use it in the interrupt function
-	var runner *runtime.Runner
+	runner, start := runtime.LaunchUnstartedInstance(
+		runtime.WithOsquerydBinary(opts.osquerydPath),
+		runtime.WithRootDirectory(rootDirectory),
+		runtime.WithConfigPluginFlag("kolide_grpc"),
+		runtime.WithLoggerPluginFlag("kolide_grpc"),
+		runtime.WithDistributedPluginFlag("kolide_grpc"),
+		runtime.WithOsqueryExtensionPlugin(config.NewPlugin("kolide_grpc", ext.GenerateConfigs)),
+		runtime.WithOsqueryExtensionPlugin(osquerylogger.NewPlugin("kolide_grpc", ext.LogString)),
+		runtime.WithOsqueryExtensionPlugin(distributed.NewPlugin("kolide_grpc", ext.GetQueries, ext.WriteResults)),
+		runtime.WithOsqueryExtensionPlugin(table.LauncherIdentifierTable(db)),
+		runtime.WithStdout(osqueryLogger),
+		runtime.WithStderr(osqueryLogger),
+		runtime.WithLogger(logger),
+	)
 
-	return &extension{
-		// add the runtime to the extension
-		Runner: runner,
-		// and the methods for starting and stopping the extension
-		Execute: func() error {
-			// Start the osqueryd instance
-			runner, err = runtime.LaunchInstance(
-				runtime.WithOsquerydBinary(opts.osquerydPath),
-				runtime.WithRootDirectory(rootDirectory),
-				runtime.WithConfigPluginFlag("kolide_grpc"),
-				runtime.WithLoggerPluginFlag("kolide_grpc"),
-				runtime.WithDistributedPluginFlag("kolide_grpc"),
-				runtime.WithOsqueryExtensionPlugin(config.NewPlugin("kolide_grpc", ext.GenerateConfigs)),
-				runtime.WithOsqueryExtensionPlugin(osquerylogger.NewPlugin("kolide_grpc", ext.LogString)),
-				runtime.WithOsqueryExtensionPlugin(distributed.NewPlugin("kolide_grpc", ext.GetQueries, ext.WriteResults)),
-				runtime.WithOsqueryExtensionPlugin(table.LauncherIdentifierTable(db)),
-				runtime.WithStdout(osqueryLogger),
-				runtime.WithStderr(osqueryLogger),
-				runtime.WithLogger(logger),
-			)
-			if err != nil {
-				return errors.Wrap(err, "launching osquery instance")
-			}
+	return &actor.Actor{
+			// and the methods for starting and stopping the extension
+			Execute: func() error {
 
-			// The runner allows querying the osqueryd instance from the extension.
-			// Used by the Enroll method below to get initial enrollment details.
-			ext.SetQuerier(runner)
-
-			// enroll this launcher with the server
-			_, invalid, err := ext.Enroll(ctx)
-			if err != nil {
-				return errors.Wrap(err, "enrolling host")
-			}
-			if invalid {
-				return errors.Wrap(err, "invalid enroll secret")
-			}
-
-			// start the extension
-			ext.Start()
-
-			level.Info(logger).Log("msg", "extension started")
-
-			// TODO: remove when underlying libs are refactored
-			// everything exits right now, so block this actor on the context finishing
-			<-ctx.Done()
-			return nil
-		},
-		Interrupt: func(err error) {
-			level.Info(logger).Log("msg", "extension interrupted", "err", err)
-			grpcConn.Close()
-			ext.Shutdown()
-			if runner != nil {
-				if err := runner.Shutdown(); err != nil {
-					level.Info(logger).Log("msg", "error shutting down runtime", "err", err)
+				// Start the osqueryd instance
+				if err := start(); err != nil {
+					return errors.Wrap(err, "launching osquery instance")
 				}
-			}
+
+				// The runner allows querying the osqueryd instance from the extension.
+				// Used by the Enroll method below to get initial enrollment details.
+				ext.SetQuerier(runner)
+
+				// enroll this launcher with the server
+				_, invalid, err := ext.Enroll(ctx)
+				if err != nil {
+					return errors.Wrap(err, "enrolling host")
+				}
+				if invalid {
+					return errors.Wrap(err, "invalid enroll secret")
+				}
+
+				// start the extension
+				ext.Start()
+
+				level.Info(logger).Log("msg", "extension started")
+
+				// TODO: remove when underlying libs are refactored
+				// everything exits right now, so block this actor on the context finishing
+				<-ctx.Done()
+				return nil
+			},
+			Interrupt: func(err error) {
+				level.Info(logger).Log("msg", "extension interrupted", "err", err)
+				grpcConn.Close()
+				ext.Shutdown()
+				if runner != nil {
+					if err := runner.Shutdown(); err != nil {
+						level.Info(logger).Log("msg", "error shutting down runtime", "err", err)
+					}
+				}
+			},
 		},
-	}, nil
-}
-
-// Shutdown shuts down the underlying osquery runtime,
-// we expose it so that the updater can call it in it's finalize step
-func (ext *extension) Shutdown() error {
-	if ext.Runner != nil {
-		return ext.Runner.Shutdown()
-	}
-	return nil
-}
-
-// Restart restarts the underlying osquery runtime,
-// we expose it so that the updater can call it in it's finalize step
-func (ext *extension) Restart() error {
-	if ext.Runner != nil {
-		return ext.Runner.Restart()
-	}
-	return nil
+		runner.Restart,
+		runner.Shutdown,
+		nil
 }

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -281,7 +281,7 @@ func main() {
 	var runGroup run.Group
 
 	// create the osquery extension for launcher
-	extension, err := createExtensionRuntime(ctx, rootDirectory, db, logger, opts)
+	extension, runnerRestart, runnerShutdown, err := createExtensionRuntime(ctx, rootDirectory, db, logger, opts)
 	if err != nil {
 		logger.Fatal("err", errors.Wrap(err, "creating extension and service"))
 	}
@@ -316,7 +316,7 @@ func main() {
 		}
 
 		// create an updater for osquery
-		osqueryUpdater, err := createUpdater(ctx, opts.osquerydPath, extension.Restart, logger, config)
+		osqueryUpdater, err := createUpdater(ctx, opts.osquerydPath, runnerRestart, logger, config)
 		if err != nil {
 			logger.Fatal(err)
 		}
@@ -330,7 +330,7 @@ func main() {
 		launcherUpdater, err := createUpdater(
 			ctx,
 			launcherPath,
-			launcherFinalizer(logger, extension.Shutdown),
+			launcherFinalizer(logger, runnerShutdown),
 			logger,
 			config,
 		)

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -318,6 +318,13 @@ func LaunchInstance(opts ...OsqueryInstanceOption) (*Runner, error) {
 	return runner, nil
 }
 
+// LaunchUnstartedInstance sets up a osqueryd instance similar to LaunchInstance, but gives the caller control over
+// when the instance will run. Useful for controlling startup and shutdown goroutines.
+func LaunchUnstartedInstance(opts ...OsqueryInstanceOption) (*Runner, func() error) {
+	runner := newRunner(opts...)
+	return runner, runner.start
+}
+
 func newRunner(opts ...OsqueryInstanceOption) *Runner {
 	// Create an OsqueryInstance and apply the functional options supplied by the
 	// caller.

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -312,7 +312,7 @@ const socketOpenInterval = 200 * time.Millisecond
 //   )
 func LaunchInstance(opts ...OsqueryInstanceOption) (*Runner, error) {
 	runner := newRunner(opts...)
-	if err := runner.start(); err != nil {
+	if err := runner.Start(); err != nil {
 		return nil, err
 	}
 	return runner, nil
@@ -320,9 +320,9 @@ func LaunchInstance(opts ...OsqueryInstanceOption) (*Runner, error) {
 
 // LaunchUnstartedInstance sets up a osqueryd instance similar to LaunchInstance, but gives the caller control over
 // when the instance will run. Useful for controlling startup and shutdown goroutines.
-func LaunchUnstartedInstance(opts ...OsqueryInstanceOption) (*Runner, func() error) {
+func LaunchUnstartedInstance(opts ...OsqueryInstanceOption) *Runner {
 	runner := newRunner(opts...)
-	return runner, runner.start
+	return runner
 }
 
 func newRunner(opts ...OsqueryInstanceOption) *Runner {
@@ -352,7 +352,7 @@ func newInstance() *OsqueryInstance {
 	return i
 }
 
-func (r *Runner) start() error {
+func (r *Runner) Start() error {
 	if err := r.launchOsqueryInstance(); err != nil {
 		return errors.Wrap(err, "starting instance")
 	}
@@ -659,5 +659,5 @@ func (o *OsqueryInstance) Query(query string) ([]map[string]string, error) {
 // kill process group kills a process and all its children.
 func killProcessGroup(cmd *exec.Cmd) error {
 	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	return errors.Wrapf(err, "kill process group %s", cmd.Process.Pid)
+	return errors.Wrapf(err, "kill process group %d", cmd.Process.Pid)
 }


### PR DESCRIPTION
Fixes a bug where the osquery runtime would not shutdown or restart correctly.
Simplified code for instantiating a runtime by providing the Shutdown and Restart functions as callbacks instead of struct fields.