### PR TITLE
Fix data flattening path handling bug

### DIFF
--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -175,12 +175,10 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			if err := fl.descend(append(path, pathKey), e, depth+1); err != nil {
 				return errors.Wrap(err, "flattening array")
 			}
-
 		}
 	case map[string]interface{}:
-		level.Debug(logger).Log("msg", "checking a map", "path", strings.Join(path, "/"))
+		level.Debug(logger).Log("msg", "checking a map")
 		for k, e := range v {
-
 			// Check that the key name matches. If not, skip this entire
 			// branch of the map
 			if !(isQueryMatched || fl.queryMatchString(k, queryTerm)) {
@@ -197,10 +195,11 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			level.Debug(logger).Log("msg", "query not matched")
 			return nil
 		}
-		fl.rows = append(fl.rows, Row{Path: path, Value: ""})
+		fl.rows = append(fl.rows, NewRow(path, ""))
 	default:
 		// non-iterable. stringify and be done
 		stringValue, err := stringify(v)
+
 		if err != nil {
 			return errors.Wrapf(err, "flattening at path %v", path)
 		}
@@ -209,8 +208,7 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			level.Debug(logger).Log("msg", "query not matched")
 			return nil
 		}
-		fl.rows = append(fl.rows, Row{Path: path, Value: stringValue})
-
+		fl.rows = append(fl.rows, NewRow(path, stringValue))
 	}
 	return nil
 }

--- a/pkg/dataflatten/flatten_test.go
+++ b/pkg/dataflatten/flatten_test.go
@@ -45,6 +45,35 @@ func TestFlatten_NullHandlingBug(t *testing.T) {
 
 }
 
