### PR TITLE
Use correct(er) spelling for systemd

### DIFF
--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -411,7 +411,7 @@ func (p *PackageOptions) setupInit(ctx context.Context) error {
 		dir = "/Library/LaunchDaemons"
 		file = fmt.Sprintf("com.%s.launcher.plist", p.Identifier)
 		renderFunc = packagekit.RenderLaunchd
-	case p.target.Platform == Linux && p.target.Init == SystemD:
+	case p.target.Platform == Linux && p.target.Init == Systemd:
 		// Default to dropping into /lib, it seems more common. But for
 		// rpm use /usr/lib.
 		dir = "/lib/systemd/system"
@@ -461,7 +461,7 @@ func (p *PackageOptions) setupPrerm(ctx context.Context) error {
 	identifier := p.Identifier
 
 	switch {
-	case p.target.Platform == Linux && p.target.Init == SystemD:
+	case p.target.Platform == Linux && p.target.Init == Systemd:
 		prermTemplate = prermSystemdTemplate()
 	default:
 		// If we don't match in the case statement, log that we're ignoring
@@ -510,7 +510,7 @@ func (p *PackageOptions) setupPostinst(ctx context.Context) error {
 	switch {
 	case p.target.Platform == Darwin && p.target.Init == LaunchD:
 		postinstTemplateName = "internal/assets/postinstall-launchd.sh"
-	case p.target.Platform == Linux && p.target.Init == SystemD:
+	case p.target.Platform == Linux && p.target.Init == Systemd:
 		postinstTemplateName = "internal/assets/postinstall-systemd.sh"
 	case p.target.Platform == Linux && p.target.Init == Upstart:
 		postinstTemplateName = "internal/assets/postinstall-upstart.sh"

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -146,12 +146,12 @@ func testedTargets() []Target {
 		},
 		{
 			Platform: Linux,
-			Init:     SystemD,
+			Init:     Systemd,
 			Package:  Rpm,
 		},
 		{
 			Platform: Linux,
-			Init:     SystemD,
+			Init:     Systemd,
 			Package:  Deb,
 		},
 		{

--- a/pkg/packaging/target.go
+++ b/pkg/packaging/target.go
@@ -19,7 +19,7 @@ type InitFlavor string
 
 const (
 	LaunchD        InitFlavor = "launchd"
-	SystemD                   = "systemd"
+	Systemd                   = "systemd"
 	Init                      = "init"
 	Upstart                   = "upstart"
 	WindowsService            = "service"
@@ -103,7 +103,7 @@ func (t *Target) PlatformBinaryName(input string) string {
 
 // InitFromString sets a target's init flavor from string representation
 func (t *Target) InitFromString(s string) error {
-	for _, testInit := range []InitFlavor{LaunchD, SystemD, Init, Upstart, NoInit, WindowsService} {
+	for _, testInit := range []InitFlavor{LaunchD, Systemd, Init, Upstart, NoInit, WindowsService} {
 		if testInit.String() == s {
 			t.Init = testInit
 			return nil

--- a/pkg/packaging/target_test.go
+++ b/pkg/packaging/target_test.go
@@ -20,7 +20,7 @@ func TestInitFromString(t *testing.T) {
 		},
 		{
 			in:  "systemd",
-			out: SystemD,
+			out: Systemd,
 		},
 		{
 			in:  "init",
@@ -146,7 +146,7 @@ func TestTargetParse(t *testing.T) {
 		},
 		{
 			in:  "linux-systemd-rpm",
-			out: &Target{Platform: Linux, Init: SystemD, Package: Rpm},
+			out: &Target{Platform: Linux, Init: Systemd, Package: Rpm},
 		},
 		{
 			in:         "windows-msi",


### PR DESCRIPTION
The correct spelling is ‘systemd’, but it seems golang has it own
particularities which conflict with that... but in any case the ‘d’ at
the end should not be capitalized, so change that.

> Yes, it is written systemd, not system D or System D, or even SystemD. And it isn't system d either. [...] — https://www.freedesktop.org/wiki/Software/systemd/