### PR TITLE
Allow windows control options

### DIFF
--- a/cmd/launcher/control_windows.go
+++ b/cmd/launcher/control_windows.go
@@ -7,10 +7,14 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/actor"
-	"github.com/pkg/errors"
 )
 
+// createControl creates a no-op actor, as the control server isn't
+// yet supported on windows.
 func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *options) (*actor.Actor, error) {
-	return nil, errors.New("control is not supported for windows")
+	level.Info(logger).Log("msg", "Cannot create control channel for windows, ignoring")
+
+	return nil, nil
 }

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -301,9 +301,13 @@ func runLauncher(ctx context.Context, cancel func(), opts *options, logger log.L
 	if opts.control {
 		control, err := createControl(ctx, db, logger, opts)
 		if err != nil {
-			return errors.Wrap(err, "create conrol actor")
+			return errors.Wrap(err, "create control actor")
 		}
-		runGroup.Add(control.Execute, control.Interrupt)
+		if control != nil {
+			runGroup.Add(control.Execute, control.Interrupt)
+		} else {
+			level.Debug(logger).Log("msg", "got nil control actor. Ignoring")
+		}
 	}
 
 	// If the autoupdater is enabled, enable it for both osquery and launcher


### PR DESCRIPTION
Windows does not support a control server. Instead of throwing an error, ignore it and continue.