### PR TITLE
Autoupdate should not exec updates older than itself

### DIFF
--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -428,9 +428,7 @@ func TestBuildTimestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("buildTimestamp="+tt.buildTimestamp, func(t *testing.T) {
 			tmpDir, binaryName, cleanupFunc := setupTestDir(t, executableUpdates)
-			fmt.Println(tmpDir)
-			//defer cleanupFunc()
-			_ = cleanupFunc
+			defer cleanupFunc()
 			ctx := context.TODO()
 
 			binaryPath := filepath.Join(tmpDir, binaryName)

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -394,6 +395,69 @@ func TestCheckExecutableTruncated(t *testing.T) {
 	require.Error(t,
 		checkExecutable(context.TODO(), truncatedBinary.Name(), "-test.run=TestHelperProcess", "--", "exit0"),
 		"truncated binary")
+}
+
+func TestBuildTimestamp(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		buildTimestamp string
+		expectedNewest string
+		expectedOnDisk int
+	}{
+		{
+			buildTimestamp: "0",
+			expectedNewest: "5",
+			expectedOnDisk: 2,
+		},
+		{
+			buildTimestamp: "3",
+			expectedNewest: "5",
+			expectedOnDisk: 1, // remember, 4 is broken, so there should only be update 5 on disk
+		},
+		{
+			buildTimestamp: "5",
+			expectedOnDisk: 0,
+		},
+		{
+			buildTimestamp: "6",
+			expectedOnDisk: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("buildTimestamp="+tt.buildTimestamp, func(t *testing.T) {
+			tmpDir, binaryName, cleanupFunc := setupTestDir(t, executableUpdates)
+			fmt.Println(tmpDir)
+			//defer cleanupFunc()
+			_ = cleanupFunc
+			ctx := context.TODO()
+
+			binaryPath := filepath.Join(tmpDir, binaryName)
+			updatesDir := binaryPath + updateDirSuffix
+
+			returnedNewest := FindNewest(
+				ctx,
+				binaryPath,
+				overrideBuildTimestamp(tt.buildTimestamp),
+				DeleteOldUpdates(),
+			)
+
+			updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedOnDisk, len(updatesOnDisk), "remaining updates on disk")
+
+			if tt.expectedNewest == "" {
+				require.Equal(t, binaryPath, returnedNewest, "Expected to get original binary path")
+			} else {
+				updateFragment := strings.TrimPrefix(strings.TrimPrefix(returnedNewest, updatesDir), "/")
+				expectedNewest := filepath.Join(tt.expectedNewest, "binary")
+				require.Equal(t, expectedNewest, updateFragment)
+			}
+
+		})
+	}
+
 }
 
 // TestHelperProcess isn't a real test. It's used as a helper process

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -443,7 +443,7 @@ func (b *Builder) BuildCmd(src, output string) func(context.Context) error {
 		}
 
 		// Set the build time for autoupdate.FindNewest
-		ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/launcher/pkg/autoupdate.buildTimestamp=%s"`, strconv.FormatInt(time.Now().Unix(), 10)))
+		ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/launcher/pkg/autoupdate.defaultBuildTimestamp=%s"`, strconv.FormatInt(time.Now().Unix(), 10)))
 
 		if len(ldFlags) != 0 {
 			baseArgs = append(baseArgs, fmt.Sprintf("--ldflags=%s", strings.Join(ldFlags, " ")))

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -440,6 +441,9 @@ func (b *Builder) BuildCmd(src, output string) func(context.Context) error {
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.buildUser=%s (%s)"`, usr.Name, usr.Username))
 			ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/kit/version.goVersion=%s"`, runtime.Version()))
 		}
+
+		// Set the build time for autoupdate.FindNewest
+		ldFlags = append(ldFlags, fmt.Sprintf(`-X "github.com/kolide/launcher/pkg/autoupdate.buildTimestamp=%s"`, strconv.FormatInt(time.Now().Unix(), 10)))
 
 		if len(ldFlags) != 0 {
 			baseArgs = append(baseArgs, fmt.Sprintf("--ldflags=%s", strings.Join(ldFlags, " ")))


### PR DESCRIPTION
As implemented in https://github.com/kolide/launcher/pull/524, the autoupdater will exec the last downloaded updated. This is _incorrect_ when there are updates on disk, and a device has installed a new package.

This adds a build timestamp, which can be used to ignore (and delete) old updates in disk

Note that it is comparing the _build timestamp_ with the update's _download_ timestamp. This is an important distinction, as it allows an intentional version downgrade. 