### PR TITLE
Travis-CI ands test updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,11 @@ os:
   - osx
 
 
+jobs:
+  include:
+    - stage: "Deps"
+      name: "Go"
+      script: make deps
+    - stage: "Build"
+      name: "build"
+      script: make -j 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - 1.11.x
+
+os:
+  - linux
+  - osx
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Use containers, not VMs
+sudo: false
+
+# Don't email me the results of the test runs.
+notifications:
+  email: false
+
 language: go
 
 go:
@@ -7,17 +14,10 @@ os:
   - linux
   - osx
 
-stages:
-  - Compile
-  - Test
-#  - deploy
+install:
+  - make deps
 
+script:
+   - make build
+   - make test
 
-jobs:
-  include:
-    - stage: "Compile"
-      name: "deps & build"
-      script: make deps build
-    - stage: "Test"
-      name: "test"
-      script: make deps test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,17 @@ os:
 
 stages:
   - Compile
-#  - test
+  - Test
 #  - deploy
 
 
 jobs:
   include:
     - stage: "Compile"
-      name: "Deps"
+      name: "deps"
       script: make deps
     - name: "build"
-      script: make -j 
+      script: make
+    - stage: "Test"
+      name: "test"
+      script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ stages:
 jobs:
   include:
     - stage: "Compile"
-      name: "deps"
-      script: make deps
-    - name: "build"
-      script: make
+      name: "deps & build"
+      script: make deps build
     - stage: "Test"
       name: "test"
-      script: make test
+      script: make deps test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Use containers, not VMs
 sudo: false
 
-# Don't email me the results of the test runs.
 notifications:
   email: false
 
@@ -13,6 +12,7 @@ go:
 os:
   - linux
   - osx
+  - windows
 
 install:
   - make deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ language: go
 go:
   - 1.11.x
 
+env:
+  - SKIP_TEST_MDM=true
+  
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 os:
   - linux
   - osx
-  - windows
 
 install:
   - make deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ go:
   - 1.11.x
 
 env:
-  - SKIP_TEST_MDM=true
+  global:
+    - SKIP_TEST_MDM=true
+  matrix:
+    - TRAVISTARGET=build
+    - TRAVISTARGET=test
+    - TRAVISTARGET=package-builder
   
 os:
   - linux
@@ -20,6 +25,5 @@ install:
   - make deps
 
 script:
-   - make build
-   - make test
+   - make $TRAVISTARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ stages:
 
 jobs:
   include:
-    - stage: "Compile"
+    - stage: "compile"
       name: "Deps"
       script: make deps
     - name: "build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ os:
   - osx
 
 stages:
-  - compile
+  - Compile
 #  - test
 #  - deploy
 
 
 jobs:
   include:
-    - stage: "compile"
+    - stage: "Compile"
       name: "Deps"
       script: make deps
     - name: "build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ os:
   - linux
   - osx
 
+stages:
+  - compile
+#  - test
+#  - deploy
+
 
 jobs:
   include:
-    - stage: "Deps"
-      name: "Go"
+    - stage: "Compile"
+      name: "Deps"
       script: make deps
-    - stage: "Build"
-      name: "build"
+    - name: "build"
       script: make -j 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -4,23 +4,48 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/fs"
 	"github.com/kolide/kit/testutil"
+	"github.com/kolide/launcher/pkg/packaging"
 	osquery "github.com/kolide/osquery-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var testOsqueryBinaryDirectory string
+
+// TestMain overrides the default test main function. This allows us to share setup/teardown.
+func TestMain(m *testing.M) {
+	binDirectory, rmBinDirectory, err := osqueryTempDir()
+	if err != nil {
+		fmt.Println("Failed to make temp dir for test binaries")
+		os.Exit(1)
+	}
+	defer rmBinDirectory()
+	testOsqueryBinaryDirectory = filepath.Join(binDirectory, "osqueryd")
+
+	if err := downloadOsqueryInBinDir(binDirectory); err != nil {
+		fmt.Printf("Failed to download osquery: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Run the tests!
+	retCode := m.Run()
+	os.Exit(retCode)
+}
 
 // getBinDir finds the directory of the currently running binary (where we will
 // look for the osquery extension)
@@ -58,13 +83,35 @@ func TestCreateOsqueryCommand(t *testing.T) {
 		extensionAutoloadPath: "/foo/bar/osquery.autoload",
 	}
 
-	osquerydPath, err := exec.LookPath("osqueryd")
-	require.NoError(t, err)
+	osquerydPath := testOsqueryBinaryDirectory
 
 	cmd, err := createOsquerydCommand(osquerydPath, paths, "config_plugin", "logger_plugin", "distributed_plugin", os.Stdout, os.Stderr)
 	require.NoError(t, err)
 	require.Equal(t, os.Stderr, cmd.Stderr)
 	require.Equal(t, os.Stdout, cmd.Stdout)
+}
+
+// downloadOsqueryInBinDir downloads osqueryd. This allows the test
+// suite to run on hosts lacking osqueryd. We could consider moving this into a deps step.
+func downloadOsqueryInBinDir(binDirectory string) error {
+	target := packaging.Target{}
+	if err := target.PlatformFromString(runtime.GOOS); err != nil {
+		return errors.Wrapf(err, "Error parsing platform: %s", runtime.GOOS)
+	}
+
+	outputFile := filepath.Join(binDirectory, "osqueryd") //, target.PlatformBinaryName("osqueryd"))
+	cacheDir := "/tmp"
+
+	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "stable", target)
+	if err != nil {
+		return errors.Wrap(err, "An error occurred fetching the osqueryd binary")
+	}
+
+	if err := fs.CopyFile(path, outputFile); err != nil {
+		return errors.Wrapf(err, "Couldn't copy file to %s", outputFile)
+	}
+
+	return nil
 }
 
 // buildOsqueryExtensionInBinDir compiles the osquery extension and places it
