### PR TITLE
Creating documentation for launcher using systemd to persistence

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -85,6 +85,9 @@ The PEM file should contain all of the root authorities you would like launcher 
 ```
 launcher --root_pem=root.pem
 ```
+## Running Launcher with systemd
+See [systemd](./systemd.md) for documentation on running launcher as a background process.
+
 
 ## Additional Build Options
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -13,7 +13,6 @@ Below is a sample unit file.
  ExecStart= $LauncherPath \
  --hostname=$FleetServer:FleetPort \
  --enroll_secret=$FleetSecret \
- --insecure \
  --autoupdate \
 --osqueryd_path=$OsquerydPath
 Restart=on-failure
@@ -32,6 +31,8 @@ sudo systemctl status launcher.service
 sudo journalctl -u launcher.service -f
 ```
 
+If running launcher for tests purposes and not using certificates for secure communication use include the option `--insecure`
+
 ## Making changes
 Sometimes you'll need to update the systemd unit file defining the service. To do that, first open `/etc/systemd/system/launcher.service` in a text editor, and make your modifications.
 
@@ -39,5 +40,5 @@ Then, run
 
 ```
 sudo systemctl daemon-reload
-sudo systemctl restart fleet.service
+sudo systemctl restart launcher.service
 ```

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -31,7 +31,7 @@ sudo systemctl status launcher.service
 sudo journalctl -u launcher.service -f
 ```
 
-If running launcher for tests purposes and using local or insecure certificates, include the option `--insecure`.
+If running launcher for tests purposes, using local or insecure certificates, include the option `--insecure`.
 
 ## Making changes
 Sometimes you'll need to update the systemd unit file defining the service. To do that, first open `/etc/systemd/system/launcher.service` in a text editor, and make your modifications.

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -31,7 +31,7 @@ sudo systemctl status launcher.service
 sudo journalctl -u launcher.service -f
 ```
 
-If running launcher for tests purposes and not using certificates for secure communication use include the option `--insecure`
+If running launcher for tests purposes and using local or insecure certificates, include the option `--insecure`.
 
 ## Making changes
 Sometimes you'll need to update the systemd unit file defining the service. To do that, first open `/etc/systemd/system/launcher.service` in a text editor, and make your modifications.

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,0 +1,43 @@
+## Running with systemd
+
+Once you've verified that you can run launcher in your shell, you'll likely want to keep launcer running in the background and after the endpoint reboots. To do that we recommend using [systemd](https://coreos.com/os/docs/latest/getting-started-with-systemd.html)
+
+Below is a sample unit file.
+
+```
+[Unit]
+ Description=The Kolide Launcher
+ After=network.service syslog.service
+
+ [Service]
+ ExecStart= $LauncherPath \
+ --hostname=$FleetServer:FleetPort \
+ --enroll_secret=$FleetSecret \
+ --insecure \
+ --autoupdate \
+--osqueryd_path=$OsquerydPath
+Restart=on-failure
+RestartSec=3
+ [Install]
+WantedBy=multi-user.target
+```
+
+Once you created the file, you need to move it to `/etc/systemd/system/launcher.service` and start the service.
+
+```
+sudo mv launcher.service /etc/systemd/system/launcher.service
+sudo systemctl start launcher.service
+sudo systemctl status launcher.service
+
+sudo journalctl -u launcher.service -f
+```
+
+## Making changes
+Sometimes you'll need to update the systemd unit file defining the service. To do that, first open `/etc/systemd/system/launcher.service` in a text editor, and make your modifications.
+
+Then, run
+
+```
+sudo systemctl daemon-reload
+sudo systemctl restart fleet.service
+```


### PR DESCRIPTION
This pull adds a new file with instructions to create a unit file to use launcher with systemd.
There's also a change to launcher.md to point to this new document.

I tried to follow as much as possible the same documentation that exists on Fleet.