### PR TITLE
Update to windows service names

### DIFF
--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -68,7 +68,7 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 
 	if includeService {
 		launcherService := wix.NewService("launcher.exe",
-			wix.ServiceName(fmt.Sprintf("KolideLauncher%sSvc", strings.Title(po.Identifier))),
+			wix.ServiceName(fmt.Sprintf("Launcher%sSvc", strings.Title(po.Identifier))),
 			wix.ServiceArgs([]string{"svc", "-config", po.FlagFile}),
 			wix.ServiceDescription(fmt.Sprintf("The Kolide Launcher (%s)", po.Identifier)),
 		)

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -110,10 +110,10 @@ type ServiceOpt func(*Service)
 
 func ServiceName(name string) ServiceOpt {
 	return func(s *Service) {
-		s.serviceControl.Id = name
-		s.serviceControl.Name = name
-		s.serviceInstall.Id = name
-		s.serviceInstall.Name = name
+		s.serviceControl.Id = cleanServiceName(name)
+		s.serviceControl.Name = cleanServiceName(name)
+		s.serviceInstall.Id = cleanServiceName(name)
+		s.serviceInstall.Name = cleanServiceName(name)
 	}
 }
 
@@ -149,17 +149,6 @@ func ServiceArgs(args []string) ServiceOpt {
 
 // New returns a service
 func NewService(matchString string, opts ...ServiceOpt) *Service {
-	// Windows seems a bit fussy about allowable characters. So, we'll
-	// replace some obvious ones, and snake case the whole thing.
-	r := strings.NewReplacer(
-		"-", "_",
-		" ", "_",
-		".", "_",
-	)
-
-	snakeName := r.Replace(strings.TrimSuffix(matchString, ".exe") + "_svc")
-	defaultName := snaker.SnakeToCamel(snakeName)
-
 	// Set some defaults. It's not clear we can reset in under a
 	// day. See https://github.com/wixtoolset/issues/issues/5963
 	sconfig := &ServiceConfig{
@@ -171,8 +160,8 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 	}
 
 	si := &ServiceInstall{
-		Name:          defaultName,
-		Id:            defaultName,
+		Name:          cleanServiceName(matchString),
+		Id:            cleanServiceName(matchString),
 		Account:       `NT AUTHORITY\SYSTEM`,
 		Start:         StartAuto,
 		Type:          "ownProcess",
@@ -182,8 +171,8 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 	}
 
 	sc := &ServiceControl{
-		Name:   defaultName,
-		Id:     defaultName,
+		Name:   cleanServiceName(matchString),
+		Id:     cleanServiceName(matchString),
 		Stop:   InstallUninstallBoth,
 		Start:  InstallUninstallInstall,
 		Remove: InstallUninstallUninstall,
@@ -240,4 +229,19 @@ func (s *Service) Xml(w io.Writer) error {
 
 	return nil
 
+}
+
+// cleanServiceName removes characters windows doesn't like in
+// services names, and converts everything to snake case.
+func cleanServiceName(in string) string {
+	r := strings.NewReplacer(
+		"-", "_",
+		" ", "_",
+		".", "_",
+	)
+
+	snakeName := r.Replace(strings.TrimSuffix(in, ".exe") + "_svc")
+	defaultName := snaker.SnakeToCamel(snakeName)
+
+	return defaultName
 }

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -232,7 +232,7 @@ func (s *Service) Xml(w io.Writer) error {
 }
 
 // cleanServiceName removes characters windows doesn't like in
-// services names, and converts everything to snake case.
+// services names, and converts everything to camel case.
 func cleanServiceName(in string) string {
 	r := strings.NewReplacer(
 		"-", "_",
@@ -241,7 +241,5 @@ func cleanServiceName(in string) string {
 	)
 
 	snakeName := r.Replace(strings.TrimSuffix(in, ".exe") + "_svc")
-	defaultName := snaker.SnakeToCamel(snakeName)
-
-	return defaultName
+	return snaker.SnakeToCamel(snakeName)
 }

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -46,25 +46,37 @@ func TestServiceOptions(t *testing.T) {
 		out []string
 	}{
 		{
+			in:  NewService("snake-case.exe"),
+			out: []string{`Id="SnakeCaseSvc"`, `Name="SnakeCaseSvc"`},
+		},
+		{
+			in:  NewService("snake-case.exe", ServiceName("Another-Case-Of-snakes")),
+			out: []string{`Id="AnotherCaseOfSnakesSvc"`, `Name="AnotherCaseOfSnakesSvc"`},
+		},
+		{
+			in:  NewService("daemon.exe"),
+			out: []string{`Id="DaemonSvc"`, `Name="DaemonSvc"`},
+		},
+		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon")),
-			out: []string{`Id="myDaemon"`, `Name="myDaemon"`},
+			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`},
 		},
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first"})),
-			out: []string{`Id="myDaemon"`, `Name="myDaemon"`, `Arguments="first"`},
+			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first"`},
 		},
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first with spaces"})),
-			out: []string{`Id="myDaemon"`, `Name="myDaemon"`, `Arguments="&#34;first with spaces&#34;"`},
+			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="&#34;first with spaces&#34;"`},
 		},
 
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first", "second"})),
-			out: []string{`Id="myDaemon"`, `Name="myDaemon"`, `Arguments="first second"`},
+			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first second"`},
 		},
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first", "second", "third has spaces"})),
-			out: []string{`Id="myDaemon"`, `Name="myDaemon"`, `Arguments="first second &#34;third has spaces&#34;"`},
+			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first second &#34;third has spaces&#34;"`},
 		},
 	}
 


### PR DESCRIPTION
In https://github.com/kolide/launcher/pull/442 I updated the logic to strip out some characters. But, that’s in the wrong place. It needs to remove them from both the inferred `defaultName`, but also from a specified `ServiceName`. At least, probably… We might argue that if one specifies a bad service name, we shouldn’t correct it and instead through an error. However, correcting it here, allows the identifier to be set consistently across all platforms and modified in the narrow place it’s needed.