### PR TITLE
Add option to install Windows Service in disabled state

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -180,6 +180,11 @@ func runMake(args []string) error {
 			false,
 			"Keep wix temp files",
 		)
+		flDisableService = flagset.Bool(
+			"disable_service",
+			false,
+			"Create persistence service in a disabled state",
+		)
 		flOsqueryFlags arrayFlags // set below with flagset.Var
 	)
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
@@ -250,6 +255,7 @@ func runMake(args []string) error {
 		NotaryPrefix:      *flNotaryPrefix,
 		WixPath:           *flWixPath,
 		WixSkipCleanup:    *flWixSkipCleanup,
+		DisableService:    *flDisableService,
 	}
 
 	outputDir := *flOutputDir

--- a/pkg/packagekit/package.go
+++ b/pkg/packagekit/package.go
@@ -10,6 +10,8 @@ type PackageOptions struct {
 	Version    string // package version
 	FlagFile   string // Path to the flagfile for configuration
 
+	DisableService bool // Whether to install a system service in a disabled state
+
 	AppleSigningKey     string   // apple signing key
 	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
 	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -120,6 +120,11 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 			wix.ServiceArgs([]string{"svc", "-config", po.FlagFile}),
 			wix.ServiceDescription(fmt.Sprintf("The Kolide Launcher (%s)", po.Identifier)),
 		)
+
+		if po.DisableService {
+			wix.WithDisabledService()(launcherService)
+		}
+
 		wixArgs = append(wixArgs, wix.WithService(launcherService))
 	}
 

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -142,6 +142,15 @@ func WithDelayedStart() ServiceOpt {
 	}
 }
 
+func WithDisabledService() ServiceOpt {
+	return func(s *Service) {
+		s.serviceInstall.Start = "disabled"
+		// If this is not set to empty the installer hangs trying to start the
+		// disabled service.
+		s.serviceControl.Start = ""
+	}
+}
+
 // ServiceArgs takes an array of args, wraps them in spaces, then
 // joins them into a string. Handling spaces in the arguments is a bit
 // gnarly. Some parts of windows use ` as an escape character, but
@@ -263,8 +272,8 @@ func (s *Service) Xml(w io.Writer) error {
 
 // cleanServiceName removes characters windows doesn't like in
 // services names, and converts everything to camel case. Right now,
-// it only removes likely bad characters. It is not as complete as a
-// whitelist.
+// it only removes likely bad characters. It is not as complete as an
+// allowlist.
 func cleanServiceName(in string) string {
 	r := strings.NewReplacer(
 		"-", "_",

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -36,6 +36,7 @@ const (
 	StartDisabled           = "disabled"
 	StartBoot               = "boot"
 	StartSystem             = "system"
+	StartNone               = ""
 )
 
 type InstallUninstallType string
@@ -144,10 +145,10 @@ func WithDelayedStart() ServiceOpt {
 
 func WithDisabledService() ServiceOpt {
 	return func(s *Service) {
-		s.serviceInstall.Start = "disabled"
-		// If this is not set to empty the installer hangs trying to start the
+		s.serviceInstall.Start = StartDisabled
+		// If this is not explicitly set to none, the installer hangs trying to start the
 		// disabled service.
-		s.serviceControl.Start = ""
+		s.serviceControl.Start = StartNone
 	}
 }
 

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -55,6 +55,7 @@ type PackageOptions struct {
 	WixPath           string
 	MSIUI             bool
 	WixSkipCleanup    bool
+	DisableService    bool
 
 	AppleSigningKey     string   // apple signing key
 	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
@@ -295,6 +296,7 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 		WixPath:             p.WixPath,
 		WixUI:               p.MSIUI,
 		WixSkipCleanup:      p.WixSkipCleanup,
+		DisableService:      p.DisableService,
 	}
 
 	if err := p.makePackage(ctx); err != nil {


### PR DESCRIPTION
In some instances it is desirable to install the files and configure the
service but leave it in a disabled state until additional configuration
is performed.

This PR will be followed up with another that adds similar functionality
for systemd. There is no need to implement the same for macOS as the
launchd service is already configured to only start when the enroll
secret file exists.