### PR TITLE
Add DEP Enroll column to MDM table

### DIFF
--- a/pkg/osquery/table/mdm.go
+++ b/pkg/osquery/table/mdm.go
@@ -60,7 +60,7 @@ func MDMInfo(logger log.Logger) *table.Plugin {
 		table.TextColumn("has_scep_payload"),
 		table.TextColumn("installed_from_dep"),
 		table.TextColumn("user_approved"),
-		table.TextColumn("dep_capable"),
+		table.TextColumn("has_dep_profile"),
 	}
 	return table.NewPlugin("kolide_mdm_info", columns, generateMDMInfo)
 }
@@ -106,7 +106,7 @@ func generateMDMInfo(ctx context.Context, queryContext table.QueryContext) ([]ma
 					"identity_certificate_uuid": enrollProfile.IdentityCertificateUUID,
 					"installed_from_dep":        depEnrolled,
 					"user_approved":             userApproved,
-					"dep_capable":               depCapable,
+					"has_dep_profile":           depCapable,
 				}
 				break
 			}
@@ -172,7 +172,7 @@ func getDEPStatus() (depStatus, error) {
 
 	var depstatus depStatus
 
-	if len(lines) > 3 {
+	if len(lines) > 3 { // This is less than ideal boolean logic and may someday break
 		depstatus.DEPCapable = true
 	}
 

--- a/pkg/osquery/table/mdm.go
+++ b/pkg/osquery/table/mdm.go
@@ -3,7 +3,6 @@ package table
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os/exec"
 	"strconv"
 
@@ -166,12 +165,12 @@ func getDEPStatus() (depStatus, error) {
 	cmd := exec.Command("/usr/bin/profiles", "show", "-type", "enrollment")
 	out, err := cmd.Output()
 	if err != nil {
-		fmt.Println(err)
+		return depStatus{}, err
 	}
 
 	lines := bytes.Split(out, []byte("\n"))
 
-	depstatus := depStatus{DEPCapable: false}
+	var depstatus depStatus
 
 	if len(lines) > 3 {
 		depstatus.DEPCapable = true

--- a/pkg/osquery/table/mdm.go
+++ b/pkg/osquery/table/mdm.go
@@ -16,18 +16,18 @@ import (
 type profilesOutput struct {
 	ComputerLevel []profilePayload `plist:"_computerlevel"`
 }
-​
+
 type profilePayload struct {
 	ProfileIdentifier  string
 	ProfileInstallDate string
 	ProfileItems       []profileItem
 }
-​
+
 type profileItem struct {
 	PayloadContent *payloadContent
 	PayloadType    string
 }
-​
+
 type payloadContent struct {
 	AccessRights            int
 	CheckInURL              string
@@ -37,12 +37,12 @@ type payloadContent struct {
 	IdentityCertificateUUID string
 	SignMessage             bool
 }
-​
+
 type profileStatus struct {
 	DEPEnrolled  bool
 	UserApproved bool
 }
-​
+
 type depStatus struct {
 	DEPCapable bool
 }
@@ -61,6 +61,7 @@ func MDMInfo(logger log.Logger) *table.Plugin {
 		table.TextColumn("has_scep_payload"),
 		table.TextColumn("installed_from_dep"),
 		table.TextColumn("user_approved"),
+		table.TextColumn("dep_capable"),
 	}
 	return table.NewPlugin("kolide_mdm_info", columns, generateMDMInfo)
 }
@@ -140,31 +141,6 @@ func getMDMProfile() (*profilesOutput, error) {
 	return &profiles, nil
 }
 
-type profilesOutput struct {
-	ComputerLevel []profilePayload `plist:"_computerlevel"`
-}
-
-type profilePayload struct {
-	ProfileIdentifier  string
-	ProfileInstallDate string
-	ProfileItems       []profileItem
-}
-
-type profileItem struct {
-	PayloadContent *payloadContent
-	PayloadType    string
-}
-
-type payloadContent struct {
-	AccessRights            int
-	CheckInURL              string
-	ServerURL               string
-	ServerCapabilities      []string
-	Topic                   string
-	IdentityCertificateUUID string
-	SignMessage             bool
-}
-
 func getMDMProfileStatus() (profileStatus, error) {
 	cmd := exec.Command("/usr/bin/profiles", "status", "-type", "enrollment")
 	out, err := cmd.Output()
@@ -192,14 +168,14 @@ func getDEPStatus() (depStatus, error) {
 	if err != nil {
 		fmt.Println(err)
 	}
-​
+
 	lines := bytes.Split(out, []byte("\n"))
-​
+
 	depstatus := depStatus{DEPCapable: false}
-​
+
 	if len(lines) > 3 {
 		depstatus.DEPCapable = true
 	}
-​
+
 	return depstatus, nil
 }


### PR DESCRIPTION
## What is being changed?

This PR adds @grahamgilbert 's DEP enrollment column to the existing MDM table #565.

### How is this helpful?
Per [Apple's Documentation:](https://www.apple.com/business/docs/site/DEP_Guide.pdf)
>Device Enrollment Program or DEP is a program available through Apple which helps businesses easily deploy and configure Apple devices. DEP simplifies initial setup by automating mobile device management (MDM) enrollment and supervision of devices during setup, which enables you to configure your organization’s devices without touching them. To further simplify the process, you can skip certain Setup Assistant screens so users can start using their devices right out of the box. 

Understanding whether a device is enrolled in DEP can be critical to guaranteeing the desired configuration of a device.

Prior to this column being added we have not had a reliable method to determine whether devices were DEP enrolled.

### What will this look like?
```SQL
osquery> SELECT * FROM kolide_mdm_info;
                 enrolled = true
               server_url = https://acme.jamfcloud.com//computer/mdm
              checkin_url = https://acme.jamfcloud.com//computer/mdm?invitation=xxxx
            access_rights = ****
             install_date = 2019-02-18 00:11:15 +0000
       payload_identifier = 00000000-0000-0000-0000-***********
                    topic = com.apple.mgmt.External.****
             sign_message = true
identity_certificate_uuid = 00000000-0000-0000-0000-***********
         has_scep_payload = true
       installed_from_dep = true
            user_approved = true
             dep_enrolled = true
```