### PR TITLE
Add fields to kolide_keyinfo

### DIFF
--- a/pkg/osquery/table/keyinfo.go
+++ b/pkg/osquery/table/keyinfo.go
@@ -25,6 +25,8 @@ func KeyInfo(client *osquery.ExtensionManagerClient, logger log.Logger) *table.P
 		table.TextColumn("type"),
 		table.IntegerColumn("encrypted"),
 		table.IntegerColumn("bits"),
+		table.TextColumn("fingerprint_sha256"),
+		table.TextColumn("fingerprint_md5"),
 	}
 
 	// we don't want the logging in osquery, so don't instantiate WithLogger()
@@ -76,6 +78,13 @@ func (t *KeyInfoTable) generate(ctx context.Context, queryContext table.QueryCon
 
 		if ki.Bits != 0 {
 			res["bits"] = strconv.FormatInt(int64(ki.Bits), 10)
+		}
+
+		if ki.FingerprintSHA256 != "" {
+			res["fingerprint_sha256"] = ki.FingerprintSHA256
+		}
+		if ki.FingerprintMD5 != "" {
+			res["fingerprint_md5"] = ki.FingerprintMD5
 		}
 
 		results = append(results, res)

--- a/pkg/osquery/table/sshkeys.go
+++ b/pkg/osquery/table/sshkeys.go
@@ -1,5 +1,9 @@
 package table
 
+// The kolide_ssh_keys table is deprecated in favor of using the
+// underlying osquery file table joined against kolide_keyinfo. The
+// latter provides more control over the directories we iterate over
+
 import (
 	"context"
 	"runtime"


### PR DESCRIPTION
Add `fingerprint_*` fields to `kolide_keyinfo`. This allows it to be used with the `file` table as a more flexible replacement for `kolide_ssh_keys`. 

Add deprecation notice to `kolide_ssh_keys`