### PR TITLE
Cross compilation version detection

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -228,6 +228,8 @@ func runMake(args []string) error {
 		return err
 	}
 
+	var builtTargets []packaging.Target
+
 	for _, target := range targets {
 		outputFileName := fmt.Sprintf("launcher.%s.%s", target.String(), target.PkgExtension())
 		outputFile, err := os.Create(filepath.Join(outputDir, outputFileName))
@@ -239,9 +241,13 @@ func runMake(args []string) error {
 		if err := packageOptions.Build(ctx, outputFile, target); err != nil {
 			return errors.Wrap(err, "could not generate packages")
 		}
+		builtTargets = append(builtTargets, target)
 	}
 
-	fmt.Printf("Built you packages in %s\n", outputDir)
+	fmt.Printf("\nBuilt the following packages in %s:\n", outputDir)
+	for _, target := range builtTargets {
+		fmt.Println(target.String())
+	}
 	return nil
 }
 

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -599,7 +599,14 @@ func (p *PackageOptions) setupDirectories() error {
 
 // BUG This doesn't work on windows
 func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
-	launcherPath := filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName("launcher"))
+	var launcherPath string
+
+	if p.crossCompiling {
+		launcherPath = filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName(hostLauncher))
+	} else {
+		launcherPath = filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName("launcher"))
+	}
+
 	stdout, err := p.execOut(ctx, launcherPath, "-version")
 	if err != nil {
 		return errors.Wrapf(err, "Failed to exec. Perhaps -- Can't autodetect while cross compiling. (%s)", stdout)

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -198,6 +198,13 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 	// The version string is the version of _launcher_ which we don't
 	// know until we've downloaded it.
 	if p.PackageVersion == "" {
+		// We need to handle the case where we have a target version that's different from the host version and we're using autodetect
+		if p.crossCompiling {
+			if err := p.getBinary(ctx, "launcher", p.hostTarget.PlatformBinaryName("launcher"), p.LauncherVersion, p.hostTarget.PlatformBinaryName(hostLauncher), p.hostTarget); err != nil {
+				return errors.Wrapf(err, "fetching binary launcher for platform %s", p.hostTarget.Platform)
+			}
+		}
+
 		if err := p.detectLauncherVersion(ctx); err != nil {
 			return errors.Wrap(err, "version detection")
 		}

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -602,7 +602,7 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 	var launcherPath string
 
 	if p.crossCompiling {
-		launcherPath = filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName(hostLauncher))
+		launcherPath = filepath.Join(p.packageRoot, p.binDir, p.hostTarget.PlatformBinaryName(hostLauncher))
 	} else {
 		launcherPath = filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName("launcher"))
 	}

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -38,6 +38,26 @@ func TestLauncherVersionDetection(t *testing.T) {
 	require.Equal(t, "0.5.6-19-g17c8589", p.PackageVersion)
 }
 
+func TestCrossCompileLauncherVersionDetection(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var err error
+
+	p := &PackageOptions{
+		crossCompiling:true,
+		hostTarget:Target{Platform: Darwin, Package: Pkg, Init: LaunchD},
+	}
+
+	p.execCC = helperCommandContext
+
+	err = p.detectLauncherVersion(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "0.5.6-19-g17c8589", p.PackageVersion)
+}
+
 func TestExecOut(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -134,7 +154,7 @@ func TestHelperProcess(t *testing.T) {
 	case cmd == "exit":
 		n, _ := strconv.Atoi(args[0])
 		os.Exit(n)
-	case strings.HasSuffix(cmd, "launcher") && args[0] == "-version":
+	case (strings.HasSuffix(cmd, "launcher") || strings.HasSuffix(cmd, "launcher-host")) && args[0] == "-version":
 		fmt.Println(`launcher - version 0.5.6-19-g17c8589
   branch: 	master
   revision: 	17c8589f47858877bb8de3d8ab1bd095cf631a11


### PR DESCRIPTION
This PR resolves the issue noted in #418 where package version detection will fail in a scenario where a user is cross-compiling and the `package_version` isn't specified. 

This change adds a check around whether the user is cross-compiling and, if so, pulls down the host architecture's launcher to detect the launcher version to use. 