### PR TITLE
Fix Munki tables when munki isn't installed

### DIFF
--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -335,7 +335,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	resp, err := client.Query("select * from kolide_best_practices")
+	resp, err := client.Query("select * from kolide_launcher_info")
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), resp.Status.Code)
 	assert.Equal(t, "OK", resp.Status.Message)

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/knightsc/system_policy/osquery/table/kextpolicy"
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/munki"
 	"github.com/kolide/launcher/pkg/osquery/tables/systemprofiler"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
@@ -14,7 +15,7 @@ import (
 )
 
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger) []*table.Plugin {
-	munki := new(MunkiInfo)
+	munki := munki.New()
 
 	return []*table.Plugin{
 		Airdrop(client),

--- a/pkg/osquery/tables/munki/munki_darwin.go
+++ b/pkg/osquery/tables/munki/munki_darwin.go
@@ -1,6 +1,6 @@
 // +build darwin
 
-package table
+package munki
 
 import (
 	"context"
@@ -17,6 +17,10 @@ import (
 
 type MunkiInfo struct {
 	report *munkiReport
+}
+
+func New() *MunkiInfo {
+	return &MunkiInfo{}
 }
 
 func (m *MunkiInfo) MunkiReport(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {

--- a/pkg/osquery/tables/munki/munki_test.go
+++ b/pkg/osquery/tables/munki/munki_test.go
@@ -90,9 +90,3 @@ func TestGenerateMunkiReport(t *testing.T) {
 		})
 	}
 }
-
-func TestGenerateMunkiInstalls(t *testing.T) {
-	t.Parallel()
-
-	//m := New()
-}

--- a/pkg/osquery/tables/munki/munki_test.go
+++ b/pkg/osquery/tables/munki/munki_test.go
@@ -1,0 +1,98 @@
+// +build darwin
+
+package munki
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateMunkiReport(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var tests = []struct {
+		name       string
+		reportPath string
+
+		expectedReportError  bool
+		expectedReportNil    bool
+		expectedReportFields map[string]string
+
+		expectedInstallsError bool
+		expectedInstallsNil   bool
+		expectedInstallsRows  []map[string]string // Don't have any examples yet
+	}{
+		{
+			name:       "normal",
+			reportPath: "testdata/ManagedInstallReport.plist",
+			expectedReportFields: map[string]string{
+				"console_user": "auser",
+			},
+		},
+		{
+			name:                "missing file",
+			reportPath:          "testdata/no such file",
+			expectedReportNil:   true,
+			expectedInstallsNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New()
+			m.reportPath = tt.reportPath
+			mockQC := tablehelpers.MockQueryContext(nil)
+
+			t.Run("generateMunkiReport", func(t *testing.T) {
+				results, err := m.generateMunkiReport(ctx, mockQC)
+
+				if tt.expectedReportError {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+
+				if tt.expectedReportNil {
+					assert.Nil(t, results)
+					return
+				}
+
+				if tt.expectedReportFields != nil {
+					for k, v := range tt.expectedReportFields {
+						assert.Equal(t, results[0][k], v, "Expected field %s matches", k)
+					}
+				}
+			})
+
+			t.Run("generateMunkiInstalls", func(t *testing.T) {
+				results, err := m.generateMunkiInstalls(ctx, mockQC)
+
+				if tt.expectedInstallsError {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+
+				if tt.expectedInstallsNil {
+					assert.Nil(t, results)
+					return
+				}
+			})
+
+		})
+	}
+}
+
+func TestGenerateMunkiInstalls(t *testing.T) {
+	t.Parallel()
+
+	//m := New()
+}

--- a/pkg/osquery/tables/munki/testdata/ManagedInstallReport.plist
+++ b/pkg/osquery/tables/munki/testdata/ManagedInstallReport.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableDiskSpace</key>
+	<integer>26635756</integer>
+	<key>ConsoleUser</key>
+	<string>auser</string>
+	<key>EndTime</key>
+	<string>2020-06-08 18:12:01 +0000</string>
+	<key>Errors</key>
+	<array>
+		<string>Could not retrieve managed install primary manifest.</string>
+	</array>
+	<key>InstallResults</key>
+	<array/>
+	<key>ItemsToInstall</key>
+	<array/>
+	<key>ItemsToRemove</key>
+	<array/>
+	<key>MachineInfo</key>
+	<dict>
+		<key>arch</key>
+		<string>x86_64</string>
+		<key>hostname</key>
+		<string>acomputer.localdomain</string>
+		<key>ipv4_address</key>
+		<array>
+			<string>10.0.0.2</string>
+		</array>
+		<key>ipv6_address</key>
+		<array>
+			<string>::ffff:10.0.0.2</string>
+		</array>
+		<key>machine_model</key>
+		<string>MacBookPro14,3</string>
+		<key>munki_version</key>
+		<string>3.1.1.3447</string>
+		<key>os_vers</key>
+		<string>10.14.6</string>
+		<key>serial_number</key>
+		<string>C11111111111</string>
+		<key>x86_64_capable</key>
+		<true/>
+	</dict>
+	<key>ManagedInstallVersion</key>
+	<string>3.1.1.3447</string>
+	<key>RemovalResults</key>
+	<array/>
+	<key>RunType</key>
+	<string>auto</string>
+	<key>StartTime</key>
+	<string>2020-06-08 18:11:59 +0000</string>
+	<key>Warnings</key>
+	<array>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
When munki isn't installed, it's plist file obviously doesn't exist. Other osquery tables return no results for non-exist files. Now this does as well.

Along the way, refactor and add some tests.