### PR TITLE
Add go-based platform info to the initial enrollment (and fix bugs)

### DIFF
--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -3,9 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/kolide/kit/logutil"
+	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/osquery/table"
 	osquery "github.com/kolide/osquery-go"
 )
@@ -15,9 +17,16 @@ func main() {
 		flSocketPath = flag.String("socket", "", "")
 		flTimeout    = flag.Int("timeout", 0, "")
 		flVerbose    = flag.Bool("verbose", false, "")
+		flVersion    = flag.Bool("version", false, "Print  version and exit")
 		_            = flag.Int("interval", 0, "")
 	)
 	flag.Parse()
+
+	if *flVersion {
+		version.PrintFull()
+		os.Exit(0)
+	}
+
 	logger := logutil.NewServerLogger(*flVerbose)
 
 	timeout := time.Duration(*flTimeout) * time.Second

--- a/cmd/make/make.go
+++ b/cmd/make/make.go
@@ -26,6 +26,7 @@ func main() {
 		flRace         = flag.Bool("race", false, "Build race-detector version of binaries.")
 		flStatic       = flag.Bool("static", false, "Build a static binary.")
 		flStampVersion = flag.Bool("linkstamp", false, "Add version info with ldflags.")
+		flFakeData     = flag.Bool("fakedata", false, "Compile with build tags to falsify some data, like serial numbers")
 	)
 	flag.Parse()
 
@@ -45,6 +46,9 @@ func main() {
 	}
 	if *flStampVersion {
 		opts = append(opts, make.WithStampVersion())
+	}
+	if *flFakeData {
+		opts = append(opts, make.WithFakeData())
 	}
 
 	b, err := make.New(opts...)

