### PR TITLE
Patch utf8 handling

### DIFF
--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -152,7 +152,8 @@ func MakePublishLogsEndpoint(svc KolideService) endpoint.Endpoint {
 func (e Endpoints) PublishLogs(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
 	newCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	request := logCollection{NodeKey: nodeKey, LogType: logType, Logs: logs}
+
+	request := logCollection{NodeKey: nodeKey, LogType: logType, Logs: patchOsqueryEmojiHandlingArray(logs)}
 	response, err := e.PublishLogsEndpoint(newCtx, request)
 	if err != nil {
 		return "", "", false, err

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"encoding/hex"
+	"strings"
+)
+
+// patchOsqueryEmojiHandling repairs utf8 data in the logs. See:
+//
+// https://github.com/kolide/launcher/issues/445
+// https://github.com/facebook/osquery/issues/5288
+func patchOsqueryEmojiHandling(in string) string {
+	if !strings.Contains(in, `\x`) {
+		return in
+	}
+
+	out := strings.Replace(in, `\x`, ``, -1)
+	outBytes, err := hex.DecodeString(out)
+	if err != nil {
+		return in
+	}
+
+	return string(outBytes)
+}
+
+// patchOsqueryEmojiHandlingArray calls patchOsqueryEmojiHandling across an array
+func patchOsqueryEmojiHandlingArray(logs []string) []string {
+	out := make([]string, len(logs))
+
+	for i, in := range logs {
+		out[i] = patchOsqueryEmojiHandling(in)
+	}
+
+	return out
+}

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+const utf8Replacement = "�"
+
+func redactNonUTF8(in string) string {
+	return strings.ToValidUTF8(in, utf8Replacement)
+}
+
 // patchOsqueryEmojiHandling repairs utf8 data in the logs. See:
 //
 // https://github.com/kolide/launcher/issues/445

--- a/pkg/service/util_test.go
+++ b/pkg/service/util_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatchOsqueryEmojiHandling(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  `\xF0\x9F\x9A\xB2`,
+			out: `🚲`,
+		},
+		{
+			in:  `\xFNOCANDOBUDDY`,
+			out: `\xFNOCANDOBUDDY`,
+		},
+		{
+			in:  `a normal string`,
+			out: `a normal string`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Input: %s", tt.in), func(t *testing.T) {
+			assert.Equal(t, tt.out, patchOsqueryEmojiHandling(tt.in))
+		})
+	}
+}
+
+func TestPatchOsqueryEmojiHandlingArray(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		in  []string
+		out []string
+	}{
+		{
+			in:  []string{},
+			out: []string{},
+		},
+		{
+			in:  []string{`\xFNOCANDOBUDDY`, `a normal string`, `\xF0\x9F\x9A\xB2`},
+			out: []string{`\xFNOCANDOBUDDY`, `a normal string`, `🚲`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Input: %s", tt.in), func(t *testing.T) {
+			require.Equal(t, tt.out, patchOsqueryEmojiHandlingArray(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
Osquery sometimes mis-encodes utf8 data https://github.com/facebook/osquery/issues/5288

This is a broad attempt to repair log files that exhibit that issue. This runs against the entire log file. Hopefully, there isn’t going to be a case where it misfires.

I'm not sure if this is great. On one hand, it fixes a bug in osquery. On the other hand, it introduces a discrepancy between osquery logs and launcher logs. Feel free to vote with 👍 or 👎. I'm going to let this sit a bit

Fixes: https://github.com/kolide/launcher/issues/445