### PR TITLE
Set minimum TLS version to 1.2

### DIFF
--- a/pkg/service/tls.go
+++ b/pkg/service/tls.go
@@ -16,6 +16,7 @@ func makeTLSConfig(host string, insecureTLS bool, certPins [][]byte, rootPool *x
 		ServerName:         host,
 		InsecureSkipVerify: insecureTLS,
 		RootCAs:            rootPool,
+		MinVersion:         tls.VersionTLS12,
 	}
 
 	if len(certPins) > 0 {


### PR DESCRIPTION
When we moved to Heroku, we changed the TLS server. Our old one allowed
us to set a minimum version, heroku does not. So, enforce a reasonable
TLS level in the client.