### PR TITLE
Windows Signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ dockerpush-%: docker-%
 
 # Porter is a kolide tool to update notary, part of the update framework
 porter-%: codesign
+	@if [ -z "${NOTARY_DELEGATION_PASSPHRASE}" ]; then echo "Missing NOTARY_DELEGATION_PASSPHRASE"; exit 1; fi
 	for p in darwin linux windows; do \
 	  echo porter mirror -debug -channel $* -platform $$p -launcher-all; \
 	  echo porter mirror -debug -channel $* -platform $$p -extension-tarball -extension-upload; \

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,15 @@ codesign-darwin: xp
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/launcher
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/osquery-extension.ext
 
-
 # Using the `osslsigncode` we can sign windows binaries from
-# non-windows platforms. This is part of our notary upload pipeline.
-codesign-windows-%:
-	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha1 -t http://timestamp.verisign.com/scripts/timstamp.dll -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -askpass
-	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha256 -nest -ts http://sha256timestamp.ws.symantec.com/sha256/timestamp -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -askpass
+# non-windows platforms.
+codesign-windows: codesign-windows-launcher.exe  codesign-windows-osquery-extension.exe
+codesign-windows-%: xp
+	@if [ -z "${AUTHENTICODE_PASSPHRASE}" ]; then echo "Missing AUTHENTICODE_PASSPHRASE"; exit 1; fi
+	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha1 -t http://timestamp.verisign.com/scripts/timstamp.dll -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -pass "${AUTHENTICODE_PASSPHRASE}"
+	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha256 -nest -ts http://sha256timestamp.ws.symantec.com/sha256/timestamp -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -pass "${AUTHENTICODE_PASSPHRASE}"
 
-codesign: codesign-darwin
+codesign: codesign-darwin codesign-windows
 
 package-builder: .pre-build deps
 	go run cmd/make/make.go -targets=package-builder -linkstamp

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,13 @@ codesign-darwin: xp
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/launcher
 	codesign --force -s "${CODESIGN_IDENTITY}" -v ./build/darwin/osquery-extension.ext
 
+
+# Using the `osslsigncode` we can sign windows binaries from
+# non-windows platforms. This is part of our notary upload pipeline.
+codesign-windows-%:
+	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha1 -t http://timestamp.verisign.com/scripts/timstamp.dll -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -askpass
+	osslsigncode -in build/windows/$*  -out build/windows/$*  -i https://kolide.com -h sha256 -nest -ts http://sha256timestamp.ws.symantec.com/sha256/timestamp -pkcs12 ~/Documents/kolide-codesigning-2019.p12  -askpass
+
 codesign: codesign-darwin
 
 package-builder: .pre-build deps

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,6 @@ dockerpush-%: docker-%
 porter-%: codesign
 	@if [ -z "${NOTARY_DELEGATION_PASSPHRASE}" ]; then echo "Missing NOTARY_DELEGATION_PASSPHRASE"; exit 1; fi
 	for p in darwin linux windows; do \
