### PR TITLE
Use conventional names for systemd service names

### DIFF
--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -418,11 +418,11 @@ func (p *PackageOptions) setupInit(ctx context.Context) error {
 		if p.target.Package == Rpm {
 			dir = "/usr/lib/systemd/system"
 		}
-		file = fmt.Sprintf("launcher.%s.service", p.Identifier)
+		file = fmt.Sprintf("%s-launcher.service", p.Identifier)
 		renderFunc = packagekit.RenderSystemd
 	case p.target.Platform == Linux && p.target.Init == Upstart:
 		dir = "/etc/init"
-		file = fmt.Sprintf("launcher-%s.conf", p.Identifier)
+		file = fmt.Sprintf("%s-launcher.conf", p.Identifier)
 		renderFunc = func(ctx context.Context, w io.Writer, io *packagekit.InitOptions) error {
 			return packagekit.RenderUpstart(ctx, w, io)
 		}


### PR DESCRIPTION
A systemd service with a name like launcher.foo-bar is confusing and
non-standard. virtually all software uses something along the lines of
‘package-foo’, with ‘package’ being the main name of the software, and
‘foo’ some detail about the specific service (there can be more than
one).

This PR changes the systemd service name to ‘%s-launcher’, e.g.
‘kolide-k2-launcher’.