### PR TITLE
Add firmwarepassword table

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/knightsc/system_policy/osquery/table/kextpolicy"
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/firmwarepasswd"
 	"github.com/kolide/launcher/pkg/osquery/tables/munki"
 	"github.com/kolide/launcher/pkg/osquery/tables/screenlock"
 	"github.com/kolide/launcher/pkg/osquery/tables/systemprofiler"
@@ -22,6 +23,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		Airdrop(client),
 		AppIcons(),
 		ChromeLoginKeychainInfo(client, logger),
+		firmwarepasswd.TablePlugin(client, logger),
 		GDriveSyncConfig(client, logger),
 		GDriveSyncHistoryInfo(client, logger),
 		KolideVulnerabilities(client, logger),

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -1,0 +1,139 @@
+// firmwarepasswd is a simple wrapper around the
+// `/usr/sbin/firmwarepasswd` tool. This should be considered beta at
+// best. It serves a bit as a pattern for future exec work.
+
+package firmwarepasswd
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+type Table struct {
+	client *osquery.ExtensionManagerClient
+	logger log.Logger
+	parser *OutputParser
+}
+
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	parser := NewParser(logger,
+		[]Matcher{
+			Matcher{
+				Match:   func(in string) bool { return strings.HasPrefix(in, "Password Enabled: ") },
+				KeyFunc: func(_ string) (string, error) { return "password_enabled", nil },
+				ValFunc: func(in string) (string, error) { return passwordValue(in) },
+			},
+			Matcher{
+				Match:   func(in string) bool { return strings.HasPrefix(in, "Mode: ") },
+				KeyFunc: func(_ string) (string, error) { return "mode", nil },
+				ValFunc: func(in string) (string, error) { return modeValue(in) },
+			},
+		})
+
+	columns := []table.ColumnDefinition{
+		table.IntegerColumn("password_enabled"),
+		table.TextColumn("mode"),
+	}
+
+	t := &Table{
+		client: client,
+		logger: level.NewFilter(logger, level.AllowInfo()),
+		parser: parser,
+	}
+
+	return table.NewPlugin("kolide_firmwarepasswd", columns, t.generate)
+
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	result := make(map[string]string)
+
+	for _, mode := range []string{"-check", "-mode"} {
+		output := new(bytes.Buffer)
+		if err := t.runFirmwarepasswd(ctx, mode, output); err != nil {
+			level.Info(t.logger).Log(
+				"msg", "Error running firmware password",
+				"command", mode,
+				"err", err,
+			)
+			continue
+		}
+
+		// Merge merge merge
+		for _, row := range t.parser.Parse(output) {
+			for k, v := range row {
+				result[k] = v
+			}
+		}
+	}
+	return []map[string]string{result}, nil
+}
+
+func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output *bytes.Buffer) error {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/sbin/firmwarepasswd", subcommand)
+
+	dir, err := ioutil.TempDir("", "osq-firmwarepasswd")
+	if err != nil {
+		return errors.Wrap(err, "mktemp")
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		return errors.Wrap(err, "chmod")
+	}
+
+	cmd.Dir = dir
+
+	stderr := new(bytes.Buffer)
+	cmd.Stderr = stderr
+
+	cmd.Stdout = output
+
+	if err := cmd.Run(); err != nil {
+		level.Info(t.logger).Log(
+			"msg", "Error running firmwarepasswd",
+			"stderr", strings.TrimSpace(stderr.String()),
+			"stdout", strings.TrimSpace(output.String()),
+			"err", err,
+		)
+		return errors.Wrap(err, "running osquery")
+	}
+	return nil
+}
+
+func modeValue(in string) (string, error) {
+	components := strings.SplitN(in, ":", 2)
+	if len(components) < 2 {
+		return "", errors.Errorf("Can't tell mode from %s", in)
+	}
+
+	return strings.TrimSpace(strings.ToLower(components[1])), nil
+}
+
+func passwordValue(in string) (string, error) {
+	components := strings.SplitN(in, ":", 2)
+	if len(components) < 2 {
+		return "", errors.Errorf("Can't tell value from %s", in)
+	}
+
+	t, err := discernValBool(components[1])
+
+	if t {
+		return "1", err
+	}
+	return "0", err
+}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -158,3 +158,14 @@ func optionRomValue(in string) (string, error) {
 	}
 	return "", errors.Errorf("Can't tell value from %s", in)
 }
