### PR TITLE
Add onepassword accounts table

### DIFF
--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -31,6 +31,7 @@ func OnePasswordAccounts(client *osquery.ExtensionManagerClient, logger log.Logg
 		table.TextColumn("username"),
 		table.TextColumn("user_email"),
 		table.TextColumn("team_name"),
+		table.TextColumn("server"),
 		table.TextColumn("user_first_name"),
 		table.TextColumn("user_last_name"),
 		table.TextColumn("account_type"),
@@ -69,9 +70,7 @@ func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo
 	}
 	defer db.Close()
 
-	db.Exec("PRAGMA journal_mode=WAL;")
-
-	rows, err := db.Query("SELECT user_email, team_name, user_first_name, user_last_name, account_type FROM accounts")
+	rows, err := db.Query("SELECT user_email, team_name, server, user_first_name, user_last_name, account_type FROM accounts")
 	if err != nil {
 		return nil, errors.Wrap(err, "query rows from onepassword account configuration db")
 	}
@@ -79,14 +78,15 @@ func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo
 
 	var results []map[string]string
 	for rows.Next() {
-		var email, team, firstName, lastName, accountType string
-		if err := rows.Scan(&email, &team, &firstName, &lastName, &accountType); err != nil {
+		var email, team, server, firstName, lastName, accountType string
+		if err := rows.Scan(&email, &team, &server, &firstName, &lastName, &accountType); err != nil {
 			return nil, errors.Wrap(err, "scanning onepassword account configuration db row")
 		}
 		results = append(results, map[string]string{
 			"user_email":      email,
 			"username":        fileInfo.user,
 			"team_name":       team,
+			"server":          server,
 			"user_first_name": firstName,
 			"user_last_name":  lastName,
 			"account_type":    accountType,

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -15,6 +15,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		ChromeUserProfiles(client, logger),
 		EmailAddresses(client, logger),
 		LauncherInfoTable(),
+		OnePasswordAccounts(client, logger),
 		SlackConfig(client, logger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -31,6 +31,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		MDMInfo(logger),
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
+		OnePasswordAccounts(client, logger),
 		SlackConfig(client, logger),
 		Spotlight(),
 		UserAvatar(logger),


### PR DESCRIPTION
This PR adds a new virtual table kolide_onepassword_accounts which returns 1Password account information collected from 

macOS
```
/Users/username/Library/Application Support/1Password 4/Data/B5.sqlite
/Users/username/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Data/B5.sqlite
/Users/username/Library/Containers/2BUA8C4S2C.com.agilebits.onepassword-osx-helper/Data/Library/Data/B5.sqlite
```
Windows 10
```
/Users/username/AppData/Local/1password/data/1Password10.sqlite
```

**Example output:**
```
select * from kolide_onepassword_accounts;
+----------+--------------------------------+-----------+-----------------+----------------+--------------+
| username | user_email                     | team_name | user_first_name | user_last_name | account_type |
+----------+--------------------------------+-----------+-----------------+----------------+--------------+
| nogueira | nogueira@example.com           | Example   | Jonathan        | Nogueira       | B            |
| nogueira | jonathan@example.com           | Jonathan  | Jonathan        |                | I            |
+----------+--------------------------------+-----------+-----------------+----------------+--------------+
```

**Limitations:**
No support for Linux/1Password X. 1Password X uses the browsers LocalStorage. This Table could be improved by finding a way to parsing the Browsers Local Storage.
