### PR TITLE
Additional error handling (and optional debug file logging)

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -90,11 +90,12 @@ func main() {
 	logger = logutil.NewServerLogger(opts.Debug)
 
 	if opts.DebugLogFile != "" {
-		logMirror, err := os.Create(opts.DebugLogFile)
+		logMirror, err := os.OpenFile(opts.DebugLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			level.Info(logger).Log("msg", "failed to create file logger", "err", err)
 			os.Exit(2)
 		}
+		defer logMirror.Close()
 
 		fileLogger := log.NewJSONLogger(log.NewSyncWriter(logMirror))
 		fileLogger = log.With(fileLogger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -104,6 +105,16 @@ func main() {
 
 		level.Info(logger).Log("msg", "mirroring logs to file", "file", logMirror.Name())
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			level.Info(logger).Log(
+				"msg", "panic occurred",
+				"err", err,
+			)
+			time.Sleep(time.Second)
+		}
+	}()
 
 	ctx = ctxlog.NewContext(ctx, logger)
 

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -72,6 +72,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 
 		// Development options
 		flDebug             = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
+		flDebugLogFile      = flagset.String("debug_log_file", "", "File to mirror debug logs to (optional)")
 		flOsqueryVerbose    = flagset.Bool("osquery_verbose", false, "Enable verbose osqueryd (default: false)")
 		flDeveloperUsage    = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options")
 		flDisableControlTLS = flagset.Bool("disable_control_tls", false, "Disable TLS encryption for the control features")
@@ -147,30 +148,31 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	}
 
 	opts := &launcher.Options{
-		KolideServerURL:     *flKolideServerURL,
-		Transport:           *flTransport,
+		Autoupdate:          *flAutoupdate,
+		AutoupdateInterval:  *flAutoupdateInterval,
+		CertPins:            certPins,
 		Control:             *flControl,
 		ControlServerURL:    *flControlServerURL,
-		GetShellsInterval:   *flGetShellsInterval,
+		Debug:               *flDebug,
+		DebugLogFile:        *flDebugLogFile,
+		DisableControlTLS:   *flDisableControlTLS,
+		EnableInitialRunner: *flInitialRunner,
 		EnrollSecret:        *flEnrollSecret,
 		EnrollSecretPath:    *flEnrollSecretPath,
-		RootDirectory:       *flRootDirectory,
-		OsquerydPath:        osquerydPath,
-		CertPins:            certPins,
-		RootPEM:             *flRootPEM,
-		LoggingInterval:     *flLoggingInterval,
-		EnableInitialRunner: *flInitialRunner,
-		Autoupdate:          *flAutoupdate,
-		Debug:               *flDebug,
-		OsqueryVerbose:      *flOsqueryVerbose,
-		OsqueryFlags:        flOsqueryFlags,
-		DisableControlTLS:   *flDisableControlTLS,
+		GetShellsInterval:   *flGetShellsInterval,
 		InsecureTLS:         *flInsecureTLS,
 		InsecureTransport:   *flInsecureTransport,
-		NotaryServerURL:     *flNotaryServerURL,
+		KolideServerURL:     *flKolideServerURL,
+		LoggingInterval:     *flLoggingInterval,
 		MirrorServerURL:     *flMirrorURL,
 		NotaryPrefix:        *flNotaryPrefix,
-		AutoupdateInterval:  *flAutoupdateInterval,
+		NotaryServerURL:     *flNotaryServerURL,
+		OsqueryFlags:        flOsqueryFlags,
+		OsqueryVerbose:      *flOsqueryVerbose,
+		OsquerydPath:        osquerydPath,
+		RootDirectory:       *flRootDirectory,
+		RootPEM:             *flRootPEM,
+		Transport:           *flTransport,
 		UpdateChannel:       updateChannel,
 	}
 	return opts, nil
@@ -250,6 +252,7 @@ func developerUsage(flagset *flag.FlagSet) {
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("debug")
 	printOpt("osquery_verbose")
+	printOpt("debug_log_file")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("insecure")
 	printOpt("insecure_transport")

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -102,6 +102,7 @@ func runWindowsSvc(args []string) error {
 				"msg", "panic occurred",
 				"err", err,
 			)
+			time.Sleep(time.Second)
 		}
 	}()
 
@@ -114,8 +115,13 @@ func runWindowsSvc(args []string) error {
 			"err", err,
 			"version", version.Version().Version,
 		)
+		time.Sleep(time.Second)
 		return err
 	}