+
+func discernValBool(in string) (bool, error) {
+	switch strings.TrimSpace(strings.ToLower(in)) {
+	case "true", "t", "1", "y", "yes":
+		return true, nil
+	case "false", "f", "0", "n", "no":
+		return false, nil
+	}
+
+	return false, errors.Errorf("Can't discern boolean from string <%s>", in)
+}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
@@ -1,0 +1,68 @@
+package firmwarepasswd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		input    string
+		expected map[string]string
+	}{
+		{
+			input:    "check-no.txt",
+			expected: map[string]string{"password_enabled": "0"},
+		},
+
+		{
+			input:    "check-yes.txt",
+			expected: map[string]string{"password_enabled": "1"},
+		},
+
+		{
+			input: "mode-command.txt",
+			expected: map[string]string{
+				"mode":                "command",
+				"option_roms_allowed": "0",
+			},
+		},
+
+		{
+			input: "mode-none.txt",
+			expected: map[string]string{
+				"mode":                "none",
+				"option_roms_allowed": "1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		parser := New(nil, log.NewNopLogger()).parser
+
+		t.Run(tt.input, func(t *testing.T) {
+			inputBytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.input))
+			require.NoError(t, err, "read file %s", tt.input)
+
+			inputBuffer := bytes.NewBuffer(inputBytes)
+
+			result := make(map[string]string)
+			for _, row := range parser.Parse(inputBuffer) {
+				for k, v := range row {
+					result[k] = v
+				}
+			}
+
+			require.EqualValues(t, tt.expected, result)
+
+		})
+	}
+
+}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
@@ -21,12 +21,14 @@ func TestParser(t *testing.T) {
 			input:    "check-no.txt",
 			expected: map[string]string{"password_enabled": "0"},
 		},
-
+		{
+			input:    "check-garbage.txt",
+			expected: map[string]string{"password_enabled": "0"},
+		},
 		{
 			input:    "check-yes.txt",
 			expected: map[string]string{"password_enabled": "1"},
 		},
