### PR TITLE
compile launcher on windows

### DIFF
--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (

--- a/cmd/launcher/control_windows.go
+++ b/cmd/launcher/control_windows.go
@@ -1,0 +1,16 @@
+// +build windows
+
+package main
+
+import (
+	"context"
+
+	"github.com/boltdb/bolt"
+	"github.com/go-kit/kit/log"
+	"github.com/kolide/kit/actor"
+	"github.com/pkg/errors"
+)
+
+func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *options) (*actor.Actor, error) {
+	return nil, errors.New("control is not supported for windows")
+}

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,18 +1,14 @@
 package debug
 
 import (
-	"context"
 	"html/template"
 	"io/ioutil"
 	"net"
 	"net/http"
 	nhpprof "net/http/pprof"
 	"net/url"
-	"os"
-	"os/signal"
 	"runtime/pprof"
 	"strings"
-	"syscall"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -20,43 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const debugSignal = syscall.SIGUSR1
 const debugPrefix = "/debug/"
-
-// AttachDebugHandler attaches a signal handler that toggles the debug server
-// state when SIGUSR1 is sent to the process.
-func AttachDebugHandler(addrPath string, logger log.Logger) {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, debugSignal)
-	go func() {
-		for {
-			// Start server on first signal
-			<-sig
-			serv, err := startDebugServer(addrPath, logger)
-			if err != nil {
-				level.Info(logger).Log(
-					"msg", "starting debug server",
-					"err", err,
-				)
-				continue
-			}
-
-			// Stop server on next signal
-			<-sig
-			if err := serv.Shutdown(context.Background()); err != nil {
-				level.Info(logger).Log(
-					"msg", "error shutting down debug server",
-					"err", err,
-				)
-				continue
-			}
-
-			level.Info(logger).Log(
-				"msg", "shutdown debug server",
-			)
-		}
-	}()
-}
 
 func startDebugServer(addrPath string, logger log.Logger) (*http.Server, error) {
 	// Generate new (random) token to use for debug server auth

--- a/pkg/debug/signal_debug.go
+++ b/pkg/debug/signal_debug.go
@@ -1,0 +1,50 @@
+// +build !windows
+
+package debug
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+const debugSignal = syscall.SIGUSR1
+
+// AttachDebugHandler attaches a signal handler that toggles the debug server
+// state when SIGUSR1 is sent to the process.
+func AttachDebugHandler(addrPath string, logger log.Logger) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, debugSignal)
+	go func() {
+		for {
+			// Start server on first signal
+			<-sig
+			serv, err := startDebugServer(addrPath, logger)
+			if err != nil {
+				level.Info(logger).Log(
+					"msg", "starting debug server",
+					"err", err,
+				)
+				continue
+			}
+
+			// Stop server on next signal
+			<-sig
+			if err := serv.Shutdown(context.Background()); err != nil {
+				level.Info(logger).Log(
+					"msg", "error shutting down debug server",
+					"err", err,
+				)
+				continue
+			}
+
+			level.Info(logger).Log(
+				"msg", "shutdown debug server",
+			)
+		}
+	}()
+}

--- a/pkg/debug/signal_debug_windows.go
+++ b/pkg/debug/signal_debug_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package debug
+
+import "github.com/go-kit/kit/log"
+
+func AttachDebugHandler(addrPath string, logger log.Logger) {
+	// TODO: noop for now
+}

--- a/pkg/osquery/runtime/processgroup.go
+++ b/pkg/osquery/runtime/processgroup.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package runtime
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func setpgid() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// kill process group kills a process and all its children.
+func killProcessGroup(cmd *exec.Cmd) error {
+	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	return errors.Wrapf(err, "kill process group %d", cmd.Process.Pid)
+}

--- a/pkg/osquery/runtime/processgroup_windows.go
+++ b/pkg/osquery/runtime/processgroup_windows.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package runtime
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setpgid() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	// TODO: implement
+	return nil
+}

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -474,7 +473,7 @@ func (r *Runner) launchOsqueryInstance() error {
 	}
 
 	// Assign a PGID that matches the PID. This lets us kill the entire process group later.
-	o.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	o.cmd.SysProcAttr = setpgid()
 
 	// Launch osquery process (async)
 	err = o.cmd.Start()
@@ -654,10 +653,4 @@ func (o *OsqueryInstance) Query(query string) ([]map[string]string, error) {
 	}
 
 	return resp.Response, nil
-}
-
-// kill process group kills a process and all its children.
-func killProcessGroup(cmd *exec.Cmd) error {
-	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	return errors.Wrapf(err, "kill process group %d", cmd.Process.Pid)
 }


### PR DESCRIPTION
moves all the incompatible syscalls behind build tags, but leaves them as TODOs.

my plan is to merge this then pick it up again on windows and begin an idiomatic runtime & logger implementation.

```
env GOOS=windows go build -o build/launcher.exe ./cmd/launcher
ls build |grep exe
launcher.exe
```
