### PR TITLE
Adjust MSI Service Settings

### DIFF
--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -163,6 +163,16 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 	// and CamelCase it. (eg: daemon.exe becomes DaemonSvc). It is
 	// probably better to specific a ServiceName, but this might be an
 	// okay default.
+	//
+	// It's not really clear what we want for Vital and Wait. Vital is
+	// whether the MSI should error out if the service fails. While that
+	// _sounds_ appropriate, it turns out it will break if something
+	// caused a prior service to still be present. (Note that not
+	// rebooting enough can trigger that)
+	//
+	// Wait refers to whether the MSI should wait for the service. Which
+	// seems like an obvious tradeoff between MSIs just working, and
+	// services working.
 	defaultName := cleanServiceName(strings.TrimSuffix(matchString, ".exe") + ".svc")
 	si := &ServiceInstall{
 		Name:          defaultName,
@@ -171,7 +181,7 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 		Start:         StartAuto,
 		Type:          "ownProcess",
 		ErrorControl:  ErrorControlNormal,
-		Vital:         Yes,
+		Vital:         No,
 		ServiceConfig: sconfig,
 	}
 
@@ -181,7 +191,7 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 		Stop:   InstallUninstallBoth,
 		Start:  InstallUninstallInstall,
 		Remove: InstallUninstallUninstall,
-		Wait:   No,
+		Wait:   Yes,
 	}
 
 	s := &Service{

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -26,10 +26,10 @@ func TestService(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, expectTrue2)
 
-	expectedXml := `<ServiceInstall Account="[SERVICEACCOUNT]" ErrorControl="normal" Id="DaemonSvc" Name="DaemonSvc" Start="auto" Type="ownProcess" Vital="yes">
+	expectedXml := `<ServiceInstall Account="[SERVICEACCOUNT]" ErrorControl="normal" Id="DaemonSvc" Name="DaemonSvc" Start="auto" Type="ownProcess" Vital="no">
                         <ServiceConfig xmlns="http://schemas.microsoft.com/wix/UtilExtension" FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" ResetPeriodInDays="1"></ServiceConfig>
                     </ServiceInstall>
-                    <ServiceControl Name="DaemonSvc" Id="DaemonSvc" Remove="uninstall" Start="install" Stop="both" Wait="no"></ServiceControl>`
+                    <ServiceControl Name="DaemonSvc" Id="DaemonSvc" Remove="uninstall" Start="install" Stop="both" Wait="yes"></ServiceControl>`
 
 	var xmlString bytes.Buffer
 


### PR DESCRIPTION
If there are service install problems, say because a prior install left the service in a weird state, `Vital=yes` means the MSI install will fail.

Adjust to `Vital=no`, and `Wait=yes` to see how that behaves

Relates To: https://github.com/kolide/launcher/issues/467