### PR TITLE
Collapse doubled slashes in wmi namespace

### DIFF
--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -87,6 +87,15 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 				continue
 			}
 			for _, ns := range namespaces {
+				// The namespace argument uses a bare
+				// backslash, not a doubled one. But,
+				// it's common to double backslashes
+				// to escape them through quoting
+				// blocks. We can collapse them it
+				// down here, and create a small ux
+				// improvement.
+				ns = strings.ReplaceAll(ns, `\\`, `\`)
+
 				for _, whereClause := range whereClauses {
 					// Set a timeout in case wmi hangs
 					ctx, cancel := context.WithTimeout(ctx, 120*time.Second)

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -72,12 +72,18 @@ func TestQueries(t *testing.T) {
 			namespace:  `root\unknown\namespace`,
 			noData:     true,
 		},
-
 		{
 			name:       "different namespace",
 			class:      "MSKeyboard_PortInformation",
 			properties: []string{"ConnectorType,FunctionKeys,Indicators"},
 			namespace:  `root\wmi`,
+			minRows:    3,
+		},
+		{
+			name:       "different namespace, double slash",
+			class:      "MSKeyboard_PortInformation",
+			properties: []string{"ConnectorType,FunctionKeys,Indicators"},
+			namespace:  `root\\wmi`,
 			minRows:    3,
 		},
 		{


### PR DESCRIPTION
This is a ux improvement to how we query `namespace`

Unfortunately, I don't think we can blindly double the slashes for `whereclause`, because that would undifferenciate `\a` from `\\a` :(