### PR TITLE
prepend fake serial numbers with fake

### DIFF
--- a/pkg/osquery/extension_serial_fakeserial.go
+++ b/pkg/osquery/extension_serial_fakeserial.go
@@ -2,9 +2,13 @@
 
 package osquery
 
-import "github.com/kolide/kit/ulid"
+import (
+	"fmt"
 
-var fakeSerialNumber = ulid.New()
+	"github.com/kolide/kit/ulid"
+)
+
+var fakeSerialNumber = fmt.Sprintf("fake%s", ulid.New())
 
 func serialForRow(row map[string]string) string {
 	return fakeSerialNumber


### PR DESCRIPTION
Not much to say. Prepend "fake" so it's easier to visually scan for it