### PR TITLE
Guard against errors on bioutil

### DIFF
--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -74,8 +74,10 @@ func (t *touchIDSystemConfigTable) generate(ctx context.Context, queryContext ta
 	}
 	configOutStr := string(stdout.Bytes())
 	configSplit := strings.Split(configOutStr, ":")
-	touchIDEnabled = configSplit[2][1:2]
-	touchIDUnlock = configSplit[3][1:2]
+	if len(configSplit) >= 3 {
+		touchIDEnabled = configSplit[2][1:2]
+		touchIDUnlock = configSplit[3][1:2]
+	}
 
 	result := map[string]string{
 		"touchid_compatible": touchIDCompatible,


### PR DESCRIPTION
Some machines don't return output from `bioutil`. In that case, don't parse it.