### PR TITLE
jsonrpc updates

### DIFF
--- a/pkg/service/check_health.go
+++ b/pkg/service/check_health.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -49,17 +48,11 @@ func encodeGRPCHealthcheckResponse(_ context.Context, request interface{}) (inte
 func encodeJSONRPCHealthcheckResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(healthcheckResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *healthcheckResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *healthcheckResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func decodeJSONRPCHealthCheckResponse(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/check_health.go
+++ b/pkg/service/check_health.go
@@ -15,8 +15,9 @@ import (
 
 type healthcheckRequest struct{}
 type healthcheckResponse struct {
-	Status int32 `json:"status"`
-	Err    error
+	Status    int32  `json:"status"`
+	ErrorCode string `json:"error_code,omitempty"`
+	Err       error  `json:"err,omitempty"`
 }
 
 func decodeGRPCHealthCheckRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/pkg/service/client_jsonrpc.go
+++ b/pkg/service/client_jsonrpc.go
@@ -47,6 +47,7 @@ func NewJSONRPCClient(
 	certPins [][]byte,
 	rootPool *x509.CertPool,
 	logger log.Logger,
+	options ...jsonrpc.ClientOption,
 ) KolideService {
 	serviceURL := &url.URL{
 		Scheme: "https",
@@ -77,6 +78,8 @@ func NewJSONRPCClient(
 			forceNoChunkedEncoding,
 		),
 	}
+
+	commonOpts = append(commonOpts, options...)
 
 	requestEnrollmentEndpoint := jsonrpc.NewClient(
 		serviceURL,

--- a/pkg/service/error_handling.go
+++ b/pkg/service/error_handling.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"encoding/json"
+
+	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,5 +27,18 @@ func encodeResponse(resp interface{}, err error) (interface{}, error) {
 		return nil, status.Error(codes.Unauthenticated, "Node Invalid")
 	default:
 		return nil, status.Error(codes.Unknown, "Server Error")
+	}
+}
+
+func encodeJSONResponse(resp json.RawMessage, err error) (json.RawMessage, error) {
+	if err == nil {
+		return resp, nil
+	}
+
+	// Encode as jsonrpc error
+	return nil, &jsonrpc.Error{
+		Code:    -32000,
+		Message: "Server Error",
+		Data:    err,
 	}
 }

--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -115,17 +115,11 @@ func encodeGRPCPublishLogsResponse(_ context.Context, request interface{}) (inte
 func encodeJSONRPCPublishLogsResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(publishLogsResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *publishLogsResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *publishLogsResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func decodeJSONRPCPublishLogsResponse(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -24,9 +24,9 @@ type logCollection struct {
 
 type publishLogsResponse struct {
 	Message     string `json:"message"`
-	ErrorCode   string `json:"error_code"`
 	NodeInvalid bool   `json:"node_invalid"`
-	Err         error
+	ErrorCode   string `json:"error_code,omitempty"`
+	Err         error  `json:"err,omitempty"`
 }
 
 func decodeGRPCLogCollection(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -23,9 +23,9 @@ type resultCollection struct {
 
 type publishResultsResponse struct {
 	Message     string `json:"message"`
-	ErrorCode   string `json:"error_code"`
 	NodeInvalid bool   `json:"node_invalid"`
-	Err         error
+	ErrorCode   string `json:"error_code,omitempty"`
+	Err         error  `json:"err,omitempty"`
 }
 
 func decodeGRPCResultCollection(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -138,18 +138,11 @@ func encodeGRPCPublishResultsResponse(_ context.Context, request interface{}) (i
 func encodeJSONRPCPublishResultsResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(publishResultsResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *enrollmentResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *publishResultsResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
-
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func MakePublishResultsEndpoint(svc KolideService) endpoint.Endpoint {

--- a/pkg/service/request_config.go
+++ b/pkg/service/request_config.go
@@ -71,17 +71,11 @@ func encodeGRPCConfigResponse(_ context.Context, request interface{}) (interface
 func encodeJSONRPCConfigResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(configResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *configResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *configResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func decodeJSONRPCConfigResponse(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/request_config.go
+++ b/pkg/service/request_config.go
@@ -22,7 +22,8 @@ type configRequest struct {
 type configResponse struct {
 	ConfigJSONBlob string `json:"config"`
 	NodeInvalid    bool   `json:"node_invalid"`
-	Err            error  `json:"error_code,omitempty"`
+	ErrorCode      string `json:"error_code,omitempty"`
+	Err            error  `json:"err,omitempty"`
 }
 
 func decodeGRPCConfigRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/pkg/service/request_enrollment.go
+++ b/pkg/service/request_enrollment.go
@@ -98,17 +98,11 @@ func decodeJSONRPCEnrollmentResponse(_ context.Context, res jsonrpc.Response) (i
 func encodeJSONRPCEnrollmentResponse(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(enrollmentResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *enrollmentResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *enrollmentResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func encodeGRPCEnrollmentRequest(_ context.Context, request interface{}) (interface{}, error) {

--- a/pkg/service/request_enrollment.go
+++ b/pkg/service/request_enrollment.go
@@ -40,8 +40,8 @@ type EnrollmentDetails struct {
 type enrollmentResponse struct {
 	NodeKey     string `json:"node_key"`
 	NodeInvalid bool   `json:"node_invalid"`
-	ErrorCode   string `json:"error_code"`
-	Err         error
+	ErrorCode   string `json:"error_code,omitempty"`
+	Err         error  `json:"err,omitempty"`
 }
 
 func decodeGRPCEnrollmentRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -116,11 +116,14 @@ func MakeRequestQueriesEndpoint(svc KolideService) endpoint.Endpoint {
 		if err != nil {
 			return queryCollectionResponse{Err: err}, nil
 		}
-		return queryCollectionResponse{
-			Queries:     *result,
+		resp := queryCollectionResponse{
 			NodeInvalid: valid,
 			Err:         err,
-		}, nil
+		}
+		if result != nil {
+			resp.Queries = *result
+		}
+		return resp, nil
 	}
 }
 

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -102,17 +102,11 @@ func encodeGRPCQueryCollection(_ context.Context, request interface{}) (interfac
 func encodeJSONRPCQueryCollection(_ context.Context, obj interface{}) (json.RawMessage, error) {
 	res, ok := obj.(queryCollectionResponse)
 	if !ok {
-		return nil, &jsonrpc.Error{
-			Code:    -32000,
-			Message: fmt.Sprintf("Asserting result to *queryCollectionResponse failed. Got %T, %+v", obj, obj),
-		}
+		return encodeJSONResponse(nil, errors.Errorf("Asserting result to *queryCollectionResponse failed. Got %T, %+v", obj, obj))
 	}
 
 	b, err := json.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal response: %s", err)
-	}
-	return b, nil
+	return encodeJSONResponse(b, errors.Wrap(err, "marshal json response"))
 }
 
 func MakeRequestQueriesEndpoint(svc KolideService) endpoint.Endpoint {

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -23,8 +23,8 @@ type queriesRequest struct {
 type queryCollectionResponse struct {
 	Queries     distributed.GetQueriesResult
 	NodeInvalid bool   `json:"node_invalid"`
-	ErrorCode   string `json:"error_code"`
-	Err         error
+	ErrorCode   string `json:"error_code,omitempty"`
+	Err         error  `json:"err,omitempty"`
 }
 
 func decodeJSONRPCQueryCollection(_ context.Context, res jsonrpc.Response) (interface{}, error) {

--- a/pkg/service/server_jsonrpc.go
+++ b/pkg/service/server_jsonrpc.go
@@ -5,10 +5,11 @@ import (
 	"github.com/go-kit/kit/transport/http/jsonrpc"
 )
 
-func NewJSONRPCServer(endpoints Endpoints, logger log.Logger) *jsonrpc.Server {
+func NewJSONRPCServer(endpoints Endpoints, logger log.Logger, options ...jsonrpc.ServerOption) *jsonrpc.Server {
+	options = append(options, jsonrpc.ServerErrorLogger(logger))
 	handler := jsonrpc.NewServer(
 		makeEndpointCodecMap(endpoints),
-		jsonrpc.ServerErrorLogger(logger),
+		options...,
 	)
 	return handler
 }


### PR DESCRIPTION
1. Normalize the responses around how errors are handled
2. Move json encoding to helper functions
3. Pass `options ...jsonrpc.ClientOption` to `NewJSONRPCClient` (mirroring the grpc side)

I've been running this on a branch for a bit. I think it's good to merge now.