### PR TITLE
Filter out excess verbosity

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -73,7 +73,9 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 	// fix, we have a quick mitagation in dropping osquery into
 	// verbose mode, but we also want to filter out the
 	// unimportant logs
-	if bytes.HasPrefix(p, []byte("I")) && !bytes.Contains(p, []byte("Executing scheduled query")) {
+	if bytes.HasPrefix(p, []byte("I")) &&
+		!bytes.Contains(p, []byte("Executing scheduled query")) &&
+		!bytes.Contains(p, []byte("Executing distributed query")) {
 		lf = level.Debug
 	}
 

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -144,8 +144,8 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 		"--utc",
 	)
 
-	// TODO: This is a short term hack.
-	// In https://github.com/osquery/osquery/pull/6271 osquery
+	// TODO: This is a short term hack.  In
+	// https://github.com/osquery/osquery/pull/6271 osquery
 	// shifted some debugging info from INFO to VERBOSE. This has
 	// the unfortunate effect of making it hard to correlate
 	// distributed query logs with the distributed query that
@@ -153,7 +153,8 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 	// fix, we have a quick mitagation in dropping osquery into
 	// verbose mode. (This is duplicative with the opts.verbose
 	// parsing, because this whole block should be struck once we
-	// have a better approach)
+	// have a better approach) Additionally we filter out the
+	// verbosity in the log handler.
 	cmd.Args = append(cmd.Args, "--verbose")
 
 	if opts.verbose {


### PR DESCRIPTION
Launcher is currently running osquery in verbose mode. This is because we need a single line of the verbose output. While we're doing this, we can filter out the excess verbosity.

This pair with #602 