### PR TITLE
Windows is picky about characters in service names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/peterbourgon/ff v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2 // indirect
+	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/viper v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 h1:ofR1ZdrNSkiWcMsRrubK9tb2/SlZVWttAfqUjJi6QYc=
+github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/serenize/snaker"
 )
 
 // http://wixtoolset.org/documentation/manual/v3/xsd/wix/serviceinstall.html
@@ -127,7 +128,16 @@ func ServiceArgs(args []string) ServiceOpt {
 
 // New returns a service
 func NewService(matchString string, opts ...ServiceOpt) *Service {
-	defaultName := strings.TrimSuffix(matchString, ".exe") + "Svc"
+	// Windows seems a bit fussy about allowable characters. So, we'll
+	// replace some obvious ones, and snake case the whole thing.
+	r := strings.NewReplacer(
+		"-", "_",
+		" ", "_",
+		".", "_",
+	)
+
+	snakeName := r.Replace(strings.TrimSuffix(matchString, ".exe") + "_svc")
+	defaultName := snaker.SnakeToCamel(snakeName)
 
 	si := &ServiceInstall{
 		Name:         defaultName,

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -26,8 +26,8 @@ func TestService(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, expectTrue2)
 
-	expectedXml := `<ServiceInstall Account="NT AUTHORITY\SYSTEM" ErrorControl="normal" Id="daemonSvc" Name="daemonSvc" Start="auto" Type="ownProcess" Vital="yes"></ServiceInstall>
-                    <ServiceControl Name="daemonSvc" Id="daemonSvc" Remove="uninstall" Start="install" Stop="both" Wait="no"></ServiceControl>`
+	expectedXml := `<ServiceInstall Account="NT AUTHORITY\SYSTEM" ErrorControl="normal" Id="DaemonSvc" Name="DaemonSvc" Start="auto" Type="ownProcess" Vital="yes"></ServiceInstall>
+                    <ServiceControl Name="DaemonSvc" Id="DaemonSvc" Remove="uninstall" Start="install" Stop="both" Wait="no"></ServiceControl>`
 
 	var xmlString bytes.Buffer
 
@@ -44,6 +44,11 @@ func TestServiceOptions(t *testing.T) {
 		in  *Service
 		out string
 	}{
+		{
+			in: NewService("my.daemon-is_Great snakeCase.exe"),
+			out: `<ServiceInstall Account="NT AUTHORITY\SYSTEM" ErrorControl="normal" Id="MyDaemonIsGreatSnakeCaseSvc" Name="MyDaemonIsGreatSnakeCaseSvc" Start="auto" Type="ownProcess" Vital="yes"></ServiceInstall>
+                    <ServiceControl Name="MyDaemonIsGreatSnakeCaseSvc" Id="MyDaemonIsGreatSnakeCaseSvc" Remove="uninstall" Start="install" Stop="both" Wait="no"></ServiceControl>`,
+		},
 		{
 			in: NewService("daemon.exe", ServiceName("myDaemon")),
 			out: `<ServiceInstall Account="NT AUTHORITY\SYSTEM" ErrorControl="normal" Id="myDaemon" Name="myDaemon" Start="auto" Type="ownProcess" Vital="yes"></ServiceInstall>


### PR DESCRIPTION
Problem: Windows is picky about characters in service names. We often include hyphens (ie: `kolide-app`) and this causes packaging errors.

Solution: replace those with _, and then camel case it all. We use snaker elsewhere in Kolide. So, import it.