### PR TITLE
Add env variable support to builder.go for NotaryURL and NotaryPrefix

### DIFF
--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fs"
-	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/pkg/errors"
 	"github.com/theupdateframework/notary/client"
@@ -308,7 +307,7 @@ func (b *Builder) GenerateTUF(ctx context.Context) error {
 
 	notaryPrefix := os.Getenv("NOTARY_PREFIX")
 	if notaryPrefix == "" {
-		notaryPrefix = autoupdate.DefaultNotaryPrefix
+		notaryPrefix = "kolide"
 	}
 
 	for _, t := range binaryTargets {


### PR DESCRIPTION
This adds environment variable support for `NotaryURL` and `NotaryPrefix` so they can be specified as part of a build pipeline without needing to change files on disk.