-
 		{
 			input: "mode-command.txt",
 			expected: map[string]string{
@@ -34,7 +36,6 @@ func TestParser(t *testing.T) {
 				"option_roms_allowed": "0",
 			},
 		},
-
 		{
 			input: "mode-none.txt",
 			expected: map[string]string{

--- a/pkg/osquery/tables/firmwarepasswd/parser.go
+++ b/pkg/osquery/tables/firmwarepasswd/parser.go
@@ -3,11 +3,9 @@ package firmwarepasswd
 import (
 	"bufio"
 	"bytes"
-	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/pkg/errors"
 )
 
 type Matcher struct {
@@ -81,15 +79,4 @@ func (p *OutputParser) Parse(input *bytes.Buffer) []map[string]string {
 		level.Debug(p.logger).Log("msg", "scanner error", "err", err)
 	}
 	return results
-}
-
-func discernValBool(in string) (bool, error) {
-	switch strings.TrimSpace(strings.ToLower(in)) {
-	case "true", "t", "1", "y", "yes":
-		return true, nil
-	case "false", "f", "0", "n", "no":
-		return false, nil
-	}
-
-	return false, errors.Errorf("Can't discern boolean from string <%s>", in)
 }

--- a/pkg/osquery/tables/firmwarepasswd/parser.go
+++ b/pkg/osquery/tables/firmwarepasswd/parser.go
@@ -1,0 +1,96 @@
+package firmwarepasswd
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+)
+
+type Matcher struct {
+	Match   func(string) bool
+	KeyFunc func(string) (string, error)
+	ValFunc func(string) (string, error)
+}
+
+type OutputParser struct {
+	matchers []Matcher
+	logger   log.Logger
+}
+
+func NewParser(logger log.Logger, matchers []Matcher) *OutputParser {
+	p := &OutputParser{
+		matchers: matchers,
+		logger:   logger,
+	}
+	return p
+}
+
+// Parse looks at command output, line by line. It assumes kv output deliminated by a :
+func (p *OutputParser) Parse(input *bytes.Buffer) []map[string]string {
+	var results []map[string]string
+
+	// FIXME: should be possible to do this without a string in the middle
+	scanner := bufio.NewScanner(input) // strings.NewReader(input.String()))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		row := make(map[string]string)
+
+		// check each possible key match
+		for _, m := range p.matchers {
+			if m.Match(line) {
+				key, err := m.KeyFunc(line)
+				if err != nil {
+					level.Debug(p.logger).Log(
+						"msg", "key match failed",
+						"line", line,
+						"err", err,
+					)
+					continue
+				}
+
+				val, err := m.ValFunc(line)
+				if err != nil {
+					level.Debug(p.logger).Log(
+						"msg", "value match failed",
+						"line", line,
+						"err", err,
+					)
+					continue
+				}
+
+				row[key] = val
+				continue
+			}
+		}
+
+		if len(row) == 0 {
+			level.Debug(p.logger).Log("msg", "No matched keys", "line", line)
+			continue
+		}
+		results = append(results, row)
+
+	}
+	if err := scanner.Err(); err != nil {
+		level.Debug(p.logger).Log("msg", "scanner error", "err", err)
+	}
+	return results
+}
+
+func discernValBool(in string) (bool, error) {
+	switch strings.TrimSpace(strings.ToLower(in)) {
+	case "true", "t", "1", "y", "yes":
+		return true, nil
+	case "false", "f", "0", "n", "no":
+		return false, nil
+	}
+
+	return false, errors.Errorf("Can't discern boolean from string <%s>", in)
+}

--- a/pkg/osquery/tables/firmwarepasswd/parser.go
+++ b/pkg/osquery/tables/firmwarepasswd/parser.go
@@ -33,8 +33,7 @@ func NewParser(logger log.Logger, matchers []Matcher) *OutputParser {
 func (p *OutputParser) Parse(input *bytes.Buffer) []map[string]string {
 	var results []map[string]string
 
-	// FIXME: should be possible to do this without a string in the middle
-	scanner := bufio.NewScanner(input) // strings.NewReader(input.String()))
+	scanner := bufio.NewScanner(input)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {

--- a/pkg/osquery/tables/firmwarepasswd/parser.go
+++ b/pkg/osquery/tables/firmwarepasswd/parser.go
@@ -29,7 +29,7 @@ func NewParser(logger log.Logger, matchers []Matcher) *OutputParser {
 	return p
 }
 
-// Parse looks at command output, line by line. It assumes kv output deliminated by a :
+// Parse looks at command output, line by line. It uses the defined Matchers to set any appropriate values
 func (p *OutputParser) Parse(input *bytes.Buffer) []map[string]string {
 	var results []map[string]string
 

--- a/pkg/osquery/tables/firmwarepasswd/testdata/check-garbage.txt
+++ b/pkg/osquery/tables/firmwarepasswd/testdata/check-garbage.txt
@@ -1,0 +1,3 @@
+Hello: world
+Password Enabled: No
+Unknown: xxx

--- a/pkg/osquery/tables/firmwarepasswd/testdata/check-no.txt
+++ b/pkg/osquery/tables/firmwarepasswd/testdata/check-no.txt
@@ -1,0 +1,1 @@
+Password Enabled: No

--- a/pkg/osquery/tables/firmwarepasswd/testdata/check-yes.txt
+++ b/pkg/osquery/tables/firmwarepasswd/testdata/check-yes.txt
@@ -1,0 +1,1 @@
+Password Enabled: Yes

--- a/pkg/osquery/tables/firmwarepasswd/testdata/mode-command.txt
+++ b/pkg/osquery/tables/firmwarepasswd/testdata/mode-command.txt
@@ -1,0 +1,2 @@
+Mode: command
+Option roms not allowed

--- a/pkg/osquery/tables/firmwarepasswd/testdata/mode-none.txt
+++ b/pkg/osquery/tables/firmwarepasswd/testdata/mode-none.txt
@@ -1,0 +1,3 @@
+Mode: none
+Option roms allowed
+


### PR DESCRIPTION
Add a table based on exec'ing `/usr/sbin/firmwarepasswd`. This also
plumbs in most of a exec and parse interface for similar work.

Fixes: #544

Needs tests