### PR TITLE
Subcommand test should bail early if no subcommand or flag is provided.

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -56,7 +56,7 @@ func main() {
 }
 
 func isSubCommand() bool {
-	if len(os.Args) != 2 {
+	if len(os.Args) == 1 {
 		return false
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the launcher will get a `panic`:
```
Feb 11 11:29:10 hostname launcher[103732]: panic: runtime error: index out of range
Feb 11 11:29:10 hostname launcher[103732]: goroutine 1 [running]:
Feb 11 11:29:10 hostname launcher[103732]: main.isSubCommand(0xa52c20)
Feb 11 11:29:10 hostname launcher[103732]:         /Users/seph/go/src/github.com/kolide/launcher/cmd/launcher/main.go:69 +0xf3
Feb 11 11:29:10 hostname launcher[103732]: main.main()
Feb 11 11:29:10 hostname launcher[103732]:         /Users/seph/go/src/github.com/kolide/launcher/cmd/launcher/main.go:23 +0x83
```
if the launcher is executed without command line args and all relevant settings being provided via ENV var.