### PR TITLE
Continue with GCB

### DIFF
--- a/cloudbuild/master/cloudbuild.json
+++ b/cloudbuild/master/cloudbuild.json
@@ -30,7 +30,7 @@
 	"linux-xp-grpc-extension"
       ],
       "entrypoint": "make",
-      "timeout": "300s",
+      "timeout": "600s",
       "name": "gcr.io/cloud-builders/go",
       "waitFor": [
 	"checkout_repo",
@@ -44,13 +44,37 @@
 	"lint"
       ],
       "entrypoint": "make",
-      "timeout": "300s",
+      "timeout": "600s",
       "name": "gcr.io/cloud-builders/go",
       "waitFor": [
 	"checkout_repo",
 	"deps"
       ],
       "id": "lint"
+    },
+    {
+      "args": [
+	"-j",
+	"build-docker"
+      ],
+      "entrypoint": "make",
+      "id": "build-docker",
+      "waitFor": [
+	"lint",
+	"build"
+      ]
+    },
+    {
+      "id": "build-dockerfake",
+      "entrypoint": "make",
+      "args": [
+	"-j",
+	"build-dockerfake"
+      ],
+      "waitFor": [
+	"lint",
+	"build"
+      ]
     }
   ]
 }

--- a/cloudbuild/master/cloudbuild.json
+++ b/cloudbuild/master/cloudbuild.json
@@ -14,6 +14,9 @@
 	"-j",
 	"deps"
       ],
+      "env": [
+	"GOPATH=/go"
+      ],
       "entrypoint": "make",
       "timeout": "300s",
       "name": "gcr.io/cloud-builders/go",


### PR DESCRIPTION
This should fix the issue we saw we `make deps`. The underlying docker images has `/go` in the path, but that was not set in GOPATH.

This continues trying to get the docker images building