### PR TITLE
set extra debug options for windows svc-fg

### DIFF
--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -79,6 +79,10 @@ func runWindowsSvcForeground(args []string) error {
 		os.Exit(1)
 	}
 
+	// set extra debug options
+	opts.Debug = true
+	opts.OsqueryVerbose = true
+
 	run := debug.Run
 
 	return run(serviceName, &winSvc{logger: logger, opts: opts})


### PR DESCRIPTION
When using windows, in svc-fg mode, we are in a debugging mode. Set additional debugging option.