### PR TITLE
Add osquerygo virtual table, kolide_chrome_login_keychain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ extension: .pre-build
 
 osqueryi: .pre-build
 	go build -i -o build/launcher.ext ./cmd/launcher.ext/
-	osqueryi --extension=./build/launcher.ext
+	osqueryi --extension=./build/launcher.ext --verbose
 
 xp-extension: .pre-build
 	GOOS=darwin go build -i -o build/darwin/osquery-extension.ext ./cmd/osquery-extension/

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -1,0 +1,98 @@
+package table
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func ChromeLoginKeychainInfo(client *osquery.ExtensionManagerClient) *table.Plugin {
+	//figure it out
+	c := &ChromeLoginKeychain{
+		client: client,
+	}
+	columns := []table.ColumnDefinition{
+		table.TextColumn("origin_url"),
+		table.TextColumn("action_url"),
+		table.TextColumn("username_value"),
+	}
+	return table.NewPlugin("kolide_chrome_login_keychain", columns, c.generate)
+}
+
+type ChromeLoginKeychain struct {
+	// take a client instead of db
+	client *osquery.ExtensionManagerClient
+}
+
+// this function is not necessary, use columns := to just return the column definition in the top function
+/* func (c *ChromeLoginKeychain) ChromeLoginKeychainColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("origin_url"),
+		table.TextColumn("action_url"),
+		table.TextColumn("username_value"),
+	}
+} */
+
+// ChromeLoginKeychainGenerate will be called whenever the table is queried. It should return
+// a full table scan.
+func (c *ChromeLoginKeychain) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	paths, err := queryDbPath(c.client)
+	if err != nil {
+		return nil, err
+	}
+	// open and close db here, same as other table
+	db, err := sql.Open("sqlite3", paths)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	db.Exec("PRAGMA journal_mode=WAL;")
+
+	rows, err := db.Query("SELECT origin_url, action_url, username_value FROM logins")
+	if err != nil {
+		return nil, errors.Wrap(err, "query rows from chrome login keychain db")
+	}
+	defer rows.Close()
+
+	var results []map[string]string
+
+	// loop through all the sqlite rows and add them as osquery rows in the results map
+	for rows.Next() { // we initialize these variables for every row, that way we don't have data from the previous iteration
+		var origin_url string
+		var action_url string
+		var username_value string
+		rows.Scan(&origin_url, &action_url, &username_value) // handle this error
+		if err := rows.Scan(&origin_url, &action_url, &username_value); err != nil {
+			return nil, errors.Wrap(err, "scanning chrome login keychain db row")
+		}
+
+		results = append(results, map[string]string{
+			"origin_url":     origin_url,
+			"action_url":     action_url,
+			"username_value": username_value,
+		})
+	}
+	return results, nil //no error
+}
+
+func queryDbPath(client *osquery.ExtensionManagerClient) (string, error) {
+	query := `select username from last where username not in ('', 'root') group by username order by count(username) desc limit 1`
+	row, err := client.QueryRow(query)
+	if err != nil {
+		return "", errors.Wrap(err, "querying for primaryUser version")
+	}
+	var username string
+	if val, ok := row["username"]; ok {
+		username = val
+	}
+	path := filepath.Join("/Users", username, "/Library/Application Support/Google/Chrome/Default/Login Data")
+	return path, nil
+}

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -17,7 +17,6 @@ import (
 )
 
 func ChromeLoginKeychainInfo(client *osquery.ExtensionManagerClient) *table.Plugin {
-	//figure it out
 	c := &ChromeLoginKeychain{
 		client: client,
 	}
@@ -30,18 +29,8 @@ func ChromeLoginKeychainInfo(client *osquery.ExtensionManagerClient) *table.Plug
 }
 
 type ChromeLoginKeychain struct {
-	// take a client instead of db
 	client *osquery.ExtensionManagerClient
 }
