### PR TITLE
Add --offset flag to launcher-pummel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ package-builder: .pre-build deps
 
 package-builder-windows: .pre-build deps
 	go run cmd/make/make.go -targets=package-builder -linkstamp --os windows
+
 launcher-pummel:
 	go run cmd/make/make.go -targets=launcher-pummel
 

--- a/cmd/launcher-pummel/launcher-pummel.go
+++ b/cmd/launcher-pummel/launcher-pummel.go
@@ -32,7 +32,7 @@ func main() {
 			env.Bool("DEBUG", false),
 			"Print debug logs",
 		)
-		flJson = flag.Bool(
+		flJSON = flag.Bool(
 			"json",
 			env.Bool("JSON", false),
 			"Print logs in JSON format",
@@ -72,12 +72,17 @@ func main() {
 			env.Bool("INSECURE_GRPC", false),
 			"Dial GRPC without a TLS config (default: false)",
 		)
+		flOffset = flag.Int(
+			"offset",
+			env.Int("OFFSET", 0),
+			"Offset to use for host UUID generation",
+		)
 	)
 	flag.Parse()
 
 	var logger log.Logger
 
-	if *flJson {
+	if *flJSON {
 		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 	} else {
 		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
@@ -172,7 +177,7 @@ func main() {
 		}
 
 		// Start hosts
-		for i := 0; i < count; i++ {
+		for i := *flOffset; i < *flOffset+count; i++ {
 			simulator.LaunchSimulation(
 				logger,
 				host,

--- a/cmd/make/make.go
+++ b/cmd/make/make.go
@@ -67,6 +67,7 @@ func main() {
 		"grpc-extension":  b.BuildCmd("./cmd/grpc.ext", b.PlatformExtensionName("grpc")),
 		"package-builder": b.BuildCmd("./cmd/package-builder", b.PlatformBinaryName("package-builder")),
 		"make":            b.BuildCmd("./cmd/make", b.PlatformBinaryName("make")),
+		"launcher-pummel": b.BuildCmd("./cmd/launcher-pummel", b.PlatformBinaryName("launcher-pummel")),
 	}
 
 	if t := strings.Split(*flTargets, ","); len(t) != 0 && t[0] != "" {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3 // indirect
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/knightsc/system_policy v1.1.1-0.20190125011806-04a47ae55cf7
-	github.com/kolide/kit v0.0.0-20181124013649-bd1a9de64d48
+	github.com/kolide/kit v0.0.0-20190123023048-c155a91098e3
 	github.com/kolide/osquery-go v0.0.0-20190113061206-be0a8de4cf1d
 	github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/knightsc/system_policy v1.1.1-0.20190125011806-04a47ae55cf7 h1:LkPVVN
 github.com/knightsc/system_policy v1.1.1-0.20190125011806-04a47ae55cf7/go.mod h1:Ah+zOuAz6TBHVeG1UiExiExlo8jeuU9yTchmhDVrAdY=
 github.com/kolide/kit v0.0.0-20181124013649-bd1a9de64d48 h1:n8FMcks5eBrK5+LGMw5WU3539+CjDpDx6h0ToqKKBQ4=
 github.com/kolide/kit v0.0.0-20181124013649-bd1a9de64d48/go.mod h1:wdtviHFxzZ59XeVE7KnsKbj/F+g9J5Cbx1mcXEdLKgY=
+github.com/kolide/kit v0.0.0-20190123023048-c155a91098e3 h1:Ii9fpYpVTsnibfXFHctbDJ78azLTz5Qiph4o6zpIj4o=
+github.com/kolide/kit v0.0.0-20190123023048-c155a91098e3/go.mod h1:wdtviHFxzZ59XeVE7KnsKbj/F+g9J5Cbx1mcXEdLKgY=
 github.com/kolide/osquery-go v0.0.0-20190113061206-be0a8de4cf1d h1:2/+lLTfZan4IGrD8TGC1ZVkehWLtrRuah47FASAnifE=
 github.com/kolide/osquery-go v0.0.0-20190113061206-be0a8de4cf1d/go.mod h1:umPEbeG8R8RDJpQ0EMyRdj+6pfnJK4FTzjafwgovDUk=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=


### PR DESCRIPTION
Allows creating a large number of hosts with only some running at a given time.
This makes it easier to fill up a test DB on a local development machine, where
large numbers of hosts running simultaneously would overwhelm the resources
available.