### PR TITLE
kolide_json table is platform independent

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -32,7 +32,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		kextpolicy.TablePlugin(),
 		legacyexec.TablePlugin(),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.JsonType),
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
 	}

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"github.com/kolide/launcher/pkg/launcher"
+	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
@@ -32,6 +33,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		OnePasswordAccounts(client, logger),
 		SlackConfig(client, logger),
 		SshKeys(client, logger),
+		dataflattentable.TablePlugin(client, logger, dataflattentable.JsonType),
 	}
 
 	// add in the platform specific ones (as denboted by build tags)


### PR DESCRIPTION
The `kolide_json` table is platform independent. It should not have been flagged as darwin only.