### PR TITLE
refactor launcher to use the logger from kolide/kit

### DIFF
--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"flag"
-	"os"
 	"time"
 
-	"github.com/kolide/launcher/pkg/log"
+	"github.com/kolide/kit/logutil"
 	"github.com/kolide/launcher/pkg/osquery/table"
 	osquery "github.com/kolide/osquery-go"
 )
@@ -18,10 +17,7 @@ func main() {
 		_            = flag.Int("interval", 0, "")
 	)
 	flag.Parse()
-	logger := log.NewLogger(os.Stderr)
-	if *flVerbose {
-		logger.AllowDebug()
-	}
+	logger := logutil.NewServerLogger(*flVerbose)
 
 	timeout := time.Duration(*flTimeout) * time.Second
 
@@ -35,12 +31,12 @@ func main() {
 		osquery.ServerTimeout(timeout),
 	)
 	if err != nil {
-		logger.Fatal("err", err, "msg", "creating osquery extension server")
+		logutil.Fatal(logger, "err", err, "msg", "creating osquery extension server")
 	}
 
 	client, err := osquery.NewClient(*flSocketPath, timeout)
 	if err != nil {
-		logger.Fatal("err", err, "creating osquery extension client")
+		logutil.Fatal(logger, "err", err, "creating osquery extension client")
 	}
 
 	var plugins []osquery.OsqueryPlugin
@@ -50,6 +46,6 @@ func main() {
 	server.RegisterPlugin(plugins...)
 
 	if err := server.Run(); err != nil {
-		logger.Fatal("err", err)
+		logutil.Fatal(logger, "err", err)
 	}
 }

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -17,33 +17,11 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
-	kolidelog "github.com/kolide/launcher/pkg/log"
 	"github.com/pkg/errors"
 )
 
 const debugSignal = syscall.SIGUSR1
 const debugPrefix = "/debug/"
-
-// AttachLogToggle attaches a signal handler that toggles debug logging when
-// SIGUSR2 is sent to the process.
-func AttachLogToggle(logger *kolidelog.Logger, debug bool) {
-	// Start a loop that will toggle the log level when SIGUSR2 is sent to
-	// the process.
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGUSR2)
-	go func() {
-		for {
-			<-sigChan
-			if debug {
-				logger.AllowInfo()
-			} else {
-				logger.AllowDebug()
-			}
-
-			debug = !debug
-		}
-	}()
-}
 
 // AttachDebugHandler attaches a signal handler that toggles the debug server
 // state when SIGUSR1 is sent to the process.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,77 +1,11 @@
 package log
 
 import (
-	"io"
-	"os"
 	"regexp"
 	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 )
-
-type Logger struct {
-	// baseLogger stores the un-leveled logger. Writes should not be done
-	// directly to this logger.
-	baseLogger kitlog.Logger
-	// swapLogger stores the leveled logger, using go-kit's SwapLogger to
-	// ensure that updates to the logger are atomic and avoid race
-	// conditions. All logging should be done through swapLogger.
-	swapLogger kitlog.SwapLogger
-}
-
-func (l *Logger) AllowDebug() {
-	l.allowedLevel(level.AllowDebug(), "debug")
-}
-
-func (l *Logger) AllowInfo() {
-	l.allowedLevel(level.AllowInfo(), "info")
-}
-
-func (l *Logger) allowedLevel(lev level.Option, name string) {
-	newLogger := level.NewFilter(l.baseLogger, lev)
-	l.swapLogger.Swap(newLogger)
-	level.Info(&l.swapLogger).Log(
-		"msg", "allowed log level set",
-		"allowed_level", name,
-	)
-}
-
-// Log will log with level: unknown (filtered as if it were info). Prefer using
-// an explicitly leveled log.Debug or log.Info.
-func (l *Logger) Log(keyvals ...interface{}) error {
-	return l.swapLogger.Log(keyvals...)
-}
-
-// Fatal will log with level: fatal and exit with a status 1
-func (l *Logger) Fatal(keyvals ...interface{}) error {
-	// Call this directly instead of using l.Info so that we get the
-	// correct caller.
-	level.Info(&l.swapLogger).Log(keyvals...)
-	os.Exit(1)
-	// never hit
-	return nil
-}
-
-func NewLogger(w io.Writer) *Logger {
-	base := kitlog.NewJSONLogger(kitlog.NewSyncWriter(w))
-	base = kitlog.With(base, "ts", kitlog.DefaultTimestampUTC)
-	base = kitlog.With(base, "component", "launcher")
-	base = level.NewInjector(base, level.InfoValue())
-
-	// The constant in log.Caller is fragile and must be set
-	// appropriately based on the level of wrapping of the logger. If the
-	// wrapping changes and this value becomes set incorrectly, TestCaller
-	// should fail.
-	base = kitlog.With(base, "caller", kitlog.Caller(7))
-
-	l := &Logger{
-		baseLogger: base,
-	}
-	l.swapLogger.Swap(level.NewFilter(l.baseLogger, level.AllowInfo()))
-
-	return l
-}
 
 // OsqueryLogAdapater creates an io.Writer implementation useful for attaching
 // to the osquery stdout/stderr

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,65 +1,10 @@
 package log
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
-	"sync"
 	"testing"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestConcurrentLogging(t *testing.T) {
-	// Validate that the logging level can be changed while multiple
-	// goroutines are logging without races.
-	l := NewLogger(ioutil.Discard)
-	var wg sync.WaitGroup
-
-	// Write via multiple goroutines
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(i int) {
-			for j := 0; j < 10; j++ {
-				level.Info(l).Log(i, j)
-			}
-			wg.Done()
-		}(i)
-	}
-
-	// Change log level in separate goroutine
-	wg.Add(1)
-	go func() {
-		for i := 0; i < 10; i++ {
-			l.AllowDebug()
-			l.AllowInfo()
-		}
-		wg.Done()
-	}()
-
-	wg.Wait()
-}
-
-func TestCaller(t *testing.T) {
-	// Ensure the correct caller is returned with all the crazy wrapping
-	// of loggers
-	buf := &bytes.Buffer{}
-	l := NewLogger(buf)
-
-	var parsedLog struct {
-		Caller string `json:"caller"`
-	}
-
-	level.Info(l).Log("foo", "bar")
-
-	err := json.Unmarshal(buf.Bytes(), &parsedLog)
-	require.Nil(t, err)
-	// This line could fail if the filename for these tests changes from
-	// "log_test"
-	assert.Contains(t, parsedLog.Caller, "log_test.go:")
-}
 
 func TestExtractOsqueryCaller(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
The kolide/kit logger implements the same functionality as the launcher logger.
It's also been updated to be compatible with windows.