### PR TITLE
Revert "Force osquery to verbose mode (#602)"

### DIFF
--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -144,18 +144,6 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 		"--utc",
 	)
 
-	// TODO: This is a short term hack.
-	// In https://github.com/osquery/osquery/pull/6271 osquery
-	// shifted some debugging info from INFO to VERBOSE. This has
-	// the unfortunate effect of making it hard to correlate
-	// distributed query logs with the distributed query that
-	// caused them. While we're thinking through the longer term
-	// fix, we have a quick mitagation in dropping osquery into
-	// verbose mode. (This is duplicative with the opts.verbose
-	// parsing, because this whole block should be struck once we
-	// have a better approach)
-	cmd.Args = append(cmd.Args, "--verbose")
-
 	if opts.verbose {
 		cmd.Args = append(cmd.Args, "--verbose")
 	}


### PR DESCRIPTION
This reverts commit 4c9f0cf4480eb9886dd5a1c402f1201321ba5041 and undoes #602

We no longer need osquery running in verbose mode. 