+
+	level.Info(logger).Log("msg", "svc exited", "version", version.Version().Version)
+	time.Sleep(time.Second)
+
 	return nil
 }
 

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/logutil"
+	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/launcher"
@@ -33,7 +34,10 @@ func runWindowsSvc(args []string) error {
 	defer eventLogWriter.Close()
 
 	logger := eventlog.New(eventLogWriter)
-	level.Debug(logger).Log("msg", "service start requested")
+	level.Debug(logger).Log(
+		"msg", "service start requested",
+		"version", version.Version().Version,
+	)
 
 	opts, err := parseOptions(os.Args[2:])
 	if err != nil {
@@ -63,6 +67,11 @@ func runWindowsSvc(args []string) error {
 	}()
 
 	run := svc.Run
+
+	level.Info(logger).Log(
+		"msg", "launching service",
+		"version", version.Version().Version,
+	)
 
 	if err := run(serviceName, &winSvc{logger: logger, opts: opts}); err != nil {
 		// TODO The caller doesn't have the event log configured, so we

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -185,7 +185,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				time.Sleep(100 * time.Millisecond)
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				level.Info(w.logger).Log("msg", "shutdown request recieved")
+				level.Info(w.logger).Log("msg", "shutdown request received")
 				changes <- svc.Status{State: svc.StopPending}
 				cancel()
 				time.Sleep(100 * time.Millisecond)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -111,6 +111,7 @@ type winSvc struct {
 
 func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	level.Info(w.logger).Log("msg", "windows service executing")
 	changes <- svc.Status{State: svc.StartPending}
 	level.Info(w.logger).Log("msg", "windows service starting")
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -114,7 +114,7 @@ func runWindowsSvc(args []string) error {
 		return err
 	}
 
-	level.Info(logger).Log("msg", "Service exited", "version", version.Version().Version)
+	level.Debug(logger).Log("msg", "Service exited", "version", version.Version().Version)
 	time.Sleep(time.Second)
 
 	return nil
@@ -148,9 +148,8 @@ type winSvc struct {
 
 func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
-	level.Info(w.logger).Log("msg", "windows service executing")
 	changes <- svc.Status{State: svc.StartPending}
-	level.Info(w.logger).Log("msg", "windows service starting")
+	level.Debug(w.logger).Log("msg", "windows service starting")
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -52,11 +52,12 @@ func runWindowsSvc(args []string) error {
 	}
 
 	if opts.DebugLogFile != "" {
-		logMirror, err := os.Create(opts.DebugLogFile)
+		logMirror, err := os.OpenFile(opts.DebugLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			level.Info(logger).Log("msg", "failed to create file logger", "err", err)
 			os.Exit(2)
 		}
+		defer logMirror.Close()
 
 		fileLogger := log.NewJSONLogger(log.NewSyncWriter(logMirror))
 		fileLogger = log.With(fileLogger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -95,13 +95,22 @@ func runWindowsSvc(args []string) error {
 		"version", version.Version().Version,
 	)
 
+	// Log panics from the windows service
+	defer func() {
+		if r := recover(); r != nil {
+			level.Info(logger).Log(
+				"msg", "panic occurred",
+				"err", err,
+			)
+		}
+	}()
+
 	if err := run(serviceName, &winSvc{logger: logger, opts: opts}); err != nil {
 		// TODO The caller doesn't have the event log configured, so we
 		// need to log here. this implies we need some deeper refactoring
 		// of the logging
 		level.Info(logger).Log(
-			"msg",
-			"svc run",
+			"msg", "svc run",
 			"err", err,
 			"version", version.Version().Version,
 		)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -77,7 +77,12 @@ func runWindowsSvc(args []string) error {
 		// TODO The caller doesn't have the event log configured, so we
 		// need to log here. this implies we need some deeper refactoring
 		// of the logging
-		level.Info(logger).Log("msg", "svc run", "err", err)
+		level.Info(logger).Log(
+			"msg",
+			"svc run",
+			"err", err,
+			"version", version.Version().Version,
+		)
 		return err
 	}
 	return nil
@@ -149,6 +154,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				time.Sleep(100 * time.Millisecond)
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
+				level.Info(w.logger).Log("msg", "shutdown request recieved")
+
 				changes <- svc.Status{State: svc.StopPending}
 				cancel()
 				time.Sleep(100 * time.Millisecond)

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	golang.org/x/image v0.0.0-20190227222117-0694c2d4d067
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
+	golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/grpc v1.23.0
 	gopkg.in/dancannon/gorethink.v3 v3.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd h1:DBH9mDw0zluJT/R+nGuV3jWFWLFaHyYZWD4tOT+cjn0=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3 h1:Q8sHd8ZmZZguDQWkUYcD4pIRG5dG+euDEmNyknTRbGs=
+golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -60,6 +60,8 @@ type Options struct {
 
 	// Debug enables debug logging.
 	Debug bool
+	// Optional file to mirror debug logs to
+	DebugLogFile string
 	// OsqueryVerbose puts osquery into verbose mode
 	OsqueryVerbose bool
 	// OsqueryFlags defines additional flags to pass to osquery (possibly

--- a/pkg/log/teelogger/teelogger.go
+++ b/pkg/log/teelogger/teelogger.go
@@ -1,0 +1,32 @@
+// Package filetee provides a go-kit compatible logger, which will
+// mirror logs into a tmp file. This is designed to aid in debugging.
+package teelogger
+
+import (
+	"github.com/go-kit/kit/log"
+)
+
+type teeLogger struct {
+	loggers []log.Logger
+}
+
+func New(loggers ...log.Logger) log.Logger {
+	l := &teeLogger{
+		loggers: loggers,
+	}
+
+	return l
+}
+
+// Log will log to each logger. If any of them error, it will return a
+// random error.
+func (l *teeLogger) Log(keyvals ...interface{}) error {
+	var randomErr error
+	for _, logger := range l.loggers {
+		if err := logger.Log(keyvals...); err != nil {
+			randomErr = err
+		}
+	}
+
+	return randomErr
+}

--- a/pkg/log/teelogger/teelogger.go
+++ b/pkg/log/teelogger/teelogger.go
@@ -1,5 +1,4 @@
-// Package filetee provides a go-kit compatible logger, which will
-// mirror logs into a tmp file. This is designed to aid in debugging.
+// Package filetee provides a go-kit compatible log mirroring tool.
 package teelogger
 
 import (


### PR DESCRIPTION
Adds several additional logging capabilities. Panic is now caught, and logged. A handful of extra startup log lines have been added.

Adds the capability to mirror debug to a file. This greatly helps when debugging on windows, as extracting structed json from a file is simpler than extracting from the event log. This is something of an early preview -- I'd rather enable this by default, we until we have a log rotation ability, it won't work.

Lastly, this upgrades the go svc version