### PR TITLE
Add jsonrpc go-kit boilerplate

### DIFF
--- a/pkg/service/check_health.go
+++ b/pkg/service/check_health.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -23,6 +24,10 @@ func decodeGRPCHealthCheckRequest(_ context.Context, grpcReq interface{}) (inter
 	return healthcheckRequest{}, nil
 }
 
+func decodeJSONRPCHealthCheckRequest(_ context.Context, msg json.RawMessage) (interface{}, error) {
+	return healthcheckRequest{}, nil
+}
+
 func encodeGRPCHealcheckRequest(_ context.Context, request interface{}) (interface{}, error) {
 	return &pb.AgentApiRequest{}, nil
 }
@@ -39,6 +44,22 @@ func encodeGRPCHealthcheckResponse(_ context.Context, request interface{}) (inte
 	return &pb.HealthCheckResponse{
 		Status: pb.HealthCheckResponse_ServingStatus(req.Status),
 	}, nil
+}
+
+func encodeJSONRPCHealthcheckResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
+	res, ok := obj.(healthcheckResponse)
+	if !ok {
+		return nil, &jsonrpc.Error{
+			Code:    -32000,
+			Message: fmt.Sprintf("Asserting result to *healthcheckResponse failed. Got %T, %+v", obj, obj),
+		}
+	}
+
+	b, err := json.Marshal(res)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal response: %s", err)
+	}
+	return b, nil
 }
 
 func decodeJSONRPCHealthCheckResponse(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/middleware.go
+++ b/pkg/service/middleware.go
@@ -4,7 +4,9 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-func LoggingMiddleware(logger log.Logger) func(KolideService) KolideService {
+type Middleware func(KolideService) KolideService
+
+func LoggingMiddleware(logger log.Logger) Middleware {
 	return func(next KolideService) KolideService {
 		return logmw{logger, next}
 	}

--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -57,6 +57,18 @@ func decodeGRPCLogCollection(_ context.Context, grpcReq interface{}) (interface{
 	}, nil
 }
 
+func decodeJSONRPCLogCollection(_ context.Context, msg json.RawMessage) (interface{}, error) {
+	var req logCollection
+
+	if err := json.Unmarshal(msg, &req); err != nil {
+		return nil, &jsonrpc.Error{
+			Code:    -32000,
+			Message: fmt.Sprintf("couldn't unmarshal body to logCollection: %s", err),
+		}
+	}
+	return req, nil
+}
+
 func encodeGRPCLogCollection(_ context.Context, request interface{}) (interface{}, error) {
 	req := request.(logCollection)
 	logs := make([]*pb.LogCollection_Log, 0, len(req.Logs))
@@ -98,6 +110,22 @@ func encodeGRPCPublishLogsResponse(_ context.Context, request interface{}) (inte
 		NodeInvalid: req.NodeInvalid,
 	}
 	return encodeResponse(resp, req.Err)
+}
+
+func encodeJSONRPCPublishLogsResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
+	res, ok := obj.(publishLogsResponse)
+	if !ok {
+		return nil, &jsonrpc.Error{
+			Code:    -32000,
+			Message: fmt.Sprintf("Asserting result to *publishLogsResponse failed. Got %T, %+v", obj, obj),
+		}
+	}
+
+	b, err := json.Marshal(res)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal response: %s", err)
+	}
+	return b, nil
 }
 
 func decodeJSONRPCPublishLogsResponse(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -46,6 +47,18 @@ func decodeGRPCQueriesRequest(_ context.Context, grpcReq interface{}) (interface
 	}, nil
 }
 
+func decodeJSONRPCQueriesRequest(_ context.Context, msg json.RawMessage) (interface{}, error) {
+	var req queriesRequest
+
+	if err := json.Unmarshal(msg, &req); err != nil {
+		return nil, &jsonrpc.Error{
+			Code:    -32000,
+			Message: fmt.Sprintf("couldn't unmarshal body to queriesRequest: %s", err),
+		}
+	}
+	return req, nil
+}
+
 func encodeGRPCQueriesRequest(_ context.Context, request interface{}) (interface{}, error) {
 	req := request.(queriesRequest)
 	return &pb.AgentApiRequest{
@@ -84,6 +97,22 @@ func encodeGRPCQueryCollection(_ context.Context, request interface{}) (interfac
 		NodeInvalid: req.NodeInvalid,
 	}
 	return encodeResponse(resp, req.Err)
+}
+
+func encodeJSONRPCQueryCollection(_ context.Context, obj interface{}) (json.RawMessage, error) {
+	res, ok := obj.(queryCollectionResponse)
+	if !ok {
+		return nil, &jsonrpc.Error{
+			Code:    -32000,
+			Message: fmt.Sprintf("Asserting result to *queryCollectionResponse failed. Got %T, %+v", obj, obj),
+		}
+	}
+
+	b, err := json.Marshal(res)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal response: %s", err)
+	}
+	return b, nil
 }
 
 func MakeRequestQueriesEndpoint(svc KolideService) endpoint.Endpoint {

--- a/pkg/service/server_jsonrpc.go
+++ b/pkg/service/server_jsonrpc.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/transport/http/jsonrpc"
+)
+
+func NewJSONRPCServer(endpoints Endpoints, logger log.Logger) *jsonrpc.Server {
+	handler := jsonrpc.NewServer(
+		makeEndpointCodecMap(endpoints),
+		jsonrpc.ServerErrorLogger(logger),
+	)
+	return handler
+}
+
+// makeEndpointCodecMap returns a codec map configured.
+func makeEndpointCodecMap(endpoints Endpoints) jsonrpc.EndpointCodecMap {
+	return jsonrpc.EndpointCodecMap{
+		"RequestEnrollment": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.RequestEnrollmentEndpoint,
+			Decode:   decodeJSONRPCEnrollmentRequest,
+			Encode:   encodeJSONRPCEnrollmentResponse,
+		},
+		"RequestConfig": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.RequestConfigEndpoint,
+			Decode:   decodeJSONRPCConfigRequest,
+			Encode:   encodeJSONRPCConfigResponse,
+		},
+		"RequestQueries": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.RequestQueriesEndpoint,
+			Decode:   decodeJSONRPCQueriesRequest,
+			Encode:   encodeJSONRPCQueryCollection,
+		},
+		"PublishLogs": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.PublishLogsEndpoint,
+			Decode:   decodeJSONRPCLogCollection,
+			Encode:   encodeJSONRPCPublishLogsResponse,
+		},
+		"PublishResults": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.PublishResultsEndpoint,
+			Decode:   decodeJSONRPCResultCollection,
+			Encode:   encodeJSONRPCPublishResultsResponse,
+		},
+		"CheckHealth": jsonrpc.EndpointCodec{
+			Endpoint: endpoints.CheckHealthEndpoint,
+			Decode:   decodeJSONRPCHealthCheckRequest,
+			Encode:   encodeJSONRPCHealthcheckResponse,
+		},
+	}
+
+}


### PR DESCRIPTION
This continues the work in #428 and adds the missing endpoint encode/decode functions. 