### PR TITLE
Record installer info in the windows registry

### DIFF
--- a/pkg/packagekit/internal/assets.go
+++ b/pkg/packagekit/internal/assets.go
@@ -351,7 +351,7 @@ start on {{ .Opts.StartOn }}
 stop on {{ .Opts.StopOn }}
 {{- end }}
 
-# Respawn upto 15 times within 5 seconds.
+# Respawn up to 15 times within 5 seconds.
 # Exceeding that will be considered a failure
 respawn
 respawn limit 15 5

--- a/pkg/packagekit/internal/assets.go
+++ b/pkg/packagekit/internal/assets.go
@@ -194,8 +194,6 @@ var _internalAssetsMainWxs = []byte(`<?xml version="1.0" encoding="UTF-8"?>
 	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
 	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
 	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
-	  <RegistryValue Key="Timestamp" Value="[DATE] [TIME]" Type="string" />
-
 	</RegistryKey>
       </Component>
     </DirectoryRef>
@@ -216,7 +214,7 @@ var _internalAssetsMainWxs = []byte(`<?xml version="1.0" encoding="UTF-8"?>
 	Title="InstallerInfo"
 	Level="1"
 	Display="hidden">
-      <ComponentGroupRef Id="InstallerInfoRegistryEntries" />
+      <ComponentRef Id="InstallerInfoRegistryEntries" />
     </Feature>
 
 

--- a/pkg/packagekit/internal/assets.go
+++ b/pkg/packagekit/internal/assets.go
@@ -184,12 +184,39 @@ var _internalAssetsMainWxs = []byte(`<?xml version="1.0" encoding="UTF-8"?>
       </Directory>
     </Directory>
 
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="InstallerInfoRegistryEntries" Guid="*">
+	<RegistryKey Root="HKLM"
+		     Key="Software\Kolide\Launcher\{{.Opts.Identifier}}"
+		     Action="createAndRemoveOnUninstall">
+	  <RegistryValue Key="DownloadPath" Value="[OriginalDatabase]" Type="string" />
+	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
+	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
+	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
+	  <RegistryValue Key="Timestamp" Value="[DATE] [TIME]" Type="string" />
+
+	</RegistryKey>
+      </Component>
+    </DirectoryRef>
+
+
+
     <!-- Install the files -->
     <Feature
 	Id="LauncherFiles"
 	Title="Launcher"
-	Level="1">
+	Level="1"
+	Display="hidden">
       <ComponentGroupRef Id="AppFiles" />
+    </Feature>
+
+    <Feature
+	Id="InstallerInfo"
+	Title="InstallerInfo"
+	Level="1"
+	Display="hidden">
+      <ComponentGroupRef Id="InstallerInfoRegistryEntries" />
     </Feature>
 
 

--- a/pkg/packagekit/internal/assets/main.wxs
+++ b/pkg/packagekit/internal/assets/main.wxs
@@ -53,8 +53,12 @@
 	<RegistryKey Root="HKLM"
 		     Key="Software\Kolide\Launcher\{{.Opts.Identifier}}"
 		     Action="createAndRemoveOnUninstall">
-	  <RegistryValue Type="integer" Name="SomeIntegerValue" Value="1" KeyPath="yes"/>
-	  <RegistryValue Type="string" Value="Default Value"/>
+	  <RegistryValue Key="DownloadPath" Value="[OriginalDatabase]" Type="string" />
+	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
+	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
+	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
+	  <RegistryValue Key="Timestamp" Value="[DATE] [TIME]" Type="string" />
+
 	</RegistryKey>
       </Component>
     </DirectoryRef>
@@ -65,14 +69,16 @@
     <Feature
 	Id="LauncherFiles"
 	Title="Launcher"
-	Level="1">
+	Level="1"
+	Display="hidden">
       <ComponentGroupRef Id="AppFiles" />
     </Feature>
 
     <Feature
 	Id="InstallerInfo"
 	Title="InstallerInfo"
-	Level="1">
+	Level="1"
+	Display="hidden">
       <ComponentGroupRef Id="InstallerInfoRegistryEntries" />
     </Feature>
 

--- a/pkg/packagekit/internal/assets/main.wxs
+++ b/pkg/packagekit/internal/assets/main.wxs
@@ -47,12 +47,33 @@
       </Directory>
     </Directory>
 
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="InstallerInfoRegistryEntries" Guid="*">
+	<RegistryKey Root="HKLM"
+		     Key="Software\Kolide\Launcher\{{.Opts.Identifier}}"
+		     Action="createAndRemoveOnUninstall">
+	  <RegistryValue Type="integer" Name="SomeIntegerValue" Value="1" KeyPath="yes"/>
+	  <RegistryValue Type="string" Value="Default Value"/>
+	</RegistryKey>
+      </Component>
+    </DirectoryRef>
+
+
+
     <!-- Install the files -->
     <Feature
 	Id="LauncherFiles"
 	Title="Launcher"
 	Level="1">
       <ComponentGroupRef Id="AppFiles" />
+    </Feature>
+
+    <Feature
+	Id="InstallerInfo"
+	Title="InstallerInfo"
+	Level="1">
+      <ComponentGroupRef Id="InstallerInfoRegistryEntries" />
     </Feature>
 
 

--- a/pkg/packagekit/internal/assets/main.wxs
+++ b/pkg/packagekit/internal/assets/main.wxs
@@ -57,8 +57,6 @@
 	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
 	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
 	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
-	  <RegistryValue Key="Timestamp" Value="[DATE] [TIME]" Type="string" />
-
 	</RegistryKey>
       </Component>
     </DirectoryRef>
@@ -79,7 +77,7 @@
 	Title="InstallerInfo"
 	Level="1"
 	Display="hidden">
-      <ComponentGroupRef Id="InstallerInfoRegistryEntries" />
+      <ComponentRef Id="InstallerInfoRegistryEntries" />
     </Feature>
 
 


### PR DESCRIPTION
This records installer information in the windows registry. It is equivalent to the `installer-info.json` info files left by the macOS and linux installers.

### Why the windows registry?

I spend a long while trying to do this in a similar looking json file. First, I experimented with wix's `XMLFile` and `XMLConfig` elements. I was unable to get those to work reliably.

I then spent awhile setting up a launcher `postinstall` subcommand that would create the `installer-info.json`. This worked, but calling it from wix felt a bit flakey. I had to use `ExeCommand` and go through some weird quoting hassle. It did not feel stable.

Then, I remembered that this is the sort of thing the windows registry is designed for. Both wix and osquery have straightforward support.