### PR TITLE
Add build tags to the version string

### DIFF
--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -396,6 +396,8 @@ func (b *Builder) BuildCmd(src, output string) func(context.Context) error {
 				return err
 			}
 
+			taggedVersion := strings.Join([]string{v, buildTagFS()}, "")
+
 			branch, err := b.execOut(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
 			if err != nil {
 				return err
@@ -412,7 +414,7 @@ func (b *Builder) BuildCmd(src, output string) func(context.Context) error {
 			}
 
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.appName=%s"`, appName))
-			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.version=%s"`, v))
+			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.version=%s"`, taggedVersion))
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.branch=%s"`, branch))
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.revision=%s"`, revision))
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.buildDate=%s"`, time.Now().UTC().Format("2006-01-02")))

--- a/pkg/make/tagfs.go
+++ b/pkg/make/tagfs.go
@@ -1,0 +1,7 @@
+// +build !fakeserial
+
+package make
+
+func buildTagFS() string {
+	return ""
+}

--- a/pkg/make/tagfs_fakeserial.go
+++ b/pkg/make/tagfs_fakeserial.go
@@ -1,0 +1,7 @@
+// +build fakeserial
+
+package make
+
+func buildTagFS() string {
+	return "-fakeserial"
+}


### PR DESCRIPTION
When running with a fake serial number, also emit that in the version.