### PR TITLE
Support for upstart

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -316,6 +316,11 @@ func getTargets(input string) ([]packaging.Target, error) {
 			Init:     packaging.SystemD,
 			Package:  packaging.Deb,
 		},
+		{
+			Platform: packaging.Linux,
+			Init:     packaging.Upstart,
+			Package:  packaging.Deb,
+		},
 	}
 
 	// Nothing specified, return a default set

--- a/pkg/packagekit/render_init_test.go
+++ b/pkg/packagekit/render_init_test.go
@@ -1,0 +1,48 @@
+package packagekit
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderInitEmpty(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`NAME="empty"`,
+	}
+
+	var output bytes.Buffer
+	err := RenderInit(context.TODO(), &output, emptyInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}
+
+func TestRenderInitComplex(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`NAME="kolide-app"`,
+		`KOLIDE_LAUNCHER_OSQUERYD_PATH=/usr/local/kolide-app/bin/osqueryd`,
+		`export KOLIDE_LAUNCHER_OSQUERYD_PATH`,
+		`--with_initial_runner`,
+	}
+
+	var output bytes.Buffer
+	err := RenderInit(context.TODO(), &output, complexInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 300)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}

--- a/pkg/packagekit/render_launchd_test.go
+++ b/pkg/packagekit/render_launchd_test.go
@@ -1,0 +1,98 @@
+package packagekit
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+func TestRenderLaunchdEmpty(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+	}
+
+	var output bytes.Buffer
+	err := RenderLaunchd(context.TODO(), &output, emptyInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}
+
+func TestRenderLaunchdComplex(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := RenderLaunchd(context.TODO(), &output, complexInitOptions())
+	require.NoError(t, err)
+
+	expectedData, err := expectedComplex()
+	require.NoError(t, err)
+
+	var generatedData launchdOptions
+	_, err = plist.Unmarshal(output.Bytes(), &generatedData)
+	require.NoError(t, err)
+
+	require.True(t, len(output.String()) > 1000)
+	require.Equal(t, expectedData, generatedData)
+}
+
+// expectedComplex returns the expected data. It uses
+// `DHowett/go-plist` so we can cross-check our encoder.
+func expectedComplex() (launchdOptions, error) {
+	expected := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.kolide-app.launcher</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>KOLIDE_LAUNCHER_ROOT_DIRECTORY</key>
+      <string>/var/kolide-app/device.kolide.com-443</string>
+      <key>KOLIDE_LAUNCHER_HOSTNAME</key>
+      <string>device.kolide.com:443</string>
+      <key>KOLIDE_LAUNCHER_ENROLL_SECRET_PATH</key>
+      <string>/etc/kolide-app/secret</string>
+      <key>KOLIDE_LAUNCHER_OSQUERYD_PATH</key>
+      <string>/usr/local/kolide-app/bin/osqueryd</string>
+      <key>KOLIDE_LAUNCHER_UPDATE_CHANNEL</key>
+      <string>nightly</string>
+    </dict>
+    <key>KeepAlive</key>
+    <dict>
+      <key>PathState</key>
+      <dict>
+        <key>/etc/kolide-app/secret</key>
+        <true/>
+      </dict>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/kolide-app/bin/launcher</string>
+      <string>--autoupdate</string>
+      <string>--with_initial_runner</string>
+    </array>
+    <key>StandardErrorPath</key>
+    <string>/var/log/kolide-app/launcher-stderr.log</string>
+    <key>StandardOutPath</key>
+    <string>/var/log/kolide-app/launcher-stdout.log</string>
+  </dict>
+</plist>`
+
+	// TODO this should be unmarshaled into a generic struct, so we can
+	// capture any missing fields.
+	var expectedData launchdOptions
+	_, err := plist.Unmarshal([]byte(expected), &expectedData)
+	return expectedData, err
+}

--- a/pkg/packagekit/render_systemd_test.go
+++ b/pkg/packagekit/render_systemd_test.go
@@ -1,0 +1,69 @@
+package packagekit
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSystemdEmpty(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`[Unit]`,
+	}
+
+	var output bytes.Buffer
+	err := RenderSystemd(context.TODO(), &output, emptyInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}
+
+func TestRenderSystemdComplex(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`[Unit]`,
+	}
+
+	var output bytes.Buffer
+	err := RenderSystemd(context.TODO(), &output, complexInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+	require.Equal(t, expectedComplexUnit(), output.String())
+}
+
+func expectedComplexUnit() string {
+
+	return `[Unit]
+Description=The Kolide Launcher
+After=network.service syslog.service
+
+[Service]
+Environment=KOLIDE_LAUNCHER_ENROLL_SECRET_PATH=/etc/kolide-app/secret
+Environment=KOLIDE_LAUNCHER_HOSTNAME=device.kolide.com:443
+Environment=KOLIDE_LAUNCHER_OSQUERYD_PATH=/usr/local/kolide-app/bin/osqueryd
+Environment=KOLIDE_LAUNCHER_ROOT_DIRECTORY=/var/kolide-app/device.kolide.com-443
+Environment=KOLIDE_LAUNCHER_UPDATE_CHANNEL=nightly
+ExecStart=/usr/local/kolide-app/bin/launcher \
+--autoupdate \
+--with_initial_runner
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target`
+
+}

--- a/pkg/packagekit/render_test.go
+++ b/pkg/packagekit/render_test.go
@@ -1,18 +1,8 @@
 package packagekit
 
-import (
-	"bytes"
-	"context"
-	"io"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-	"howett.net/plist"
-)
-
-func TestRenderEmpty(t *testing.T) {
-	t.Parallel()
-
+// emptyInitOptions() returns a trivial set of init options for
+// testing basic template rendering
+func emptyInitOptions() *InitOptions {
 	initOptions := &InitOptions{
 		Name:        "empty",
 		Identifier:  "empty",
@@ -20,139 +10,11 @@ func TestRenderEmpty(t *testing.T) {
 		Path:        "/dev/null",
 	}
 
-	var tests = []struct {
-		renderFunc func(context.Context, io.Writer, *InitOptions) error
-		outSize    int
-	}{
-		{
-			renderFunc: RenderLaunchd,
-			outSize:    100,
-		},
-		{
-			renderFunc: RenderSystemd,
-			outSize:    100,
-		},
-		{
-			renderFunc: RenderInit,
-			outSize:    100,
-		},
-	}
-
-	for _, tt := range tests {
-		var output bytes.Buffer
-		err := tt.renderFunc(context.TODO(), &output, initOptions)
-		require.NoError(t, err)
-		require.True(t, len(output.String()) > tt.outSize)
-	}
+	return initOptions
 }
 
-func TestRenderComplex(t *testing.T) {
-	t.Parallel()
-
-	env := map[string]string{
-		"FOO": "bar",
-		"BAR": "qux",
-	}
-
-	flags := []string{
-		"--debug",
-		"--hello", "world",
-		"--array", "one",
-		"--array=two",
-	}
-
-	initOptions := &InitOptions{
-		Name:        "complex",
-		Identifier:  "complex",
-		Description: "Complex Example",
-		Environment: env,
-		Flags:       flags,
-		Path:        "/usr/bin/true",
-	}
-
-	var tests = []struct {
-		renderFunc func(context.Context, io.Writer, *InitOptions) error
-		outSize    int
-	}{
-		{
-			renderFunc: RenderLaunchd,
-			outSize:    200,
-		},
-		{
-			renderFunc: RenderSystemd,
-			outSize:    200,
-		},
-		{
-			renderFunc: RenderInit,
-			outSize:    200,
-		},
-	}
-
-	for _, tt := range tests {
-		var output bytes.Buffer
-		err := tt.renderFunc(context.TODO(), &output, initOptions)
-		require.NoError(t, err)
-		require.True(t, len(output.String()) > tt.outSize)
-		// TODO Check some of the rendered content
-	}
-
-}
-
-// TestRenderLauncher tests rendering a startup file exactly as we have it
-func TestRenderLauncherSystemd(t *testing.T) {
-	t.Parallel()
-
-	launcherFlags := []string{}
-
-	initOptions := &InitOptions{
-		Name:        "launcher",
-		Description: "The Kolide Launcher",
-		Identifier:  "kolide-app",
-		Path:        "/usr/local/kolide-app/bin/launcher",
-		Flags:       launcherFlags,
-	}
-
-	initOptions.Flags = append(initOptions.Flags,
-		"--root_directory=/var/kolide-app/device.kolide.com-443",
-		"--hostname=device.kolide.com:443",
-		"--enroll_secret_path=/etc/kolide-app/secret",
-		"--with_initial_runner",
-		"--autoupdate",
-		"--update_channel=nightly",
-		"--osqueryd_path=/usr/local/kolide-app/bin/osqueryd",
-	)
-
-	var output bytes.Buffer
-	err := RenderSystemd(context.TODO(), &output, initOptions)
-	require.NoError(t, err)
-
-	expected := `[Unit]
-Description=The Kolide Launcher
-After=network.service syslog.service
-
-[Service]
-ExecStart=/usr/local/kolide-app/bin/launcher \
---root_directory=/var/kolide-app/device.kolide.com-443 \
---hostname=device.kolide.com:443 \
---enroll_secret_path=/etc/kolide-app/secret \
---with_initial_runner \
---autoupdate \
---update_channel=nightly \
---osqueryd_path=/usr/local/kolide-app/bin/osqueryd
-Restart=on-failure
-RestartSec=3
-
-[Install]
-WantedBy=multi-user.target`
-
-	require.Equal(t, expected, output.String())
-
-}
-
-// TestRenderLauncher tests rendering a startup file exactly as we have it
-func TestRenderLauncherLaunchd(t *testing.T) {
-	t.Parallel()
-
+// complexInitOptions returns an initOptions for real world style testing
+func complexInitOptions() *InitOptions {
 	launcherEnv := map[string]string{
 		"KOLIDE_LAUNCHER_ROOT_DIRECTORY":     "/var/kolide-app/device.kolide.com-443",
 		"KOLIDE_LAUNCHER_HOSTNAME":           "device.kolide.com:443",
@@ -174,66 +36,5 @@ func TestRenderLauncherLaunchd(t *testing.T) {
 		Environment: launcherEnv,
 	}
 
-	var output bytes.Buffer
-	err := RenderLaunchd(context.TODO(), &output, initOptions)
-	require.NoError(t, err)
-
-	// Now, let's check that the content matches. We're doing this with
-	// `DHowett/go-plist` so we can cross-check our encoder.
-
-	expected := `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.kolide-app.launcher</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-      <key>KOLIDE_LAUNCHER_ROOT_DIRECTORY</key>
-      <string>/var/kolide-app/device.kolide.com-443</string>
-      <key>KOLIDE_LAUNCHER_HOSTNAME</key>
-      <string>device.kolide.com:443</string>
-      <key>KOLIDE_LAUNCHER_ENROLL_SECRET_PATH</key>
-      <string>/etc/kolide-app/secret</string>
-      <key>KOLIDE_LAUNCHER_OSQUERYD_PATH</key>
-      <string>/usr/local/kolide-app/bin/osqueryd</string>
-      <key>KOLIDE_LAUNCHER_UPDATE_CHANNEL</key>
-      <string>nightly</string>
-    </dict>
-    <key>KeepAlive</key>
-    <dict>
-      <key>PathState</key>
-      <dict>
-        <key>/etc/kolide-app/secret</key>
-        <true/>
-      </dict>
-    </dict>
-    <key>ThrottleInterval</key>
-    <integer>60</integer>
-    <key>ProgramArguments</key>
-    <array>
-      <string>/usr/local/kolide-app/bin/launcher</string>
-      <string>--autoupdate</string>
-      <string>--with_initial_runner</string>
-    </array>
-    <key>StandardErrorPath</key>
-    <string>/var/log/kolide-app/launcher-stderr.log</string>
-    <key>StandardOutPath</key>
-    <string>/var/log/kolide-app/launcher-stdout.log</string>
-  </dict>
-</plist>`
-
-	// TODO this should be unmarshaled into a generic struct, so we can
-	// capture any missing fields.
-	var expectedData launchdOptions
-	_, err = plist.Unmarshal([]byte(expected), &expectedData)
-	require.NoError(t, err)
-
-	var generatedData launchdOptions
-	_, err = plist.Unmarshal(output.Bytes(), &generatedData)
-	require.NoError(t, err)
-
-	require.True(t, len(output.String()) > 1000)
-	require.Equal(t, expectedData, generatedData)
-
+	return initOptions
 }

--- a/pkg/packagekit/render_upstart.go
+++ b/pkg/packagekit/render_upstart.go
@@ -1,0 +1,128 @@
+package packagekit
+
+import (
+	"context"
+	"html/template"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+)
+
+// upstartOptions contains upstart specific options that are passed to
+// the rendering template.
+type upstartOptions struct {
+	PreStartScript  []string
+	PostStartScript []string
+	PreStopScript   []string
+	Expect          string
+}
+
+type UpstartOption func(*upstartOptions)
+
+// WithExpect sets the expect option. This is how upstart tracks the
+// pid of the daemon. See http://upstart.ubuntu.com/cookbook/#expect
+func WithExpect(s string) UpstartOption {
+	return func(uo *upstartOptions) {
+		uo.Expect = s
+	}
+}
+
+func WithPreStartScript(s []string) UpstartOption {
+	return func(uo *upstartOptions) {
+		uo.PreStartScript = s
+	}
+}
+
+func WithPostStartScript(s []string) UpstartOption {
+	return func(uo *upstartOptions) {
+		uo.PostStartScript = s
+	}
+}
+
+func WithPreStopScript(s []string) UpstartOption {
+	return func(uo *upstartOptions) {
+		uo.PreStopScript = s
+	}
+}
+
+func RenderUpstart(ctx context.Context, w io.Writer, initOptions *InitOptions, uOpts ...UpstartOption) error {
+	ctx, span := trace.StartSpan(ctx, "packagekit.Upstart")
+	defer span.End()
+
+	uOptions := &upstartOptions{}
+	for _, uOpt := range uOpts {
+		uOpt(uOptions)
+	}
+
+	// Prepend a "" so that the merged output looks a bit cleaner in the rendered templates
+	if len(initOptions.Flags) > 0 {
+		initOptions.Flags = append([]string{""}, initOptions.Flags...)
+	}
+
+	upstartTemplate := `#!upstart
+#
+# Name: {{ .Common.Name }}
+# Description: {{.Common.Description}}
+
+{{ if .Opts.Expect }}
+expect {{ .Opts.Expect }}
+{{- end }}
+
+# Start and stop on boot events
+start on net-device-up
+stop on shutdown
+
+# Respawn upto 15 times within 5 seconds.
+# Exceeding that will be considered a failure
+respawn
+respawn limit 15 5
+
+# Send logs to the default upstart location, /var/log/upstart/
+# (This should be rotated by the upstart managed logrotate)
+console log
+
+# Environment Variables
+{{- if .Common.Environment}}{{- range $key, $value := .Common.Environment }}
+env {{$key}}={{$value}}
+{{- end }}{{- end }}
+
+exec {{.Common.Path}}{{ StringsJoin .Common.Flags " \\\n  " }}
+
+{{- if .Opts.PreStopScript }}
+pre-stop script
+{{StringsJoin .Opts.PreStopScript "\n"}}
+end script
+{{- end }}
+
+{{- if .Opts.PreStartScript }}
+pre-start script
+{{StringsJoin .Opts.PreStartScript "\n"}}
+end script
+{{- end }}
+
+{{- if .Opts.PostStartScript }}
+post-start script
+{{StringsJoin .Opts.PostStartScript "\n"}}
+end script
+{{- end }}`
+
+	var data = struct {
+		Common InitOptions
+		Opts   upstartOptions
+	}{
+		Common: *initOptions,
+		Opts:   *uOptions,
+	}
+
+	funcsMap := template.FuncMap{
+		"StringsJoin": strings.Join,
+	}
+
+	t, err := template.New("UpstartConf").Funcs(funcsMap).Parse(upstartTemplate)
+	if err != nil {
+		return errors.Wrap(err, "not able to parse Upstart template")
+	}
+	return t.ExecuteTemplate(w, "UpstartConf", data)
+}

--- a/pkg/packagekit/render_upstart_test.go
+++ b/pkg/packagekit/render_upstart_test.go
@@ -1,0 +1,109 @@
+package packagekit
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderUpstartEmpty(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`#!upstart`,
+		`# Name: empty`,
+	}
+
+	var output bytes.Buffer
+	err := RenderUpstart(context.TODO(), &output, emptyInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}
+
+func TestRenderUpstartComplex(t *testing.T) {
+	t.Parallel()
+
+	expectedOutputStrings := []string{
+		`#!upstart`,
+		`# Name: launcher`,
+	}
+
+	var output bytes.Buffer
+	err := RenderUpstart(context.TODO(), &output, complexInitOptions())
+	require.NoError(t, err)
+	require.True(t, len(output.String()) > 100)
+
+	for _, s := range expectedOutputStrings {
+		require.Contains(t, output.String(), s)
+	}
+
+}
+
+func TestRenderUpstartOptions(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		uOpts             []UpstartOption
+		expectedStrings   []string
+		unexpectedStrings []string
+	}{
+		{
+			uOpts: []UpstartOption{WithPreStartScript([]string{"hello", "world"})},
+			expectedStrings: []string{
+				"pre-start script\nhello\nworld\nend script",
+			},
+			unexpectedStrings: []string{
+				"pre-stop script\nhello\nworld\nend script",
+				"post-start script\nhello\nworld\nend script",
+			},
+		},
+		{
+			uOpts: []UpstartOption{WithPostStartScript([]string{"hello", "world"})},
+			expectedStrings: []string{
+				"post-start script\nhello\nworld\nend script",
+			},
+			unexpectedStrings: []string{
+				"pre-stop script\nhello\nworld\nend script",
+				"pre-start script\nhello\nworld\nend script",
+			},
+		},
+		{
+			uOpts: []UpstartOption{WithPreStopScript([]string{"hello", "world"})},
+			expectedStrings: []string{
+				"pre-stop script\nhello\nworld\nend script",
+			},
+			unexpectedStrings: []string{
+				"pre-start script\nhello\nworld\nend script",
+				"post-start script\nhello\nworld\nend script",
+			},
+		},
+		{
+			uOpts: []UpstartOption{WithExpect("fork")},
+			expectedStrings: []string{
+				"expect fork",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var output bytes.Buffer
+		err := RenderUpstart(context.TODO(), &output, emptyInitOptions(), tt.uOpts...)
+		require.NoError(t, err)
+		require.True(t, len(output.String()) > 100)
+
+		for _, s := range tt.expectedStrings {
+			require.Contains(t, output.String(), s)
+		}
+
+		for _, s := range tt.unexpectedStrings {
+			require.NotContains(t, output.String(), s)
+		}
+	}
+}

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -269,14 +269,19 @@ func (p *PackageOptions) makePackage(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "packaging.makePackage")
 	defer span.End()
 
+	// Linux packages used to be distributed named "launcher". We've
+	// moved to naming them "launcher-<identifier>". To provide a
+	// cleaner package replacement, we can flag this to the underlying
+	// packaging systems.
+	oldPackageNames := []string{"launcher"}
+
 	switch {
 	case p.target.Package == Deb:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsDeb()); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsDeb(), packagekit.WithReplaces(oldPackageNames)); err != nil {
 			return errors.Wrapf(err, "packaging, target %s", p.target.String())
 		}
