### PR TITLE
Add table to expose autoupdate configuration

### DIFF
--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -10,23 +10,24 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/actor"
 	"github.com/kolide/launcher/pkg/control"
+	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/pkg/errors"
 )
 
-func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *options) (*actor.Actor, error) {
+func createControl(ctx context.Context, db *bolt.DB, logger log.Logger, opts *launcher.Options) (*actor.Actor, error) {
 	level.Debug(logger).Log("msg", "creating control client")
 
 	controlOpts := []control.Option{
 		control.WithLogger(logger),
-		control.WithGetShellsInterval(opts.getShellsInterval),
+		control.WithGetShellsInterval(opts.GetShellsInterval),
 	}
-	if opts.insecureTLS {
+	if opts.InsecureTLS {
 		controlOpts = append(controlOpts, control.WithInsecureSkipVerify())
 	}
-	if opts.disableControlTLS {
+	if opts.DisableControlTLS {
 		controlOpts = append(controlOpts, control.WithDisableTLS())
 	}
-	controlClient, err := control.NewControlClient(db, opts.controlServerURL, controlOpts...)
+	controlClient, err := control.NewControlClient(db, opts.ControlServerURL, controlOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating control client")
 	}

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -30,7 +30,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger = logutil.NewServerLogger(opts.debug)
+	logger = logutil.NewServerLogger(opts.Debug)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -11,38 +11,10 @@ import (
 
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/autoupdate"
+	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/peterbourgon/ff"
 	"github.com/pkg/errors"
 )
-
-// options is the set of configurable options that may be set when launching this
-// program
-type options struct {
-	kolideServerURL     string
-	enrollSecret        string
-	enrollSecretPath    string
-	rootDirectory       string
-	osquerydPath        string
-	certPins            [][]byte
-	rootPEM             string
-	loggingInterval     time.Duration
-	enableInitialRunner bool
-	transport           string
-
-	control           bool
-	controlServerURL  string
-	getShellsInterval time.Duration
-
-	autoupdate         bool
-	debug              bool
-	disableControlTLS  bool
-	insecureTLS        bool
-	insecureTransport  bool
-	notaryServerURL    string
-	mirrorServerURL    string
-	autoupdateInterval time.Duration
-	updateChannel      autoupdate.UpdateChannel
-}
 
 const (
 	defaultRootDirectory = "launcher-root"
@@ -51,7 +23,7 @@ const (
 // parseOptions parses the options that may be configured via command-line flags
 // and/or environment variables, determines order of precedence and returns a
 // typed struct of options for further application use
-func parseOptions(args []string) (*options, error) {
+func parseOptions(args []string) (*launcher.Options, error) {
 	flagset := flag.NewFlagSet("launcher", flag.ExitOnError)
 	flagset.Usage = func() { usage(flagset) }
 
@@ -140,29 +112,29 @@ func parseOptions(args []string) (*options, error) {
 		return nil, err
 	}
 
-	opts := &options{
-		kolideServerURL:     *flKolideServerURL,
-		transport:           *flTransport,
-		control:             *flControl,
-		controlServerURL:    *flControlServerURL,
-		getShellsInterval:   *flGetShellsInterval,
-		enrollSecret:        *flEnrollSecret,
-		enrollSecretPath:    *flEnrollSecretPath,
-		rootDirectory:       *flRootDirectory,
-		osquerydPath:        osquerydPath,
-		certPins:            certPins,
-		rootPEM:             *flRootPEM,
-		loggingInterval:     *flLoggingInterval,
-		enableInitialRunner: *flInitialRunner,
-		autoupdate:          *flAutoupdate,
-		debug:               *flDebug,
-		disableControlTLS:   *flDisableControlTLS,
-		insecureTLS:         *flInsecureTLS,
-		insecureTransport:   *flInsecureTransport,
-		notaryServerURL:     *flNotaryServerURL,
-		mirrorServerURL:     *flMirrorURL,
-		autoupdateInterval:  *flAutoupdateInterval,
-		updateChannel:       updateChannel,
+	opts := &launcher.Options{
+		KolideServerURL:     *flKolideServerURL,
+		Transport:           *flTransport,
+		Control:             *flControl,
+		ControlServerURL:    *flControlServerURL,
+		GetShellsInterval:   *flGetShellsInterval,
+		EnrollSecret:        *flEnrollSecret,
+		EnrollSecretPath:    *flEnrollSecretPath,
+		RootDirectory:       *flRootDirectory,
+		OsquerydPath:        osquerydPath,
+		CertPins:            certPins,
+		RootPEM:             *flRootPEM,
+		LoggingInterval:     *flLoggingInterval,
+		EnableInitialRunner: *flInitialRunner,
+		Autoupdate:          *flAutoupdate,
+		Debug:               *flDebug,
+		DisableControlTLS:   *flDisableControlTLS,
+		InsecureTLS:         *flInsecureTLS,
+		InsecureTransport:   *flInsecureTransport,
+		NotaryServerURL:     *flNotaryServerURL,
+		MirrorServerURL:     *flMirrorURL,
+		AutoupdateInterval:  *flAutoupdateInterval,
+		UpdateChannel:       updateChannel,
 	}
 	return opts, nil
 }

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/stringutil"
+	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,7 +81,7 @@ func TestOptionsFromFile(t *testing.T) {
 	require.Equal(t, expectedOpts, opts)
 }
 
-func getArgsAndResponse() (map[string]string, *options) {
+func getArgsAndResponse() (map[string]string, *launcher.Options) {
 	randomHostname := fmt.Sprintf("%s.example.com", stringutil.RandomString(8))
 	randomInt := rand.Intn(1024)
 
@@ -94,17 +95,17 @@ func getArgsAndResponse() (map[string]string, *options) {
 		"-transport":           "grpc",
 	}
 
-	opts := &options{
-		control:            true,
-		osquerydPath:       "/dev/null",
-		kolideServerURL:    randomHostname,
-		getShellsInterval:  3 * time.Second,
-		loggingInterval:    time.Duration(randomInt) * time.Second,
-		autoupdateInterval: 48 * time.Hour,
-		notaryServerURL:    "https://notary.kolide.co",
-		mirrorServerURL:    "https://dl.kolide.co",
-		updateChannel:      "stable",
-		transport:          "grpc",
+	opts := &launcher.Options{
+		Control:            true,
+		OsquerydPath:       "/dev/null",
+		KolideServerURL:    randomHostname,
+		GetShellsInterval:  3 * time.Second,
+		LoggingInterval:    time.Duration(randomInt) * time.Second,
+		AutoupdateInterval: 48 * time.Hour,
+		NotaryServerURL:    "https://notary.kolide.co",
+		MirrorServerURL:    "https://dl.kolide.co",
+		UpdateChannel:      "stable",
+		Transport:          "grpc",
 	}
 
 	return args, opts

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
 	github.com/client9/misspell v0.3.4
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -1,0 +1,67 @@
+package launcher
+
+import (
+	"time"
+
+	"github.com/kolide/launcher/pkg/autoupdate"
+)
+
+// Options is the set of options that may be configured for Launcher.
+type Options struct {
+	// KolideServerURL is the URL of the management server to connect to.
+	KolideServerURL string
+	// EnrollSecret contains the raw enroll secret.
+	EnrollSecret string
+	// EnrollSecretPath contains the path to a file containing the enroll
+	// secret.
+	EnrollSecretPath string
+	// RootDirectory is the directory that should be used as the osquery
+	// root directory (database files, pidfile, etc.).
+	RootDirectory string
+	// OsquerydPath is the path to the osqueryd binary.
+	OsquerydPath string
+	// CertPins are optional hashes of subject public key info to use for
+	// certificate pinning.
+	CertPins [][]byte
+	// RootPEM is the path to the pem file containing the certificate
+	// chain, if necessary for verification.
+	RootPEM string
+	// LoggingInterval is the interval at which logs should be flushed to
+	// the server.
+	LoggingInterval time.Duration
+	// EnableInitialRunner enables running scheduled queries immediately
+	// (before first schedule interval passes).
+	EnableInitialRunner bool
+	// Transport the transport that should be used for remote
+	// communication.
+	Transport string
+
+	// Control enables the remote control functionality.
+	Control bool
+	// ControlServerURL URL for control server.
+	ControlServerURL string
+	// GetShellsInterval is the interval at which the control server should
+	// be checked for shells.
+	GetShellsInterval time.Duration
+
+	// Autoupdate enables the autoupdate functionality.
+	Autoupdate bool
+	// NotaryServerURL is the URL for the Notary server.
+	NotaryServerURL string
+	// MirrorServerURL is the URL for the Notary mirror.
+	MirrorServerURL string
+	// AutoupdateInterval is the interval at which Launcher will check for
+	// updates.
+	AutoupdateInterval time.Duration
+	// UpdateChannel is the channel to pull options from (stable, beta, nightly).
+	UpdateChannel autoupdate.UpdateChannel
+
+	// Debug enables debug logging.
+	Debug bool
+	// DisableControlTLS disables TLS transport with the control server.
+	DisableControlTLS bool
+	// InsecureTLS disables TLS certificate verification.
+	InsecureTLS bool
+	// InsecureTransport disables TLS in the transport layer.
+	InsecureTransport bool
+}

--- a/pkg/osquery/table/kolide_launcher_autoupdate_config.go
+++ b/pkg/osquery/table/kolide_launcher_autoupdate_config.go
@@ -1,0 +1,44 @@
+package table
+
+import (
+	"context"
+
+	"github.com/kolide/launcher/pkg/launcher"
+	"github.com/kolide/osquery-go/plugin/table"
+)
+
+const launcherAutoupdateConfigTableName = "kolide_launcher_autoupdate_config"
+
+func LauncherAutoupdateConfigTable(opts *launcher.Options) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("autoupdate"),
+		table.TextColumn("notary_server_url"),
+		table.TextColumn("mirror_server_url"),
+		table.TextColumn("autoupdate_interval"),
+		table.TextColumn("update_channel"),
+	}
+
+	return table.NewPlugin(launcherAutoupdateConfigTableName, columns, generateLauncherAutoupdateConfigTable(opts))
+}
+
+func boolToString(in bool) string {
+	if in {
+		return "1"
+	} else {
+		return "0"
+	}
+}
+
+func generateLauncherAutoupdateConfigTable(opts *launcher.Options) table.GenerateFunc {
+	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		return []map[string]string{
+			map[string]string{
+				"autoupdate":          boolToString(opts.Autoupdate),
+				"notary_server_url":   opts.NotaryServerURL,
+				"mirror_server_url":   opts.MirrorServerURL,
+				"autoupdate_interval": opts.AutoupdateInterval.String(),
+				"update_channel":      string(opts.UpdateChannel),
+			},
+		}, nil
+	}
+}

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"github.com/kolide/launcher/pkg/launcher"
+
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
 	osquery "github.com/kolide/osquery-go"
@@ -8,11 +10,12 @@ import (
 )
 
 // LauncherTables returns launcher-specific tables
-func LauncherTables(db *bolt.DB) []osquery.OsqueryPlugin {
+func LauncherTables(db *bolt.DB, opts *launcher.Options) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		LauncherConfigTable(db),
 		LauncherIdentifierTable(db),
 		TargetMembershipTable(db),
+		LauncherAutoupdateConfigTable(opts),
 	}
 }
 


### PR DESCRIPTION
kolide_launcher_autoupdate_config table exposes the autoupdate config
via live query or scheduled query when Launcher is running.

Required some refactoring of the options (making struct members public).