### PR TITLE
Retrieve SQLite databases from user home directory paths

### DIFF
--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -3,6 +3,7 @@ package table
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,19 +19,9 @@ type onePasswordAccountConfig struct {
 	client *osquery.ExtensionManagerClient
 }
 
-// OnePasswordAccountConfigGenerate will be called whenever the table is queried. It should return
-// a full table scan.
-func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	user, err := getPrimaryUser(o.client)
-	if err != nil {
-		return nil, errors.Wrap(err, "get primary user for onepassword config")
-	}
-	paths := filepath.Join("/Users", user, "/Library/Application Support/1Password 4/Data/B5.sqlite")
-
-	if _, err := os.Stat(paths); os.IsNotExist(err) {
-		return nil, nil // only populate results if path exists
-	}
-
+// generate the onepassword account info results given the path to a
+// onepassword sqlite DB
+func (o *onePasswordAccountConfig) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
 	dir, err := ioutil.TempDir("", "kolide_onepassword_account_config")
 	if err != nil {
 		return nil, err
@@ -38,7 +29,7 @@ func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext ta
 	defer os.RemoveAll(dir) // clean up
 
 	dst := filepath.Join(dir, "tmpfile")
-	if err := fs.CopyFile(paths, dst); err != nil {
+	if err := fs.CopyFile(path, dst); err != nil {
 		return nil, err
 	}
 
@@ -67,5 +58,24 @@ func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext ta
 		}
 		results = addEmailToResults(email, results)
 	}
+	return results, nil
+}
+
+func (o *onePasswordAccountConfig) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	paths, err := findFileInUserDirs("Library/Application Support/1Password 4/Data/B5.sqlite")
+	if err != nil {
+		return nil, errors.Wrap(err, "find onepassword sqlite DBs")
+	}
+
+	var results []map[string]string
+	for _, path := range paths {
+		res, err := o.generateForPath(ctx, path)
+		if err != nil {
+			fmt.Println("Error generating result for path ", path)
+			continue
+		}
+		results = append(results, res...)
+	}
+
 	return results, nil
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -22,6 +22,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		KolideVulnerabilities(client, logger),
 		BestPractices(client),
 		Airdrop(client),
-		ChromeLoginKeychainInfo(client),
+		ChromeLoginKeychainInfo(client, logger),
 	}
 }


### PR DESCRIPTION
Replaces the old method of determining "primary user" by querying the `last`
table. This will return more results and avoid the expensive query to the
`last` table.