### PR TITLE
Fix an infinite exec bug

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -41,7 +41,7 @@ func main() {
 	//
 	// launcher is _also_ called when we're checking update
 	// validity (with autoupdate.checkExectuable). This is
-	// somewhat awkward as we emnd up with extra call layers.
+	// somewhat awkward as we end up with extra call layers.
 	newerBinary, err := autoupdate.FindNewestSelf(ctx)
 	if err != nil {
 		logutil.Fatal(logger, err, "checking for updated version")

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -40,7 +40,7 @@ func main() {
 	// a straight forward exec.
 	//
 	// launcher is _also_ called when we're checking update
-	// validity (with autoupdate.checkExectuable). This is
+	// validity (with autoupdate.checkExecutable). This is
 	// somewhat awkward as we end up with extra call layers.
 	newerBinary, err := autoupdate.FindNewestSelf(ctx)
 	if err != nil {

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -38,6 +38,10 @@ func main() {
 	// This does not call DeleteOldUpdates, on the theory that
 	// it's better left to the service to handle cleanup. This is
 	// a straight forward exec.
+	//
+	// launcher is _also_ called when we're checking update
+	// validity (with autoupdate.checkExectuable). This is
+	// somewhat awkward as we emnd up with extra call layers.
 	newerBinary, err := autoupdate.FindNewestSelf(ctx)
 	if err != nil {
 		logutil.Fatal(logger, err, "checking for updated version")

--- a/cmd/launcher/updater-finalizer.go
+++ b/cmd/launcher/updater-finalizer.go
@@ -25,12 +25,18 @@ func updateFinalizer(logger log.Logger, shutdownOsquery func() error) func() err
 			level.Debug(logger).Log("method", "updateFinalizer", "err", err, "stack", fmt.Sprintf("%+v", err))
 		}
 		// find the newest version of launcher on disk.
-		// FindNewest uses context as a way to get a logger, so we need to create and pass one.
-		binaryPath := autoupdate.FindNewest(
+		// FindNewestSelf uses context as a way to get a
+		// logger, so we need to create and pass one.
+		binaryPath, err := autoupdate.FindNewestSelf(
 			ctxlog.NewContext(context.TODO(), logger),
-			os.Args[0],
+			autoupdate.DeleteCorruptUpdates(),
 			autoupdate.DeleteOldUpdates(),
 		)
+
+		if err != nil {
+			level.Info(logger).Log("method", "updateFinalizer", "err", err)
+			return errors.Wrap(err, "finding newest")
+		}
 
 		// replace launcher
 		level.Info(logger).Log(

--- a/cmd/launcher/updater-finalizer_windows.go
+++ b/cmd/launcher/updater-finalizer_windows.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -30,9 +29,9 @@ func updateFinalizer(logger log.Logger, shutdownOsquery func() error) func() err
 		// the update in main, which does not delete.  Note
 		// that this will likely produce non-fatal errors when
 		// it tries to delete the running one.
-		_ = autoupdate.FindNewest(
+		autoupdate.FindNewestSelf(
 			ctxlog.NewContext(context.TODO(), logger),
-			os.Args[0],
+			autoupdate.DeleteCorruptUpdates(),
 			autoupdate.DeleteOldUpdates(),
 		)
 


### PR DESCRIPTION
The FindNewestSelf function calls FindNewest. Which, in turns, calls `checkExecutable`. Which launchers the binary. Which goes back to the beginning. This bug only manifests for `launcher`, but not for the `osquery` side. This isn't a fatal error, as there's a 5s timeout on it. But it is slow.

Add an option to skip the final check, solving this. And add comments.

Convert the finalizers over to using `FindNewestSelf`. First, because that's what it's there for. Second, because `os.Executable()` is more correct than `os.Args[0]`