### PR TITLE
Add slack config table

### DIFF
--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -14,5 +14,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		ChromeLoginDataEmails(client, logger),
 		EmailAddresses(client, logger),
 		LauncherInfoTable(),
+		SlackConfig(client, logger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -30,6 +30,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		MDMInfo(logger),
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
+		SlackConfig(client, logger),
 		Spotlight(),
 		UserAvatar(logger),
 		legacyexec.TablePlugin(),

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -17,7 +17,7 @@ import (
 
 var slackConfigDirs = map[string][]string{
 	"windows": []string{"AppData/Roaming/Slack/storage"},
-	"darwin":  []string{"/Library/Application Support/Slack/storage"},
+	"darwin":  []string{"Library/Application Support/Slack/storage"},
 }
 var slackConfigDirDefault = []string{".config/Slack/storage/"}
 

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -19,6 +19,7 @@ var slackConfigDirs = map[string][]string{
 	"windows": []string{"AppData/Roaming/Slack/storage"},
 	"darwin":  []string{"Library/Application Support/Slack/storage"},
 }
+// try the list of known linux paths if runtime.GOOS doesn't match 'darwin' or 'windows'
 var slackConfigDirDefault = []string{".config/Slack/storage/"}
 
 func SlackConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -106,6 +106,7 @@ func (t *SlackConfigTable) generate(ctx context.Context, queryContext table.Quer
 					"path", file.path,
 					"err", err,
 				)
+				continue
 			}
 			results = append(results, res...)
 		}

--- a/pkg/osquery/table/table_util.go
+++ b/pkg/osquery/table/table_util.go
@@ -113,3 +113,10 @@ func findFileInUserDirs(pattern string, logger log.Logger, opts ...FindFileOpt) 
 	}
 	return foundPaths, nil
 }
+
+func btoi(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This Commit: 
- added a new table kolide_slack_config

The new table requires a team_id constraint to be part of the query
```
select * from kolide_slack_config where team_id='T08V7PM9C';
+-----------+-----------+----------------------------+-----------+-------------+-----------+
| team_id   | team_name | team_url                   | logged_in | user_handle | user_id   |
+-----------+-----------+----------------------------+-----------+-------------+-----------+
| T08V7PM9C | osquery   | https://osquery.slack.com/ | 1         | jonathan    | 000000000 |
+-----------+-----------+----------------------------+-----------+-------------+-----------+
```