+func TestFlatten_NestingBug(t *testing.T) {
+	t.Parallel()
+
+	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "nested.json"))
+	require.NoError(t, err, "reading file")
+	var dataIn interface{}
+	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")
+
+	var tests = []flattenTestCase{
+		{
+			out: []Row{
+				Row{Path: []string{"addons", "0", "name"}, Value: "Nested Strings"},
+				Row{Path: []string{"addons", "0", "nest1", "string3"}, Value: "string3"},
+				Row{Path: []string{"addons", "0", "nest1", "string4"}, Value: "string4"},
+				Row{Path: []string{"addons", "0", "nest1", "string5"}, Value: "string5"},
+				Row{Path: []string{"addons", "0", "nest1", "string6"}, Value: "string6"},
+				Row{Path: []string{"addons", "0", "nest1", "string7"}, Value: "string7"},
+				Row{Path: []string{"addons", "0", "nest1", "string8"}, Value: "string8"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actual, err := Flatten(dataIn, tt.options...)
+		testFlattenCase(t, tt, actual, err)
+	}
+
+}
+
 func TestFlatten_Complex(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dataflatten/flatten_test.go
+++ b/pkg/dataflatten/flatten_test.go
@@ -18,6 +18,33 @@ type flattenTestCase struct {
 	err     bool
 }
 
+func TestFlatten_NullHandlingBug(t *testing.T) {
+	t.Parallel()
+
+	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "nulls.json"))
+	require.NoError(t, err, "reading file")
+	var dataIn interface{}
+	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")
+
+	var tests = []flattenTestCase{
+		{
+			out: []Row{
+				Row{Path: []string{"addons", "0", "bool1"}, Value: "true"},
+				Row{Path: []string{"addons", "0", "nest2", "0", "string2"}, Value: "foo"},
+				Row{Path: []string{"addons", "0", "nest3", "string7"}, Value: "A Very Long Sentence"},
+				Row{Path: []string{"addons", "0", "nest3", "string8"}, Value: "short"},
+				Row{Path: []string{"addons", "0", "string1"}, Value: "hello"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actual, err := Flatten(dataIn, tt.options...)
+		testFlattenCase(t, tt, actual, err)
+	}
+
+}
+
 func TestFlatten_Complex(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dataflatten/flatten_test.go
+++ b/pkg/dataflatten/flatten_test.go
@@ -18,10 +18,10 @@ type flattenTestCase struct {
 	err     bool
 }
 
-func TestFlatten_NullHandlingBug(t *testing.T) {
+func TestFlatten_Complex2(t *testing.T) {
 	t.Parallel()
 
-	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "nulls.json"))
+	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "complex2.json"))
 	require.NoError(t, err, "reading file")
 	var dataIn interface{}
 	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")
@@ -31,10 +31,30 @@ func TestFlatten_NullHandlingBug(t *testing.T) {
 			out: []Row{
 				Row{Path: []string{"addons", "0", "bool1"}, Value: "true"},
 				Row{Path: []string{"addons", "0", "nest2", "0", "string2"}, Value: "foo"},
+				Row{Path: []string{"addons", "0", "nest3", "string6"}, Value: "null"},
 				Row{Path: []string{"addons", "0", "nest3", "string7"}, Value: "A Very Long Sentence"},
 				Row{Path: []string{"addons", "0", "nest3", "string8"}, Value: "short"},
 				Row{Path: []string{"addons", "0", "string1"}, Value: "hello"},
 			},
+		},
+		{
+			out: []Row{
+				Row{Path: []string{"addons", "0", "bool1"}, Value: "true"},
+				Row{Path: []string{"addons", "0", "nest2", "0", "null3"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest2", "0", "null4"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest2", "0", "string2"}, Value: "foo"},
+				Row{Path: []string{"addons", "0", "nest3", "string3"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest3", "string4"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest3", "string5"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest3", "string6"}, Value: "null"},
+				Row{Path: []string{"addons", "0", "nest3", "string7"}, Value: "A Very Long Sentence"},
+				Row{Path: []string{"addons", "0", "nest3", "string8"}, Value: "short"},
+				Row{Path: []string{"addons", "0", "null1"}, Value: ""},
+				Row{Path: []string{"addons", "0", "null2"}, Value: ""},
+				Row{Path: []string{"addons", "0", "string1"}, Value: "hello"},
+			},
+			options: []FlattenOpts{IncludeNulls()},
+			comment: "includes null",
 		},
 	}
 
@@ -61,9 +81,20 @@ func TestFlatten_NestingBug(t *testing.T) {
 				Row{Path: []string{"addons", "0", "nest1", "string4"}, Value: "string4"},
 				Row{Path: []string{"addons", "0", "nest1", "string5"}, Value: "string5"},
 				Row{Path: []string{"addons", "0", "nest1", "string6"}, Value: "string6"},
-				Row{Path: []string{"addons", "0", "nest1", "string7"}, Value: "string7"},
-				Row{Path: []string{"addons", "0", "nest1", "string8"}, Value: "string8"},
 			},
+		},
+		{
+			out: []Row{
+				Row{Path: []string{"addons", "0", "name"}, Value: "Nested Strings"},
+				Row{Path: []string{"addons", "0", "nest1", "string1"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest1", "string2"}, Value: ""},
+				Row{Path: []string{"addons", "0", "nest1", "string3"}, Value: "string3"},
+				Row{Path: []string{"addons", "0", "nest1", "string4"}, Value: "string4"},
+				Row{Path: []string{"addons", "0", "nest1", "string5"}, Value: "string5"},
+				Row{Path: []string{"addons", "0", "nest1", "string6"}, Value: "string6"},
+			},
+			options: []FlattenOpts{IncludeNulls()},
+			comment: "includes null",
 		},
 	}
 
@@ -102,7 +133,7 @@ func TestFlatten_Complex(t *testing.T) {
 				Row{Path: []string{"users", "0", "id"}, Value: "1"},
 				Row{Path: []string{"users", "0", "name"}, Value: "Alex Aardvark"},
 				Row{Path: []string{"users", "0", "uuid"}, Value: "abc123"},
-				Row{Path: []string{"users", "1", "favorites", "1"}, Value: "mice"},
+				Row{Path: []string{"users", "1", "favorites", "0"}, Value: "mice"},
 				Row{Path: []string{"users", "1", "favorites", "1"}, Value: "birds"},
 				Row{Path: []string{"users", "1", "id"}, Value: "2"},
 				Row{Path: []string{"users", "1", "name"}, Value: "Bailey Bobcat"},
@@ -112,6 +143,7 @@ func TestFlatten_Complex(t *testing.T) {
 				Row{Path: []string{"users", "2", "name"}, Value: "Cam Chipmunk"},
 				Row{Path: []string{"users", "2", "uuid"}, Value: "ghi789"},
 			},
+			comment: "all together",
 		},
 		{
 			options: []FlattenOpts{WithQuery([]string{"metadata"})},

--- a/pkg/dataflatten/row.go
+++ b/pkg/dataflatten/row.go
@@ -8,6 +8,17 @@ type Row struct {
 	Value string
 }
 
+// NewRow does a copy of the path elements, and returns a row. We do
+// this copy to correct for some odd pointer passing bugs
+func NewRow(path []string, value string) Row {
+	copiedPath := make([]string, len(path))
+	copy(copiedPath, path)
+	return Row{
+		Path:  copiedPath,
+		Value: value,
+	}
+}
+
 func (r Row) StringPath(sep string) string {
 	return strings.Join(r.Path, sep)
 }

--- a/pkg/dataflatten/testdata/complex2.json
+++ b/pkg/dataflatten/testdata/complex2.json
@@ -16,9 +16,9 @@
         }
       ],
       "nest3": {
-        "string3": "null",
-        "string4": "null",
-        "string5": "null",
+        "string3": null,
+        "string4": null,
+        "string5": null,
         "string6": "null",
         "string7": "A Very Long Sentence",
         "string8": "short"

--- a/pkg/dataflatten/testdata/nested.json
+++ b/pkg/dataflatten/testdata/nested.json
@@ -1,15 +1,15 @@
 {
   "addons": [
     {
+      "name": "Nested Strings",
       "nest1": {
-        "string8": "string8",
-        "string7": "string7",
-        "string6": "string6",
-        "string5": "string5",
+        "string1": null,
+        "string2": null,
+        "string3": "string3",
         "string4": "string4",
-        "string3": "string3"
-      },
-      "name": "Nested Strings"
+        "string5": "string5",
+        "string6": "string6"
+      }
     }
   ]
 }

--- a/pkg/dataflatten/testdata/nested.json
+++ b/pkg/dataflatten/testdata/nested.json
@@ -1,0 +1,15 @@
+{
+  "addons": [
+    {
+      "nest1": {
+        "string8": "string8",
+        "string7": "string7",
+        "string6": "string6",
+        "string5": "string5",
+        "string4": "string4",
+        "string3": "string3"
+      },
+      "name": "Nested Strings"
+    }
+  ]
+}

--- a/pkg/dataflatten/testdata/nulls.json
+++ b/pkg/dataflatten/testdata/nulls.json
@@ -1,28 +1,28 @@
 {
   "addons": [
     {
-      "nest3": {
-        "string8": "short",
-        "string7": "A Very Long Sentence",
-        "string6": null,
-        "string5": null,
-        "string4": null,
-        "string3": null
-      },
-      "nest2": [
-        {
-          "string2": "foo",
-          "null4": null,
-          "null3": null
-        }
-      ],
+      "string1": "hello",
+      "null1": null,
+      "null2": null,
+      "bool1": true,
       "nest1": {
         "anArray": []
       },
-      "bool1": true,
-      "null2": null,
-      "null1": null,
-      "string1": "hello"
+      "nest2": [
+        {
+          "null3": null,
+          "null4": null,
+          "string2": "foo"
+        }
+      ],
+      "nest3": {
+        "string3": "null",
+        "string4": "null",
+        "string5": "null",
+        "string6": "null",
+        "string7": "A Very Long Sentence",
+        "string8": "short"
+      }
     }
   ]
 }

--- a/pkg/dataflatten/testdata/nulls.json
+++ b/pkg/dataflatten/testdata/nulls.json
@@ -1,0 +1,28 @@
+{
+  "addons": [
+    {
+      "nest3": {
+        "string8": "short",
+        "string7": "A Very Long Sentence",
+        "string6": null,
+        "string5": null,
+        "string4": null,
+        "string3": null
+      },
+      "nest2": [
+        {
+          "string2": "foo",
+          "null4": null,
+          "null3": null
+        }
+      ],
+      "nest1": {
+        "anArray": []
+      },
+      "bool1": true,
+      "null2": null,
+      "null1": null,
+      "string1": "hello"
+    }
+  ]
+}


### PR DESCRIPTION
This fixes a `path` handling bug in data flattening. When it was called with a data structure like:
```json
  "addons": [
    {
      "nest1": {
        "string3": "string3",
        "string4": "string4",
      }
    }
  ]
}
```

The path would end up with a pointer, and be re-written. Eg, instead of getting: `[ ["addons", "0", "nest1", "string3"], ["addons", "0", "nest1", "string4"]`

We would instead get: `[ ["addons", "0", "nest1", "string3"], ["addons", "0", "nest1", "string3"]`

This introduces more tests cases (though, embarrassingly there was an error in an earlier test case that should have caught this).

The underlying bug is fixed by making a copy of `path` when we add the row to the results. 