### PR TITLE
fix overly verbose osquery

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -60,6 +60,10 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 		lf = level.Debug
 	}
 
+	if bytes.Contains(p, []byte("Accelerating distributed query checkins")) {
+		lf = level.Debug
+	}
+
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
 	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {


### PR DESCRIPTION
osquery defaults to logging some debugging things to the `INFO` logs. This is probably an error (see https://github.com/osquery/osquery/pull/6271)

Meanwhile, we can quiet them here.