-	  echo porter mirror -debug -channel $* -platform $$p -launcher-all; \
-	  echo porter mirror -debug -channel $* -platform $$p -extension-tarball -extension-upload; \
+	  porter mirror -debug -channel $* -platform $$p -launcher-all; \
+	  porter mirror -debug -channel $* -platform $$p -extension-tarball -extension-upload; \
 	done

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -67,7 +67,7 @@ func runMake(args []string) error {
 		flSigningKey = flagset.String(
 			"mac_package_signing_key",
 			env.String("SIGNING_KEY", ""),
-			"The name of the key that should be used to packages. Behavior is platform and packaging specific",
+			"The name of the key that should be used for signing on apple platforms",
 		)
 		flTransport = flagset.String(
 			"transport",
@@ -188,7 +188,7 @@ func runMake(args []string) error {
 		ExtensionVersion:  *flExtensionVersion,
 		Hostname:          *flHostname,
 		Secret:            *flEnrollSecret,
-		SigningKey:        *flSigningKey,
+		AppleSigningKey:   *flSigningKey,
 		Transport:         *flTransport,
 		Insecure:          *flInsecure,
 		InsecureTransport: *flInsecureTransport,

--- a/pkg/packagekit/authenticode/authenticode.go
+++ b/pkg/packagekit/authenticode/authenticode.go
@@ -1,0 +1,38 @@
+package authenticode
+
+import (
+	"context"
+	"os/exec"
+)
+
+// signtoolOptions are the options for how we call signtool.exe. These
+// are *not* the tool options, but instead our own representation of
+// the arguments.w
+type signtoolOptions struct {
+	subjectName    string // If present, use this as the `/n` argument
+	skipValidation bool
+	signtoolPath   string
+
+	execCC func(context.Context, string, ...string) *exec.Cmd // Allows test overrides
+
+}
+
+type SigntoolOpt func(*signtoolOptions)
+
+func SkipValidation() SigntoolOpt {
+	return func(so *signtoolOptions) {
+		so.skipValidation = true
+	}
+}
+
+func WithSubjectName(sn string) SigntoolOpt {
+	return func(so *signtoolOptions) {
+		so.subjectName = sn
+	}
+}
+
+func WithSigntoolPath(path string) SigntoolOpt {
+	return func(so *signtoolOptions) {
+		so.signtoolPath = path
+	}
+}

--- a/pkg/packagekit/authenticode/authenticode.go
+++ b/pkg/packagekit/authenticode/authenticode.go
@@ -34,7 +34,8 @@ func SkipValidation() SigntoolOpt {
 	}
 }
 
-// WithExtraArgs set additional arguments for signtool. Common ones may be {`\n`, "subject name"}
+// WithExtraArgs set additional arguments for signtool. Common ones
+// may be {`\n`, "subject name"}
 func WithExtraArgs(args []string) SigntoolOpt {
 	return func(so *signtoolOptions) {
 		so.extraArgs = args

--- a/pkg/packagekit/authenticode/authenticode.go
+++ b/pkg/packagekit/authenticode/authenticode.go
@@ -1,8 +1,14 @@
 package authenticode
 
 import (
+	"bytes"
 	"context"
 	"os/exec"
+	"strings"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/pkg/errors"
 )
 
 // signtoolOptions are the options for how we call signtool.exe. These
@@ -35,4 +41,22 @@ func WithSigntoolPath(path string) SigntoolOpt {
 	return func(so *signtoolOptions) {
 		so.signtoolPath = path
 	}
+}
+
+func (so *signtoolOptions) execOut(ctx context.Context, argv0 string, args ...string) (string, string, error) {
+	logger := ctxlog.FromContext(ctx)
+
+	cmd := so.execCC(ctx, argv0, args...)
+
+	level.Debug(logger).Log(
+		"msg", "execing",
+		"cmd", strings.Join(cmd.Args, " "),
+	)
+
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), errors.Wrapf(err, "run command %s %v, stderr=%s", argv0, args, stderr)
+	}
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), nil
 }

--- a/pkg/packagekit/authenticode/authenticode.go
+++ b/pkg/packagekit/authenticode/authenticode.go
@@ -15,9 +15,12 @@ import (
 // are *not* the tool options, but instead our own representation of
 // the arguments.w
 type signtoolOptions struct {
-	subjectName    string // If present, use this as the `/n` argument
-	skipValidation bool
-	signtoolPath   string
+	extraArgs       []string
+	subjectName     string // If present, use this as the `/n` argument
+	skipValidation  bool
+	signtoolPath    string
+	timestampServer string
+	rfc3161Server   string
 
 	execCC func(context.Context, string, ...string) *exec.Cmd // Allows test overrides
 
@@ -31,9 +34,10 @@ func SkipValidation() SigntoolOpt {
 	}
 }
 
-func WithSubjectName(sn string) SigntoolOpt {
+// WithExtraArgs set additional arguments for signtool. Common ones may be {`\n`, "subject name"}
+func WithExtraArgs(args []string) SigntoolOpt {
 	return func(so *signtoolOptions) {
-		so.subjectName = sn
+		so.extraArgs = args
 	}
 }
 

--- a/pkg/packagekit/authenticode/authenticode_dummy.go
+++ b/pkg/packagekit/authenticode/authenticode_dummy.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package authenticode
+
+import "context"
+
+func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
+	return nil
+}

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,9 +28,11 @@ func TestSign(t *testing.T) {
 
 	// create a signtoolOptions object so we can call the exec method
 	so := &signtoolOptions{
-
 		execCC: exec.CommandContext,
 	}
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
 
 	tmpDir, err := ioutil.TempDir("", "packagekit-authenticode-signing")
 	defer os.RemoveAll(tmpDir)
@@ -48,7 +51,7 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sign it!
-	err = Sign(context.TODO(), testExe, WithSigntoolPath(signtoolPath))
+	err = Sign(ctx, testExe, WithSigntoolPath(signtoolPath))
 	require.NoError(t, err)
 
 	// verify, as an explicit test. Gotta check both indexes manually.

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -22,6 +23,12 @@ func TestSign(t *testing.T) {
 
 	if runtime.GOOS != "windows" {
 		t.Skip("not windows")
+	}
+
+	// create a signtoolOptions object so we can call the exec method
+	so := &signtoolOptions{
+
+		execCC: exec.CommandContext,
 	}
 
 	tmpDir, err := ioutil.TempDir("", "packagekit-authenticode-signing")

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -41,7 +41,7 @@ func TestSign(t *testing.T) {
 	testExe := filepath.Join(tmpDir, "test.exe")
 
 	// confirm that we _don't_ have a sig on this file
-	verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
+	_, verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
 	require.Error(t, err, "no initial signature")
 	require.Contains(t, verifyInitial, "No signature found", "no initial signature")
 
@@ -56,12 +56,12 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify, as an explicit test. Gotta check both indexes manually.
-	verifyOut0, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "0", testExe)
+	verifyOut0, _, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "0", testExe)
 	require.NoError(t, err, "verify signature position 0")
 	require.Contains(t, verifyOut0, "sha1", "contains algorithm verify output")
 	require.Contains(t, verifyOut0, "Authenticode", "contains timestamp verify output")
 
-	verifyOut1, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "1", testExe)
+	verifyOut1, _, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "1", testExe)
 	require.NoError(t, err, "verify signature position 1")
 	require.Contains(t, verifyOut1, "sha1", "contains algorithm verify output")
 	require.Contains(t, verifyOut1, "Authenticode", "contains timestamp verify output")

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -64,6 +64,6 @@ func TestSign(t *testing.T) {
 	verifyOut1, _, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "1", testExe)
 	require.NoError(t, err, "verify signature position 1")
 	require.Contains(t, verifyOut1, "sha256", "contains algorithm verify output")
-	require.Contains(t, verifyOut1, "Authenticode", "contains timestamp verify output")
+	require.Contains(t, verifyOut1, "RFC3161", "contains timestamp verify output")
 
 }

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//const notepadeExe = `C:\Windows\System32\Notepad.exe`
 const (
 	srcExe       = `C:\Windows\System32\netmsg.dll`
 	signtoolPath = `C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe`

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -30,6 +30,10 @@ func TestSign(t *testing.T) {
 
 	testExe := filepath.Join(tmpDir, "test.exe")
 
+	// confirm that we _don't_ have a sig on this file
+	verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
+	require.Error(t, err, "no initial signature")
+
 	// copy our test file
 	data, err := ioutil.ReadFile(srcExe)
 	require.NoError(t, err)
@@ -41,12 +45,12 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify, as an explicit test. Gotta check both indexes manually.
-	verifyOut0, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/ds", "0", file)
+	verifyOut0, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "0", testExe)
 	require.NoError(t, err, "verify signature position 0")
 	require.Contains(t, verifyOut0, "sha1", "contains algorithm verify output")
 	require.Contains(t, verifyOut0, "Authenticode", "contains timestamp verify output")
 
-	verifyOut1, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/ds", "1", file)
+	verifyOut1, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "1", testExe)
 	require.NoError(t, err, "verify signature position 1")
 	require.Contains(t, verifyOut1, "sha1", "contains algorithm verify output")
 	require.Contains(t, verifyOut1, "Authenticode", "contains timestamp verify output")

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -43,6 +43,7 @@ func TestSign(t *testing.T) {
 	// confirm that we _don't_ have a sig on this file
 	verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
 	require.Error(t, err, "no initial signature")
+	require.Contains(t, verifyInitial, "No signature found", "no initial signature")
 
 	// copy our test file
 	data, err := ioutil.ReadFile(srcExe)

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -1,0 +1,45 @@
+package authenticode
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//const notepadeExe = `C:\Windows\System32\Notepad.exe`
+const (
+	srcExe       = `C:\Windows\System32\netmsg.dll`
+	signtoolPath = `C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe`
+)
+
+func TestSign(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("not windows")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "packagekit-authenticode-signing")
+	defer os.RemoveAll(tmpDir)
+	require.NoError(t, err)
+
+	testExe := filepath.Join(tmpDir, "test.exe")
+
+	// copy our test file
+	data, err := ioutil.ReadFile(srcExe)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(testExe, data, 0755)
+	require.NoError(t, err)
+
+	// Sign it!
+	fmt.Println("seph in ")
+	err = Sign(context.TODO(), testExe, WithSigntoolPath("echo"))
+	require.NoError(t, err)
+
+}

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -40,16 +40,16 @@ func TestSign(t *testing.T) {
 
 	testExe := filepath.Join(tmpDir, "test.exe")
 
-	// confirm that we _don't_ have a sig on this file
-	_, verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
-	require.Error(t, err, "no initial signature")
-	require.Contains(t, verifyInitial, "No signature found", "no initial signature")
-
 	// copy our test file
 	data, err := ioutil.ReadFile(srcExe)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(testExe, data, 0755)
 	require.NoError(t, err)
+
+	// confirm that we _don't_ have a sig on this file
+	_, verifyInitial, err := so.execOut(ctx, signtoolPath, "verify", "/pa", testExe)
+	require.Error(t, err, "no initial signature")
+	require.Contains(t, verifyInitial, "No signature found", "no initial signature")
 
 	// Sign it!
 	err = Sign(ctx, testExe, WithSigntoolPath(signtoolPath))

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -32,7 +32,7 @@ func TestSign(t *testing.T) {
 	}
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+	defer ctxCancel()
 
 	tmpDir, err := ioutil.TempDir("", "packagekit-authenticode-signing")
 	defer os.RemoveAll(tmpDir)

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -63,7 +63,7 @@ func TestSign(t *testing.T) {
 
 	verifyOut1, _, err := so.execOut(ctx, signtoolPath, "verify", "/pa", "/ds", "1", testExe)
 	require.NoError(t, err, "verify signature position 1")
-	require.Contains(t, verifyOut1, "sha1", "contains algorithm verify output")
+	require.Contains(t, verifyOut1, "sha256", "contains algorithm verify output")
 	require.Contains(t, verifyOut1, "Authenticode", "contains timestamp verify output")
 
 }

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -39,7 +39,7 @@ func TestSign(t *testing.T) {
 
 	// Sign it!
 	fmt.Println("seph in ")
-	err = Sign(context.TODO(), testExe, WithSigntoolPath("echo"))
+	err = Sign(context.TODO(), testExe, WithSigntoolPath(signtoolPath))
 	require.NoError(t, err)
 
 }

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -2,7 +2,6 @@ package authenticode
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -38,8 +37,18 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sign it!
-	fmt.Println("seph in ")
 	err = Sign(context.TODO(), testExe, WithSigntoolPath(signtoolPath))
 	require.NoError(t, err)
+
+	// verify, as an explicit test. Gotta check both indexes manually.
+	verifyOut0, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/ds", "0", file)
+	require.NoError(t, err, "verify signature position 0")
+	require.Contains(t, verifyOut0, "sha1", "contains algorithm verify output")
+	require.Contains(t, verifyOut0, "Authenticode", "contains timestamp verify output")
+
+	verifyOut1, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/ds", "1", file)
+	require.NoError(t, err, "verify signature position 1")
+	require.Contains(t, verifyOut1, "sha1", "contains algorithm verify output")
+	require.Contains(t, verifyOut1, "Authenticode", "contains timestamp verify output")
 
 }

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -63,7 +63,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		}
 
 		if err := so.signtoolSign(ctx, file, "/as", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
-			return errors.Wrap(err, "signing msi with sha1")
+			return errors.Wrap(err, "signing msi with sha256")
 		}
 	}
 

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -54,15 +54,15 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	// References:
 	// https://knowledge.digicert.com/generalinformation/INFO2274.html
 	if strings.HasSuffix(file, ".msi") {
-		if err := so.signtoolSign(ctx, file, "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
+		if err := so.signtoolSign(ctx, file, "/ph", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
 			return errors.Wrap(err, "signing msi with sha1")
 		}
 	} else {
-		if err := so.signtoolSign(ctx, file, "/fd", "sha1", "/t", so.timestampServer); err != nil {
+		if err := so.signtoolSign(ctx, file, "/ph", "/fd", "sha1", "/t", so.timestampServer); err != nil {
 			return errors.Wrap(err, "signing file with sha1")
 		}
 
-		if err := so.signtoolSign(ctx, file, "/as", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
+		if err := so.signtoolSign(ctx, file, "/as", "/ph", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
 			return errors.Wrap(err, "signing file with sha256")
 		}
 	}

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -59,11 +59,11 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		}
 	} else {
 		if err := so.signtoolSign(ctx, file, "/fd", "sha1", "/t", so.timestampServer); err != nil {
-			return errors.Wrap(err, "signing msi with sha1")
+			return errors.Wrap(err, "signing file with sha1")
 		}
 
 		if err := so.signtoolSign(ctx, file, "/as", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
-			return errors.Wrap(err, "signing msi with sha256")
+			return errors.Wrap(err, "signing file with sha256")
 		}
 	}
 

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -70,8 +70,16 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		}
 	}
 