@@ -131,7 +178,10 @@ func TestSimplePath(t *testing.T) {
 	defer rmRootDirectory()
 
 	require.NoError(t, buildOsqueryExtensionInBinDir(getBinDir(t)))
-	runner, err := LaunchInstance(WithRootDirectory(rootDirectory))
+	runner, err := LaunchInstance(
+		WithRootDirectory(rootDirectory),
+		WithOsquerydBinary(testOsqueryBinaryDirectory),
+	)
 	require.NoError(t, err)
 
 	waitHealthy(t, runner)
@@ -158,7 +208,10 @@ func TestOsqueryDies(t *testing.T) {
 	defer rmRootDirectory()
 
 	require.NoError(t, buildOsqueryExtensionInBinDir(getBinDir(t)))
-	runner, err := LaunchInstance(WithRootDirectory(rootDirectory))
+	runner, err := LaunchInstance(
+		WithRootDirectory(rootDirectory),
+		WithOsquerydBinary(testOsqueryBinaryDirectory),
+	)
 	require.NoError(t, err)
 
 	waitHealthy(t, runner)
@@ -221,7 +274,11 @@ func TestExtensionSocketPath(t *testing.T) {
 
 	require.NoError(t, buildOsqueryExtensionInBinDir(getBinDir(t)))
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
-	runner, err := LaunchInstance(WithRootDirectory(rootDirectory), WithExtensionSocketPath(extensionSocketPath))
+	runner, err := LaunchInstance(
+		WithRootDirectory(rootDirectory),
+		WithExtensionSocketPath(extensionSocketPath),
+		WithOsquerydBinary(testOsqueryBinaryDirectory),
+	)
 	require.NoError(t, err)
 
 	waitHealthy(t, runner)
@@ -245,7 +302,10 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, extensionPid in
 	require.NoError(t, err)
 
 	require.NoError(t, buildOsqueryExtensionInBinDir(getBinDir(t)))
-	runner, err = LaunchInstance(WithRootDirectory(rootDirectory))
+	runner, err = LaunchInstance(
+		WithRootDirectory(rootDirectory),
+		WithOsquerydBinary(testOsqueryBinaryDirectory),
+	)
 	require.NoError(t, err)
 	waitHealthy(t, runner)
 

--- a/pkg/osquery/table/mdm_test.go
+++ b/pkg/osquery/table/mdm_test.go
@@ -5,10 +5,15 @@ package table
 import (
 	"testing"
 
+	"github.com/kolide/kit/env"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMDMProfileStatus(t *testing.T) {
+	if env.Bool("SKIP_TEST_MDM", true) {
+		t.Skip("No docker")
+	}
+
 	_, err := getMDMProfileStatus()
 	require.Nil(t, err)
 }

--- a/pkg/service/dial_test.go
+++ b/pkg/service/dial_test.go
@@ -88,17 +88,20 @@ func TestSwappingCert(t *testing.T) {
 	client := New(conn, log.NewNopLogger())
 
 	_, _, err = client.RequestEnrollment(context.Background(), "", "", EnrollmentDetails{})
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	stop()
 
 	cert, err = tls.LoadX509KeyPair(goodCert, goodKey)
 	require.Nil(t, err)
 	stop = startServer(t, &tls.Config{Certificates: []tls.Certificate{cert}})
-	time.Sleep(1 * time.Second)
+
+	// Wait for amount of time
+	timer := time.NewTimer(time.Second * 2)
+	<-timer.C
 
 	_, _, err = client.RequestEnrollment(context.Background(), "", "", EnrollmentDetails{})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	stop()
 }
@@ -107,7 +110,10 @@ func TestCertRemainsBad(t *testing.T) {
 	cert, err := tls.LoadX509KeyPair(badCert, badKey)
 	require.Nil(t, err)
 	stop := startServer(t, &tls.Config{Certificates: []tls.Certificate{cert}})
-	time.Sleep(1 * time.Second)
+
+	// Wait for amount of time
+	timer := time.NewTimer(time.Second * 2)
+	<-timer.C
 
 	pem1, err := ioutil.ReadFile(badCert)
 	require.Nil(t, err)


### PR DESCRIPTION
Some initial work to get travis-ci running. This includes updates to the make the tests more reliable, and have fewer dependancies on on the initial container setup. Travis-ci is desirable for it's multiple-platforms.

* Added travis-ci
* Updated runtime_test to download osqueryd as part of a test setup step.
* moved downloadOsqueryInBinDir to test setup and removed race conditions

This does mean that we have duplicate CI systems