-
 	case p.target.Package == Rpm:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsRPM()); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsRPM(), packagekit.WithReplaces(oldPackageNames)); err != nil {
 			return errors.Wrapf(err, "packaging, target %s", p.target.String())
 		}
 	case p.target.Package == Pkg:

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -353,6 +353,12 @@ func (p *PackageOptions) setupInit(ctx context.Context) error {
 		dir = "/etc/systemd/system"
 		file = fmt.Sprintf("launcher.%s.service", p.Identifier)
 		renderFunc = packagekit.RenderSystemd
+	case p.target.Platform == Linux && p.target.Init == Upstart:
+		dir = "/etc/init"
+		file = fmt.Sprintf("launcher-%s.conf", p.Identifier)
+		renderFunc = func(ctx context.Context, w io.Writer, io *packagekit.InitOptions) error {
+			return packagekit.RenderUpstart(ctx, w, io)
+		}
 	default:
 		return errors.Errorf("Unsupported target %s", p.target.String())
 	}
@@ -408,6 +414,8 @@ func (p *PackageOptions) setupPostinst(ctx context.Context) error {
 		identifier = fmt.Sprintf("com.%s.launcher", p.Identifier)
 	case p.target.Platform == Linux && p.target.Init == SystemD:
 		postinstTemplate = postinstallSystemdTemplate()
+	case p.target.Platform == Linux && p.target.Init == Upstart:
+		postinstTemplate = postinstallUpstartTemplate()
 	case p.target.Platform == Linux && p.target.Init == Init:
 		postinstTemplate = postinstallInitTemplate()
 	default:
@@ -465,8 +473,19 @@ sleep 5
 /bin/launchctl load {{.Path}}`
 }
 
+// postinstallUpstartTemplate is a post install restart script.
+// upstart's stop and restart commands error out if the daemon isn't
+// running. So stop and start are seperate, and `set -e` is after the
+// stop.
+func postinstallUpstartTemplate() string {
+	return `#!/bin/sh
+stop launcher-{{.Identifier}}
+set -e
+start launcher-{{.Identifier}}`
+}
+
 func postinstallSystemdTemplate() string {
-	return `#!/bin/bash
+	return `#!/bin/sh
 set -e
 systemctl daemon-reload
 systemctl enable launcher.{{.Identifier}}

--- a/pkg/packaging/target.go
+++ b/pkg/packaging/target.go
@@ -19,6 +19,7 @@ const (
 	LaunchD InitFlavor = "launchd"
 	SystemD            = "systemd"
 	Init               = "init"
+    Upstart            = "upstart"
 	NoInit             = "none"
 )
 


### PR DESCRIPTION
Add support for upstart to packagekit. 

Rework packagekit tests. Expand them to cover more of the options.

Split the render functions to have different signatures. 

Start passing in conflicts/replaces options to FPM

Add Upstart into the package-builder builds.