### PR TITLE
Move stackdumps to debug

### DIFF
--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/logutil"
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/osquery/table"
@@ -41,12 +42,14 @@ func main() {
 		osquery.ServerTimeout(timeout),
 	)
 	if err != nil {
-		logutil.Fatal(logger, "err", err, "msg", "creating osquery extension server", "stack", fmt.Sprintf("%+v", err))
+		level.Debug(logger).Log("err", err, "msg", "creating osquery extension server", "stack", fmt.Sprintf("%+v", err))
+		logutil.Fatal(logger, "err", err, "msg", "creating osquery extension server")
 	}
 
 	client, err := osquery.NewClient(*flSocketPath, timeout)
 	if err != nil {
-		logutil.Fatal(logger, "err", err, "creating osquery extension client", "stack", fmt.Sprintf("%+v", err))
+		level.Debug(logger).Log("err", err, "creating osquery extension client", "stack", fmt.Sprintf("%+v", err))
+		logutil.Fatal(logger, "err", err, "creating osquery extension client")
 	}
 
 	var plugins []osquery.OsqueryPlugin
@@ -56,6 +59,7 @@ func main() {
 	server.RegisterPlugin(plugins...)
 
 	if err := server.Run(); err != nil {
-		logutil.Fatal(logger, "err", err, "stack", fmt.Sprintf("%+v", err))
+		level.Debug(logger).Log("err", err, "stack", fmt.Sprintf("%+v", err))
+		logutil.Fatal(logger, "err", err)
 	}
 }

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -121,11 +121,13 @@ func createExtensionRuntime(ctx context.Context, db *bolt.DB, launcherClient ser
 				return nil
 			},
 			Interrupt: func(err error) {
-				level.Info(logger).Log("msg", "extension interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
+				level.Info(logger).Log("msg", "extension interrupted", "err", err)
+				level.Debug(logger).Log("msg", "extension interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
 				ext.Shutdown()
 				if runner != nil {
 					if err := runner.Shutdown(); err != nil {
-						level.Info(logger).Log("msg", "error shutting down runtime", "err", err, "stack", fmt.Sprintf("%+v", err))
+						level.Info(logger).Log("msg", "error shutting down runtime", "err", err)
+						level.Debug(logger).Log("msg", "error shutting down runtime", "err", err, "stack", fmt.Sprintf("%+v", err))
 					}
 				}
 			},

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -122,7 +122,8 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			return nil
 		}
 	}, func(err error) {
-		level.Info(logger).Log("msg", "interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
+		level.Info(logger).Log("msg", "interrupted", "err", err)
+		level.Debug(logger).Log("msg", "interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
 		cancel()
 		close(sigChannel)
 	})

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -78,7 +78,8 @@ func main() {
 	ctx = ctxlog.NewContext(ctx, logger)
 
 	if err := runLauncher(ctx, cancel, opts); err != nil {
-		logutil.Fatal(logger, err, "run launcher", "stack", fmt.Sprintf("%+v", err))
+		level.Debug(logger).Log(err, "run launcher", "stack", fmt.Sprintf("%+v", err))
+		logutil.Fatal(logger, err, "run launcher")
 	}
 }
 

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -107,7 +107,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	go func() {
 		err := runLauncher(ctx, cancel, w.opts)
 		if err != nil {
-			level.Info(w.logger).Log("msg", "runLauncher exited", "err", err, "stack", fmt.Sprintf("%+v", err))
+			level.Info(w.logger).Log("msg", "runLauncher exited", "err", err)
+			level.Debug(w.logger).Log("msg", "runLauncher exited", "err", err, "stack", fmt.Sprintf("%+v", err))
 			changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
 			os.Exit(1)
 		}

--- a/cmd/launcher/updater-finalizer.go
+++ b/cmd/launcher/updater-finalizer.go
@@ -21,11 +21,8 @@ import (
 func updateFinalizer(logger log.Logger, shutdownOsquery func() error) func() error {
 	return func() error {
 		if err := shutdownOsquery(); err != nil {
-			level.Info(logger).Log(
-				"method", "updateFinalizer",
-				"err", err,
-				"stack", fmt.Sprintf("%+v", err),
-			)
+			level.Info(logger).Log("method", "updateFinalizer", "err", err)
+			level.Debug(logger).Log("method", "updateFinalizer", "err", err, "stack", fmt.Sprintf("%+v", err))
 		}
 		// find the newest version of launcher on disk.
 		// FindNewest uses context as a way to get a logger, so we need to create and pass one.

--- a/cmd/launcher/updater-finalizer_windows.go
+++ b/cmd/launcher/updater-finalizer_windows.go
@@ -21,12 +21,8 @@ import (
 func updateFinalizer(logger log.Logger, shutdownOsquery func() error) func() error {
 	return func() error {
 		if err := shutdownOsquery(); err != nil {
-			level.Info(logger).Log(
-				"msg", "calling shutdownOsquery",
-				"method", "updateFinalizer",
-				"err", err,
-				"stack", fmt.Sprintf("%+v", err),
-			)
+			level.Info(logger).Log("msg", "calling shutdownOsquery", "method", "updateFinalizer", "err", err)
+			level.Debug(logger).Log("msg", "calling shutdownOsquery", "method", "updateFinalizer", "err", err, "stack", fmt.Sprintf("%+v", err))
 		}
 
 		// Use the FindNewest mechanism to delete old

--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -99,7 +99,8 @@ func createUpdater(
 			return nil
 		},
 		Interrupt: func(err error) {
-			level.Info(config.Logger).Log("msg", "updater interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
+			level.Info(config.Logger).Log("msg", "updater interrupted", "err", err)
+			level.Debug(config.Logger).Log("msg", "updater interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
 
 			// non-blocking channel send
 			select {


### PR DESCRIPTION
Awhile ago we started including the stack dumps as part of the logged errors. This has proved not as valuable, and quite noisy. Move them to debug.