-
-// this function is not necessary, use columns := to just return the column definition in the top function
-/* func (c *ChromeLoginKeychain) ChromeLoginKeychainColumns() []table.ColumnDefinition {
-	return []table.ColumnDefinition{
-		table.TextColumn("origin_url"),
-		table.TextColumn("action_url"),
-		table.TextColumn("username_value"),
-	}
-} */
 
 // ChromeLoginKeychainGenerate will be called whenever the table is queried. It should return
 // a full table scan.
@@ -61,7 +50,7 @@ func (c *ChromeLoginKeychain) generate(ctx context.Context, queryContext table.Q
 	if err := fs.CopyFile(paths, dst); err != nil {
 		return nil, err
 	}
-	// open and close db here, same as other table
+
 	db, err := sql.Open("sqlite3", dst)
 	if err != nil {
 		return nil, err
@@ -93,7 +82,7 @@ func (c *ChromeLoginKeychain) generate(ctx context.Context, queryContext table.Q
 			"username_value": username_value,
 		})
 	}
-	return results, nil //no error
+	return results, nil
 }
 
 func queryDbPath(client *osquery.ExtensionManagerClient) (string, error) {

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -22,5 +22,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		KolideVulnerabilities(client, logger),
 		BestPractices(client),
 		Airdrop(client),
+		ChromeLoginKeychainInfo(client),
 	}
 }

--- a/pkg/osquery/table/table_util.go
+++ b/pkg/osquery/table/table_util.go
@@ -1,0 +1,15 @@
+package table
+
+import (
+	"github.com/kolide/osquery-go"
+	"github.com/pkg/errors"
+)
+
+func getPrimaryUser(client *osquery.ExtensionManagerClient) (string, error) {
+	query := `select username from last where username not in ('', 'root') group by username order by count(username) desc limit 1`
+	row, err := client.QueryRow(query)
+	if err != nil {
+		return "", errors.Wrap(err, "querying for primaryUser version")
+	}
+	return row["username"], nil
+}


### PR DESCRIPTION
## What does this table do?
This PR adds a new virtual table chrome_login_keychain which outputs historical website login attempts from the Google Chrome login keychain database located at: `/Users/username/Library/Application Support/Google/Chrome/Default/Login Data`

## Example output below:

```
osquery> SELECT * FROM kolide_chrome_login_keychain where username_value LIKE '%kolide.co';

+------------------------------------------+-----------------------------------------+--------------------------+
| origin_url                               | action_url                              | username_value           |
+------------------------------------------+-----------------------------------------+--------------------------+
| https://osquery.slack.com/               | https://osquery.slack.com/              | fritz@kolide.co          |
| https://projects.invisionapp.com/d/login | https://projects.invisionapp.com/d/main | fritz@kolide.co          |
| https://app.intercom.io/admins/sign_in   | https://app.intercom.io/admins/sign_in  | fritz+intercom@kolide.co |
| https://www.dropbox.com/paper            | https://www.dropbox.com/ajax_login      | fritz@kolide.co          |
| https://www.dropbox.com/paper            | https://www.dropbox.com/                | fritz@kolide.co          |
| https://app.intercom.io/admins/sign_in   | https://app.intercom.io/admins/sign_in  | fritz@kolide.co          |
+------------------------------------------+-----------------------------------------+--------------------------+
```
## Why do we need this table?
I would like to see the output of this table bolster the results set that we are currently collecting in the kolide_email_addresses to perform user:device assignments.

## Why are we adding this as an osquery-go table and not using ATC functionality?
Currently, we do not have an existing workflow setup for distributing new atc tables via custom osquery configuration files.

Furthermore, the existing implementation of ATC suffers from an issue which prohibits parsing SQLite DB's which utilize the WAL type Journal Mode.
facebook/osquery#5225

## What are the limitations of this table and possible improvements?
It is currently written in a way that will only return results for the Primary User and as such does not require a JOIN, but also means that it is naturally limited in a multi-user environment.

The table could be improved by gathering the paths for every user directory so that you could perform a CROSS JOIN and output the sync configurations for every user or specific users.