### PR TITLE
Add Notary config flags to package-builder make.

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -139,6 +139,21 @@ func runMake(args []string) error {
 			env.String("TARGETS", defaultTargets()),
 			"Target platforms to build. Specified in the form platform-init-package",
 		)
+		flNotaryURL = flagset.String(
+			"notary_url",
+			env.String("NOTARY_URL", ""),
+			"The Notary update server",
+		)
+		flMirrorURL = flagset.String(
+			"mirror_url",
+			env.String("MIRROR_URL", ""),
+			"The mirror server for autoupdates",
+		)
+		flNotaryPrefix = flagset.String(
+			"notary_prefix",
+			env.String("NOTARY_PREFIX", ""),
+			"The prefix for Notary path that contains the collections",
+		)
 	)
 
 	flagset.Usage = usageFor(flagset, "package-builder make [flags]")
@@ -201,6 +216,9 @@ func runMake(args []string) error {
 		CertPins:          *flCertPins,
 		RootPEM:           *flRootPEM,
 		CacheDir:          cacheDir,
+		NotaryURL:         *flNotaryURL,
+		MirrorURL:         *flMirrorURL,
+		NotaryPrefix:      *flNotaryPrefix,
 	}
 
 	outputDir := *flOutputDir

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -44,6 +44,9 @@ type PackageOptions struct {
 	CertPins          string
 	RootPEM           string
 	CacheDir          string
+	NotaryURL         string
+	MirrorURL         string
+	NotaryPrefix      string
 
 	AppleSigningKey     string   // apple signing key
 	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
@@ -142,6 +145,18 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 
 	if p.Insecure {
 		launcherBoolFlags = append(launcherBoolFlags, "insecure")
+	}
+
+	if p.NotaryURL != "" {
+		launcherMapFlags["notary_url"] = p.NotaryURL
+	}
+
+	if p.MirrorURL != "" {
+		launcherMapFlags["mirror_url"] = p.MirrorURL
+	}
+
+	if p.NotaryPrefix != "" {
+		launcherMapFlags["notary_prefix"] = p.NotaryPrefix
 	}
 
 	if p.RootPEM != "" {


### PR DESCRIPTION
This adds `notary_url`, `mirror_url`, and `notary_prefix` flags to `package-builder make` which are passed to `launcher`. This is done so that organizations running their own Notary server can use `package-builder`.