### PR TITLE
Merge insecureGRPC and insecureJSONRPC

### DIFF
--- a/cmd/grpc.ext/grpc.go
+++ b/cmd/grpc.ext/grpc.go
@@ -55,10 +55,10 @@ func main() {
 		enrollSecret  = env.String("KOLIDE_LAUNCHER_ENROLL_SECRET", "")
 		rootDirectory = env.String("KOLIDE_LAUNCHER_ROOT_DIRECTORY", "")
 
-		serverURL       = env.String("KOLIDE_LAUNCHER_HOSTNAME", "")
-		insecureTLS     = env.Bool("KOLIDE_LAUNCHER_INSECURE", false)
-		insecureGRPC    = env.Bool("KOLIDE_LAUNCHER_INSECURE_GRPC", false)
-		loggingInterval = env.Duration("KOLIDE_LAUNCHER_LOGGING_INTERVAL", 60*time.Second)
+		serverURL         = env.String("KOLIDE_LAUNCHER_HOSTNAME", "")
+		insecureTLS       = env.Bool("KOLIDE_LAUNCHER_INSECURE", false)
+		insecureTransport = env.Bool("KOLIDE_LAUNCHER_INSECURE_TRANSPORT", false)
+		loggingInterval   = env.Duration("KOLIDE_LAUNCHER_LOGGING_INTERVAL", 60*time.Second)
 
 		// TODO(future pr): these values are unset
 		// they'll have to be parsed from a string
@@ -68,7 +68,7 @@ func main() {
 	conn, err := service.DialGRPC(
 		serverURL,
 		insecureTLS,
-		insecureGRPC,
+		insecureTransport,
 		certPins,
 		rootPool,
 		logger,

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -34,11 +34,11 @@ func runFlare(args []string) error {
 		flHostname = flag.String("hostname", "dababe.launcher.kolide.com:443", "")
 
 		// not documented via flags on purpose
-		enrollSecret    = env.String("KOLIDE_LAUNCHER_ENROLL_SECRET", "flare_ping")
-		serverURL       = env.String("KOLIDE_LAUNCHER_HOSTNAME", *flHostname)
-		insecureTLS     = env.Bool("KOLIDE_LAUNCHER_INSECURE", false)
-		insecureGRPC    = env.Bool("KOLIDE_LAUNCHER_INSECURE_GRPC", false)
-		flareSocketPath = env.String("FLARE_SOCKET_PATH", filepath.Join(os.TempDir(), "flare.sock"))
+		enrollSecret      = env.String("KOLIDE_LAUNCHER_ENROLL_SECRET", "flare_ping")
+		serverURL         = env.String("KOLIDE_LAUNCHER_HOSTNAME", *flHostname)
+		insecureTLS       = env.Bool("KOLIDE_LAUNCHER_INSECURE", false)
+		insecureTransport = env.Bool("KOLIDE_LAUNCHER_INSECURE_TRANSPORT", false)
+		flareSocketPath   = env.String("FLARE_SOCKET_PATH", filepath.Join(os.TempDir(), "flare.sock"))
 
 		certPins [][]byte
 		rootPool *x509.CertPool
@@ -115,7 +115,7 @@ func runFlare(args []string) error {
 		logger,
 		serverURL,
 		insecureTLS,
-		insecureGRPC,
+		insecureTransport,
 		enrollSecret,
 		certPins,
 		rootPool,
@@ -259,7 +259,7 @@ func reportGRPCNetwork(
 	logger log.Logger,
 	serverURL string,
 	insecureTLS bool,
-	insecureGRPC bool,
+	insecureTransport bool,
 	enrollSecret string,
 	certPins [][]byte,
 	rootPool *x509.CertPool,
@@ -270,7 +270,7 @@ func reportGRPCNetwork(
 	conn, err := service.DialGRPC(
 		serverURL,
 		insecureTLS,
-		insecureGRPC,
+		insecureTransport,
 		certPins,
 		rootPool,
 		logger,

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -250,7 +250,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *options, logger log.L
 	{
 		switch opts.transport {
 		case "grpc":
-			grpcConn, err := service.DialGRPC(opts.kolideServerURL, opts.insecureTLS, opts.insecureGRPC, opts.certPins, rootPool, logger)
+			grpcConn, err := service.DialGRPC(opts.kolideServerURL, opts.insecureTLS, opts.insecureTransport, opts.certPins, rootPool, logger)
 			if err != nil {
 				return errors.Wrap(err, "dialing grpc server")
 			}
@@ -259,7 +259,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *options, logger log.L
 			queryTargeter := createQueryTargetUpdater(logger, db, grpcConn)
 			runGroup.Add(queryTargeter.Execute, queryTargeter.Interrupt)
 		case "jsonrpc":
-			client = service.NewJSONRPCClient(opts.kolideServerURL, opts.insecureTLS, opts.insecureJSONRPC, opts.certPins, rootPool, logger)
+			client = service.NewJSONRPCClient(opts.kolideServerURL, opts.insecureTLS, opts.insecureTransport, opts.certPins, rootPool, logger)
 		default:
 			return errors.New("invalid transport option selected")
 		}

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -37,8 +37,7 @@ type options struct {
 	debug              bool
 	disableControlTLS  bool
 	insecureTLS        bool
-	insecureGRPC       bool
-	insecureJSONRPC    bool
+	insecureTransport  bool
 	notaryServerURL    string
 	mirrorServerURL    string
 	autoupdateInterval time.Duration
@@ -85,8 +84,7 @@ func parseOptions(args []string) (*options, error) {
 		flDebug             = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
 		flDeveloperUsage    = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options")
 		flDisableControlTLS = flagset.Bool("disable_control_tls", false, "Disable TLS encryption for the control features")
-		flInsecureGRPC      = flagset.Bool("insecure_grpc", false, "Dial GRPC without a TLS config (default: false)")
-		flInsecureJSONRPC   = flagset.Bool("insecure_jsonrpc", false, "Use JSONPRC without a tls config (default: false)")
+		flInsecureTransport = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
 		flInsecureTLS       = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
 	)
 	ff.Parse(flagset, args,
@@ -160,8 +158,7 @@ func parseOptions(args []string) (*options, error) {
 		debug:               *flDebug,
 		disableControlTLS:   *flDisableControlTLS,
 		insecureTLS:         *flInsecureTLS,
-		insecureGRPC:        *flInsecureGRPC,
-		insecureJSONRPC:     *flInsecureJSONRPC,
+		insecureTransport:   *flInsecureTransport,
 		notaryServerURL:     *flNotaryServerURL,
 		mirrorServerURL:     *flMirrorURL,
 		autoupdateInterval:  *flAutoupdateInterval,

--- a/pkg/service/client_grpc.go
+++ b/pkg/service/client_grpc.go
@@ -102,7 +102,7 @@ func NewGRPCClient(conn *grpc.ClientConn, logger log.Logger) KolideService {
 func DialGRPC(
 	serverURL string,
 	insecureTLS bool,
-	insecureGRPC bool,
+	insecureTransport bool,
 	certPins [][]byte,
 	rootPool *x509.CertPool,
 	logger log.Logger,
@@ -112,13 +112,13 @@ func DialGRPC(
 		"msg", "dialing grpc server",
 		"server", serverURL,
 		"tls_secure", insecureTLS == false,
-		"grpc_secure", insecureGRPC == false,
+		"transport_secure", insecureTransport == false,
 		"cert_pinning", len(certPins) > 0,
 	)
 	grpcOpts := []grpc.DialOption{
 		grpc.WithTimeout(time.Second),
 	}
-	if insecureGRPC {
+	if insecureTransport {
 		grpcOpts = append(grpcOpts, grpc.WithInsecure())
 	} else {
 		host, _, err := net.SplitHostPort(serverURL)

--- a/pkg/service/client_jsonrpc.go
+++ b/pkg/service/client_jsonrpc.go
@@ -43,7 +43,7 @@ func forceNoChunkedEncoding(ctx context.Context, r *http.Request) context.Contex
 func NewJSONRPCClient(
 	serverURL string,
 	insecureTLS bool,
-	insecureJSONRPC bool,
+	insecureTransport bool,
 	certPins [][]byte,
 	rootPool *x509.CertPool,
 	logger log.Logger,
@@ -53,7 +53,7 @@ func NewJSONRPCClient(
 		Host:   serverURL,
 	}
 
-	if insecureJSONRPC {
+	if insecureTransport {
 		serviceURL.Scheme = "http"
 	}
 
@@ -63,7 +63,7 @@ func NewJSONRPCClient(
 			DisableKeepAlives: true,
 		},
 	}
-	if !insecureJSONRPC {
+	if !insecureTransport {
 		tlsConfig := makeTLSConfig(serverURL, insecureTLS, certPins, rootPool, logger)
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig:   tlsConfig,


### PR DESCRIPTION
Create insecureTransport as a unification of insecureGRPC and insecureJSONRPC.

These options are meaningless to split, and this way has less to get tangled up with.