### PR TITLE
Update osquery logging

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -11,7 +11,23 @@ import (
 // OsqueryLogAdapater creates an io.Writer implementation useful for attaching
 // to the osquery stdout/stderr
 type OsqueryLogAdapter struct {
-	kitlog.Logger
+	logger       kitlog.Logger
+	levelFunc    func(kitlog.Logger) kitlog.Logger
+	extraKeyVals []interface{} // log.With expects an interface, not string
+}
+
+type Option func(*OsqueryLogAdapter)
+
+func WithKeyValue(key, value string) Option {
+	return func(l *OsqueryLogAdapter) {
+		l.extraKeyVals = append(l.extraKeyVals, key, value)
+	}
+}
+
+func WithLevelFunc(lf func(kitlog.Logger) kitlog.Logger) Option {
+	return func(l *OsqueryLogAdapter) {
+		l.levelFunc = lf
+	}
 }
 
 var callerRegexp = regexp.MustCompile(`[\w.]+:\d+]`)
@@ -20,10 +36,25 @@ func extractOsqueryCaller(msg string) string {
 	return strings.TrimSuffix(callerRegexp.FindString(msg), "]")
 }
 
+func NewOsqueryLogAdapter(logger kitlog.Logger, opts ...Option) *OsqueryLogAdapter {
+	l := &OsqueryLogAdapter{
+		logger:       logger,
+		levelFunc:    level.Debug,
+		extraKeyVals: []interface{}{},
+	}
+
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
+
+}
+
 func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
-	if err := level.Debug(l.Logger).Log("msg", msg, "caller", caller); err != nil {
+	if err := l.levelFunc(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {
 		return 0, err
 	}
 	return len(p), nil


### PR DESCRIPTION
Updates the log wrapper to allow osquery stderr going into our info logs, and stdout into the debug logs