### PR TITLE
TouchID compat should be decided by bioutil output

### DIFF
--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -76,8 +76,6 @@ func (t *touchIDSystemConfigTable) generate(ctx context.Context, queryContext ta
 		touchIDCompatible = "1"
 		touchIDEnabled = configSplit[2][1:2]
 		touchIDUnlock = configSplit[3][1:2]
-	} else {
-		touchIDCompatible = "0"
 	}
 
 	result := map[string]string{

--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -58,10 +58,8 @@ func (t *touchIDSystemConfigTable) generate(ctx context.Context, queryContext ta
 	r := regexp.MustCompile(` (?P<chip>T\d) `) // Matching on: Apple T[1|2] Security Chip
 	match := r.FindStringSubmatch(string(stdout.Bytes()))
 	if len(match) == 0 {
-		touchIDCompatible = "0"
 		secureEnclaveCPU = ""
 	} else {
-		touchIDCompatible = "1"
 		secureEnclaveCPU = match[1]
 	}
 
@@ -75,8 +73,11 @@ func (t *touchIDSystemConfigTable) generate(ctx context.Context, queryContext ta
 	configOutStr := string(stdout.Bytes())
 	configSplit := strings.Split(configOutStr, ":")
 	if len(configSplit) >= 3 {
+		touchIDCompatible = "1"
 		touchIDEnabled = configSplit[2][1:2]
 		touchIDUnlock = configSplit[3][1:2]
+	} else {
+		touchIDCompatible = "0"
 	}
 
 	result := map[string]string{


### PR DESCRIPTION
This PR fixes a business logic issue where we assume if a device has a T1/T2 chip it has touchID capability. This is not the case for devices like the iMac Pro which feature a T series chip but do not have the fingerprint sensor.

The correct logic is if bioutil -r -s reports no config, then we know it isn't touchid capable.