### PR TITLE
Add namespace support to kolide_wmi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ launcher: .pre-build
 
 table.ext: .pre-build
 	go run cmd/make/make.go -targets=table-extension -linkstamp
+table.ext-windows: .pre-build deps
+	go run cmd/make/make.go -targets=table-extension -linkstamp --os windows
+
 
 osqueryi-tables: table.ext
 	osqueryd -S --allow-unsafe --verbose --extension ./build/darwin/tables.ext

--- a/pkg/osquery/tables/tablehelpers/getconstraints.go
+++ b/pkg/osquery/tables/tablehelpers/getconstraints.go
@@ -1,0 +1,22 @@
+package tablehelpers
+
+import "github.com/kolide/osquery-go/plugin/table"
+
+// GetConstraints returns a []string of the constraint expressions on
+// a column. It's meant for the common, simple, usecase of iterating over them.
+func GetConstraints(queryContext table.QueryContext, columnName string, defaults ...string) []string {
+	q, ok := queryContext.Constraints[columnName]
+	if !ok || len(q.Constraints) == 0 {
+		return defaults
+	}
+
+	constraints := make([]string, len(q.Constraints))
+
+	for i, c := range q.Constraints {
+		constraints[i] = c.Expression
+	}
+
+	// FIXME: need uniq
+
+	return constraints
+}

--- a/pkg/osquery/tables/tablehelpers/getconstraints.go
+++ b/pkg/osquery/tables/tablehelpers/getconstraints.go
@@ -1,6 +1,8 @@
 package tablehelpers
 
-import "github.com/kolide/osquery-go/plugin/table"
+import (
+	"github.com/kolide/osquery-go/plugin/table"
+)
 
 // GetConstraints returns a []string of the constraint expressions on
 // a column. It's meant for the common, simple, usecase of iterating over them.
@@ -10,13 +12,19 @@ func GetConstraints(queryContext table.QueryContext, columnName string, defaults
 		return defaults
 	}
 
-	constraints := make([]string, len(q.Constraints))
+	constraintSet := make(map[string]struct{})
 
-	for i, c := range q.Constraints {
-		constraints[i] = c.Expression
+	for _, c := range q.Constraints {
+		constraintSet[c.Expression] = struct{}{}
 	}
 
-	// FIXME: need uniq
+	constraints := make([]string, len(constraintSet))
+
+	i := 0
+	for key := range constraintSet {
+		constraints[i] = key
+		i++
+	}
 
 	return constraints
 }

