### PR TITLE
Add 1Password Teams Configuration osquerygo virtual table

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -201,6 +201,14 @@
   version = "v1.1.2"
 
 [[projects]]
+  digest = "1:3cafc6a5a1b8269605d9df4c6956d43d8011fc57f266ca6b9d04da6c09dee548"
+  name = "github.com/mattn/go-sqlite3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "25ecb14adfc7543176f7d85291ec7dba82c6f7e4"
+  version = "v1.9.0"
+
+[[projects]]
   branch = "master"
   digest = "1:f6a6660a60d7082ebc819948d910534d501984b04c7df7fb3c1e9a000fcd721a"
   name = "github.com/miekg/pkcs11"
@@ -446,6 +454,7 @@
     "github.com/kolide/osquery-go/plugin/table",
     "github.com/kolide/updater/tuf",
     "github.com/kr/pty",
+    "github.com/mattn/go-sqlite3",
     "github.com/mixer/clock",
     "github.com/oklog/run",
     "github.com/pkg/errors",

--- a/pkg/osquery/table/email_addresses.go
+++ b/pkg/osquery/table/email_addresses.go
@@ -16,32 +16,43 @@ func EmailAddresses(client *osquery.ExtensionManagerClient) *table.Plugin {
 		table.TextColumn("email"),
 		table.TextColumn("domain"),
 	}
-	return table.NewPlugin("kolide_email_addresses", columns, generateEmailAddresses(client))
+	t := &emailAddressesTable{
+		onePasswordAccountConfig: &onePasswordAccountConfig{client: client},
+	}
+	return table.NewPlugin("kolide_email_addresses", columns, t.generateEmailAddresses)
 }
 
