### PR TITLE
Add username context to kolide_pwpolicy

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/firmwarepasswd"
 	"github.com/kolide/launcher/pkg/osquery/tables/ioreg"
 	"github.com/kolide/launcher/pkg/osquery/tables/munki"
+	"github.com/kolide/launcher/pkg/osquery/tables/pwpolicy"
 	"github.com/kolide/launcher/pkg/osquery/tables/screenlock"
 	"github.com/kolide/launcher/pkg/osquery/tables/systemprofiler"
 	osquery "github.com/kolide/osquery-go"
@@ -40,10 +41,9 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		legacyexec.TablePlugin(),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
 		dataflattentable.TablePluginExec(client, logger,
-			"kolide_pwpolicy", dataflattentable.PlistType, []string{"/usr/bin/pwpolicy", "getaccountpolicies"}),
-		dataflattentable.TablePluginExec(client, logger,
 			"kolide_apfs_users", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "listUsers", "/", "-plist"}),
 		screenlock.TablePlugin(client, logger, currentOsquerydBinaryPath),
+		pwpolicy.TablePlugin(client, logger),
 		systemprofiler.TablePlugin(client, logger),
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -1,5 +1,12 @@
 //+build darwin
 
+// Package pwpolicy provides a table wrapper around the `pwpolicy` macOS
+// command.
+//
+// As the returned data is a complex nested plist, this uses the
+// dataflatten tooling. (See
+// https://godoc.org/github.com/kolide/launcher/pkg/dataflatten)
+
 package pwpolicy
 
 import (
@@ -7,99 +14,96 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/dataflatten"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
 
-type Table struct {
-	client       *osquery.ExtensionManagerClient
-	logger       log.Logger
-	tableName    string
-	execDataFunc func([]byte, ...dataflatten.FlattenOpts) ([]dataflatten.Row, error)
-}
-
 const PwpolicyPath = "/usr/bin/pwpolicy"
 const PwpolicyCmd = "getaccountpolicies"
 
+type Table struct {
+	client    *osquery.ExtensionManagerClient
+	logger    log.Logger
+	tableName string
+}
+
 func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+
 	columns := []table.ColumnDefinition{
 		table.TextColumn("fullkey"),
 		table.TextColumn("parent"),
 		table.TextColumn("key"),
 		table.TextColumn("value"),
 		table.TextColumn("query"),
+
 		table.TextColumn("username"),
 	}
 
 	t := &Table{
-		client:       client,
-		logger:       level.NewFilter(logger, level.AllowInfo()),
-		tableName:    "kolide_pwpolicy",
-		execDataFunc: dataflatten.Plist,
+		client:    client,
+		logger:    logger,
+		tableName: "kolide_pwpolicy",
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generateExec)
+	return table.NewPlugin(t.tableName, columns, t.generate)
 }
 
