### PR TITLE
Set RunAtLoad to false in macOS launchd configuration

### DIFF
--- a/pkg/packagekit/render_launchd.go
+++ b/pkg/packagekit/render_launchd.go
@@ -53,7 +53,7 @@ func RenderLaunchd(ctx context.Context, w io.Writer, initOptions *InitOptions) e
 		StandardErrorPath: filepath.Join("/var/log", initOptions.Identifier, "launcher-stderr.log"),
 		StandardOutPath:   filepath.Join("/var/log", initOptions.Identifier, "launcher-stdout.log"),
 		KeepAlive:         keepAlive,
-		RunAtLoad:         true,
+		RunAtLoad:         false,
 	}
 
 	enc := plist.NewEncoder(w)

--- a/pkg/packagekit/render_launchd_test.go
+++ b/pkg/packagekit/render_launchd_test.go
@@ -86,7 +86,7 @@ func expectedComplex() (launchdOptions, error) {
       <string>--with_initial_runner</string>
     </array>
     <key>RunAtLoad</key>
-    <true/>
+    <false/>
     <key>StandardErrorPath</key>
     <string>/var/log/kolide-app/launcher-stderr.log</string>
     <key>StandardOutPath</key>


### PR DESCRIPTION
The existing behavior conflicted with the KeepAlive configuration that
only starts the daemon if the enroll secret path is present.

Setting this option to false leaves the general case the same: If a
package includes an enroll secret, the daemon is started immediately on
completion of install.

Setting this option to false allows the less-common case to work as
intended: The daemon will only start after an enroll secret is written
to the expected path.

The previous behavior would be to start the daemon even if no enroll
secret exists, and the daemon would then promptly exit with a nonzero status.