### PR TITLE
Fix plist generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/gorilla/websocket v1.2.0
-	github.com/groob/plist v0.0.0-20171204151034-2805b357fb23
+	github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/jinzhu/gorm v1.9.1 // indirect
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTM
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/groob/plist v0.0.0-20171204151034-2805b357fb23 h1:nmNKT1NDQ0XE2uQAopKtKDNRzWL0Earp5zeiTnLgkY0=
 github.com/groob/plist v0.0.0-20171204151034-2805b357fb23/go.mod h1:qg2Nek0ND/hIr+nY8H1oVqEW2cLzVVNaAQ0QexOyjyc=
+github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03 h1:z4Na/Ihs7LelUWfkSkr3sixCMwF3Ln1a/3K4eXynhBg=
+github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03/go.mod h1:qg2Nek0ND/hIr+nY8H1oVqEW2cLzVVNaAQ0QexOyjyc=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=

--- a/pkg/packagekit/render_launchd.go
+++ b/pkg/packagekit/render_launchd.go
@@ -22,6 +22,7 @@ type launchdOptions struct {
 	StandardErrorPath string                 `plist:"StandardErrorPath"`
 	StandardOutPath   string                 `plist:"StandardOutPath"`
 	KeepAlive         map[string]interface{} `plist:"KeepAlive"`
+	RunAtLoad         bool                   `plist:"RunAtLoad"`
 }
 
 func RenderLaunchd(ctx context.Context, w io.Writer, initOptions *InitOptions) error {
@@ -52,6 +53,7 @@ func RenderLaunchd(ctx context.Context, w io.Writer, initOptions *InitOptions) e
 		StandardErrorPath: filepath.Join("/var/log", initOptions.Identifier, "launcher-stderr.log"),
 		StandardOutPath:   filepath.Join("/var/log", initOptions.Identifier, "launcher-stdout.log"),
 		KeepAlive:         keepAlive,
+		RunAtLoad:         true,
 	}
 
 	enc := plist.NewEncoder(w)

--- a/pkg/packagekit/render_launchd_test.go
+++ b/pkg/packagekit/render_launchd_test.go
@@ -83,6 +83,8 @@ func expectedComplex() (launchdOptions, error) {
       <string>--autoupdate</string>
       <string>--with_initial_runner</string>
     </array>
+    <key>RunAtLoad</key>
+    <true/>
     <key>StandardErrorPath</key>
     <string>/var/log/kolide-app/launcher-stderr.log</string>
     <key>StandardOutPath</key>


### PR DESCRIPTION
We should be setting this to RunAtLoad, add that.

launchd seems to require self closing tags. This is probably
a bug from apple, but we still need to work around it. See https://github.com/groob/plist/issues/15