### PR TITLE
Allow package-builder to specify wix path

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kolide/kit/env"
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/kolide/launcher/pkg/packagekit/wix"
 	"github.com/kolide/launcher/pkg/packaging"
 	"github.com/pkg/errors"
 )
@@ -38,6 +39,8 @@ func (i *arrayFlags) Set(value string) error {
 	*i = append(*i, value)
 	return nil
 }
+
+var defaultWixPath = wix.FindWixInstall()
 
 func runMake(args []string) error {
 	flagset := flag.NewFlagSet("macos", flag.ExitOnError)
@@ -167,6 +170,11 @@ func runMake(args []string) error {
 			env.String("NOTARY_PREFIX", ""),
 			"The prefix for Notary path that contains the collections",
 		)
+		flWixPath = flagset.String(
+			"wix_path",
+			defaultWixPath,
+			fmt.Sprintf(`Location of wix binaries (default: "%s")`, defaultWixPath),
+		)
 		flOsqueryFlags arrayFlags // set below with flagset.Var
 	)
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
@@ -235,6 +243,7 @@ func runMake(args []string) error {
 		NotaryURL:         *flNotaryURL,
 		MirrorURL:         *flMirrorURL,
 		NotaryPrefix:      *flNotaryPrefix,
+		WixPath:           *flWixPath,
 	}
 
 	outputDir := *flOutputDir

--- a/pkg/packagekit/package.go
+++ b/pkg/packagekit/package.go
@@ -13,4 +13,6 @@ type PackageOptions struct {
 	AppleSigningKey     string   // apple signing key
 	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
 	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key
+
+	WixPath string // path to wix installation
 }

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -72,6 +72,10 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 
 	wixArgs := []wix.WixOpt{}
 
+	if po.WixPath != "" {
+		wixArgs = append(wixArgs, wix.WithWix(po.WixPath))
+	}
+
 	if includeService {
 		launcherService := wix.NewService("launcher.exe",
 			wix.WithDelayedStart(),

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -30,11 +30,9 @@ const (
 // PackageOptions encapsulates the launcher build options. It's
 // populated by callers, such as command line flags. It may change.
 type PackageOptions struct {
-	PackageVersion string // What version in this package. If unset, autodetection will be attempted.
-	OsqueryVersion string
-	// OsuqeryFlags is a slice of flags to add to the config file to override
-	// flags passed to osquery.
-	OsqueryFlags      []string
+	PackageVersion    string // What version in this package. If unset, autodetection will be attempted.
+	OsqueryVersion    string
+	OsqueryFlags      []string // Additional flags to pass to the runtime osquery instance
 	LauncherVersion   string
 	ExtensionVersion  string
 	Hostname          string
@@ -54,6 +52,7 @@ type PackageOptions struct {
 	NotaryURL         string
 	MirrorURL         string
 	NotaryPrefix      string
+	WixPath           string
 
 	AppleSigningKey     string   // apple signing key
 	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
@@ -283,6 +282,7 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 		WindowsSigntoolArgs: p.WindowsSigntoolArgs,
 		Version:             p.PackageVersion,
 		FlagFile:            p.canonicalizePath(flagFilePath),
+		WixPath:             p.WixPath,
 	}
 
 	if err := p.makePackage(ctx); err != nil {


### PR DESCRIPTION
Allow runtime invocation of package-builder to specify the path to wix.
If not specified, attempt to check the WIX variable.

Fixes: #546