### PR TITLE
Fix xml and ini bug in dataflatten table

### DIFF
--- a/pkg/dataflatten/ini.go
+++ b/pkg/dataflatten/ini.go
@@ -9,11 +9,11 @@ import (
 )
 
 func IniFile(file string, opts ...FlattenOpts) ([]Row, error) {
-	return flattenIni(file)
+	return flattenIni(file, opts...)
 }
 
 func Ini(rawdata []byte, opts ...FlattenOpts) ([]Row, error) {
-	return flattenIni(rawdata)
+	return flattenIni(rawdata, opts...)
 }
 
 // flattenIni uses go-ini to flatten ini data. The underlying library

--- a/pkg/dataflatten/xml.go
+++ b/pkg/dataflatten/xml.go
@@ -18,7 +18,7 @@ func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
 		return nil, err
 	}
 
-	return Flatten(mv.Old())
+	return Flatten(mv.Old(), opts...)
 }
 
 func Xml(rawdata []byte, opts ...FlattenOpts) ([]Row, error) {
@@ -28,5 +28,5 @@ func Xml(rawdata []byte, opts ...FlattenOpts) ([]Row, error) {
 		return nil, errors.Wrap(err, "mxj parse")
 	}
 
-	return Flatten(mv.Old())
+	return Flatten(mv.Old(), opts...)
 }

--- a/pkg/osquery/tables/dataflattentable/plist_test.go
+++ b/pkg/osquery/tables/dataflattentable/plist_test.go
@@ -3,6 +3,7 @@ package dataflattentable
 import (
 	"context"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/kolide/launcher/pkg/dataflatten"
@@ -61,6 +62,7 @@ func TestPlist(t *testing.T) {
 			require.Error(t, err)
 			continue
 		}
+		require.NoError(t, err)
 
 		// delete the path and query keys, so we don't need to enumerate them in the test case
 		for _, row := range rows {
@@ -68,7 +70,10 @@ func TestPlist(t *testing.T) {
 			delete(row, "query")
 		}
 
-		require.NoError(t, err)
+		// Despite being an array. data is returned unordered. Sort it.
+		sort.SliceStable(tt.expected, func(i, j int) bool { return tt.expected[i]["fullkey"] < tt.expected[j]["fullkey"] })
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i]["fullkey"] < rows[j]["fullkey"] })
+
 		require.EqualValues(t, tt.expected, rows)
 	}
 

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -48,7 +48,7 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 
 	t := &Table{
 		client: client,
-		logger: logger, //level.NewFilter(logger, level.AllowInfo()),
+		logger: logger,
 	}
 
 	switch dataSourceType {
@@ -103,17 +103,13 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 }
 
 func (t *Table) generatePath(filePath string, dataQuery string) ([]map[string]string, error) {
-	level.Info(t.logger).Log(
-		"msg", "seph: running query",
-		"query", dataQuery,
-	)
-
 	flattenOpts := []dataflatten.FlattenOpts{
 		dataflatten.WithNestedPlist(),
 	}
 
 	if t.logger != nil {
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(t.logger))
+		// dataflatten is noisy, so unless we're not debugging it, filter it to info
+		flattenOpts = append(flattenOpts, dataflatten.WithLogger(level.NewFilter(logger, level.AllowInfo())))
 	}
 
 	if dataQuery != "" {

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -109,7 +109,7 @@ func (t *Table) generatePath(filePath string, dataQuery string) ([]map[string]st
 
 	if t.logger != nil {
 		// dataflatten is noisy, so unless we're not debugging it, filter it to info
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(level.NewFilter(logger, level.AllowInfo())))
+		flattenOpts = append(flattenOpts, dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())))
 	}
 
 	if dataQuery != "" {

--- a/pkg/osquery/tables/dataflattentable/testdata/simple.xml
+++ b/pkg/osquery/tables/dataflattentable/testdata/simple.xml
@@ -1,0 +1,12 @@
+<simple>
+  <Items>
+    <item1>One</item1>
+    <item2>Two</item2>
+    <item3>Three</item3>
+  </Items>
+  <Animals>
+    <Cat/>
+    <Dog/>
+    <Mouse/>
+  </Animals>
+</simple>


### PR DESCRIPTION
While doing some test case refactoring, I noticed the flatten options weren't being passed to through ini or xml tables. This caused the `query` parameter to get dropped. Fix argument passing.

Also update test cases

And refactor tables a little to use the current helpers. 