--- a/cmd/osquery-extension/osquery-extension.go
+++ b/cmd/osquery-extension/osquery-extension.go
@@ -6,14 +6,24 @@ import (
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/kolide/kit/version"
 )
 
 func main() {
-	flag.String("socket", "", "")
-	flag.Int("timeout", 0, "")
-	flag.Int("interval", 0, "")
-	flag.Bool("verbose", false, "")
+	var (
+		_         = flag.Bool("verbose", false, "")
+		_         = flag.Int("interval", 0, "")
+		_         = flag.Int("timeout", 0, "")
+		_         = flag.String("socket", "", "")
+		flVersion = flag.Bool("version", false, "Print  version and exit")
+	)
 	flag.Parse()
+
+	if *flVersion {
+		version.PrintFull()
+		os.Exit(0)
+	}
 
 	fmt.Fprintf(os.Stderr, "%+v", os.Args)
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.3 // indirect
 	github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/alexkohler/nakedret v0.0.0-20171106223215-c0e305a4f690
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
@@ -17,6 +18,7 @@ require (
 	github.com/bugsnag/bugsnag-go v1.3.2 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
+	github.com/client9/misspell v0.3.4
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f // indirect
@@ -57,6 +59,7 @@ require (
 	github.com/spf13/viper v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/theupdateframework/notary v0.0.0-20180129185925-f234167994cf
+	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9
 	go.opencensus.io v0.18.0
 	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea/go.mod h1:N5eJIl14
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alexkohler/nakedret v0.0.0-20171106223215-c0e305a4f690 h1:+tfdYWf4oDrj9c0/77f5oDBxZT2EPjS1AJf+PApGNCk=
+github.com/alexkohler/nakedret v0.0.0-20171106223215-c0e305a4f690/go.mod h1:tfDQbtPt67HhBK/6P0yNktIX7peCxfOp0jO9007DrLE=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
@@ -38,6 +40,8 @@ github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABF
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7 h1:ROpiky+uT1fstFCMZCka5Cr9GmtpTakLMmvwFsVOtJA=
 github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -61,7 +65,6 @@ github.com/go-bindata/go-bindata v1.0.0 h1:DZ34txDXWn1DyWa+vQf7V9ANc2ILTtrEjtlsd
 github.com/go-bindata/go-bindata v1.0.0/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-kit/kit v0.7.0 h1:ApufNmWF1H6/wUbAG81hZOHmqwd0zRf8mNfLjYj/064=
 github.com/go-kit/kit v0.7.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2ic=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
@@ -193,6 +196,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/theupdateframework/notary v0.0.0-20180129185925-f234167994cf h1:AB7+4nZZKV5rmU0zVm0njznX8fyGlH0SrK3sc3e8Ap4=
 github.com/theupdateframework/notary v0.0.0-20180129185925-f234167994cf/go.mod h1:MOfgIfmox8s7/7fduvB2xyPPMJCrjRLRizA8OFwpnKY=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 h1:vY5WqiEon0ZSTGM3ayVVi+twaHKHDFUVloaQ/wug9/c=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=

--- a/pkg/make/tagfs.go
+++ b/pkg/make/tagfs.go
@@ -1,7 +1,0 @@
-// +build !fakeserial
-
-package make
-
-func buildTagFS() string {
-	return ""
-}

--- a/pkg/make/tagfs_fakeserial.go
+++ b/pkg/make/tagfs_fakeserial.go
@@ -1,7 +1,0 @@
-// +build fakeserial
-
-package make
-
-func buildTagFS() string {
-	return "-fakeserial"
-}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -325,11 +325,14 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 
 	// We've seen this fail, so add some retry logic.
 	var enrollDetails service.EnrollmentDetails
-	backoff := backoff.New(backoff.MaxAttempts(5))
-	backoff.Run(func() error {
+	backoff := backoff.New(backoff.MaxAttempts(10))
+	if err := backoff.Run(func() error {
 		enrollDetails, err = getEnrollDetails(e.osqueryClient)
 		return err
-	})
+	}); err != nil {
+		return "", true, errors.Wrap(err, "query enrollment details, (even with retries)")
+	}
+
 
 	// If no cached node key, enroll for new node key
 	// note that we set invalid two ways. Via the return, _or_ via isNodeInvaliderr

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -804,9 +804,7 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 		system_info.hardware_model,
 		system_info.hardware_serial,
 		system_info.hardware_vendor,
-		system_info.hostname,
-		kolide_launcher_info.goos,
-		kolide_launcher_info.goarch
+		system_info.hostname
 	FROM
 		os_version,
 		system_info,
@@ -850,13 +848,6 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	if val, ok := resp[0]["hostname"]; ok {
 		details.Hostname = val
 	}
-	if val, ok := resp[0]["goos"]; ok {
-		details.GOOS = val
-	}
-	if val, ok := resp[0]["goarch"]; ok {
-		details.GOARCH = val
-	}
-
 	spew.Dump("seph")
 	spew.Dump(details)
 

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -6,11 +6,13 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/boltdb/bolt"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
@@ -852,9 +854,16 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 		details.GOARCH = val
 	}
 
-	// Using the version field from the binary.
-	// The extension uses the same value to build the table, but the query runs before the extension tables are registered.
+	spew.Dump("seph")
+	spew.Dump(details)
+
+	// This runs before the extensions are registered. These mirror the
+	// underlying tables.
 	details.LauncherVersion = version.Version().Version
+	details.GOOS = runtime.GOOS
+	details.GOARCH = runtime.GOARCH
+
+	spew.Dump(details)
 
 	return details, nil
 }

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/boltdb/bolt"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
@@ -332,7 +331,6 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	}); err != nil {
 		return "", true, errors.Wrap(err, "query enrollment details, (even with retries)")
 	}
-
 
 	// If no cached node key, enroll for new node key
 	// note that we set invalid two ways. Via the return, _or_ via isNodeInvaliderr
@@ -793,6 +791,7 @@ func (e *Extension) writeResultsWithReenroll(ctx context.Context, results []dist
 }
 
 func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
+	fmt.Println("seph 1")
 	query := `
 	SELECT
 		osquery_info.version as osquery_version,
@@ -813,8 +812,11 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	var details service.EnrollmentDetails
 	resp, err := client.Query(query)
 	if err != nil {
+		fmt.Println("seph fail 1")
 		return details, errors.Wrap(err, "query enrollment details")
 	}
+
+	fmt.Println("seph 2")
 
 	if len(resp) < 1 {
 		return details, errors.New("expected at least one row from the enrollment details query")
@@ -848,16 +850,12 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	if val, ok := resp[0]["hostname"]; ok {
 		details.Hostname = val
 	}
-	spew.Dump("seph")
-	spew.Dump(details)
 
 	// This runs before the extensions are registered. These mirror the
 	// underlying tables.
 	details.LauncherVersion = version.Version().Version
 	details.GOOS = runtime.GOOS
 	details.GOARCH = runtime.GOARCH
-
-	spew.Dump(details)
 
 	return details, nil
 }

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -799,7 +799,9 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 		system_info.hardware_model,
 		system_info.hardware_serial,
 		system_info.hardware_vendor,
-		system_info.hostname
+		system_info.hostname,
+		kolide_launcher_info.goos,
+		kolide_launcher_info.goarch
 	FROM
 		os_version,
 		system_info,
@@ -842,6 +844,12 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	}
 	if val, ok := resp[0]["hostname"]; ok {
 		details.Hostname = val
+	}
+	if val, ok := resp[0]["goos"]; ok {
+		details.GOOS = val
+	}
+	if val, ok := resp[0]["goarch"]; ok {
+		details.GOARCH = val
 	}
 
 	// Using the version field from the binary.

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -428,7 +428,7 @@ func (e *Extension) generateConfigsWithReenroll(ctx context.Context, reenroll bo
 		}
 
 		if !reenroll {
-			return "", errors.New("enrollment invalid, reenroll disabled")
+			return "", errors.Wrap(err, "enrollment invalid, reenroll disabled")
 		}
 
 		e.RequireReenroll(ctx)
@@ -791,7 +791,6 @@ func (e *Extension) writeResultsWithReenroll(ctx context.Context, results []dist
 }
 
 func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
-	fmt.Println("seph 1")
 	query := `
 	SELECT
 		osquery_info.version as osquery_version,
