### PR TITLE
Fix empty string in KOLIDE_LAUNCHER_UPDATE_CHANNEL

### DIFF
--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -208,7 +208,7 @@ func parseOptions() (*options, error) {
 
 	updateChannel := autoupdate.Stable
 	switch *flUpdateChannel {
-	case "stable":
+	case "", "stable":
 		updateChannel = autoupdate.Stable
 	case "beta":
 		updateChannel = autoupdate.Beta

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -94,7 +94,6 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 
 	launcherEnv := map[string]string{
 		"KOLIDE_LAUNCHER_HOSTNAME":           p.Hostname,
-		"KOLIDE_LAUNCHER_UPDATE_CHANNEL":     p.UpdateChannel,
 		"KOLIDE_LAUNCHER_ROOT_DIRECTORY":     p.rootDir,
 		"KOLIDE_LAUNCHER_OSQUERYD_PATH":      filepath.Join(p.binDir, "osqueryd"),
 		"KOLIDE_LAUNCHER_ENROLL_SECRET_PATH": filepath.Join(p.confDir, "secret"),


### PR DESCRIPTION
Two fixes for the empty string in KOLIDE_LAUNCHER_UPDATE_CHANNEL

First, we remove the part that always sets it in the packaging/init
scripts. This was superfluous, as it was already being set if
`p.Autoupdate && p.UpdateChannel != ""`

Second, add empty string to the case statement parsing it.