### PR TITLE
Add new table kolide_gdrive_sync_config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ extension: .pre-build
 
 osqueryi: .pre-build
 	go build -i -o build/launcher.ext ./cmd/launcher.ext/
-	osqueryi --extension=./build/launcher.ext --verbose
+	osqueryi --extension=./build/launcher.ext
 
 xp-extension: .pre-build
 	GOOS=darwin go build -i -o build/darwin/osquery-extension.ext ./cmd/osquery-extension/

--- a/pkg/osquery/table/email_addresses.go
+++ b/pkg/osquery/table/email_addresses.go
@@ -7,18 +7,19 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-kit/kit/log"
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
 
-func EmailAddresses(client *osquery.ExtensionManagerClient) *table.Plugin {
+func EmailAddresses(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("email"),
 		table.TextColumn("domain"),
 	}
 	t := &emailAddressesTable{
-		onePasswordAccountConfig: &onePasswordAccountConfig{client: client},
+		onePasswordAccountConfig: &onePasswordAccountConfig{client: client, logger: logger},
 	}
 	return table.NewPlugin("kolide_email_addresses", columns, t.generateEmailAddresses)
 }

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -7,17 +7,18 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fs"
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
-func GDriveSyncConfig(client *osquery.ExtensionManagerClient) *table.Plugin {
+func GDriveSyncConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
 	g := &gdrive{
 		client: client,
+		logger: logger,
 	}
 
 	columns := []table.ColumnDefinition{
@@ -29,17 +30,10 @@ func GDriveSyncConfig(client *osquery.ExtensionManagerClient) *table.Plugin {
 
 type gdrive struct {
 	client *osquery.ExtensionManagerClient
+	logger log.Logger
 }
 
-// generate will be called whenever the table is queried. It should return a
-// full table scan.
-func (g *gdrive) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	user, err := getPrimaryUser(g.client)
-	if err != nil {
-		return nil, errors.Wrap(err, "get primary user for gdrive sync info")
-	}
-	paths := filepath.Join("/Users", user, "/Library/Application Support/Google/Drive/user_default/sync_config.db")
-
+func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
 	dir, err := ioutil.TempDir("", "kolide_gdrive_sync_config")
 	if err != nil {
 		return nil, err
@@ -47,7 +41,7 @@ func (g *gdrive) generate(ctx context.Context, queryContext table.QueryContext) 
 	defer os.RemoveAll(dir) // clean up
 
 	dst := filepath.Join(dir, "tmpfile")
-	if err := fs.CopyFile(paths, dst); err != nil {
+	if err := fs.CopyFile(path, dst); err != nil {
 		return nil, err
 	}
 
@@ -92,4 +86,24 @@ func (g *gdrive) generate(ctx context.Context, queryContext table.QueryContext) 
 			"local_sync_root_path": localsyncpath,
 		},
 	}, nil
+}
+
+func (g *gdrive) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	paths, err := findFileInUserDirs("/Library/Application Support/Google/Drive/user_default/sync_config.db")
+	if err != nil {
+		return nil, errors.Wrap(err, "find gdrive sync config sqlite DBs")
+	}
+
+	var results []map[string]string
+	for _, path := range paths {
+		res, err := g.generateForPath(ctx, path)
+		if err != nil {
+			level.Error(g.logger).Log("Generating gdrive sync result for path %s: %s", path, err.Error())
+			continue
+		}
+		results = append(results, res...)
+	}
+
+	return results, nil
+
 }

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -1,6 +1,30 @@
+package table
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
 func GDrivePlugin(client *osquery.ExtensionManagerClient) *table.Plugin {
-	paths := queryDbPath...
-	database, _ := sql.Open("sqlite3", path)
+	t := &gDriveTable{client: client}
+	paths, err := queryDbPath(t.client)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	database, err := sql.Open("sqlite3", path)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
 	g := &gdrive{
 		db: database,
 	}
@@ -9,7 +33,7 @@ func GDrivePlugin(client *osquery.ExtensionManagerClient) *table.Plugin {
 		table.TextColumn("user_email"),
 		table.TextColumn("local_sync_root_path"),
 	}
-	return table.NewPlugin("kolide_gdrive_sync_config", columns, generate)
+	return table.NewPlugin("kolide_gdrive_sync_config", columns, g.generate)
 }
 
 type gdrive struct {

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func GDrivePlugin(client *osquery.ExtensionManagerClient) *table.Plugin {

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -1,0 +1,61 @@
+func GDrivePlugin(client *osquery.ExtensionManagerClient) *table.Plugin {
+	paths := queryDbPath...
+	database, _ := sql.Open("sqlite3", path)
+	g := &gdrive{
+		db: database,
+	}
+
+	columns := []table.ColumnDefinition{
+		table.TextColumn("user_email"),
+		table.TextColumn("local_sync_root_path"),
+	}
+	return table.NewPlugin("kolide_gdrive_sync_config", columns, generate)
+}
+
+type gdrive struct {
+	db *sql.DB
+}
+
+// GdriveGenerate will be called whenever the table is queried. It should return
+// a full table scan.
+func (g *gdrive) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	rows, _ := g.db.Query("SELECT entry_key, data_key, data_value FROM data")
+	defer rows.Close()
+	var email string
+	var localsyncpath string
+	for rows.Next() {
+		var entry_key string
+		var data_key string
+		var data_value string
+		rows.Scan(&entry_key, &data_key, &data_value)
+
+		switch entry_key {
+		case "user_email":
+			email = data_value
+		case "local_sync_root_path":
+			localsyncpath = data_value
+		default:
+			continue
+		}
+	}
+	return []map[string]string{
+		{
+			"user_email":           email,
+			"local_sync_root_path": localsyncpath,
+		},
+	},nil
+}
+
+func queryDbPath(client *osquery.ExtensionManagerClient) (string, error) {
+	query := `select username from last where username not in ('', 'root') group by username order by count(username) desc limit 1`
+	row, err := client.QueryRow(query)
+	if err != nil {
+		return "", errors.Wrap(err, "querying for primaryUser version")
+	}
+	var username string
+	if val, ok := row["username"]; ok {
+		username = val
+	}
+	path := filepath.Join("/Users", username,"/Library/Application Support/Google/Drive/user_default/sync_config.db")
+	return path, nil
+}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -3,11 +3,12 @@ package table
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 
 	"github.com/kolide/kit/fs"
@@ -17,6 +18,7 @@ import (
 
 type onePasswordAccountConfig struct {
 	client *osquery.ExtensionManagerClient
+	logger log.Logger
 }
 
 // generate the onepassword account info results given the path to a
@@ -71,7 +73,7 @@ func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext ta
 	for _, path := range paths {
 		res, err := o.generateForPath(ctx, path)
 		if err != nil {
-			fmt.Println("Error generating result for path ", path)
+			level.Error(o.logger).Log("Error generating onepassword result for path %s: %s", path, err.Error())
 			continue
 		}
 		results = append(results, res...)

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -12,6 +12,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 	return []*table.Plugin{
 		LauncherInfo(client),
 		BestPractices(client),
-		EmailAddresses(client),
+		EmailAddresses(client, logger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -17,12 +17,12 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		MachoInfo(),
 		MacOSUpdate(client),
 		LauncherInfo(client),
-		EmailAddresses(client),
+		EmailAddresses(client, logger),
 		Spotlight(),
 		KolideVulnerabilities(client, logger),
 		BestPractices(client),
 		Airdrop(client),
 		ChromeLoginKeychainInfo(client, logger),
-		GDriveSyncConfig(client),
+		GDriveSyncConfig(client, logger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -23,5 +23,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		BestPractices(client),
 		Airdrop(client),
 		ChromeLoginKeychainInfo(client, logger),
+		GDriveSyncConfig(client),
 	}
 }


### PR DESCRIPTION
Major shoutouts to @groob who was instrumental in holding my hand through the process of building this table.
## What does this table do?

This PR adds a new table gdrive_sync_config which outputs the `user_email` and `local_sync_root_path` from a local device's Google Drive configuration database: `/Users/username/Library/Application Support/Google/Drive/user_default/sync_config.db`. 

Example output below:
```
osquery> SELECT * FROM kolide_gdrive_sync_config;
+-----------------+--------------------------------+
| user_email      | local_sync_root_path           |
+-----------------+--------------------------------+
| fritz@kolide.co | /Users/fritz-imac/Google Drive |
+-----------------+--------------------------------+
```

## Why do we need this table?

Customers have asked us to collect information on the configuration of their user's cloud storage usage. This is done both to determine:

- data-exfiltration risk (eg. when a user is storing company IP on a personal cloud storage account)
- compliance with IT practice / onboarding (having a properly configured cloud storage account)

Furthermore, I would like to see the output of this table bolster the results set that we are currently collecting in the `kolide_email_addresses` to perform user:device assignments.

## Why are we adding this as an osquery-go table and not using ATC functionality?

Currently, we do not have an existing workflow setup for distributing new atc tables via custom osquery configuration files.

Furthermore, the existing implementation of ATC suffers from an issue which prohibits parsing SQLite DB's which utilize the WAL type Journal Mode.
https://github.com/facebook/osquery/issues/5225