### PR TITLE
Use mxj to implement an xml dataflattening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bugsnag/bugsnag-go v1.3.2 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
+	github.com/clbanning/mxj v1.8.4
 	github.com/client9/misspell v0.3.4
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7 // indirect
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABF
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
+github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7 h1:ROpiky+uT1fstFCMZCka5Cr9GmtpTakLMmvwFsVOtJA=

--- a/pkg/dataflatten/examples/flatten/main.go
+++ b/pkg/dataflatten/examples/flatten/main.go
@@ -27,6 +27,7 @@ func main() {
 	var (
 		flPlist = flagset.String("plist", "", "Path to plist")
 		flJson  = flagset.String("json", "", "Path to json file")
+		flXml   = flagset.String("xml", "", "Path to xml file")
 		flQuery = flagset.String("q", "", "query")
 
 		flDebug = flagset.Bool("debug", false, "use a debug logger")
@@ -60,6 +61,12 @@ func main() {
 	if *flJson != "" {
 		data, err := dataflatten.JsonFile(*flJson, opts...)
 		checkError(errors.Wrap(err, "flattening json file"))
+		rows = append(rows, data...)
+	}
+
+	if *flXml != "" {
+		data, err := dataflatten.XmlFile(*flXml, opts...)
+		checkError(errors.Wrap(err, "flattening xml file"))
 		rows = append(rows, data...)
 	}
 

--- a/pkg/dataflatten/xml.go
+++ b/pkg/dataflatten/xml.go
@@ -14,6 +14,9 @@ func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
 	}
 
 	mv, err := mxj.NewMapXmlReader(rdr)
+	if err != nil {
+		return nil, err
+	}
 
 	return Flatten(mv.Old())
 }

--- a/pkg/dataflatten/xml.go
+++ b/pkg/dataflatten/xml.go
@@ -1,0 +1,26 @@
+package dataflatten
+
+import (
+	"io/ioutil"
+
+	"github.com/clbanning/mxj"
+	"github.com/pkg/errors"
+)
+
+func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
+	rawdata, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return Xml(rawdata, opts...)
+}
+
+func Xml(rawdata []byte, opts ...FlattenOpts) ([]Row, error) {
+	mv, err := mxj.NewMapXml(rawdata)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "mxj parse")
+	}
+
+	return Flatten(mv.Old())
+}

--- a/pkg/dataflatten/xml.go
+++ b/pkg/dataflatten/xml.go
@@ -1,18 +1,21 @@
 package dataflatten
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/clbanning/mxj"
 	"github.com/pkg/errors"
 )
 
 func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
-	rawdata, err := ioutil.ReadFile(file)
+	rdr, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
-	return Xml(rawdata, opts...)
+
+	mv, err := mxj.NewMapXmlReader(rdr)
+
+	return Flatten(mv.Old())
 }
 
 func Xml(rawdata []byte, opts ...FlattenOpts) ([]Row, error) {

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -34,6 +34,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger) [
 		SlackConfig(client, logger),
 		SshKeys(client, logger),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.JsonType),
+		dataflattentable.TablePlugin(client, logger, dataflattentable.XmlType),
 	}
 
 	// add in the platform specific ones (as denboted by build tags)

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -59,7 +59,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 	case XmlType:
 		t.dataFunc = dataflatten.XmlFile
 		t.tableName = "kolide_xml"
-
 	default:
 		panic("Unknown data source type")
 	}

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -19,6 +19,7 @@ const (
 	PlistType DataSourceType = iota + 1
 	JsonType
 	ExecType
+	XmlType
 )
 
 type Table struct {
@@ -55,6 +56,10 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 	case JsonType:
 		t.dataFunc = dataflatten.JsonFile
 		t.tableName = "kolide_json"
+	case XmlType:
+		t.dataFunc = dataflatten.XmlFile
+		t.tableName = "kolide_xml"
+
 	default:
 		panic("Unknown data source type")
 	}


### PR DESCRIPTION
Implement an xml dataflattening using mxj.

The general issue with xml encoding, is that because of the difference between elements and attributes, it's hard to write a fully generic parser. Luckily, other people already have. This uses `mxj` as a generalized xml parser.

An alternative would be to implement our own. 

