### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ codesign-darwin:
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/launcher
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/osquery-extension.ext
 
-xp-codesign: xp codesign-darwin
+codesign: xp codesign-darwin
 
 package-builder: .pre-build deps
 	go run cmd/make/make.go -targets=package-builder -linkstamp
@@ -99,7 +99,7 @@ builder:
 	cd tools/builders/launcher-builder/1.11/ && gcloud builds submit --project=kolide-public-containers --config=cloudbuild.yml
 
 binary-bundle: VERSION = $(shell git describe --tags --always --dirty)
-binary-bundle: xp-codesign
+binary-bundle: codesign
 	rm -rf build/binary-bundle
 	$(MAKE) -j $(foreach p, darwin linux windows, build/binary-bundle/$(p))
 	cd build/binary-bundle && zip -r "launcher_${VERSION}.zip" *


### PR DESCRIPTION
When the `xp-%` make rule was introduced, it broke some other targets. Rename targets to fix