### PR TITLE
Log to debug, not error if GetTargets not implemented by server

### DIFF
--- a/pkg/querytarget/query_target.go
+++ b/pkg/querytarget/query_target.go
@@ -3,7 +3,6 @@ package querytarget
 import (
 	"context"
 	"time"
-	"strings"
 
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
@@ -14,6 +13,8 @@ import (
 	qt "github.com/kolide/launcher/pkg/pb/querytarget"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type QueryTargetUpdater struct {
@@ -66,17 +67,15 @@ func (qtu *QueryTargetUpdater) Run(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			if err := qtu.updateTargetMemberships(ctx); err != nil {
-				if strings.Contains(err.Error(), "code = Unimplemented") {
+				if status.Code(errors.Cause(err)) == codes.Unimplemented {
 					level.Debug(qtu.logger).Log(
 						"msg", "server does not implement GetTargets",
-						"err", err,
 					)
 				} else {
 					level.Error(qtu.logger).Log(
 						"msg", "updating kolide_target_membership data",
 						"err", err,
 					)
-
 				}
 			}
 		case <-ctx.Done():

--- a/pkg/querytarget/query_target.go
+++ b/pkg/querytarget/query_target.go
@@ -3,6 +3,7 @@ package querytarget
 import (
 	"context"
 	"time"
+	"strings"
 
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
@@ -65,10 +66,18 @@ func (qtu *QueryTargetUpdater) Run(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			if err := qtu.updateTargetMemberships(ctx); err != nil {
-				level.Error(qtu.logger).Log(
-					"msg", "updating kolide_target_membership data",
-					"err", err,
-				)
+				if strings.Contains(err.Error(), "code = Unimplemented") {
+					level.Debug(qtu.logger).Log(
+						"msg", "server does not implement GetTargets",
+						"err", err,
+					)
+				} else {
+					level.Error(qtu.logger).Log(
+						"msg", "updating kolide_target_membership data",
+						"err", err,
+					)
+
+				}
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
This commit:
 - Checks errors returned during calls to `GetTargets`, and logs
 w/'debug' severity instead of 'error' if the error code is
 'Unimplemented..'

Why?
 - There are many clients (most importantly fleet and cloud) that
 don't support this endpoint, and we can safely ignore this error in
 that case. This should reduce the number of unactionable errors that
 launcher produces when used with fleet or other servers that don't
 implement the GetTargets endpoint.