-	// Verify!
-	// FIXME
+	if so.skipValidation {
+		return nil
+	}
+
+	verifyOut, err := so.execOut(ctx, so.signtoolPath, "verify", "/v", file)
+	if err != nil {
+		return errors.Wrap(err, "verify")
+	}
+	fmt.Printf(verifyOut)
+
 	return nil
 }
 

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -1,0 +1,96 @@
+// +build windows
+
+// Authenticode is a light wrapper around signing code under windows.
+//
+// See
+//
+// https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
+
+package authenticode
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/pkg/errors"
+)
+
+func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
+	so := &signtoolOptions{
+		signtoolPath: "signtool.exe",
+		execCC:       exec.CommandContext,
+	}
+
+	for _, opt := range opts {
+		opt(so)
+	}
+
+	// signtool.exe can be called multiple times to apply multiple
+	// signatures. _But_ it uses different arguments for the subsequent
+	// signatures. So, multiple calls.
+	// Some info at https://knowledge.digicert.com/generalinformation/INFO2274.html
+	{
+		args := []string{
+			"sign",
+			"/fd", "sha1",
+			"/t", "http://timestamp.verisign.com/scripts/timstamp.dll",
+			"/v",
+		}
+		if so.subjectName != "" {
+			args = append(args, "/n", so.subjectName)
+		}
+
+		if _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
+			return errors.Wrap(err, "calling signtool")
+		}
+	}
+	{
+
+		args = []string{
+			"sign",
+			"/as",
+			"/fd", "sha256",
+			"/tr", "http://sha256timestamp.ws.symantec.com/sha256/timestamp",
+			"/td", "sha256",
+			"/v",
+		}
+
+		if so.subjectName != "" {
+			args = append(args, "/n", so.subjectName)
+		}
+		if _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
+			return errors.Wrap(err, "calling signtool")
+		}
+	}
+
+	fmt.Println("seph")
+
+	// Verify!
+	// FIXME
+	return nil
+}
+
+func (so *signtoolOptions) execOut(ctx context.Context, argv0, args ...string) (string, error) {
+	logger := ctxlog.FromContext(ctx)
+
+	cmd := so.execCC(ctx, argv0, args...)
+
+	fmt.Println(strings.Join(cmd.Args, " "))
+
+	level.Debug(logger).Log(
+		"msg", "execing",
+		"cmd", strings.Join(cmd.Args, " "),
+	)
+
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		return "", errors.Wrapf(err, "run command %s %v, stderr=%s", argv0, args, stderr)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -54,7 +54,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	// References:
 	// https://knowledge.digicert.com/generalinformation/INFO2274.html
 	if strings.HasSuffix(file, ".msi") {
-		if err := so.signtoolSign(ctx, file, "/fd", "sha1", "/t", so.timestampServer); err != nil {
+		if err := so.signtoolSign(ctx, file, "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
 			return errors.Wrap(err, "signing msi with sha1")
 		}
 	} else {

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -74,7 +74,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		return nil
 	}
 
-	verifyOut, err := so.execOut(ctx, so.signtoolPath, "verify", "/v", file)
+	verifyOut, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/v", file)
 	if err != nil {
 		return errors.Wrap(err, "verify")
 	}

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -11,7 +11,6 @@ package authenticode
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -74,11 +73,10 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		return nil
 	}
 
-	verifyOut, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/v", file)
+	_, err := so.execOut(ctx, so.signtoolPath, "verify", "/pa", "/v", file)
 	if err != nil {
 		return errors.Wrap(err, "verify")
 	}
-	fmt.Printf(verifyOut)
 
 	return nil
 }
