### PR TITLE
Arch's lib is /usr/lib

### DIFF
--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -103,6 +103,10 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 		"-C", "/pkgsrc",
 	}
 
+	if f.outputType == Pacman {
+		fpmCommand = append(fpmCommand, "--pacman-compression", "gz")
+	}
+
 	// Pass each replaces in. Set it as a conflict and a replace.
 	for _, r := range f.replaces {
 		fpmCommand = append(fpmCommand, "--replaces", r, "--conflicts", r)

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -427,6 +427,9 @@ func (p *PackageOptions) setupInit(ctx context.Context) error {
 		if p.target.Package == Rpm {
 			dir = "/usr/lib/systemd/system"
 		}
+		if p.target.Package == Pacman {
+			dir = "/usr/lib/systemd/system"
+		}
 		file = fmt.Sprintf("launcher.%s.service", p.Identifier)
 		renderFunc = packagekit.RenderSystemd
 	case p.target.Platform == Linux && p.target.Init == Upstart:


### PR DESCRIPTION
Arch has `/lib/` as a symlink to `/usr/lib`. This means packages cannot install files to `/lib` and must use `/usr/lib` instead.

See https://bbs.archlinux.org/viewtopic.php?id=192018 for more information