### PR TITLE
Add table for gsettings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ grpc-extension: .pre-build
 # Convenience tools
 osqueryi-tables: table.ext
 	osqueryd -S --allow-unsafe --verbose --extension ./build/darwin/tables.ext
+osqueryi-tables-linux: table.ext
+	osqueryd -S --allow-unsafe --verbose --extension ./build/linux/tables.ext
 osqueryi-tables-windows: table.ext
 	osqueryd.exe -S --allow-unsafe --verbose --extension .\build\windows\tables.exe
 sudo-osqueryi-tables: table.ext

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -13,6 +13,7 @@ import (
 // unimplemented platforms.
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
 	return []*table.Plugin{
-		gsettings.TablePlugin(client, logger),
+		gsettings.Settings(client, logger),
+		gsettings.Metadata(client, logger),
 	}
 }

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -4,6 +4,7 @@ package table
 
 import (
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/gsettings"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 )
@@ -11,5 +12,7 @@ import (
 // platformTables returns an empty set. It's here as a catchall for
 // unimplemented platforms.
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
-	return []*table.Plugin{}
+	return []*table.Plugin{
+		gsettings.TablePlugin(client, logger),
+	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -1,9 +1,10 @@
-// +build !darwin,!windows,!linux
+// +build linux
 
 package table
 
 import (
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/gsettings"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 )
@@ -11,5 +12,8 @@ import (
 // platformTables returns an empty set. It's here as a catchall for
 // unimplemented platforms.
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
-	return []*table.Plugin{}
+	return []*table.Plugin{
+		gsettings.Settings(client, logger),
+		gsettings.Metadata(client, logger),
+	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -9,8 +9,6 @@ import (
 	"github.com/kolide/osquery-go/plugin/table"
 )
 
-// platformTables returns an empty set. It's here as a catchall for
-// unimplemented platforms.
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
 	return []*table.Plugin{
 		gsettings.Settings(client, logger),

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -107,11 +107,11 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 	}
 
 	if u.Uid != currentUser.Uid {
-		uid, err := strconv.Atoi(u.Uid)
+		uid, err := strconv.ParseInt(u.Uid, 10, 32)
 		if err != nil {
 			return errors.Wrap(err, "converting uid from string to int")
 		}
-		gid, err := strconv.Atoi(u.Gid)
+		gid, err := strconv.ParseInt(u.Gid, 10, 32)
 		if err != nil {
 			return errors.Wrap(err, "converting gid from string to int")
 		}

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -1,0 +1,282 @@
+package gsettings
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	osquery "github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+type Table struct {
+	client *osquery.ExtensionManagerClient
+	logger log.Logger
+}
+
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		// TODO: maybe need to add 'path' for relocatable schemas..
+		table.TextColumn("domain"),
+		table.TextColumn("key"),
+		table.TextColumn("type"),
+		table.TextColumn("value"),
+		table.TextColumn("description"),
+	}
+
+	t := &Table{
+		client: client,
+		logger: logger,
+	}
+
+	return table.NewPlugin("kolide_gsettings", columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	domainQ, ok := queryContext.Constraints["domain"]
+	if !ok || len(domainQ.Constraints) == 0 {
+		return nil, errors.New("the kolide_gsettings table requires a domain to be specified")
+	}
+
+	for _, domainConstraint := range domainQ.Constraints {
+		// TODO: this doesn't handle wildcards or partial matches..
+		osqueryResults, err := t.gsettings(ctx, domainConstraint.Expression)
+		if err != nil {
+			continue
+		}
+
+		for _, row := range osqueryResults {
+			results = append(results, row)
+		}
+	}
+	return results, nil
+}
+
+func (t *Table) gsettings(ctx context.Context, domain string) ([]map[string]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "list-recursively", domain)
+	dir, err := ioutil.TempDir("", "osq-gsettings")
+	if err != nil {
+		return nil, errors.Wrap(err, "mktemp")
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		return nil, errors.Wrap(err, "chmod")
+	}
+	cmd.Dir = dir
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+
+	if err := cmd.Run(); err != nil {
+		level.Info(t.logger).Log(
+			"msg", "Error running gsettings",
+			"stderr", strings.TrimSpace(stderr.String()),
+			"stdout", strings.TrimSpace(stdout.String()),
+			"err", err,
+		)
+		return nil, errors.Wrap(err, "running osquery")
+	}
+	osqueryResults := t.parse(stdout)
+	for _, row := range osqueryResults {
+		d, err := t.gsettingsDescribe(ctx, row["key"], row["domain"])
+		if err != nil {
+			continue
+		}
+		row["description"] = d.Description
+		row["type"] = d.Type
+	}
+
+	return osqueryResults, nil
+}
+
+type datatype struct {
+	raw string
+}
+
+type keyDescription struct {
+	Description string
+	Type        string
+}
+
+func (t *Table) gsettingsDescribe(ctx context.Context, key, domain string) (keyDescription, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	var desc keyDescription
+	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "describe", domain, key)
+	dir, err := ioutil.TempDir("", "osq-gsettings-desc")
+	if err != nil {
+		return keyDescription{}, errors.Wrap(err, "mktemp")
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		return keyDescription{}, errors.Wrap(err, "chmod")
+	}
+	cmd.Dir = dir
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+
+	if err := cmd.Run(); err != nil {
+		level.Debug(t.logger).Log(
+			"msg", "Error running gsettings describe",
+			"key", key,
+			"domain", domain,
+			"stderr", strings.TrimSpace(stderr.String()),
+			"stdout", strings.TrimSpace(stdout.String()),
+			"err", err,
+		)
+		return keyDescription{}, errors.Wrap(err, "running gsettings describe")
+	}
+	desc.Description = strings.TrimSpace(stdout.String())
+	datatype, err := t.getType(ctx, key, domain)
+	if err != nil {
+		return desc, errors.Wrap(err, "discerning key's type")
+	}
+	desc.Type = datatype
+
+	return desc, nil
+}
+
+func (t *Table) getType(ctx context.Context, key, domain string) (string, error) {
+	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "range", domain, key)
+	dir, err := ioutil.TempDir("", "osq-gsettings-range")
+	if err != nil {
+		return "", errors.Wrap(err, "mktemp")
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		return "", errors.Wrap(err, "chmod")
+	}
+	cmd.Dir = dir
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+
+	if err := cmd.Run(); err != nil {
+		level.Debug(t.logger).Log(
+			"msg", "Error running gsettings range",
+			"key", key,
+			"domain", domain,
+			"stderr", strings.TrimSpace(stderr.String()),
+			"stdout", strings.TrimSpace(stdout.String()),
+			"err", err,
+		)
+		return "", errors.Wrap(err, "running gsettings range")
+	}
+
+	result := strings.ReplaceAll(strings.TrimSpace(stdout.String()), "\n", " ")
+
+	// enum types need special formatting to distinguish the type (enum) from
+	// the possible values
+	if strings.HasPrefix(result, "enum") {
+		s := strings.TrimPrefix(result, "enum")
+		vals := strings.Split(s, " ")
+		return fmt.Sprintf("enum: [ %s ]", strings.Join(vals, ",")), nil
+	}
+
+	// 'range' datatypes also need special handling
+	if strings.HasPrefix(result, "range ") {
+		s := strings.TrimPrefix(result, "range ")
+		parts := strings.Split(s, " ")
+
+		typ := convertType(parts[0])
+		var scope string
+		if len(parts) > 2 {
+			scope = fmt.Sprintf(" (%v to %v)", parts[1], parts[2])
+		}
+
+		return fmt.Sprintf("%s%s", typ, scope), nil
+	}
+
+	return convertType(result), nil
+}
+
+// this feels.. not idiomatic
+var gvariantMapping = map[string]string{
+	/*
+		b: the type string of G_VARIANT_TYPE_BOOLEAN; a boolean value.
+		y: the type string of G_VARIANT_TYPE_BYTE; a byte.
+		n: the type string of G_VARIANT_TYPE_INT16; a signed 16 bit integer.
+		q: the type string of G_VARIANT_TYPE_UINT16; an unsigned 16 bit integer.
+		i: the type string of G_VARIANT_TYPE_INT32; a signed 32 bit integer.
+		u: the type string of G_VARIANT_TYPE_UINT32; an unsigned 32 bit integer.
+		x: the type string of G_VARIANT_TYPE_INT64; a signed 64 bit integer.
+		t: the type string of G_VARIANT_TYPE_UINT64; an unsigned 64 bit integer.
+		h: the type string of G_VARIANT_TYPE_HANDLE; a signed 32 bit value that, by convention, is used as an index into an array of file descriptors that are sent alongside a D-Bus message.
+		d: the type string of G_VARIANT_TYPE_DOUBLE; a double precision floating point value.
+		s: the type string of G_VARIANT_TYPE_STRING; a string.
+		a: used as a prefix on another type string to mean an array of that type; the type string "ai", for example, is the type of an array of signed 32-bit integers.
+	*/
+	"b": "bool",
+	"n": "int16",
+	"q": "uint16",
+	"i": "int32",
+	"u": "uint32",
+	"x": "int64",
+	"t": "uint64",
+	"d": "double",
+	"s": "string",
+	"a": "array",
+}
+
+// convertType returns a string describing the GVariantType corresponding to the
+// GVariant-formatted type string. see  https://developer.gnome.org/glib/unstable/glib-GVariantType.html
+// for documentation. Note that not all types listed in the documentation above
+// are supported, for example:
+//  - tuples (e.g. tuple of 2 strings `(ss)`)
+//  - nested types (e.g.// array of tuples: `a(ss)`)
+// and other complex types are not supported.
+func convertType(typ string) string {
+	typ = strings.Replace(typ, "type ", "", 1) // remove any leading 'type ', eg 'type b'
+	var prefix string
+	if strings.HasPrefix(typ, "a") {
+		typ = typ[1:]
+		prefix = "array of "
+	}
+	primitive_typ, ok := gvariantMapping[typ]
+	if !ok {
+		return "other"
+	}
+	return fmt.Sprintf("%s%s", prefix, primitive_typ)
+}
+
+func (t *Table) parse(input *bytes.Buffer) []map[string]string {
+	var results []map[string]string
+
+	scanner := bufio.NewScanner(input)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		row := make(map[string]string)
+		parts := strings.SplitN(line, " ", 3)
+		row["domain"] = parts[0]
+		row["key"] = parts[1]
+		row["value"] = parts[2]
+		results = append(results, row)
+	}
+
+	if err := scanner.Err(); err != nil {
+		level.Debug(t.logger).Log("msg", "scanner error", "err", err)
+	}
+
+	return results
+}

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -4,14 +4,18 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
+	"os/user"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
@@ -21,10 +25,12 @@ const gsettingsPath = "/usr/bin/gsettings"
 
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
 
+type gsettingsExecer func(ctx context.Context, uid int, logger log.Logger, buf *bytes.Buffer) error
+
 type GsettingsValues struct {
 	client   *osquery.ExtensionManagerClient
 	logger   log.Logger
-	getBytes func(ctx context.Context, buf *bytes.Buffer) error
+	getBytes gsettingsExecer
 }
 
 // Settings returns a table plugin for querying setting values from the
@@ -34,6 +40,7 @@ func Settings(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 		table.TextColumn("schema"),
 		table.TextColumn("key"),
 		table.TextColumn("value"),
+		table.TextColumn("user"),
 	}
 
 	t := &GsettingsValues{
@@ -47,32 +54,74 @@ func Settings(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 
 func (t *GsettingsValues) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	var results []map[string]string
-	var output bytes.Buffer
 
-	err := t.getBytes(ctx, &output)
-	if err != nil {
-		level.Info(t.logger).Log("msg", "gsettings failed", "err", err)
-
-		return results, err
+	users := tablehelpers.GetConstraints(queryContext, "user", tablehelpers.WithAllowedCharacters(allowedCharacters))
+	if len(users) < 1 {
+		return results, errors.New("kolide_gsettings requires at least one user id to be specified")
 	}
-	results = t.parse(&output)
-	if err != nil {
-		level.Info(t.logger).Log(
-			"msg", "error flattening data",
-			"err", err,
-		)
-		return results, err
+
+	for _, u := range users {
+		var output bytes.Buffer
+		uid, err := strconv.Atoi(u)
+		if err != nil {
+			level.Info(t.logger).Log("msg", "unable to cast supplied uid as int", "uid", uid)
+		}
+		err = t.getBytes(ctx, uid, t.logger, &output)
+		if err != nil {
+			// assume that getBytes logs the error.. might be better to log it here, but for debugging it's nice to log it in getBytes to append the stdout and stderr
+			// return results, errors.Wrap(err, "calling getbytes")
+			return results, errors.Wrap(err, "getting bytes")
+		}
+
+		user_results := t.parse(&output)
+		for _, r := range user_results {
+			r["user"] = u
+			results = append(results, r)
+		}
 	}
 
 	return results, nil
 }
 
 // execGsettings writes the output of running 'gsettings' command into the supplied bytes buffer
-func execGsettings(ctx context.Context, buf *bytes.Buffer) error {
+// TODO: would maybe be cleaner to make logger a functional option..
+func execGsettings(ctx context.Context, uid int, l log.Logger, buf *bytes.Buffer) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	u, err := user.LookupId(string(uid))
+	if err != nil {
+		return errors.Wrap(err, "looking up user by uid")
+	}
+
+	// cmd := exec.CommandContext(ctx, gsettingsPath, "list-recursively", "--schemadir", u.HomeDir)
 	cmd := exec.CommandContext(ctx, gsettingsPath, "list-recursively")
+
+	// EXPERIMENTAL: uncommenting this seems to cause no results to be returned.
+	// set the HOME for the the cmd so that gsettings is exec'd properly as the
+	// new user.
+	cmd.Env = append(os.Environ(), fmt.Sprintf("HOME=%s", u.HomeDir))
+
+	// Check if the supplied UID is that of the current user
+	currentUser, err := user.Current()
+	if err != nil {
+		return errors.Wrap(err, "checking current user uid")
+	}
+
+	// adding a cmd.SysProcAttr.Credential sets the user the command is run
+	// under, as identified by the uid
+	if strconv.Itoa(uid) != currentUser.Uid {
+		// guid, err := strconv.Atoi(u.Gid)
+		// if err != nil {
+		// 	return errors.Wrap(err, "converting guid from string to int")
+		// }
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.Credential = &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: 20,
+		}
+	}
+
 	dir, err := ioutil.TempDir("", "osq-gsettings")
 	if err != nil {
 		return errors.Wrap(err, "mktemp")
@@ -83,12 +132,20 @@ func execGsettings(ctx context.Context, buf *bytes.Buffer) error {
 		return errors.Wrap(err, "chmod")
 	}
 	cmd.Dir = dir
+
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
 	cmd.Stdout = buf
 
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "running osquery")
+		// level.Error(l).Log(
+		// 	"msg", "error running gsettings",
+		// 	"stderr", strings.TrimSpace(stderr.String()),
+		// 	"stdout", strings.TrimSpace(buf.String()),
+		// 	"cmd", cmd.Args,
+		// 	"err", err,
+		// )
+		return errors.Wrapf(err, "exec-ing gsettings, cmd was %a, stderr: %s", cmd.Args)
 	}
 
 	return nil
@@ -105,16 +162,26 @@ func (t *GsettingsValues) parse(input *bytes.Buffer) []map[string]string {
 			continue
 		}
 
+		// parts := strings.SplitN(line, " ", 3)
+		// if len(parts) < 3 {
+		// 	level.Error(t.logger).Log(
+		// 		"msg", "unable to process line, not enough segments",
+		// 		"line", line,
+		// 	)
+		// 	continue
+		// }
 		row := make(map[string]string)
-		parts := strings.SplitN(line, " ", 3)
-		row["schema"] = parts[0]
-		row["key"] = parts[1]
-		row["value"] = parts[2]
+		// row["schema"] = parts[0]
+		// row["key"] = parts[1]
+		// row["value"] = parts[2]
+
+		row["value"] = line
 		results = append(results, row)
 	}
 
 	if err := scanner.Err(); err != nil {
 		level.Debug(t.logger).Log("msg", "scanner error", "err", err)
+		panic(err)
 	}
 
 	return results

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gsettings
 
 import (

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -35,7 +35,7 @@ func Settings(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 	var columns []table.ColumnDefinition
 
 	// we don't need the 'query' column.
-	// we could also just type out all the cols we do want
+	// we could also just type out all the cols we *do* want..
 	for _, col := range dataflattentable.Columns(table.TextColumn("schema")) {
 		if col.Name != "query" {
 			columns = append(columns, col)
@@ -91,7 +91,7 @@ func execGsettings(ctx context.Context, buf *bytes.Buffer) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "list-recursively")
+	cmd := exec.CommandContext(ctx, gsettingsPath, "list-recursively")
 	dir, err := ioutil.TempDir("", "osq-gsettings")
 	if err != nil {
 		return errors.Wrap(err, "mktemp")
@@ -114,12 +114,6 @@ func execGsettings(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 func (t *GsettingsValues) flatten(buffer *bytes.Buffer) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{}
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
-	}
 	results := t.parse(buffer)
 	var rows []dataflatten.Row
 

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -149,7 +150,7 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 	return nil
 }
 
-func (t *GsettingsValues) parse(input *bytes.Buffer) []map[string]string {
+func (t *GsettingsValues) parse(input io.Reader) []map[string]string {
 	var results []map[string]string
 
 	scanner := bufio.NewScanner(input)

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,24 +14,19 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
-	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
 
 const gsettingsPath = "/usr/bin/gsettings"
+
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
 
 type GsettingsValues struct {
 	client   *osquery.ExtensionManagerClient
 	logger   log.Logger
 	getBytes func(ctx context.Context, buf *bytes.Buffer) error
-}
-
-type GsettingsMetadata struct {
-	client *osquery.ExtensionManagerClient
-	logger log.Logger
 }
 
 // Settings returns a table plugin for querying setting values from the
@@ -134,273 +128,6 @@ func (t *GsettingsValues) flatten(buffer *bytes.Buffer) ([]dataflatten.Row, erro
 		rows = append(rows, row)
 	}
 	return rows, nil
-}
-
-// Metadata returns a table plugin for querying metadata about specific keys in
-// specific schemas
-func Metadata(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
-
-	columns := []table.ColumnDefinition{
-		// TODO: maybe need to add 'path' for relocatable schemas..
-		table.TextColumn("schema"),
-		table.TextColumn("key"),
-		table.TextColumn("description"),
-		table.TextColumn("type"),
-	}
-
-	t := &GsettingsMetadata{
-		client: client,
-		logger: logger,
-	}
-
-	return table.NewPlugin("kolide_gsettings_metadata", columns, t.generate)
-}
-
-func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-
-	var results []map[string]string
-
-	for _, schema := range tablehelpers.GetConstraints(queryContext, "schema", tablehelpers.WithAllowedCharacters(allowedCharacters)) {
-		descriptions, err := t.gsettingsDescribeForSchema(ctx, schema, "")
-		if err != nil {
-			level.Info(t.logger).Log(
-				"msg", "error describing keys for schema",
-				"schema", schema,
-				"err", err,
-			)
-			continue
-		}
-		for _, d := range descriptions {
-			row := map[string]string{
-				"description": d.Description,
-				"type":        d.Type,
-				"schema":      schema,
-				"key":         d.Key,
-			}
-			results = append(results, row)
-		}
-
-	}
-
-	return results, nil
-}
-
-type datatype struct {
-	raw string
-}
-
-type keyDescription struct {
-	Description string
-	Type        string
-	Key         string
-}
-
-func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema, key string) ([]keyDescription, error) {
-	var descriptions []keyDescription
-	var keys []string
-	var err error
-
-	if key != "" {
-		keys = append(keys, key)
-	} else {
-		keys, err = t.listKeys(ctx, schema, t.logger)
-		if err != nil {
-			return descriptions, errors.Wrap(err, "fetching keys to describe")
-		}
-	}
-
-	for _, k := range keys {
-		desc, err := t.describeKey(ctx, schema, k)
-		if err != nil {
-			level.Info(t.logger).Log(
-				"msg", "error describing key",
-				"key", key,
-				"schema", schema,
-				"err", err,
-			)
-			continue
-		}
-		descriptions = append(descriptions, desc)
-	}
-
-	return descriptions, nil
-}
-
-func (t *GsettingsMetadata) listKeys(ctx context.Context, schema string, l log.Logger) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-	var keys []string
-
-	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "list-keys", schema)
-	dir, err := ioutil.TempDir("", "osq-gsettings-list-keys")
-	if err != nil {
-		return keys, errors.Wrap(err, "mktemp")
-	}
-	defer os.RemoveAll(dir)
-
-	if err := os.Chmod(dir, 0755); err != nil {
-		return keys, errors.Wrap(err, "chmod")
-	}
-	cmd.Dir = dir
-	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd.Stdout, cmd.Stderr = stdout, stderr
-
-	if err := cmd.Run(); err != nil {
-		level.Info(t.logger).Log(
-			"msg", "Error running gsettings list-keys",
-			"schema", schema,
-			"stderr", strings.TrimSpace(stderr.String()),
-			"stdout", strings.TrimSpace(stdout.String()),
-			"err", err,
-		)
-		return keys, errors.Wrap(err, "running gsettings list-keys")
-	}
-
-	scanner := bufio.NewScanner(stdout)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		keys = append(keys, line)
-	}
-
-	if err := scanner.Err(); err != nil {
-		level.Info(t.logger).Log("msg", "scanner error", "err", err)
-	}
-
-	return keys, nil
-}
-
-func (t *GsettingsMetadata) describeKey(ctx context.Context, schema, key string) (keyDescription, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-	desc := keyDescription{Key: key}
-	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "describe", schema, key)
-	dir, err := ioutil.TempDir("", "osq-gsettings-desc")
-	if err != nil {
-		return keyDescription{}, errors.Wrap(err, "mktemp")
-	}
-	defer os.RemoveAll(dir)
-
-	if err := os.Chmod(dir, 0755); err != nil {
-		return keyDescription{}, errors.Wrap(err, "chmod")
-	}
-	cmd.Dir = dir
-	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd.Stdout, cmd.Stderr = stdout, stderr
-
-	if err := cmd.Run(); err != nil {
-		level.Debug(t.logger).Log(
-			"msg", "Error running gsettings describe",
-			"key", key,
-			"schema", schema,
-			"stderr", strings.TrimSpace(stderr.String()),
-			"stdout", strings.TrimSpace(stdout.String()),
-			"err", err,
-		)
-		return keyDescription{}, errors.Wrap(err, "running gsettings describe")
-	}
-
-	desc.Description = strings.TrimSpace(stdout.String())
-	datatype, err := t.getType(ctx, key, schema)
-	if err != nil {
-		return desc, errors.Wrap(err, "discerning key's type")
-	}
-	desc.Type = datatype
-
-	return desc, nil
-}
-
-func (t *GsettingsMetadata) getType(ctx context.Context, key, schema string) (string, error) {
-	cmd := exec.CommandContext(ctx, "/usr/bin/gsettings", "range", schema, key)
-	dir, err := ioutil.TempDir("", "osq-gsettings-range")
-	if err != nil {
-		return "", errors.Wrap(err, "mktemp")
-	}
-	defer os.RemoveAll(dir)
-
-	if err := os.Chmod(dir, 0755); err != nil {
-		return "", errors.Wrap(err, "chmod")
-	}
-	cmd.Dir = dir
-	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd.Stdout, cmd.Stderr = stdout, stderr
-
-	if err := cmd.Run(); err != nil {
-		level.Debug(t.logger).Log(
-			"msg", "Error running gsettings range",
-			"key", key,
-			"schema", schema,
-			"stderr", strings.TrimSpace(stderr.String()),
-			"stdout", strings.TrimSpace(stdout.String()),
-			"err", err,
-		)
-		return "", errors.Wrap(err, "running gsettings range")
-	}
-
-	result := strings.ReplaceAll(strings.TrimSpace(stdout.String()), "\n", " ")
-
-	// enum types need special formatting to distinguish the type (enum) from
-	// the possible values
-	if strings.HasPrefix(result, "enum") {
-		s := strings.TrimPrefix(result, "enum")
-		vals := strings.Split(s, " ")
-		return fmt.Sprintf("enum: [ %s ]", strings.Join(vals, ",")), nil
-	}
-
-	// 'range' datatypes also need special handling
-	if strings.HasPrefix(result, "range ") {
-		s := strings.TrimPrefix(result, "range ")
-		parts := strings.Split(s, " ")
-
-		typ := convertType(parts[0])
-		var scope string
-		if len(parts) > 2 {
-			scope = fmt.Sprintf(" (%v to %v)", parts[1], parts[2])
-		}
-
-		return fmt.Sprintf("%s%s", typ, scope), nil
-	}
-
-	return convertType(result), nil
-}
-
-// this feels.. not idiomatic
-var gvariantMapping = map[string]string{
-	"b": "bool",
-	"n": "int16",
-	"q": "uint16",
-	"i": "int32",
-	"u": "uint32",
-	"x": "int64",
-	"t": "uint64",
-	"d": "double",
-	"s": "string",
-	"a": "array",
-}
-
-// convertType returns a string describing the GVariantType corresponding to the
-// GVariant-formatted type string. see  https://developer.gnome.org/glib/unstable/glib-GVariantType.html
-// for documentation. Note that not all types listed in the documentation above
-// are supported, for example:
-//  - tuples (e.g. tuple of 2 strings `(ss)`)
-//  - nested types (e.g.// array of tuples: `a(ss)`)
-// and other complex types are not supported.
-func convertType(typ string) string {
-	typ = strings.Replace(typ, "type ", "", 1) // remove any leading 'type ', eg 'type b'
-	var prefix string
-	if strings.HasPrefix(typ, "a") {
-		typ = typ[1:]
-		prefix = "array of "
-	}
-	primitive_typ, ok := gvariantMapping[typ]
-	if !ok {
-		return "other"
-	}
-	return fmt.Sprintf("%s%s", prefix, primitive_typ)
 }
 
 func (t *GsettingsValues) parse(input *bytes.Buffer) []map[string]string {

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -98,7 +98,7 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 
 	// set the HOME for the the cmd so that gsettings is exec'd properly as the
 	// new user.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("HOME=%s", u.HomeDir))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", u.HomeDir))
 
 	// Check if the supplied UID is that of the current user
 	currentUser, err := user.Current()

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputParsing(t *testing.T) {
+func TestGsettingsValues(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -30,16 +30,16 @@ func TestGsettingsValues(t *testing.T) {
 			filename: "simple.txt",
 			expected: []map[string]string{
 				{
-					"user":   "tester",
-					"key":    "access-key",
-					"value":  "''",
-					"schema": "org.gnome.rhythmbox.plugins.webremote",
+					"username": "tester",
+					"key":      "access-key",
+					"value":    "''",
+					"schema":   "org.gnome.rhythmbox.plugins.webremote",
 				},
 				{
-					"user":   "tester",
-					"key":    "foo-bar",
-					"value":  "2",
-					"schema": "org.gnome.rhythmbox.plugins.webremote",
+					"username": "tester",
+					"key":      "foo-bar",
+					"value":    "2",
+					"schema":   "org.gnome.rhythmbox.plugins.webremote",
 				},
 			},
 		},
@@ -60,7 +60,7 @@ func TestGsettingsValues(t *testing.T) {
 		t.Run(tt.filename, func(t *testing.T) {
 			ctx := context.TODO()
 			qCon := tablehelpers.MockQueryContext(map[string][]string{
-				"user": {"tester"},
+				"username": {"tester"},
 			})
 
 			results, err := table.generate(ctx, qCon)
@@ -94,16 +94,16 @@ func TestPerUser(t *testing.T) {
 			keyNames:    []string{"idle-delay"},
 			schemaNames: []string{"org.gnome.desktop.session"},
 			expected: map[string]string{
-				"user":   "blaed",
-				"key":    "idle-delay",
-				"value":  "uint32 240", //  TODO: should parse out the uint32...
-				"schema": "org.gnome.desktop.session",
+				"username": "blaed",
+				"key":      "idle-delay",
+				"value":    "uint32 240", //  TODO: should parse out the uint32...
+				"schema":   "org.gnome.desktop.session",
 			},
 			unexpected: map[string]string{
-				"user":   "blaed",
-				"key":    "idle-delay",
-				"value":  "uint32 300", // the default/global value
-				"schema": "org.gnome.desktop.session",
+				"username": "blaed",
+				"key":      "idle-delay",
+				"value":    "uint32 300", // the default/global value
+				"schema":   "org.gnome.desktop.session",
 			},
 		},
 		{
@@ -111,16 +111,16 @@ func TestPerUser(t *testing.T) {
 			keyNames:    []string{"idle-delay"},
 			schemaNames: []string{"org.gnome.desktop.session"},
 			expected: map[string]string{
-				"user":   "kids",
-				"key":    "idle-delay",
-				"value":  "uint32 600",
-				"schema": "org.gnome.desktop.session",
+				"username": "kids",
+				"key":      "idle-delay",
+				"value":    "uint32 600",
+				"schema":   "org.gnome.desktop.session",
 			},
 			unexpected: map[string]string{
-				"user":   "kids",
-				"key":    "idle-delay",
-				"value":  "uint32 300", // the default/global value
-				"schema": "org.gnome.desktop.session",
+				"username": "kids",
+				"key":      "idle-delay",
+				"value":    "uint32 300", // the default/global value
+				"schema":   "org.gnome.desktop.session",
 			},
 		},
 	}
@@ -131,9 +131,9 @@ func TestPerUser(t *testing.T) {
 			getBytes: execGsettings,
 		}
 		mockQC := tablehelpers.MockQueryContext(map[string][]string{
-			"user":   tt.usernames,
-			"schema": tt.schemaNames,
-			"key":    tt.keyNames,
+			"username": tt.usernames,
+			"schema":   tt.schemaNames,
+			"key":      tt.keyNames,
 		})
 
 		rows, err := table.generate(context.TODO(), mockQC)

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -238,3 +238,68 @@ func TestGetType(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertType(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "b",
+			expected: "bool",
+		},
+		{
+			input:    "n",
+			expected: "int16",
+		},
+		{
+			input:    "q",
+			expected: "uint16",
+		},
+		{
+			input:    "u",
+			expected: "uint32",
+		},
+		{
+			input:    "x",
+			expected: "int64",
+		},
+		{
+			input:    "t",
+			expected: "uint64",
+		},
+		{
+			input:    "d",
+			expected: "double",
+		},
+		{
+			input:    "s",
+			expected: "string",
+		},
+		{
+			input:    "as",
+			expected: "array of string",
+		},
+		{
+			input:    "ax",
+			expected: "array of int64",
+		},
+		{
+			input:    "at",
+			expected: "array of uint64",
+		},
+		{
+			input:    "(ss)", // tuples currently unsupported
+			expected: "other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := convertType(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -1,0 +1,56 @@
+package gsettings
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		input    string
+		expected []map[string]string
+	}{
+		{
+			input:    "blank.txt",
+			expected: []map[string]string{},
+		},
+		{
+			input: "simple.txt",
+			expected: []map[string]string{{
+				"domain": "org.gnome.rhythmbox.plugins.webremote",
+				"key":    "access-key",
+				"value":  "''",
+			},
+				{
+					"domain": "org.gnome.rhythmbox.plugins.webremote",
+					"key":    "foo-bar",
+					"value":  "2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		table := Table{logger: log.NewNopLogger()}
+		t.Run(tt.input, func(t *testing.T) {
+			inputBytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.input))
+			require.NoError(t, err, "read file %s", tt.input)
+
+			inputBuffer := bytes.NewBuffer(inputBytes)
+
+			results := []map[string]string{}
+			for _, row := range table.parse(inputBuffer) {
+				results = append(results, row)
+			}
+
+			require.EqualValues(t, tt.expected, results)
+		})
+	}
+}

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -5,7 +5,6 @@ package gsettings
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -184,14 +183,7 @@ func TestListKeys(t *testing.T) {
 		t.Run(tt.filename, func(t *testing.T) {
 			ctx := context.TODO()
 
-			dir, err := ioutil.TempDir("", "testlistkeys")
-			require.NoError(t, err, "making tmp dir")
-			defer os.RemoveAll(dir)
-
-			// err = os.Chmod(dir, 0755)
-			// require.NoError(t, err, "chmod tmp dir")
-
-			results, err := table.listKeys(ctx, "org.gnome.Mines", dir)
+			results, err := table.listKeys(ctx, "org.gnome.Mines", "faketmpdir")
 			require.NoError(t, err, "generating results from %s", tt.filename)
 			require.ElementsMatch(t, tt.expected, results)
 		})
@@ -240,14 +232,7 @@ func TestGetType(t *testing.T) {
 		t.Run(tt.expected, func(t *testing.T) {
 			ctx := context.TODO()
 
-			dir, err := ioutil.TempDir("", "testlistkeys")
-			require.NoError(t, err, "making tmp dir")
-			defer os.RemoveAll(dir)
-
-			// err = os.Chmod(dir, 0755)
-			// require.NoError(t, err, "chmod tmp dir")
-
-			result, err := table.getType(ctx, "key", "schema", dir)
+			result, err := table.getType(ctx, "key", "schema", "fake-tmp-dir")
 			require.NoError(t, err, "getting type", tt.expected)
 			require.Equal(t, tt.expected, result)
 		})

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -38,7 +38,7 @@ func TestParser(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		table := Table{logger: log.NewNopLogger()}
+		table := GsettingsValues{logger: log.NewNopLogger()}
 		t.Run(tt.input, func(t *testing.T) {
 			inputBytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.input))
 			require.NoError(t, err, "read file %s", tt.input)

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gsettings
 
 import (

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -27,19 +27,15 @@ func TestGsettingsValues(t *testing.T) {
 			filename: "simple.txt",
 			expected: []map[string]string{
 				{
-					"fullkey": "org.gnome.rhythmbox.plugins.webremote/access-key",
-					"parent":  "org.gnome.rhythmbox.plugins.webremote",
-					"key":     "access-key",
-					"value":   "''",
-					"schema":  "org.gnome.rhythmbox.plugins.webremote",
+					"key":    "access-key",
+					"value":  "''",
+					"schema": "org.gnome.rhythmbox.plugins.webremote",
 				},
 				{
 
-					"fullkey": "org.gnome.rhythmbox.plugins.webremote/foo-bar",
-					"parent":  "org.gnome.rhythmbox.plugins.webremote",
-					"key":     "foo-bar",
-					"value":   "2",
-					"schema":  "org.gnome.rhythmbox.plugins.webremote",
+					"key":    "foo-bar",
+					"value":  "2",
+					"schema": "org.gnome.rhythmbox.plugins.webremote",
 				},
 			},
 		},

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -46,7 +46,7 @@ func TestGsettingsValues(t *testing.T) {
 	for _, tt := range tests {
 		table := GsettingsValues{
 			logger: log.NewNopLogger(),
-			getBytes: func(ctx context.Context, username string, l log.Logger, buf *bytes.Buffer) error {
+			getBytes: func(ctx context.Context, username string, buf *bytes.Buffer) error {
 				f, err := os.Open(filepath.Join("testdata", tt.filename))
 				require.NoError(t, err, "opening file %s", tt.filename)
 				_, err = buf.ReadFrom(f)
@@ -94,7 +94,7 @@ func TestPerUser(t *testing.T) {
 			expected: map[string]string{
 				"user":   "blaed",
 				"key":    "idle-delay",
-				"value":  "uint32 240",
+				"value":  "uint32 240", //  TODO: should parse out the uint32...
 				"schema": "org.gnome.desktop.session",
 			},
 			unexpected: map[string]string{

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -67,3 +67,151 @@ func TestGsettingsValues(t *testing.T) {
 		})
 	}
 }
+
+// func TestGsettingsMetadata(t *testing.T) {
+// 	t.Parallel()
+
+// 	var tests = []struct {
+// 		filename string
+// 		expected []map[string]string
+// 	}{
+// 		{
+// 			filename: "simple.txt",
+// 			expected: []map[string]string{
+// 				{
+// 					"fullkey": "org.gnome.rhythmbox.plugins.webremote/access-key",
+// 					"parent":  "org.gnome.rhythmbox.plugins.webremote",
+// 					"key":     "access-key",
+// 					"value":   "''",
+// 					"schema":  "org.gnome.rhythmbox.plugins.webremote",
+// 				},
+// 				{
+
+// 					"fullkey": "org.gnome.rhythmbox.plugins.webremote/foo-bar",
+// 					"parent":  "org.gnome.rhythmbox.plugins.webremote",
+// 					"key":     "foo-bar",
+// 					"value":   "2",
+// 					"schema":  "org.gnome.rhythmbox.plugins.webremote",
+// 				},
+// 			},
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		table := GsettingsValues{
+// 			logger: log.NewNopLogger(),
+// 			getBytes: func(ctx context.Context, buf *bytes.Buffer) error {
+// 				f, err := os.Open(filepath.Join("testdata", tt.filename))
+// 				require.NoError(t, err, "opening file %s", tt.filename)
+// 				_, err = buf.ReadFrom(f)
+// 				require.NoError(t, err, "read file %s", tt.filename)
+
+// 				return nil
+// 			},
+// 		}
+// 		t.Run(tt.filename, func(t *testing.T) {
+// 			ctx := context.TODO()
+// 			qCon := tablehelpers.MockQueryContext(map[string][]string{})
+
+// 			results, err := table.generate(ctx, qCon)
+// 			require.NoError(t, err, "generating results from %s", tt.filename)
+// 			require.ElementsMatch(t, tt.expected, results)
+// 		})
+// 	}
+// }
+
+func TestListKeys(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		filename string
+		expected []string
+	}{
+		{
+			filename: "listkeys.txt",
+			expected: []string{
+				"nmines",
+				"window-width",
+				"ysize",
+				"use-question-marks",
+				"use-autoflag",
+				"use-animations",
+				"mode",
+				"xsize",
+				"theme",
+				"window-height",
+				"window-is-maximized",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		table := GsettingsMetadata{
+			logger: log.NewNopLogger(),
+			cmdRunner: func(ctx context.Context, args []string, buf *bytes.Buffer) error {
+				f, err := os.Open(filepath.Join("testdata", tt.filename))
+				require.NoError(t, err, "opening file %s", tt.filename)
+				_, err = buf.ReadFrom(f)
+				require.NoError(t, err, "read file %s", tt.filename)
+
+				return nil
+			},
+		}
+		t.Run(tt.filename, func(t *testing.T) {
+			ctx := context.TODO()
+
+			results, err := table.listKeys(ctx, "org.gnome.Mines")
+			require.NoError(t, err, "generating results from %s", tt.filename)
+			require.ElementsMatch(t, tt.expected, results)
+		})
+	}
+}
+
+func TestGetType(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "type i",
+			expected: "int32",
+		},
+		{
+			input:    "range i 4 100",
+			expected: "int32 (4 to 100)",
+		},
+		{
+			input: `enum
+'artists-albums'
+'genres-artists'
+'genres-artists-albums'
+`,
+			expected: "enum: [ 'artists-albums','genres-artists','genres-artists-albums' ]",
+		},
+		{
+			input:    "type as",
+			expected: "array of string",
+		},
+	}
+
+	for _, tt := range tests {
+		table := GsettingsMetadata{
+			logger: log.NewNopLogger(),
+			cmdRunner: func(ctx context.Context, args []string, buf *bytes.Buffer) error {
+				_, err := buf.WriteString(tt.input)
+				require.NoError(t, err)
+
+				return nil
+			},
+		}
+		t.Run(tt.expected, func(t *testing.T) {
+			ctx := context.TODO()
+
+			result, err := table.getType(ctx, "key", "schema")
+			require.NoError(t, err, "getting type", tt.expected)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -2,55 +2,68 @@ package gsettings
 
 import (
 	"bytes"
-	"io/ioutil"
+	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParser(t *testing.T) {
+func TestOutputParsing(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {
-		input    string
+		filename string
 		expected []map[string]string
 	}{
 		{
-			input:    "blank.txt",
+			filename: "blank.txt",
 			expected: []map[string]string{},
 		},
 		{
-			input: "simple.txt",
-			expected: []map[string]string{{
-				"domain": "org.gnome.rhythmbox.plugins.webremote",
-				"key":    "access-key",
-				"value":  "''",
-			},
+			filename: "simple.txt",
+			expected: []map[string]string{
 				{
-					"domain": "org.gnome.rhythmbox.plugins.webremote",
-					"key":    "foo-bar",
-					"value":  "2",
+					"fullkey": "org.gnome.rhythmbox.plugins.webremote/access-key",
+					"parent":  "org.gnome.rhythmbox.plugins.webremote",
+					"key":     "access-key",
+					"value":   "''",
+					"schema":  "org.gnome.rhythmbox.plugins.webremote",
+				},
+				{
+
+					"fullkey": "org.gnome.rhythmbox.plugins.webremote/foo-bar",
+					"parent":  "org.gnome.rhythmbox.plugins.webremote",
+					"key":     "foo-bar",
+					"value":   "2",
+					"schema":  "org.gnome.rhythmbox.plugins.webremote",
 				},
 			},
 		},
 	}
 
 	for _, tt := range tests {
-		table := GsettingsValues{logger: log.NewNopLogger()}
-		t.Run(tt.input, func(t *testing.T) {
-			inputBytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.input))
-			require.NoError(t, err, "read file %s", tt.input)
+		table := GsettingsValues{
+			logger: log.NewNopLogger(),
+			getBytes: func(ctx context.Context, buf *bytes.Buffer) error {
+				f, err := os.Open(filepath.Join("testdata", tt.filename))
+				require.NoError(t, err, "opening file %s", tt.filename)
+				_, err = buf.ReadFrom(f)
+				require.NoError(t, err, "read file %s", tt.filename)
 
-			inputBuffer := bytes.NewBuffer(inputBytes)
+				return nil
+			},
+		}
+		t.Run(tt.filename, func(t *testing.T) {
+			ctx := context.TODO()
+			qCon := tablehelpers.MockQueryContext(map[string][]string{})
 
-			results := []map[string]string{}
-			for _, row := range table.parse(inputBuffer) {
-				results = append(results, row)
-			}
-
-			require.EqualValues(t, tt.expected, results)
+			results, err := table.generate(ctx, qCon)
+			require.NoError(t, err, "generating results from %s", tt.filename)
+			require.ElementsMatch(t, tt.expected, results)
 		})
 	}
 }

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -49,8 +49,8 @@ func Metadata(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 }
 
 func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-
 	var results []map[string]string
+
 	schemas := tablehelpers.GetConstraints(queryContext, "schema", tablehelpers.WithAllowedCharacters(allowedCharacters))
 	if len(schemas) < 1 {
 		return results, errors.New("kolide_gsettings_metadata table requires at least one schema to be specified")
@@ -269,9 +269,10 @@ var gvariantMapping = map[string]string{
 }
 
 // convertType returns a string describing the GVariantType corresponding to the
-// GVariant-formatted type string. see  https://developer.gnome.org/glib/unstable/glib-GVariantType.html
-// for documentation. Note that not all types listed in the documentation above
-// are supported, for example:
+// GVariant-formatted type string. see
+// https://developer.gnome.org/glib/unstable/glib-GVariantType.html for
+// documentation. Note that not all types listed in the documentation above are
+// supported, for example:
 //  - tuples (e.g. tuple of 2 strings `(ss)`)
 //  - nested types (e.g.// array of tuples: `a(ss)`)
 // and other complex types are not supported.

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -226,16 +226,6 @@ func execGsettingsCommand(ctx context.Context, args []string, tmpdir string, out
 	command := args[0]
 	cmd := exec.CommandContext(ctx, gsettingsPath, args...)
 
-	// dir, err := ioutil.TempDir("", fmt.Sprintf("osq-gsettings-%s", command))
-	// if err != nil {
-	// 	return errors.Wrap(err, "mktemp")
-	// }
-	// defer os.RemoveAll(dir)
-
-	// if err := os.Chmod(dir, 0755); err != nil {
-	// 	return errors.Wrap(err, "chmod")
-	// }
-
 	cmd.Dir = tmpdir
 	cmd.Stderr = new(bytes.Buffer)
 	cmd.Stdout = output

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -51,7 +51,7 @@ func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.Que
 	var results []map[string]string
 	schemas := tablehelpers.GetConstraints(queryContext, "schema", tablehelpers.WithAllowedCharacters(allowedCharacters))
 	if len(schemas) < 1 {
-		return results, errors.New("kolide_gsettings_metadata table requires at least one schemas to be specified")
+		return results, errors.New("kolide_gsettings_metadata table requires at least one schema to be specified")
 	}
 
 	for _, schema := range schemas {

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gsettings
 
 import (

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -1,0 +1,274 @@
+package gsettings
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	osquery "github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+type GsettingsMetadata struct {
+	client    *osquery.ExtensionManagerClient
+	logger    log.Logger
+	cmdRunner func(ctx context.Context, args []string, output *bytes.Buffer) error
+}
+
+// Metadata returns a table plugin for querying metadata about specific keys in
+// specific schemas
+func Metadata(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+
+	columns := []table.ColumnDefinition{
+		// TODO: maybe need to add 'path' for relocatable schemas..
+		table.TextColumn("schema"),
+		table.TextColumn("key"),
+		table.TextColumn("description"),
+		table.TextColumn("type"),
+	}
+
+	t := &GsettingsMetadata{
+		client:    client,
+		logger:    logger,
+		cmdRunner: execGsettingsCommand,
+	}
+
+	return table.NewPlugin("kolide_gsettings_metadata", columns, t.generate)
+}
+
+func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+
+	var results []map[string]string
+
+	for _, schema := range tablehelpers.GetConstraints(queryContext, "schema", tablehelpers.WithAllowedCharacters(allowedCharacters)) {
+		descriptions, err := t.gsettingsDescribeForSchema(ctx, schema, "")
+		if err != nil {
+			level.Info(t.logger).Log(
+				"msg", "error describing keys for schema",
+				"schema", schema,
+				"err", err,
+			)
+			continue
+		}
+		for _, d := range descriptions {
+			row := map[string]string{
+				"description": d.Description,
+				"type":        d.Type,
+				"schema":      schema,
+				"key":         d.Key,
+			}
+			results = append(results, row)
+		}
+
+	}
+
+	return results, nil
+}
+
+type datatype struct {
+	raw string
+}
+
+type keyDescription struct {
+	Description string
+	Type        string
+	Key         string
+}
+
+func (k *keyDescription) toMap() map[string]string {
+	return map[string]string{
+		"description": k.Description,
+		"type":        k.Type,
+		"key":         k.Key,
+	}
+}
+
+func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema, key string) ([]keyDescription, error) {
+	var descriptions []keyDescription
+	var keys []string
+	var err error
+
+	if key != "" {
+		keys = append(keys, key)
+	} else {
+		keys, err = t.listKeys(ctx, schema)
+		if err != nil {
+			return descriptions, errors.Wrap(err, "fetching keys to describe")
+		}
+	}
+
+	for _, k := range keys {
+		desc, err := t.describeKey(ctx, schema, k)
+		if err != nil {
+			level.Info(t.logger).Log(
+				"msg", "error describing key",
+				"key", key,
+				"schema", schema,
+				"err", err,
+			)
+			continue
+		}
+		descriptions = append(descriptions, desc)
+	}
+
+	return descriptions, nil
+}
+
+func (t *GsettingsMetadata) listKeys(ctx context.Context, schema string) ([]string, error) {
+	var keys []string
+	output := new(bytes.Buffer)
+
+	err := t.cmdRunner(ctx, []string{"list-keys", schema}, output)
+	if err != nil {
+		return keys, errors.Wrap(err, "fetching keys")
+	}
+	scanner := bufio.NewScanner(output)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		keys = append(keys, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		level.Info(t.logger).Log("msg", "scanner error", "err", err)
+	}
+
+	return keys, nil
+}
+
+func (t *GsettingsMetadata) describeKey(ctx context.Context, schema, key string) (keyDescription, error) {
+	desc := keyDescription{Key: key}
+
+	d, err := t.getDescription(ctx, schema, key)
+	if err != nil {
+		return desc, errors.Wrap(err, "getting key's description")
+	}
+	desc.Description = d
+
+	datatype, err := t.getType(ctx, key, schema)
+	if err != nil {
+		return desc, errors.Wrap(err, "discerning key's type")
+	}
+	desc.Type = datatype
+
+	return desc, nil
+}
+
+func (t *GsettingsMetadata) getDescription(ctx context.Context, schema, key string) (string, error) {
+	output := new(bytes.Buffer)
+
+	err := t.cmdRunner(ctx, []string{"describe", schema, key}, output)
+	if err != nil {
+		return "", errors.Wrap(err, "describing key")
+	}
+
+	return strings.TrimSpace(output.String()), nil
+}
+
+func (t *GsettingsMetadata) getType(ctx context.Context, key, schema string) (string, error) {
+	output := new(bytes.Buffer)
+
+	err := t.cmdRunner(ctx, []string{"range", schema, key}, output)
+	if err != nil {
+		return "", errors.Wrap(err, "running 'gsettings range'")
+	}
+
+	result := strings.TrimSpace(strings.ReplaceAll(output.String(), "\n", " "))
+	// enum types need special formatting to distinguish the type (enum) from
+	// the possible values
+	if strings.HasPrefix(result, "enum") {
+		s := strings.TrimPrefix(result, "enum ")
+		vals := strings.Split(s, " ")
+		return fmt.Sprintf("enum: [ %s ]", strings.Join(vals, ",")), nil
+	}
+
+	// 'range' datatypes also need special handling
+	if strings.HasPrefix(result, "range ") {
+		s := strings.TrimPrefix(result, "range ")
+		parts := strings.Split(s, " ")
+
+		typ := convertType(parts[0])
+		var scope string
+		if len(parts) > 2 {
+			scope = fmt.Sprintf(" (%v to %v)", parts[1], parts[2])
+		}
+
+		return fmt.Sprintf("%s%s", typ, scope), nil
+	}
+
+	return convertType(result), nil
+}
+
+func execGsettingsCommand(ctx context.Context, args []string, output *bytes.Buffer) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	command := args[0]
+	cmd := exec.CommandContext(ctx, gsettingsPath, args...)
+	dir, err := ioutil.TempDir("", fmt.Sprintf("osq-gsettings-%s", command))
+	if err != nil {
+		return errors.Wrap(err, "mktemp")
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		return errors.Wrap(err, "chmod")
+	}
+	cmd.Dir = dir
+	cmd.Stderr = new(bytes.Buffer)
+	cmd.Stdout = output
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "running gsettings %s", command)
+	}
+
+	return nil
+}
+
+var gvariantMapping = map[string]string{
+	"b": "bool",
+	"n": "int16",
+	"q": "uint16",
+	"i": "int32",
+	"u": "uint32",
+	"x": "int64",
+	"t": "uint64",
+	"d": "double",
+	"s": "string",
+	"a": "array",
+}
+
+// convertType returns a string describing the GVariantType corresponding to the
+// GVariant-formatted type string. see  https://developer.gnome.org/glib/unstable/glib-GVariantType.html
+// for documentation. Note that not all types listed in the documentation above
+// are supported, for example:
+//  - tuples (e.g. tuple of 2 strings `(ss)`)
+//  - nested types (e.g.// array of tuples: `a(ss)`)
+// and other complex types are not supported.
+func convertType(typ string) string {
+	typ = strings.Replace(typ, "type ", "", 1) // remove any leading 'type ', eg 'type b'
+	var prefix string
+	if strings.HasPrefix(typ, "a") {
+		typ = typ[1:]
+		prefix = "array of "
+	}
+	primitive_typ, ok := gvariantMapping[typ]
+	if !ok {
+		return "other"
+	}
+	return fmt.Sprintf("%s%s", prefix, primitive_typ)
+}

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -81,22 +81,10 @@ func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.Que
 	return results, nil
 }
 
-type datatype struct {
-	raw string
-}
-
 type keyDescription struct {
 	Description string
 	Type        string
 	Key         string
-}
-
-func (k *keyDescription) toMap() map[string]string {
-	return map[string]string{
-		"description": k.Description,
-		"type":        k.Type,
-		"key":         k.Key,
-	}
 }
 
 func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema string) ([]keyDescription, error) {
@@ -192,6 +180,10 @@ func (t *GsettingsMetadata) getDescription(ctx context.Context, schema, key, tmp
 	return strings.TrimSpace(output.String()), nil
 }
 
+// getType fetches the type _as described by the gsettings cli tool_ and
+// converts it into something human readable. The conversion of the actual
+// GVariant type from 'GVariant code' to golang-ish type descriptions is handled
+// by convertType
 func (t *GsettingsMetadata) getType(ctx context.Context, schema, key, tmpdir string) (string, error) {
 	output := new(bytes.Buffer)
 

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -276,7 +276,7 @@ var gvariantMapping = map[string]string{
 //  - nested types (e.g.// array of tuples: `a(ss)`)
 // and other complex types are not supported.
 func convertType(typ string) string {
-	typ = strings.Replace(typ, "type ", "", 1) // remove any leading 'type ', eg 'type b'
+	typ = strings.TrimPrefix(typ, "type ") // remove any leading 'type ', eg in 'type b'
 	var prefix string
 	if strings.HasPrefix(typ, "a") {
 		typ = typ[1:]

--- a/pkg/osquery/tables/gsettings/testdata/listkeys.txt
+++ b/pkg/osquery/tables/gsettings/testdata/listkeys.txt
@@ -1,0 +1,11 @@
+nmines
+window-width
+ysize
+use-question-marks
+use-autoflag
+use-animations
+mode
+xsize
+theme
+window-height
+window-is-maximized

--- a/pkg/osquery/tables/gsettings/testdata/simple.txt
+++ b/pkg/osquery/tables/gsettings/testdata/simple.txt
@@ -1,0 +1,2 @@
+org.gnome.rhythmbox.plugins.webremote access-key ''
+org.gnome.rhythmbox.plugins.webremote foo-bar 2


### PR DESCRIPTION
This commit:
 -  adds `kolide_gsettings` and `kolide_gsettings_metadata` tables 
 - adds an 'osqueryi-tables' makefile target variant for linux

Closes #508

### Examples

```
osquery> select * from kolide_gsettings_metadata where schema = 'org.gnome.Mines' or schema = 'org.gnome.rhythmbox.sources';
+-----------------------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
| schema                      | key                 | description                                                                                                           | type                                                                |
+-----------------------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
| org.gnome.Mines             | nmines              | The number of mines in a custom game                                                                                  | int32                                                               |
| org.gnome.Mines             | window-width        | Width of the window in pixels                                                                                         | int32                                                               |
| org.gnome.Mines             | ysize               | Number of rows in a custom game                                                                                       | int32 (4 to 100)                                                    |
| org.gnome.Mines             | use-question-marks  | Set to true to be able to mark squares as unknown.                                                                    | bool                                                                |
| org.gnome.Mines             | use-autoflag        | Set to true to automatically flag squares as mined when enough squares are revealed                                   | bool                                                                |
| org.gnome.Mines             | use-animations      | Set to false to disable theme-defined transition animations                                                           | bool                                                                |
| org.gnome.Mines             | mode                | Size of the board (0-2 = small-large, 3=custom)                                                                       | int32 (0 to 3)                                                      |
| org.gnome.Mines             | xsize               | Number of columns in a custom game                                                                                    | int32 (4 to 100)                                                    |
| org.gnome.Mines             | theme               | The title of the tile theme to use.                                                                                   | string                                                              |
| org.gnome.Mines             | window-height       | Height of the window in pixels                                                                                        | int32                                                               |
| org.gnome.Mines             | window-is-maximized | true if the window is maximized                                                                                       | bool                                                                |
| org.gnome.rhythmbox.sources | visible-columns     | The list of columns that will be shown. If a given source doesn't support a particular column, it won't be displayed. | array of string                                                     |
| org.gnome.rhythmbox.sources | browser-views       | Views to show in the library browser.                                                                                 | enum: [ 'artists-albums','genres-artists','genres-artists-albums' ] |
+-----------------------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+

```


```
osquery> select * from kolide_gsettings where (schema = 'org.gnome.Mines' or schema = 'org.gnome.rhythmbox.sources') and username = 'blaed';
+-----------------------------+---------------------+-----------------------------------------------------------------------+----------+
| schema                      | key                 | value                                                                 | username |
+-----------------------------+---------------------+-----------------------------------------------------------------------+----------+
| org.gnome.Mines             | nmines              | 40                                                                    | blaed    |
| org.gnome.Mines             | window-width        | 600                                                                   | blaed    |
| org.gnome.Mines             | ysize               | 16                                                                    | blaed    |
| org.gnome.Mines             | use-question-marks  | true                                                                  | blaed    |
| org.gnome.Mines             | use-autoflag        | false                                                                 | blaed    |
| org.gnome.Mines             | use-animations      | false                                                                 | blaed    |
| org.gnome.Mines             | mode                | 0                                                                     | blaed    |
| org.gnome.Mines             | xsize               | 16                                                                    | blaed    |
| org.gnome.Mines             | theme               | 'bgcolors'                                                            | blaed    |
| org.gnome.Mines             | window-height       | 400                                                                   | blaed    |
| org.gnome.Mines             | window-is-maximized | false                                                                 | blaed    |
| org.gnome.rhythmbox.sources | visible-columns     | ['track-number', 'artist', 'album', 'genre', 'duration', 'post-time'] | blaed    |
| org.gnome.rhythmbox.sources | browser-views       | 'artists-albums'                                                      | blaed    |
+-----------------------------+---------------------+-----------------------------------------------------------------------+----------+

```