### PR TITLE
Small Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ binary-bundle: codesign
 	rm -rf build/binary-bundle
 	$(MAKE) -j $(foreach p, darwin linux windows, build/binary-bundle/$(p))
 	cd build/binary-bundle && zip -r "launcher_${VERSION}.zip" *
-	cp build/binary-bundle/launcher_${VERSION}.zip build/binary-bundle/launcher_latest.zip
 
 build/binary-bundle/%:
 	mkdir -p $@

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -94,11 +94,6 @@ func runMake(args []string) error {
 			env.String("UPDATE_CHANNEL", ""),
 			"the value that should be used when invoking the launcher's --update_channel flag",
 		)
-		flControl = flagset.Bool(
-			"control",
-			env.Bool("CONTROL", false),
-			"whether or not the launcher packages should invoke the launcher's --control flag",
-		)
 		flControlHostname = flagset.String(
 			"control_hostname",
 			env.String("CONTROL_HOSTNAME", ""),
@@ -204,7 +199,6 @@ func runMake(args []string) error {
 		InsecureTransport: *flInsecureTransport,
 		Autoupdate:        *flAutoupdate,
 		UpdateChannel:     *flUpdateChannel,
-		Control:           *flControl,
 		InitialRunner:     *flInitialRunner,
 		ControlHostname:   *flControlHostname,
 		DisableControlTLS: *flDisableControlTLS,

--- a/pkg/packagekit/package_pkg.go
+++ b/pkg/packagekit/package_pkg.go
@@ -54,7 +54,7 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
 
 	level.Debug(logger).Log(
 		"msg", "Running pkbuild",
-		"args", args,
+		"args", fmt.Sprintf("%v", args),
 	)
 
 	cmd := exec.CommandContext(ctx, "pkgbuild", args...)

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -16,7 +16,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-//go:generate go-bindata   -nocompress -pkg internal -o internal/assets.go internal/assets/
+//go:generate go-bindata -nometadata -nocompress -pkg internal -o internal/assets.go internal/assets/
 
 func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, includeService bool) error {
 	ctx, span := trace.StartSpan(ctx, "packagekit.PackageWixMSI")

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -38,7 +38,6 @@ type PackageOptions struct {
 	InsecureTransport bool
 	Autoupdate        bool
 	UpdateChannel     string
-	Control           bool
 	InitialRunner     bool
 	ControlHostname   string
 	DisableControlTLS bool
@@ -113,8 +112,9 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 		launcherBoolFlags = append(launcherBoolFlags, "with_initial_runner")
 	}
 
-	if p.Control && p.ControlHostname != "" {
+	if p.ControlHostname != "" {
 		launcherMapFlags["control_hostname"] = p.ControlHostname
+		launcherBoolFlags = append(launcherBoolFlags, "control")
 	}
 
 	if p.Autoupdate && p.UpdateChannel != "" {


### PR DESCRIPTION
Update the packaging tools to _remove_ the `Control` option. It is now inferred by the `ControlHostname` option. These are always linked, and this removes the redundancy.

Fix a log line

Generated bin-data should not include metadata, so it doesn't change every `make deps` invocation

