### PR TITLE
implement log rotation

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -283,6 +284,10 @@ func main() {
 	}
 	defer db.Close()
 
+	if err := writePidFile(filepath.Join(rootDirectory, "launcher.pid")); err != nil {
+		logger.Fatal("err", err)
+	}
+
 	// create a context for all the asynchronous stuff we are starting
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -370,4 +375,9 @@ func main() {
 		logger.Fatal(err)
 	}
 
+}
+
+func writePidFile(path string) error {
+	err := ioutil.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0600)
+	return errors.Wrap(err, "writing pidfile")
 }

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -778,7 +778,7 @@ type newSyslogTemplateOptions struct {
 
 func renderNewSyslogConfig(w io.Writer, options *newSyslogTemplateOptions) error {
 	syslogTemplate := `# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
-{{.LogPath}}               640  4000     3   *   G  {{.PidPath}} 15`
+{{.LogPath}}               640  3  4000   *   G  {{.PidPath}} 15`
 	t, err := template.New("syslog").Parse(syslogTemplate)
 	if err != nil {
 		return errors.Wrap(err, "not able to parse postinstall template")

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -382,12 +382,14 @@ func CreateMacPackage(
 	logDirectory := filepath.Join("/var/log", identifier)
 	launchDaemonDirectory := "/Library/LaunchDaemons"
 	launchDaemonName := fmt.Sprintf("com.%s.launcher", identifier)
+	newSysLogDirectory := filepath.Join("/etc", "newsyslog.d")
 	pathsToCreate := []string{
 		rootDirectory,
 		binaryDirectory,
 		configurationDirectory,
 		logDirectory,
 		launchDaemonDirectory,
+		newSysLogDirectory,
 	}
 	for _, pathToCreate := range pathsToCreate {
 		err = os.MkdirAll(filepath.Join(packageRoot, pathToCreate), fs.DirMode)
@@ -503,6 +505,21 @@ func CreateMacPackage(
 	}
 	if err := renderPostinstall(postinstallFile, postinstallOpts); err != nil {
 		return "", errors.Wrap(err, "could not render postinstall script context to file")
+	}
+
+	// create newsyslog.d config file
+	newSysLogPath := filepath.Join(packageRoot, newSysLogDirectory, fmt.Sprintf("%s.conf", identifier))
+	newSyslogFile, err := os.Create(newSysLogPath)
+	if err != nil {
+		return "", errors.Wrap(err, "creating newsyslog config")
+	}
+	defer newSyslogFile.Close()
+	logOptions := newSyslogTemplateOptions{
+		LogPath: filepath.Join(logDirectory, "*.log"),
+		PidPath: filepath.Join(rootDirectory, "launcher.pid"),
+	}
+	if err := renderNewSyslogConfig(newSyslogFile, &logOptions); err != nil {
+		return "", errors.Wrap(err, "rendering newsyslog.d config")
 	}
 
 	outputPathDir, err := ioutil.TempDir("/tmp", "packaging_")
@@ -752,6 +769,21 @@ sleep 5
 		return errors.Wrap(err, "not able to parse postinstall template")
 	}
 	return t.ExecuteTemplate(w, "postinstall", options)
+}
+
+type newSyslogTemplateOptions struct {
+	LogPath string
+	PidPath string
+}
+
+func renderNewSyslogConfig(w io.Writer, options *newSyslogTemplateOptions) error {
+	syslogTemplate := `# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+{{.LogPath}}               640  4000     3   *   G  {{.PidPath}} 15`
+	t, err := template.New("syslog").Parse(syslogTemplate)
+	if err != nil {
+		return errors.Wrap(err, "not able to parse postinstall template")
+	}
+	return t.ExecuteTemplate(w, "syslog", options)
 }
 
 // pkgbuild runs the following pkgbuild command:


### PR DESCRIPTION
LaunchD does not rotate the file defined under StandardErrorPath.
Here, we render a newsyslogd config under /etc/newsyslog.d/<identifier>.conf to rotate the log once it grows past a certain size.
Upon rotation, newsyslogd will also send a SIGTERM to the launcher pid file, which will be under the launcher root directory.