### PR TITLE
Fix windows service name appending

### DIFF
--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -237,12 +237,16 @@ func (s *Service) Xml(w io.Writer) error {
 }
 
 // cleanServiceName removes characters windows doesn't like in
-// services names, and converts everything to camel case.
+// services names, and converts everything to camel case. Right now,
+// it only removes likely bad characters. It is not as complete as a
+// whitelist.
 func cleanServiceName(in string) string {
 	r := strings.NewReplacer(
 		"-", "_",
 		" ", "_",
 		".", "_",
+		"/", "_",
+		"\\", "_",
 	)
 
 	return snaker.SnakeToCamel(r.Replace(in))

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -159,9 +159,14 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 		RestartServiceDelayInSeconds: 5,
 	}
 
+	// If a service name is not specified, replace the .exe with a svc,
+	// and CamelCase it. (eg: daemon.exe becomes DaemonSvc). It is
+	// probably better to specific a ServiceName, but this might be an
+	// okay default.
+	defaultName := cleanServiceName(strings.TrimSuffix(matchString, ".exe") + ".svc")
 	si := &ServiceInstall{
-		Name:          cleanServiceName(matchString),
-		Id:            cleanServiceName(matchString),
+		Name:          defaultName,
+		Id:            defaultName,
 		Account:       `NT AUTHORITY\SYSTEM`,
 		Start:         StartAuto,
 		Type:          "ownProcess",
@@ -171,8 +176,8 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 	}
 
 	sc := &ServiceControl{
-		Name:   cleanServiceName(matchString),
-		Id:     cleanServiceName(matchString),
+		Name:   defaultName,
+		Id:     defaultName,
 		Stop:   InstallUninstallBoth,
 		Start:  InstallUninstallInstall,
 		Remove: InstallUninstallUninstall,
@@ -240,6 +245,5 @@ func cleanServiceName(in string) string {
 		".", "_",
 	)
 
-	snakeName := r.Replace(strings.TrimSuffix(in, ".exe") + "_svc")
-	return snaker.SnakeToCamel(snakeName)
+	return snaker.SnakeToCamel(r.Replace(in))
 }

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -51,7 +51,7 @@ func TestServiceOptions(t *testing.T) {
 		},
 		{
 			in:  NewService("snake-case.exe", ServiceName("Another-Case-Of-snakes")),
-			out: []string{`Id="AnotherCaseOfSnakesSvc"`, `Name="AnotherCaseOfSnakesSvc"`},
+			out: []string{`Id="AnotherCaseOfSnakes"`, `Name="AnotherCaseOfSnakes"`},
 		},
 		{
 			in:  NewService("daemon.exe"),
@@ -59,23 +59,23 @@ func TestServiceOptions(t *testing.T) {
 		},
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon")),
-			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`},
+			out: []string{`Id="MyDaemon"`, `Name="MyDaemon"`},
 		},
 		{
 			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first"})),
-			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first"`},
+			out: []string{`Id="MyDaemon"`, `Name="MyDaemon"`, `Arguments="first"`},
 		},
 		{
-			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first with spaces"})),
+			in:  NewService("daemon.exe", ServiceName("myDaemon.svc"), ServiceArgs([]string{"first with spaces"})),
 			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="&#34;first with spaces&#34;"`},
 		},
 
 		{
-			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first", "second"})),
+			in:  NewService("daemon.exe", ServiceName("myDaemon svc"), ServiceArgs([]string{"first", "second"})),
 			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first second"`},
 		},
 		{
-			in:  NewService("daemon.exe", ServiceName("myDaemon"), ServiceArgs([]string{"first", "second", "third has spaces"})),
+			in:  NewService("daemon.exe", ServiceName("myDaemon_svc"), ServiceArgs([]string{"first", "second", "third has spaces"})),
 			out: []string{`Id="MyDaemonSvc"`, `Name="MyDaemonSvc"`, `Arguments="first second &#34;third has spaces&#34;"`},
 		},
 	}


### PR DESCRIPTION
I noticed that we were getting a doubled `SvcSvc` on builds. This was clearly wrong.

Digging, it was because we _always_ striped a trailing `.exe` and then appended a `_svc`. Thinking about it, I think it’s better to do that if, and only if. We’re setting a default name. An explicit ServiceName call should get what it expects. (After the character cleaning, and Camel Casing)