### PR TITLE
Force osquery to verbose mode

### DIFF
--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -149,6 +149,18 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 		"--utc",
 	)
 
+	// TODO: This is a short term hack.
+	// In https://github.com/osquery/osquery/pull/6271 osquery
+	// shifted some debugging info from INFO to VERBOSE. This has
+	// the unfortunate effect of making it hard to correlate
+	// distributed query logs with the distributed query that
+	// caused them. While we're thinking through the longer term
+	// fix, we have a quick mitagation in dropping osquery into
+	// verbose mode. (This is duplicative wirth the opts.verbose
+	// parsing, because this whole block should be struck once we
+	// have a better approach)
+	cmd.Args = append(cmd.Args, "--verbose")
+
 	if opts.verbose {
 		cmd.Args = append(cmd.Args, "--verbose")
 	}

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -156,7 +156,7 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 	// distributed query logs with the distributed query that
 	// caused them. While we're thinking through the longer term
 	// fix, we have a quick mitagation in dropping osquery into
-	// verbose mode. (This is duplicative wirth the opts.verbose
+	// verbose mode. (This is duplicative with the opts.verbose
 	// parsing, because this whole block should be struck once we
 	// have a better approach)
 	cmd.Args = append(cmd.Args, "--verbose")


### PR DESCRIPTION
Force osquery into verbose mode as a mitigation for distributed query correlation.

This is expected to be reverted at some future point.