@@ -87,8 +85,6 @@ func (so *signtoolOptions) execOut(ctx context.Context, argv0 string, args ...st
 	logger := ctxlog.FromContext(ctx)
 
 	cmd := so.execCC(ctx, argv0, args...)
-
-	fmt.Println(strings.Join(cmd.Args, " "))
 
 	level.Debug(logger).Log(
 		"msg", "execing",

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -45,6 +45,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 			args = append(args, "/n", so.subjectName)
 		}
 
+		args = append(args, file)
 		if _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
 			return errors.Wrap(err, "calling signtool")
 		}
@@ -62,12 +63,12 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		if so.subjectName != "" {
 			args = append(args, "/n", so.subjectName)
 		}
+
+		args = append(args, file)
 		if _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
 			return errors.Wrap(err, "calling signtool")
 		}
 	}
-
-	fmt.Println("seph")
 
 	// Verify!
 	// FIXME

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -55,7 +55,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	// https://knowledge.digicert.com/generalinformation/INFO2274.html
 	if strings.HasSuffix(file, ".msi") {
 		if err := so.signtoolSign(ctx, file, "/ph", "/fd", "sha256", "/td", "sha256", "/tr", so.rfc3161Server); err != nil {
-			return errors.Wrap(err, "signing msi with sha1")
+			return errors.Wrap(err, "signing msi with sha256")
 		}
 	} else {
 		if err := so.signtoolSign(ctx, file, "/ph", "/fd", "sha1", "/t", so.timestampServer); err != nil {
@@ -83,6 +83,8 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 func (so *signtoolOptions) signtoolSign(ctx context.Context, file string, args ...string) error {
 	ctx, span := trace.StartSpan(ctx, "signtoolSign")
 	defer span.End()
+
+	args = append([]string{"sign"}, args...)
 
 	if so.extraArgs != nil {
 		args = append(args, so.extraArgs...)

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -50,8 +50,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		}
 	}
 	{
-
-		args = []string{
+		args := []string{
 			"sign",
 			"/as",
 			"/fd", "sha256",
@@ -75,7 +74,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	return nil
 }
 
-func (so *signtoolOptions) execOut(ctx context.Context, argv0, args ...string) (string, error) {
+func (so *signtoolOptions) execOut(ctx context.Context, argv0 string, args ...string) (string, error) {
 	logger := ctxlog.FromContext(ctx)
 
 	cmd := so.execCC(ctx, argv0, args...)

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -10,15 +10,40 @@ package authenticode
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"strings"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+)
+
+type digestAlgo string
+
+const (
+	SHA1   digestAlgo = "sha1"
+	SHA256            = "sha256"
 )
 
 func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
+	ctx, span := trace.StartSpan(ctx, "authenticode.Sign")
+	defer span.End()
+
+	logger := log.With(ctxlog.FromContext(ctx), "caller", "authenticode.Sign")
+
+	level.Debug(logger).Log(
+		"msg", "signing file",
+		"file", file,
+	)
+
 	so := &signtoolOptions{
-		signtoolPath: "signtool.exe",
-		execCC:       exec.CommandContext,
+		signtoolPath:    "signtool.exe",
+		timestampServer: "http://timestamp.verisign.com/scripts/timstamp.dll",
+		rfc3161Server:   "http://sha256timestamp.ws.symantec.com/sha256/timestamp",
+		execCC:          exec.CommandContext,
 	}
 
 	for _, opt := range opts {
@@ -28,40 +53,21 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	// signtool.exe can be called multiple times to apply multiple
 	// signatures. _But_ it uses different arguments for the subsequent
 	// signatures. So, multiple calls.
-	// Some info at https://knowledge.digicert.com/generalinformation/INFO2274.html
-	{
-		args := []string{
-			"sign",
-			"/fd", "sha1",
-			"/t", "http://timestamp.verisign.com/scripts/timstamp.dll",
-			"/v",
+	//
+	// _However_ it's not clear this is supported for MSIs, which maybe only have a single
+	//
+	// References:
+	// https://knowledge.digicert.com/generalinformation/INFO2274.html
+	if strings.HasSuffix(file, ".msi") {
+		if err := so.signtoolSign(ctx, file, true, SHA1); err != nil {
+			return errors.Wrap(err, "signing exe with sha1")
 		}
-		if so.subjectName != "" {
-			args = append(args, "/n", so.subjectName)
+	} else {
+		if err := so.signtoolSign(ctx, file, true, SHA1); err != nil {
+			return errors.Wrap(err, "signing file with 0:sha1")
 		}
-
-		args = append(args, file)
-		if _, _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
-			return errors.Wrap(err, "calling signtool")
-		}
-	}
-	{
-		args := []string{
-			"sign",
-			"/as",
-			"/fd", "sha256",
-			"/tr", "http://sha256timestamp.ws.symantec.com/sha256/timestamp",
-			"/td", "sha256",
-			"/v",
-		}
-
-		if so.subjectName != "" {
-			args = append(args, "/n", so.subjectName)
-		}
-
-		args = append(args, file)
-		if _, _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
-			return errors.Wrap(err, "calling signtool")
+		if err := so.signtoolSign(ctx, file, false, SHA256); err != nil {
+			return errors.Wrap(err, "signing file with 1:sha256")
 		}
 	}
 
@@ -74,5 +80,42 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 		return errors.Wrap(err, "verify")
 	}
 
+	return nil
+}
+
+// constructSigntoolArgs returns an array of signtool.exe args based
+// on whether this is the first or subsequent signature, and what the
+// algorithm is.
+//
+// This is _very_ fragile. Not everthing you think will work does
+func (so *signtoolOptions) signtoolSign(ctx context.Context, file string, firstSig bool, algo digestAlgo) error {
+	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("algo %s", algo))
+	defer span.End()
+
+	args := []string{
+		"sign",
+		"/fd", string(algo),
+	}
+
+	if !firstSig {
+		args = append(args, "/as")
+	}
+
+	switch algo {
+	case SHA1:
+		args = append(args, "/t", so.timestampServer)
+	case SHA256:
+		args = append(args, "/td", "sha256", "/tr", so.rfc3161Server)
+	}
+
+	if so.extraArgs != nil {
+		args = append(args, so.extraArgs...)
+	}
+
+	args = append(args, file)
+
+	if _, _, err := so.execOut(ctx, so.signtoolPath, args...); err != nil {
+		return errors.Wrap(err, "calling signtool")
+	}
 	return nil
 }

--- a/pkg/packagekit/package.go
+++ b/pkg/packagekit/package.go
@@ -7,7 +7,10 @@ type PackageOptions struct {
 	Name       string // What's the name for this package (eg: launcher)
 	Root       string // source directory to package
 	Scripts    string // directory of packaging scripts (postinst, prerm, etc)
-	SigningKey string // key to sign packages with (platform specific behaviors)
 	Version    string // package version
 	FlagFile   string // Path to the flagfile for configuration
+
+	AppleSigningKey     string   // apple signing key
+	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
+	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key
 }

--- a/pkg/packagekit/package_pkg.go
+++ b/pkg/packagekit/package_pkg.go
@@ -46,8 +46,8 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
 		args = append(args, "--scripts", po.Scripts)
 	}
 
-	if po.SigningKey != "" {
-		args = append(args, "--sign", po.SigningKey)
+	if po.AppleSigningKey != "" {
+		args = append(args, "--sign", po.AppleSigningKey)
 	}
 
 	args = append(args, outputPath)

--- a/pkg/packagekit/package_test.go
+++ b/pkg/packagekit/package_test.go
@@ -22,10 +22,10 @@ func TestPackageTrivial(t *testing.T) {
 	require.NoError(t, err)
 
 	po := &PackageOptions{
-		Name:       "test-empty",
-		Version:    "0.0.0",
-		Root:       inputDir,
-		SigningKey: "Developer ID Installer: Kolide Inc (YZ3EM74M78)",
+		Name:            "test-empty",
+		Version:         "0.0.0",
+		Root:            inputDir,
+		AppleSigningKey: "Developer ID Installer: Kolide Inc (YZ3EM74M78)",
 	}
 
 	err = PackageFPM(context.TODO(), ioutil.Discard, po, AsTar())

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
+	"github.com/kolide/launcher/pkg/packagekit/authenticode"
 	"github.com/kolide/launcher/pkg/packagekit/internal"
 	"github.com/kolide/launcher/pkg/packagekit/wix"
 	"github.com/pkg/errors"

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -100,7 +100,7 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 			authenticode.WithExtraArgs(po.WindowsSigntoolArgs),
 			authenticode.WithSigntoolPath(signtoolPath),
 		); err != nil {
-			return errors.Wrap(err, "authencode signing")
+			return errors.Wrap(err, "authenticode signing")
 		}
 	}
 

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -134,19 +134,19 @@ func (wo *wixTool) Cleanup() {
 // package. The path for the resultant package will be returned.
 func (wo *wixTool) Package(ctx context.Context) (string, error) {
 	if err := wo.heat(ctx); err != nil {
-		return errors.Wrap(err, "running heat")
+		return "", errors.Wrap(err, "running heat")
 	}
 
 	if err := wo.addServices(ctx); err != nil {
-		return errors.Wrap(err, "adding services")
+		return "", errors.Wrap(err, "adding services")
 	}
 
 	if err := wo.candle(ctx); err != nil {
-		return errors.Wrap(err, "running candle")
+		return "", errors.Wrap(err, "running candle")
 	}
 
 	if err := wo.light(ctx); err != nil {
-		return errors.Wrap(err, "running light")
+		return "", errors.Wrap(err, "running light")
 	}
 
 	return filepath.Join(wo.buildDir, "out.msi"), nil

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -132,9 +131,8 @@ func (wo *wixTool) Cleanup() {
 }
 
 // Package will run through the wix steps to produce a resulting
-// package. This package will be written into the provided io.Writer,
-// facilitating export to a file, buffer, or other storage backends.
-func (wo *wixTool) Package(ctx context.Context, pkgOutput io.Writer) error {
+// package. The path for the resultant package will be returned.
+func (wo *wixTool) Package(ctx context.Context) (string, error) {
 	if err := wo.heat(ctx); err != nil {
 		return errors.Wrap(err, "running heat")
 	}
@@ -151,17 +149,7 @@ func (wo *wixTool) Package(ctx context.Context, pkgOutput io.Writer) error {
 		return errors.Wrap(err, "running light")
 	}
 
-	msiFH, err := os.Open(filepath.Join(wo.buildDir, "out.msi"))
-	if err != nil {
-		return errors.Wrap(err, "opening msi output file")
-	}
-	defer msiFH.Close()
-
-	if _, err := io.Copy(pkgOutput, msiFH); err != nil {
-		return errors.Wrap(err, "copying output")
-	}
-
-	return nil
+	return filepath.Join(wo.buildDir, "out.msi"), nil
 }
 
 // addServices adds service definitions into the wix configs.

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -32,7 +32,6 @@ type PackageOptions struct {
 	ExtensionVersion  string
 	Hostname          string
 	Secret            string
-	SigningKey        string
 	Transport         string
 	Insecure          bool
 	InsecureTransport bool
@@ -45,6 +44,10 @@ type PackageOptions struct {
 	CertPins          string
 	RootPEM           string
 	CacheDir          string
+
+	AppleSigningKey     string   // apple signing key
+	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
+	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key
 
 	target        Target                     // Target build platform
 	initOptions   *packagekit.InitOptions    // options we'll pass to the packagekit renderers
@@ -243,13 +246,15 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 	}
 
 	p.packagekitops = &packagekit.PackageOptions{
-		Name:       "launcher",
-		Identifier: p.Identifier,
-		Root:       p.packageRoot,
-		Scripts:    p.scriptRoot,
-		SigningKey: p.SigningKey,
-		Version:    p.PackageVersion,
-		FlagFile:   p.canonicalizePath(flagFilePath),
+		Name:                "launcher",
+		Identifier:          p.Identifier,
+		Root:                p.packageRoot,
+		Scripts:             p.scriptRoot,
+		AppleSigningKey:     p.AppleSigningKey,
+		WindowsUseSigntool:  p.WindowsUseSigntool,
+		WindowsSigntoolArgs: p.WindowsSigntoolArgs,
+		Version:             p.PackageVersion,
+		FlagFile:            p.canonicalizePath(flagFilePath),
 	}
 
 	if err := p.makePackage(ctx); err != nil {


### PR DESCRIPTION
Add package-kit support for authenticode signing through `signtool.exe`. This should be seen as an initial pass at getting general APIs and structure right. Tools may change here.

Reworks the options. Signing keys now have platform specific configuration 

Makefile updated to include launcher code push snippets. These are Kolide specific, and part of how we update notary.

Makefile updated to use `osslsigncode` to sign windows binaries