@@ -812,11 +811,8 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	var details service.EnrollmentDetails
 	resp, err := client.Query(query)
 	if err != nil {
-		fmt.Println("seph fail 1")
 		return details, errors.Wrap(err, "query enrollment details")
 	}
-
-	fmt.Println("seph 2")
 
 	if len(resp) < 1 {
 		return details, errors.New("expected at least one row from the enrollment details query")

--- a/pkg/osquery/extension_serial_fakeserial.go
+++ b/pkg/osquery/extension_serial_fakeserial.go
@@ -4,6 +4,8 @@ package osquery
 
 import "github.com/kolide/kit/ulid"
 
+var fakeSerialNumber = ulid.New()
+
 func serialForRow(row map[string]string) string {
-	return ulid.New()
+	return fakeSerialNumber
 }

--- a/pkg/osquery/table/launcher_info.go
+++ b/pkg/osquery/table/launcher_info.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/kolide/kit/version"
 	"github.com/kolide/osquery-go/plugin/table"
@@ -15,6 +16,8 @@ func LauncherInfoTable() *table.Plugin {
 		table.TextColumn("revision"),
 		table.TextColumn("build_date"),
 		table.TextColumn("build_user"),
+		table.TextColumn("goos"),
+		table.TextColumn("goarch"),
 	}
 	return table.NewPlugin("kolide_launcher_info", columns, generateLauncherInfoTable())
 }
@@ -29,6 +32,8 @@ func generateLauncherInfoTable() table.GenerateFunc {
 				"revision":   version.Version().Revision,
 				"build_date": version.Version().BuildDate,
 				"build_user": version.Version().BuildUser,
+				"goos":       runtime.GOOS,
+				"goarch":     runtime.GOARCH,
 			},
 		}
 

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -12,5 +12,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 	return []*table.Plugin{
 		BestPractices(client),
 		EmailAddresses(client, logger),
+		LauncherInfoTable(),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -22,6 +22,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		GDriveSyncConfig(client, logger),
 		GDriveSyncHistoryInfo(client, logger),
 		KolideVulnerabilities(client, logger),
+		LauncherInfoTable(),
 		MachoInfo(),
 		MacOSUpdate(client),
 		MDMInfo(logger),

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -12,7 +12,6 @@ func LauncherTables(db *bolt.DB) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		LauncherConfigTable(db),
 		LauncherIdentifierTable(db),
-		LauncherInfoTable(),
 		TargetMembershipTable(db),
 	}
 }

--- a/pkg/service/request_enrollment.go
+++ b/pkg/service/request_enrollment.go
@@ -32,6 +32,8 @@ type EnrollmentDetails struct {
 	LauncherVersion string `json:"launcher_version"`
 	OSName          string `json:"os_name"`
 	OSPlatformLike  string `json:"os_platform_like"`
+	GOOS            string `json:"goos"`
+	GOARCH          string `json:"goarch"`
 }
 
 type enrollmentResponse struct {


### PR DESCRIPTION
A motley assortment of small fixes as I get this enrolling:
* Plumb build tags through make.go, to allow for fake data. Fix the version string appending.
* Add some go based platform indicators to kolide_launcher_info, as well as to the initial enrollment.
* Move kolide_launcher_info to being in both launcher, and tables.ext
* Fix error handling on the call to `getEnrollDetails`
* Attempt to fix suspected flakey test after https://github.com/kolide/launcher/pull/342