### PR TITLE
Don't pass debug to dataflatten

### DIFF
--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -40,7 +40,7 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 
 	t := &Table{
 		client: client,
-		logger: logger,
+		logger: level.NewFilter(logger, level.AllowInfo()),
 	}
 
 	switch dataSourceType {


### PR DESCRIPTION
The underlying dataflatten pkg uses debug for debugging the internals. As this is not something we need to pass up through launcher's logging, filter it.