--- a/pkg/osquery/tables/tablehelpers/getconstraints_test.go
+++ b/pkg/osquery/tables/tablehelpers/getconstraints_test.go
@@ -1,0 +1,73 @@
+package tablehelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConstraints(t *testing.T) {
+	t.Parallel()
+
+	mockQC := MockQueryContext(map[string][]string{
+		"empty_array": []string{},
+		"blank":       []string{""},
+		"single":      []string{"a"},
+		"double":      []string{"a", "b"},
+	})
+
+	var tests = []struct {
+		name     string
+		expected []string
+		defaults []string
+	}{
+		{
+			name:     "does_not_exist",
+			expected: []string(nil),
+		},
+		{
+			name:     "does_not_exist_with_defaults",
+			expected: []string{"a", "b"},
+			defaults: []string{"a", "b"},
+		},
+		{
+			name:     "empty_array",
+			expected: []string{"a", "b"},
+			defaults: []string{"a", "b"},
+		},
+		{
+			name:     "empty_array",
+			expected: []string(nil),
+		},
+		{
+			name:     "blank",
+			expected: []string{""},
+		},
+		{
+			name:     "blank",
+			expected: []string{""},
+			defaults: []string{"a", "b"},
+		},
+		{
+			name:     "single",
+			expected: []string{"a"},
+		},
+		{
+			name:     "single",
+			expected: []string{"a"},
+			defaults: []string{"a", "b"},
+		},
+		{
+			name:     "double",
+			expected: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := GetConstraints(mockQC, tt.name, tt.defaults...)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+
+}

--- a/pkg/osquery/tables/tablehelpers/getconstraints_test.go
+++ b/pkg/osquery/tables/tablehelpers/getconstraints_test.go
@@ -10,10 +10,12 @@ func TestGetConstraints(t *testing.T) {
 	t.Parallel()
 
 	mockQC := MockQueryContext(map[string][]string{
-		"empty_array": []string{},
-		"blank":       []string{""},
-		"single":      []string{"a"},
-		"double":      []string{"a", "b"},
+		"empty_array":      []string{},
+		"blank":            []string{""},
+		"single":           []string{"a"},
+		"double":           []string{"a", "b"},
+		"duplicates":       []string{"a", "a", "b", "b"},
+		"duplicate_blanks": []string{"a", "a", "", ""},
 	})
 
 	var tests = []struct {
@@ -60,6 +62,14 @@ func TestGetConstraints(t *testing.T) {
 		{
 			name:     "double",
 			expected: []string{"a", "b"},
+		},
+		{
+			name:     "duplicates",
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "duplicate_blanks",
+			expected: []string{"a", ""},
 		},
 	}
 

--- a/pkg/osquery/tables/wmitable/helpers.go
+++ b/pkg/osquery/tables/wmitable/helpers.go
@@ -4,9 +4,11 @@ import "strings"
 
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 
-func onlyAllowedCharacters(input string) bool {
+func onlyAllowedCharacters(input string, extras ...string) bool {
+
+	allowed := strings.Join(append(extras, allowedCharacters), "")
 	for _, char := range input {
-		if !strings.ContainsRune(allowedCharacters, char) {
+		if !strings.ContainsRune(allowed, char) {
 			return false
 		}
 	}

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -75,7 +75,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	// okay too, default to ""
 	namespaces := tablehelpers.GetConstraints(queryContext, "namespace", "")
 	for _, ns := range namespaces {
-		if !onlyAllowedCharacters(ns) {
+		if !onlyAllowedCharacters(ns, `\`) {
 			return nil, errors.New("Disallowed character in namespace expression")
 		}
 	}
@@ -94,7 +94,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 				defer cancel()
 
 				// FIXME: pass namespace here
-				wmiResults, err := wmi.Query(ctx, class, properties)
+				wmiResults, err := wmi.Query(ctx, class, properties, wmi.ConnectUseMaxWait(), wmi.ConnectNamespace(ns))
 				if err != nil {
 					level.Info(t.logger).Log(
 						"msg", "wmi query failure",

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -94,7 +94,6 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 				ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 				defer cancel()
 
-				// FIXME: pass namespace here
 				wmiResults, err := wmi.Query(ctx, class, properties, wmi.ConnectUseMaxWait(), wmi.ConnectNamespace(ns))
 				if err != nil {
 					level.Info(t.logger).Log(

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -63,7 +63,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	properties := tablehelpers.GetConstraints(queryContext, "properties")
 	for _, p := range properties {
-		if !onlyAllowedCharacters(p) {
+		// Allow comma, since we're going to split on it later.
+		if !onlyAllowedCharacters(p, `,`) {
 			return nil, errors.New("Disallowed character in properties expression")
 		}
 	}

--- a/pkg/wmi/wmi.go
+++ b/pkg/wmi/wmi.go
@@ -8,7 +8,13 @@
 //
 // To understand the available classes, take a look at the Microsoft
 // documention [3]
-
+//
+// Servers, Namespaces, and connection parameters:
+//
+// WMI has a fairly rich set of connection options. It allows querying
+// on remove servers, via authentiated users names, in different name
+// spaces... These options are exposed through functional arguments.
+//
 // References:
 //
 // 1. https://stackoverflow.com/questions/20365286/query-wmi-from-go
@@ -70,12 +76,16 @@ func (qs *querySettings) ConnectServerArgs() []interface{} {
 
 type Option func(*querySettings)
 
+// ConnectServer sets the server to connect to. It defaults to "",
+// which is localhost.
 func ConnectServer(s string) Option {
 	return func(qs *querySettings) {
 		qs.connectServer = s
 	}
 }
 
+// ConnectNamespace sets the namespace to query against. It defaults
+// to "", which is the same as `ROOT\CIMV2`
 func ConnectNamespace(s string) Option {
 	return func(qs *querySettings) {
 		qs.connectNamespace = s
@@ -83,7 +93,8 @@ func ConnectNamespace(s string) Option {
 }
 
 // ConnectUseMaxWait requires that ConnectServer use a timeout. The
-// call is then guaranteed to return in 2 minutes or less.
+// call is then guaranteed to return in 2 minutes or less. This option
+// is strongly recommended, as without it calls can block forever.
 func ConnectUseMaxWait() Option {
 	return func(qs *querySettings) {
 		// see the definition of iSecurityFlags in

--- a/pkg/wmi/wmi.go
+++ b/pkg/wmi/wmi.go
@@ -12,7 +12,7 @@
 // Servers, Namespaces, and connection parameters:
 //
 // WMI has a fairly rich set of connection options. It allows querying
-// on remove servers, via authentiated users names, in different name
+// on remote servers, via authenticated users names, in different name
 // spaces... These options are exposed through functional arguments.
 //
 // References:

--- a/pkg/wmi/wmi_test.go
+++ b/pkg/wmi/wmi_test.go
@@ -20,6 +20,7 @@ func TestQuery(t *testing.T) {
 		name       string
 		class      string
 		properties []string
+		options    []Option
 		minRows    int
 		noData     bool
 		err        bool
@@ -65,6 +66,34 @@ func TestQuery(t *testing.T) {
 			class:      "Win32_OperatingSystem;",
 			properties: []string{"madeup1", "imaginary2"},
 			noData:     true,
+		},
+		{
+			name:       "blank namespace",
+			class:      "Win32_OperatingSystem",
+			properties: []string{"name", "version"},
+			options:    ConnectNamespace(""),
+			minRows:    1,
+		},
+		{
+			name:       "default namespace",
+			class:      "Win32_OperatingSystem",
+			properties: []string{"name", "version"},
+			options:    ConnectNamespace(`root\cimv2`),
+			minRows:    1,
+		},
+		{
+			name:       "unknown namespace",
+			class:      "Win32_OperatingSystem",
+			properties: []string{"name", "version"},
+			options:    ConnectNamespace(`no\such\namespace`),
+			minRows:    1,
+		},
+		{
+			name:       "different namespace",
+			class:      "MSKeyboard_PortInformation",
+			properties: []string{"ConnectorType", "FunctionKeys", "Indicators"},
+			options:    ConnectNamespace(`root\wmi`),
+			minRows:    3,
 		},
 	}
 

--- a/pkg/wmi/wmi_test.go
+++ b/pkg/wmi/wmi_test.go
@@ -71,35 +71,36 @@ func TestQuery(t *testing.T) {
 			name:       "blank namespace",
 			class:      "Win32_OperatingSystem",
 			properties: []string{"name", "version"},
-			options:    ConnectNamespace(""),
+			options:    []Option{ConnectNamespace("")},
 			minRows:    1,
 		},
 		{
 			name:       "default namespace",
 			class:      "Win32_OperatingSystem",
 			properties: []string{"name", "version"},
-			options:    ConnectNamespace(`root\cimv2`),
+			options:    []Option{ConnectNamespace(`root\cimv2`)},
 			minRows:    1,
 		},
 		{
 			name:       "unknown namespace",
 			class:      "Win32_OperatingSystem",
 			properties: []string{"name", "version"},
-			options:    ConnectNamespace(`no\such\namespace`),
-			minRows:    1,
+			options:    []Option{ConnectNamespace(`no\such\namespace`)},
+			noData:     true,
+			err:        true,
 		},
 		{
 			name:       "different namespace",
 			class:      "MSKeyboard_PortInformation",
 			properties: []string{"ConnectorType", "FunctionKeys", "Indicators"},
-			options:    ConnectNamespace(`root\wmi`),
-			minRows:    3,
+			options:    []Option{ConnectNamespace(`root\wmi`)},
+			minRows:    1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rows, err := Query(ctx, tt.class, tt.properties)
+			rows, err := Query(ctx, tt.class, tt.properties, tt.options...)
 			if tt.err {
 				require.Error(t, err)
 				return
@@ -114,6 +115,7 @@ func TestQuery(t *testing.T) {
 
 			if tt.minRows > 0 {
 				assert.GreaterOrEqual(t, len(rows), tt.minRows, "Expected minimum rows")
+
 			}
 
 		})


### PR DESCRIPTION
Adds support for specifying the connection parameters to the underlying `wmi` package, and plumbs namespace through to the table.

To improve code readability, also adds a `tablehelper` function to extract simple arrays of specified constraints. 

The test suite for these packages has been manually compiled and run on a windows machine