### PR TITLE
remove bad cancel

### DIFF
--- a/cmd/launcher/query_target_updater.go
+++ b/cmd/launcher/query_target_updater.go
@@ -13,7 +13,6 @@ import (
 
 func createQueryTargetUpdater(logger log.Logger, db *bolt.DB, grpcConn *grpc.ClientConn) *actor.Actor {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	updater := querytarget.NewQueryTargeter(logger, db, grpcConn)
 


### PR DESCRIPTION
- what?
  - removes a defer call to cancel a ctx created by to the QueryTargetUpdater initializer

- why?
  - because the context is not passed into the initializer, the Actor returns and cancels its own context immediately. when reshuffling the ctx handling around i missed this in my last check