### PR TITLE
Fix os.Args check

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -55,7 +55,7 @@ func main() {
 }
 
 func isSubCommand() bool {
-	if len(os.Args) > 2 {
+	if len(os.Args) != 2 {
 		return false
 	}
 


### PR DESCRIPTION
Slack reports some launcher panics with the package-builder packages. Looking at this, the panic seems pretty clear. 

Running launcher without arguments should not panic.