-func generateEmailAddresses(client *osquery.ExtensionManagerClient) table.GenerateFunc {
-	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-		results := []map[string]string{}
+type emailAddressesTable struct {
+	onePasswordAccountConfig *onePasswordAccountConfig
+}
 
-		for _, stateFilePath := range findChromeStateFiles() {
-			fileContent, err := ioutil.ReadFile(stateFilePath)
-			if err != nil {
-				return nil, errors.Wrapf(err, "could not read file %s", stateFilePath)
-			}
+func (t *emailAddressesTable) generateEmailAddresses(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	results := []map[string]string{}
 
-			var parsedStateFileContent chromeLocalStateFile
-			if err := json.Unmarshal(fileContent, &parsedStateFileContent); err != nil {
-				return nil, errors.Wrap(err, "could not unmarshal json file")
-			}
-
-			for _, profile := range parsedStateFileContent.Profile.InfoCache {
-				results = addEmailToResults(profile.Username, results)
-			}
-
+	// add results from chrome profiles
+	for _, stateFilePath := range findChromeStateFiles() {
+		fileContent, err := ioutil.ReadFile(stateFilePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not read file %s", stateFilePath)
 		}
 
-		return results, nil
+		var parsedStateFileContent chromeLocalStateFile
+		if err := json.Unmarshal(fileContent, &parsedStateFileContent); err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal json file")
+		}
+
+		for _, profile := range parsedStateFileContent.Profile.InfoCache {
+			results = addEmailToResults(profile.Username, results)
+		}
 	}
+
+	// add results from 1password
+	results, err := t.onePasswordAccountConfig.generate(ctx, queryContext, results)
+	if err != nil {
+		return nil, errors.Wrap(err, "adding email results from 1password config")
+	}
+
+	return results, nil
 }
 
 type chromeLocalStateFile struct {

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -1,0 +1,103 @@
+package table
+
+import (
+	"context"
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kolide/kit/fs"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func OnePasswordAccountConfigInfo(client *osquery.ExtensionManagerClient) *table.Plugin {
+	o := &OnePasswordAccountConfig{
+		client: client,
+	}
+	columns := []table.ColumnDefinition{
+		table.TextColumn("team_name"),
+		table.TextColumn("user_email"),
+		table.TextColumn("user_first_name"),
+		table.TextColumn("user_last_name"),
+	}
+	return table.NewPlugin("kolide_onepassword_account_config", columns, o.generate)
+}
+
+type OnePasswordAccountConfig struct {
+	client *osquery.ExtensionManagerClient
+}
+
+// OnePasswordAccountConfigGenerate will be called whenever the table is queried. It should return
+// a full table scan.
+func (o *OnePasswordAccountConfig) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	paths, err := queryDbPath(o.client)
+	if err != nil {
+		return nil, err
+	}
+
+	dir, err := ioutil.TempDir("", "kolide_onepassword_account_config")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	dst := filepath.Join(dir, "tmpfile")
+	if err := fs.CopyFile(paths, dst); err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("sqlite3", dst)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	db.Exec("PRAGMA journal_mode=WAL;")
+
+	rows, err := db.Query("SELECT team_name, user_email, user_first_name, user_last_name FROM accounts")
+	if err != nil {
+		return nil, errors.Wrap(err, "query rows from onepassword account configuration db")
+	}
+	defer rows.Close()
+
+	var results []map[string]string
+
+	// loop through all the sqlite rows and add them as osquery rows in the results map
+	for rows.Next() { // we initialize these variables for every row, that way we don't have data from the previous iteration
+		var team_name string
+		var user_email string
+		var user_first_name string
+		var user_last_name string
+		if err := rows.Scan(&team_name, &user_email, &user_first_name, &user_last_name); err != nil {
+			return nil, errors.Wrap(err, "scanning onepassword account configuration db row")
+		}
+
+		results = append(results, map[string]string{
+			"team_name":       team_name,
+			"user_email":      user_email,
+			"user_first_name": user_first_name,
+			"user_last_name":  user_last_name,
+		})
+	}
+	return results, nil
+}
+
+func queryDbPath(client *osquery.ExtensionManagerClient) (string, error) {
+	query := `select username from last where username not in ('', 'root') group by username order by count(username) desc limit 1`
+	row, err := client.QueryRow(query)
+	if err != nil {
+		return "", errors.Wrap(err, "querying for primaryUser version")
+	}
+	var username string
+	if val, ok := row["username"]; ok {
+		username = val
+	}
+	path := filepath.Join("/Users", username, "/Library/Application Support/1Password 4/Data/B5.sqlite")
+	return path, nil
+}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -20,14 +20,14 @@ type onePasswordAccountConfig struct {
 
 // OnePasswordAccountConfigGenerate will be called whenever the table is queried. It should return
 // a full table scan.
-func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext table.QueryContext, results []map[string]string) ([]map[string]string, error) {
+func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	paths, err := queryDbPath(o.client)
 	if err != nil {
 		return nil, err
 	}
 
 	if _, err := os.Stat(paths); os.IsNotExist(err) {
-		return results, nil // only populate results if path exists
+		return nil, nil // only populate results if path exists
 	}
 
 	dir, err := ioutil.TempDir("", "kolide_onepassword_account_config")
@@ -55,6 +55,7 @@ func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext ta
 	}
 	defer rows.Close()
 
+	var results []map[string]string
 	for rows.Next() {
 		var email string
 		if err := rows.Scan(&email); err != nil {
@@ -74,10 +75,7 @@ func queryDbPath(client *osquery.ExtensionManagerClient) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "querying for primaryUser version")
 	}
-	var username string
-	if val, ok := row["username"]; ok {
-		username = val
-	}
+	username := row["username"]
 	path := filepath.Join("/Users", username, "/Library/Application Support/1Password 4/Data/B5.sqlite")
 	return path, nil
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -22,5 +22,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		KolideVulnerabilities(client, logger),
 		BestPractices(client),
 		Airdrop(client),
+		OnePasswordAccountConfigInfo(client),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -22,6 +22,5 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		KolideVulnerabilities(client, logger),
 		BestPractices(client),
 		Airdrop(client),
-		OnePasswordAccountConfigInfo(client),
 	}
 }

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -4,6 +4,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 // PlatformTables returns all tables for the launcher build platform.


### PR DESCRIPTION
## What does this table do?
This PR adds a new virtual table kolide_onepassword_account_config which outputs the **OnePassword SaaS** account config from the 1Password configuration database located at: `/Users/username/Library/Application Support/1Password 4/Data/B5.sqlite`

To avoid database locking issues (preventing the associated app from functioning properly without access to its respective db) we make a temporary local copy of the db file which we open to read and then subsequently delete.

## Example output below:

```
osquery> select * from kolide_onepassword_account_config;
+-----------+-----------------+-----------------+----------------+
| team_name | user_email      | user_first_name | user_last_name |
+-----------+-----------------+-----------------+----------------+
| Kolide    | fritz@kolide.co | Fritz           | Ifert-Miller   |
+-----------+-----------------+-----------------+----------------+
```
## Why do we need this table?
To output the configuration of a 1Password Teams account present on a local device.

This is also part of the greater initiative to scrape email addresses to bolster the results set that we are currently collecting in the kolide_email_addresses to perform user:device assignments.

## Why are we adding this as an osquery-go table and not using ATC functionality?
Currently, we do not have an existing workflow setup for distributing new atc tables via custom osquery configuration files.

Furthermore, the existing implementation of ATC suffers from an issue which prohibits parsing SQLite DB's which utilize the WAL type Journal Mode.
facebook/osquery#5225

## What are the limitations of this table and possible improvements?
It is currently written in a way that will only return results for the Primary User and as such does not require a JOIN, but also means that it is naturally limited in a multi-user environment.

The table could be improved by gathering the paths for every user directory so that you could perform a CROSS JOIN and output the sync configurations for every user or specific users.