### PR TITLE
Fix binary-bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ builder:
 	cd tools/builders/launcher-builder/1.11/ && gcloud builds submit --project=kolide-public-containers --config=cloudbuild.yml
 
 binary-bundle: VERSION = $(shell git describe --tags --always --dirty)
-binary-bundle: #xp-codesign
+binary-bundle: xp-codesign
 	rm -rf build/binary-bundle
 	$(MAKE) -j $(foreach p, darwin linux windows, build/binary-bundle/$(p))
 	cd build/binary-bundle && zip -r "launcher_${VERSION}.zip" *

--- a/tools/download-osquery.go
+++ b/tools/download-osquery.go
@@ -53,8 +53,9 @@ func main() {
 	}
 
 	if *flOutput != "" {
-		if err := fs.CopyFile(path, *flOutput); err != nil {
-			fmt.Printf("Couldn't copy file to %s: %s", *flOutput, err)
+		platformOutput := target.PlatformBinaryName(*flOutput)
+		if err := fs.CopyFile(path, platformOutput); err != nil {
+			fmt.Printf("Couldn't copy file to %s: %s", platformOutput, err)
 			os.Exit(1)
 		}
 		fmt.Println(*flOutput)


### PR DESCRIPTION
We moved a bunch of the launcher make tooling _from_ make, and into a go helper. Unfortunately, this broke the `binary-bundle` target. While not strictly required, it does help with the launcher releases. 

Update the binary-bundle target to work in the new build system