### PR TITLE
Update systemd.md

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -13,7 +13,7 @@ After=network.service syslog.service
 ExecStart= $LauncherPath \
   --hostname=$FleetServer:FleetPort \
   --enroll_secret=$FleetSecret \
-  --autoupdate=true \
+  --autoupdate \
   --osqueryd_path=$OsquerydPath
 Restart=on-failure
 RestartSec=3

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -6,18 +6,19 @@ Below is a sample unit file.
 
 ```
 [Unit]
- Description=The Kolide Launcher
- After=network.service syslog.service
+Description=The Kolide Launcher
+After=network.service syslog.service
 
- [Service]
- ExecStart= $LauncherPath \
- --hostname=$FleetServer:FleetPort \
- --enroll_secret=$FleetSecret \
- --autoupdate \
---osqueryd_path=$OsquerydPath
+[Service]
+ExecStart= $LauncherPath \
+  --hostname=$FleetServer:FleetPort \
+  --enroll_secret=$FleetSecret \
+  --autoupdate=true \
+  --osqueryd_path=$OsquerydPath
 Restart=on-failure
 RestartSec=3
- [Install]
+
+[Install]
 WantedBy=multi-user.target
 ```
 


### PR DESCRIPTION
Minor spacing updates and added `=true` after `--autoupdate` option

What version of launcher are you using (launcher --version)?
0.9.4

What operating system are you using?
Ubuntu 18.04

What did you do?
Minor updates to launcher systemd service doc

What did you expect to happen?
N/A

What happened instead?
N/A