### PR TITLE
Updater failure is not fatal

### DIFF
--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -91,7 +91,7 @@ func createUpdater(
 			// Don't exit unless there's a done signal TODO: remove when
 			// underlying libs are refactored, everything exits right now,
 			// so block this actor on the context finishing
-			level.Info(logger).Log("msg", "waiting")
+			level.Debug(logger).Log("msg", "waiting")
 			<-ctx.Done()
 
 			return nil

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -258,6 +258,10 @@ func (u *Updater) Run(opts ...tuf.Option) (stop func(), err error) {
 		"stagingPath", u.stagingPath,
 	)
 
+	// tuf.NewClient spawns a go thread with a running worker in
+	// the background. We don't get much for runtime
+	// communication back from it. Some can come in via the
+	// UpdateFinalizer function, but it's mostly fire-and-forget
 	client, err := tuf.NewClient(
 		u.settings,
 		updaterOpts...,


### PR DESCRIPTION
Failing to launch an updater is not a fatal error. Instead, we should sleep and try again.