### PR TITLE
Refresh configs less often

### DIFF
--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -138,12 +138,20 @@ func createOsquerydCommand(osquerydBinary string, paths *osqueryFilePaths, confi
 		"--disable_distributed=false",
 		"--distributed_interval=5",
 		"--pack_delimiter=:",
-		"--config_refresh=10",
 		"--host_identifier=uuid",
 		"--force=true",
 		"--disable_watchdog",
 		"--utc",
 	)
+
+	// Refresh configs every couple minutes. if there's a failure, try
+	// again more prompty. Values in seconds. These settings are CLI
+	// flags only.
+	cmd.Args = append(cmd.Args,
+		"--config_refresh=120",
+		"--config_accelerated_refresh=30",
+	)
+
 	cmd.Args = append(cmd.Args, platformArgs()...)
 	if stdout != nil {
 		cmd.Stdout = stdout

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -144,11 +144,11 @@ func createOsquerydCommand(osquerydBinary string, paths *osqueryFilePaths, confi
 		"--utc",
 	)
 
-	// Refresh configs every couple minutes. if there's a failure, try
-	// again more prompty. Values in seconds. These settings are CLI
-	// flags only.
+	// Configs aren't expected to change often, so refresh configs
+	// every couple minutes. if there's a failure, try again more
+	// promptly. Values in seconds. These settings are CLI flags only.
 	cmd.Args = append(cmd.Args,
-		"--config_refresh=120",
+		"--config_refresh=300",
 		"--config_accelerated_refresh=30",
 	)
 


### PR DESCRIPTION
Change the config refresh interval to 2minutes, with a retry-after-failure of 30s. This should mitigate the common complaint about network volume.