-func (t *Table) generateExec(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	var results []map[string]string
-	var username string
 
-	if q, ok := queryContext.Constraints["username"]; ok && len(q.Constraints) != 0 {
-		username = q.Constraints[0].Expression
+	gcOpts := []tablehelpers.GetConstraintOpts{
+		tablehelpers.WithDefaults(""),
+		tablehelpers.WithLogger(t.logger),
 	}
 
-	execBytes, err := t.exec(ctx, username)
-	if err != nil {
-		return results, errors.Wrap(err, "exec")
-	}
+	for _, pwpolicyUsername := range tablehelpers.GetConstraints(queryContext, "username", gcOpts...) {
+		pwpolicyArgs := []string{PwpolicyCmd}
 
-	if q, ok := queryContext.Constraints["query"]; ok && len(q.Constraints) != 0 {
-		for _, constraint := range q.Constraints {
-			dataQuery := constraint.Expression
-			results = append(results, t.getRowsFromOutput(dataQuery, execBytes, username)...)
+		if pwpolicyUsername != "" {
+			pwpolicyArgs = append(pwpolicyArgs, "-u")
+			pwpolicyArgs = append(pwpolicyArgs, pwpolicyUsername)
 		}
-	} else {
-		results = append(results, t.getRowsFromOutput("", execBytes, username)...)
+
+		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+			pwPolicyOutput, err := t.execPwpolicy(ctx, pwpolicyArgs)
+			if err != nil {
+				level.Info(t.logger).Log("msg", "pwpolicy failed", "err", err)
+				continue
+			}
+
+			flatData, err := t.flattenOutput(dataQuery, pwPolicyOutput)
+			if err != nil {
+				level.Info(t.logger).Log("msg", "flatten failed", "err", err)
+				continue
+			}
+
+			for _, row := range flatData {
+				p, k := row.ParentKey("/")
+
+				res := map[string]string{
+					"fullkey":  row.StringPath("/"),
+					"parent":   p,
+					"key":      k,
+					"value":    row.Value,
+					"query":    dataQuery,
+					"username": pwpolicyUsername,
+				}
+				results = append(results, res)
+			}
+		}
 	}
 
 	return results, nil
 }
 
-func (t *Table) exec(ctx context.Context, username string) ([]byte, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	args := []string{PwpolicyCmd}
-	if username != "" {
-		args = append(args, "-u")
-		args = append(args, username)
-	}
-
-	cmd := exec.CommandContext(ctx, PwpolicyPath, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	level.Debug(t.logger).Log("msg", "calling %s", "args", PwpolicyPath, cmd.Args)
-
-	if err := cmd.Run(); err != nil {
-		return nil, errors.Wrapf(err, "calling %s. Got: %s", PwpolicyPath, string(stderr.Bytes()))
-	}
-
-	// Remove first line of output because it always contains non-plist content
-	outputBytes := bytes.SplitAfterN(stdout.Bytes(), []byte("\n"), 2)[1]
-
-	return outputBytes, nil
-}
-
-func (t *Table) getRowsFromOutput(dataQuery string, execOutput []byte, username string) []map[string]string {
-	var results []map[string]string
-
+func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflatten.Row, error) {
 	flattenOpts := []dataflatten.FlattenOpts{}
 
 	if dataQuery != "" {
@@ -107,27 +111,33 @@ func (t *Table) getRowsFromOutput(dataQuery string, execOutput []byte, username 
 	}
 
 	if t.logger != nil {
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(t.logger))
+		flattenOpts = append(flattenOpts,
+			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
+		)
 	}
 
-	data, err := t.execDataFunc(execOutput, flattenOpts...)
-	if err != nil {
-		level.Info(t.logger).Log("msg", "failure flattening output", "err", err)
-		return nil
+	return dataflatten.Plist(systemOutput, flattenOpts...)
+}
+
+func (t *Table) execPwpolicy(ctx context.Context, args []string) ([]byte, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, PwpolicyPath, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	level.Debug(t.logger).Log("msg", "calling pwpolicy", "args", cmd.Args)
+
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrapf(err, "calling pwpolicy. Got: %s", string(stderr.Bytes()))
 	}
 
-	for _, row := range data {
-		p, k := row.ParentKey("/")
+	// Remove first line of output because it always contains non-plist content
+	outputBytes := bytes.SplitAfterN(stdout.Bytes(), []byte("\n"), 2)[1]
 
-		res := map[string]string{
-			"fullkey":  row.StringPath("/"),
-			"parent":   p,
-			"key":      k,
-			"value":    row.Value,
-			"query":    dataQuery,
-			"username": username,
-		}
-		results = append(results, res)
-	}
-	return results
+	return outputBytes, nil
 }

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -1,0 +1,133 @@
+//+build darwin
+
+package pwpolicy
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/dataflatten"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+type Table struct {
+	client       *osquery.ExtensionManagerClient
+	logger       log.Logger
+	tableName    string
+	execDataFunc func([]byte, ...dataflatten.FlattenOpts) ([]dataflatten.Row, error)
+}
+
+const PwpolicyPath = "/usr/bin/pwpolicy"
+const PwpolicyCmd = "getaccountpolicies"
+
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("fullkey"),
+		table.TextColumn("parent"),
+		table.TextColumn("key"),
+		table.TextColumn("value"),
+		table.TextColumn("query"),
+		table.TextColumn("username"),
+	}
+
+	t := &Table{
+		client:       client,
+		logger:       level.NewFilter(logger, level.AllowInfo()),
+		tableName:    "kolide_pwpolicy",
+		execDataFunc: dataflatten.Plist,
+	}
+
+	return table.NewPlugin(t.tableName, columns, t.generateExec)
+}
+
+func (t *Table) generateExec(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+	var username string
+
+	if q, ok := queryContext.Constraints["username"]; ok && len(q.Constraints) != 0 {
+		username = q.Constraints[0].Expression
+	}
+
+	execBytes, err := t.exec(ctx, username)
+	if err != nil {
+		return results, errors.Wrap(err, "exec")
+	}
+
+	if q, ok := queryContext.Constraints["query"]; ok && len(q.Constraints) != 0 {
+		for _, constraint := range q.Constraints {
+			dataQuery := constraint.Expression
+			results = append(results, t.getRowsFromOutput(dataQuery, execBytes, username)...)
+		}
+	} else {
+		results = append(results, t.getRowsFromOutput("", execBytes, username)...)
+	}
+
+	return results, nil
+}
+
+func (t *Table) exec(ctx context.Context, username string) ([]byte, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	args := []string{PwpolicyCmd}
+	if username != "" {
+		args = append(args, "-u")
+		args = append(args, username)
+	}
+
+	cmd := exec.CommandContext(ctx, PwpolicyPath, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	level.Debug(t.logger).Log("msg", "calling %s", "args", PwpolicyPath, cmd.Args)
+
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrapf(err, "calling %s. Got: %s", PwpolicyPath, string(stderr.Bytes()))
+	}
+
+	// Remove first line of output because it always contains non-plist content
+	outputBytes := bytes.SplitAfterN(stdout.Bytes(), []byte("\n"), 2)[1]
+
+	return outputBytes, nil
+}
+
+func (t *Table) getRowsFromOutput(dataQuery string, execOutput []byte, username string) []map[string]string {
+	var results []map[string]string
+
+	flattenOpts := []dataflatten.FlattenOpts{}
+
+	if dataQuery != "" {
+		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
+	}
+
+	if t.logger != nil {
+		flattenOpts = append(flattenOpts, dataflatten.WithLogger(t.logger))
+	}
+
+	data, err := t.execDataFunc(execOutput, flattenOpts...)
+	if err != nil {
+		level.Info(t.logger).Log("msg", "failure flattening output", "err", err)
+		return nil
+	}
+
+	for _, row := range data {
+		p, k := row.ParentKey("/")
+
+		res := map[string]string{
+			"fullkey":  row.StringPath("/"),
+			"parent":   p,
+			"key":      k,
+			"value":    row.Value,
+			"query":    dataQuery,
+			"username": username,
+		}
+		results = append(results, res)
+	}
+	return results
+}

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-const PwpolicyPath = "/usr/bin/pwpolicy"
-const PwpolicyCmd = "getaccountpolicies"
+const pwpolicyPath = "/usr/bin/pwpolicy"
+const pwpolicyCmd = "getaccountpolicies"
 
 type Table struct {
 	client    *osquery.ExtensionManagerClient
@@ -58,17 +58,11 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	var results []map[string]string
 
-	gcOpts := []tablehelpers.GetConstraintOpts{
-		tablehelpers.WithDefaults(""),
-		tablehelpers.WithLogger(t.logger),
-	}
-
-	for _, pwpolicyUsername := range tablehelpers.GetConstraints(queryContext, "username", gcOpts...) {
-		pwpolicyArgs := []string{PwpolicyCmd}
+	for _, pwpolicyUsername := range tablehelpers.GetConstraints(queryContext, "username", tablehelpers.WithDefaults("")) {
+		pwpolicyArgs := []string{pwpolicyCmd}
 
 		if pwpolicyUsername != "" {
-			pwpolicyArgs = append(pwpolicyArgs, "-u")
-			pwpolicyArgs = append(pwpolicyArgs, pwpolicyUsername)
+			pwpolicyArgs = append(pwpolicyArgs, "-u", pwpolicyUsername)
 		}
 
 		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
@@ -126,7 +120,7 @@ func (t *Table) execPwpolicy(ctx context.Context, args []string) ([]byte, error)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, PwpolicyPath, args...)
+	cmd := exec.CommandContext(ctx, pwpolicyPath, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 


### PR DESCRIPTION
This PR adds the `username` context to the `kolide_pwpolicy_table` so that users of launcher can obtain the password policy for a specified username. If no username is specified the table behaves as it did before 

This also fixes an issue where the first line of output from the `usr/bin/pwpolicy` binary is not valid XML and can occasionally cause the dataflatten library to fail to parse the plist (esp if that first line contains angle brackets) 