### PR TITLE
Flatten fixes from #666

### DIFF
--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -91,10 +91,6 @@ func WithNestedPlist() FlattenOpts {
 // WithLogger sets the logger to use
 func WithLogger(logger log.Logger) FlattenOpts {
 	return func(fl *Flattener) {
-		if logger == nil {
-			return
-		}
-
 		fl.logger = logger
 	}
 }
@@ -103,10 +99,11 @@ func WithLogger(logger log.Logger) FlattenOpts {
 // re-writing arrays into maps, and for filtering. See "Query
 // Specification" for docs.
 func WithQuery(q []string) FlattenOpts {
+	if q == nil || len(q) == 0 {
+		return func(_ *Flattener) {}
+	}
+
 	return func(fl *Flattener) {
-		if q == nil || len(q) == 0 {
-			return
-		}
 		fl.query = q
 	}
 }

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -82,7 +82,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 		}
 
 		for _, filePath := range filePaths {
-			for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+			for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 				subresults, err := t.generatePath(filePath, dataQuery)
 				if err != nil {
 					return results, errors.Wrapf(err, "generating for path %s with query", filePath)

--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -104,7 +104,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 								continue
 							}
 
-							for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+							for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 								// Finally, an inner loop
 
 								ioregOutput, err := t.execIoreg(ctx, ioregArgs)

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -62,7 +62,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	for _, command := range tablehelpers.GetConstraints(queryContext, "command", tablehelpers.WithAllowedCharacters("abcdefghijklmnopqrstuvwxyz"), tablehelpers.WithDefaults("show")) {
 		for _, profileType := range tablehelpers.GetConstraints(queryContext, "type", tablehelpers.WithAllowedCharacters("abcdefghijklmnopqrstuvwxyz"), tablehelpers.WithDefaults("")) {
 			for _, user := range tablehelpers.GetConstraints(queryContext, "user", tablehelpers.WithAllowedCharacters(userAllowedCharacters), tablehelpers.WithDefaults("_all")) {
-				for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+				for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 
 					profileArgs := []string{command, "-output", "stdout-xml"}
 

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -60,7 +60,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			pwpolicyArgs = append(pwpolicyArgs, "-u", pwpolicyUsername)
 		}
 
-		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 			pwPolicyOutput, err := t.execPwpolicy(ctx, pwpolicyArgs)
 			if err != nil {
 				level.Info(t.logger).Log("msg", "pwpolicy failed", "err", err)

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -33,6 +33,7 @@ type Table struct {
 	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
+	execCC    func(context.Context, string, ...string) *exec.Cmd
 }
 
 func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
@@ -45,6 +46,7 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 		client:    client,
 		logger:    logger,
 		tableName: "kolide_pwpolicy",
+		execCC:    exec.CommandContext,
 	}
 
 	return table.NewPlugin(t.tableName, columns, t.generate)
@@ -100,7 +102,7 @@ func (t *Table) execPwpolicy(ctx context.Context, args []string) ([]byte, error)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, pwpolicyPath, args...)
+	cmd := t.execCC(ctx, pwpolicyPath, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 

--- a/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
@@ -26,15 +26,15 @@ func TestQueries(t *testing.T) {
 	}{
 		{
 			name: "no data, just languages",
-			file: path.Join("testdata", "empty.out"),
+			file: path.Join("testdata", "empty.output"),
 			len:  41,
 		},
 		{
-			file: path.Join("testdata", "test1.out"),
+			file: path.Join("testdata", "test1.output"),
 			len:  148,
 		},
 		{
-			file:        path.Join("testdata", "test1.out"),
+			file:        path.Join("testdata", "test1.output"),
 			queryClause: []string{"policyCategoryAuthentication"},
 			len:         8,
 		},

--- a/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
@@ -1,0 +1,74 @@
+//+build darwin
+
+package pwpolicy
+
+import (
+	"context"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueries(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name        string
+		file        string
+		queryClause []string
+		len         int
+		err         bool
+	}{
+		{
+			name: "no data, just languages",
+			file: path.Join("testdata", "empty.out"),
+			len:  41,
+		},
+		{
+			file: path.Join("testdata", "test1.out"),
+			len:  148,
+		},
+		{
+			file:        path.Join("testdata", "test1.out"),
+			queryClause: []string{"policyCategoryAuthentication"},
+			len:         8,
+		},
+	}
+
+	for _, tt := range tests {
+		testTable := &Table{
+			logger: log.NewNopLogger(),
+			execCC: execFaker(tt.file),
+		}
+
+		testName := tt.file + "/" + tt.name
+		t.Run(testName, func(t *testing.T) {
+			mockQC := tablehelpers.MockQueryContext(map[string][]string{
+				"query": tt.queryClause,
+			})
+
+			rows, err := testTable.generate(context.TODO(), mockQC)
+
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.len, len(rows))
+		})
+	}
+
+}
+
+func execFaker(filename string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/cat", filename)
+	}
+}

--- a/pkg/osquery/tables/pwpolicy/testdata/empty.output
+++ b/pkg/osquery/tables/pwpolicy/testdata/empty.output
@@ -1,0 +1,98 @@
+Getting global account policies
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>policyCategoryPasswordContent</key>
+	<array>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '.{4,}+'</string>
+			<key>policyContentDescription</key>
+			<dict>
+				<key>Dutch</key>
+				<string>Voer een wachtwoord van vier of meer tekens in.</string>
+				<key>English</key>
+				<string>Enter a password that is four characters or more.</string>
+				<key>French</key>
+				<string>Saisissez un mot de passe comportant au moins quatre caractères.</string>
+				<key>German</key>
+				<string>Gib ein Passwort ein, das aus mindestens vier Zeichen besteht.</string>
+				<key>Italian</key>
+				<string>Inserisci una password di quattro o più caratteri.</string>
+				<key>Japanese</key>
+				<string>4文字以上のパスワードを入力してください。</string>
+				<key>Spanish</key>
+				<string>Introduce una contraseña que tenga como mínimo cuatro caracteres.</string>
+				<key>ar</key>
+				<string>أدخل كلمة سر لا تقل عن أربعة أحرف أو رموز.</string>
+				<key>ca</key>
+				<string>Introdueix una contrasenya que tingui quatre caràcters o més.</string>
+				<key>cs</key>
+				<string>Zadejte heslo o minimální délce čtyři znaky.</string>
+				<key>da</key>
+				<string>Skriv en adgangskode på mindst fire tegn.</string>
+				<key>el</key>
+				<string>Εισαγάγετε ένα συνθηματικό που περιέχει τέσσερις ή περισσότερους χαρακτήρες.</string>
+				<key>en_AU</key>
+				<string>Enter a password that is four characters or more.</string>
+				<key>en_GB</key>
+				<string>Enter a password that is four characters or more.</string>
+				<key>es_419</key>
+				<string>Ingresa una contraseña de cuatro caracteres o más.</string>
+				<key>fi</key>
+				<string>Kirjoita salasana, jossa on vähintään neljä merkkiä.</string>
+				<key>fr_CA</key>
+				<string>Saisissez un mot de passe comportant au moins quatre caractères.</string>
+				<key>he</key>
+				<string>הקש/י סיסמה בת ארבעה תווים או יותר.</string>
+				<key>hi</key>
+				<string>चार वर्णों वाला या उससे बड़ा पासवर्ड दर्ज करें।</string>
+				<key>hr</key>
+				<string>Unesite lozinku od četiri ili više znakova.</string>
+				<key>hu</key>
+				<string>Adjon meg egy legalább négy karakterből álló jelszót.</string>
+				<key>id</key>
+				<string>Masukkan kata sandi yang terdiri dari empat karakter atau lebih.</string>
+				<key>ko</key>
+				<string>4자 이상의 암호를 입력하십시오.</string>
+				<key>ms</key>
+				<string>Masukkan kata laluan yang mengandungi empat atau lebih aksara.</string>
+				<key>no</key>
+				<string>Angi et passord på minst fire tegn.</string>
+				<key>pl</key>
+				<string>Podaj hasło składające się z co najmniej czterech znaków.</string>
+				<key>pt</key>
+				<string>Digite uma senha com quatro ou mais caracteres.</string>
+				<key>pt_PT</key>
+				<string>Digite uma palavra‑passe com pelo menos quatro caracteres.</string>
+				<key>ro</key>
+				<string>Introduceți o parolă de minimum patru caractere.</string>
+				<key>ru</key>
+				<string>Введите пароль, состоящий из четырех или более символов.</string>
+				<key>sk</key>
+				<string>Zadajte heslo obsahujúce najmenej štyri znaky.</string>
+				<key>sv</key>
+				<string>Ange ett lösenord som är minst fyra tecken långt.</string>
+				<key>th</key>
+				<string>ป้อนรหัสผ่านที่มีอักขระอย่างน้อยสี่ตัว</string>
+				<key>tr</key>
+				<string>En az dört karakter uzunluğunda bir parola girin.</string>
+				<key>uk</key>
+				<string>Введіть пароль зі щонайменше чотирьох символів.</string>
+				<key>vi</key>
+				<string>Nhập mật khẩu dài 4 ký tự trở lên.</string>
+				<key>zh_CN</key>
+				<string>输入不少于 4 个字符的密码。</string>
+				<key>zh_HK</key>
+				<string>輸入一個四位或更多字元的密碼。</string>
+				<key>zh_TW</key>
+				<string>輸入 4 個字元或更長的密碼。</string>
+			</dict>
+			<key>policyIdentifier</key>
+			<string>com.apple.defaultpasswordpolicy.fde</string>
+		</dict>
+	</array>
+</dict>
+</plist>
+

--- a/pkg/osquery/tables/pwpolicy/testdata/test1.output
+++ b/pkg/osquery/tables/pwpolicy/testdata/test1.output
@@ -1,0 +1,357 @@
+Getting global account policies
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>policyCategoryAuthentication</key>
+	<array>
+		<dict>
+			<key>policyContent</key>
+			<string>(policyAttributeFailedAuthentications &lt; policyAttributeMaximumFailedAuthentications) OR (policyAttributeCurrentTime &gt; (policyAttributeLastFailedAuthenticationTime + autoEnableInSeconds))</string>
+			<key>policyIdentifier</key>
+			<string>ProfilePayload:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA:minutesUntilFailedLoginReset</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>autoEnableInSeconds</key>
+				<integer>900</integer>
+				<key>policyAttributeMaximumFailedAuthentications</key>
+				<integer>5</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>(policyAttributeFailedAuthentications &lt; policyAttributeMaximumFailedAuthentications) OR (policyAttributeCurrentTime &gt; (policyAttributeLastFailedAuthenticationTime + autoEnableInSeconds))</string>
+			<key>policyIdentifier</key>
+			<string>Authentication Lockout</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>autoEnableInSeconds</key>
+				<integer>60</integer>
+				<key>policyAttributeMaximumFailedAuthentications</key>
+				<integer>5</integer>
+			</dict>
+		</dict>
+	</array>
+	<key>policyCategoryPasswordContent</key>
+	<array>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '(.*[A-Z].*){1,}+'</string>
+			<key>policyIdentifier</key>
+			<string>Has an upper case letter</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>minimumAlphaCharacters</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '(.*[a-z].*){1,}+'</string>
+			<key>policyIdentifier</key>
+			<string>Has a lower case letter</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>minimumAlphaCharactersLowerCase</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>(policyAttributeSequentialCharacters &lt; policyAttributeMaximumSequentialCharacters) and (policyAttributeConsecutiveCharacters &lt; policyAttributeMaximumConsecutiveCharacters)</string>
+			<key>policyContentDescription</key>
+			<dict>
+				<key>ar</key>
+				<string>لا تحتوي على حرفين متتاليين، أو ثلاثة أحرف متسلسلة.</string>
+				<key>ca</key>
+				<string>No pot tenir dos caràcters consecutius o tres caràcters en ordre seqüencial.</string>
+				<key>cs</key>
+				<string>Nesmí obsahovat opakování znaku ani sekvenci tří po sobě jdoucích znaků.</string>
+				<key>da</key>
+				<string>Kan ikke have to gentagne eller tre fortløbende tegn.</string>
+				<key>de</key>
+				<string>Darf keine zwei identischen bzw. drei aufeinanderfolgenden Zeichen enthalten.</string>
+				<key>el</key>
+				<string>Να μην περιέχει δύο διαδοχικούς ή τρεις ακολουθιακούς χαρακτήρες.</string>
+				<key>en</key>
+				<string>Not have two consecutive, or three sequential characters.</string>
+				<key>en-AU</key>
+				<string>Not have two consecutive, or three sequential characters.</string>
+				<key>en-GB</key>
+				<string>Not have two consecutive or three sequential characters.</string>
+				<key>es</key>
+				<string>No debe contener dos caracteres consecutivos o tres secuenciales.</string>
+				<key>es-419</key>
+				<string>No incluir dos caracteres consecutivos o tres caracteres secuenciales.</string>
+				<key>fi</key>
+				<string>Ei sisällä kahta peräkkäistä samaa tai kolmea peräkkäistä kirjainta.</string>
+				<key>fr</key>
+				<string>Ne pas contenir deux caractères identiques consécutifs ni trois caractères séquentiels.</string>
+				<key>fr-CA</key>
+				<string>Ne pas contenir deux caractères identiques consécutifs ni trois caractères séquentiels.</string>
+				<key>he</key>
+				<string>לא להכיל שני תווים רצופים או שלושה תווים עוקבים.</string>
+				<key>hi</key>
+				<string>दो लगातार या तीन क्रमानुसार वर्ण नहीं हैं। have two consecutive, or three sequential characters.</string>
+				<key>hr</key>
+				<string>Ne smije imati dva uzastopna ili tri redoslijedna znaka.</string>
+				<key>hu</key>
+				<string>Nem követheti benne egymást két egymás utáni vagy három azonos karakter.</string>
+				<key>id</key>
+				<string>Tidak memiliki dua karakter berturut-turut, atau tiga karakter yang berurutan.</string>
+				<key>it</key>
+				<string>Non avere due caratteri consecutivi o tre caratteri sequenziali.</string>
+				<key>ja</key>
+				<string>同じ文字を2つ続けたり、連続文字を3つ続けたりしないでください。</string>
+				<key>ko</key>
+				<string>연속적인 2개의 문자 또는 순차적인 문자를 3개 이상 포함할 수 없습니다.</string>
+				<key>ms</key>
+				<string>Tidak mempunyai dua karakter berurutan, atau tiga karakter berjujukan.</string>
+				<key>nb</key>
+				<string>Ikke inneholde to identiske tegn etter hverandre eller tre tegn i rekkefølge.</string>
+				<key>nl</key>
+				<string>Mag niet twee identieke tekens na elkaar of drie opeenvolgende tekens bevatten.</string>
+				<key>pl</key>
+				<string>Nie zawiera następujących po sobie dwóch powtórzonych znaków ani trzech kolejnych znaków.</string>
+				<key>policyDefaultContentDescription</key>
+				<string>Not have two consecutive, or three sequential characters.</string>
+				<key>pt</key>
+				<string>Não deve conter dois caracteres consecutivos ou três caracteres sequenciais.</string>
+				<key>pt-PT</key>
+				<string>Não ter dois caracteres repetidos ou três sequenciais.</string>
+				<key>ro</key>
+				<string>Nu trebuie să aibă două caractere consecutive sau trei caractere secvențiale.</string>
+				<key>ru</key>
+				<string>Не содержит двух одинаковых или трех последовательных символов подряд.</string>
+				<key>sk</key>
+				<string>Nesmie obsahovať dva po sebe nasledujúce alebo tri sekvenčné znaky.</string>
+				<key>sv</key>
+				<string>Inte innehålla två tecken som är likadana eller tre tecken i ordningsföljd.</string>
+				<key>th</key>
+				<string>ไม่ใช้อักขระเรียงต่อกันสองตัวหรือเรียงตามลำดับสามตัว</string>
+				<key>tr</key>
+				<string>İki yinelenen veya üç sıralı karakter yok.</string>
+				<key>uk</key>
+				<string>не містити два однакових або три послідовних символи поспіль.</string>
+				<key>vi</key>
+				<string>Không có hai ký tự liên tiếp hoặc ba ký tự tuần tự.</string>
+				<key>zh-HK</key>
+				<string>不包括兩個連續或三個連續的字元。</string>
+				<key>zh-Hans</key>
+				<string>不能包含2个连贯或3个连续的字符。</string>
+				<key>zh-Hant</key>
+				<string>不包含兩個連續或三個連續的字元。</string>
+			</dict>
+			<key>policyIdentifier</key>
+			<string>ProfilePayload:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA:allowSimple</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>policyAttributeMaximumConsecutiveCharacters</key>
+				<integer>2</integer>
+				<key>policyAttributeMaximumSequentialCharacters</key>
+				<integer>3</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '(.*[0-9].*){1,}+'</string>
+			<key>policyIdentifier</key>
+			<string>Has a number</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>minimumNumericCharacters</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '.{8,}'</string>
+			<key>policyContentDescription</key>
+			<dict>
+				<key>ar</key>
+				<string>تحتوي على 8 من الأحرف على الأقل.</string>
+				<key>ca</key>
+				<string>Ha de tenir almenys 8 caràcters.</string>
+				<key>cs</key>
+				<string>obsahovat minimální počet znaků: 8.</string>
+				<key>da</key>
+				<string>Indeholder mindst 8 tegn.</string>
+				<key>de</key>
+				<string>Enthält mindestens 8 Zeichen.</string>
+				<key>el</key>
+				<string>Να περιέχει τουλάχιστον 8 χαρακτήρες.</string>
+				<key>en</key>
+				<string>Contain at least 8 characters.</string>
+				<key>en-AU</key>
+				<string>Contain at least 8 characters.</string>
+				<key>en-GB</key>
+				<string>Contain at least 8 characters.</string>
+				<key>es</key>
+				<string>Debe contener al menos 8 caracteres.</string>
+				<key>es-419</key>
+				<string>Contener al menos 8 caracteres.</string>
+				<key>fi</key>
+				<string>Sisältää vähintään 8 kirjainta.</string>
+				<key>fr</key>
+				<string>Contenir au moins 8 caractères.</string>
+				<key>fr-CA</key>
+				<string>Contenir au moins 8 caractères.</string>
+				<key>he</key>
+				<string>להכיל לפחות 8 תווים.</string>
+				<key>hi</key>
+				<string>कम से कम 8 वर्ण हैं।</string>
+				<key>hr</key>
+				<string>Sadrži najmanje 8 znakova.</string>
+				<key>hu</key>
+				<string>Legalább 8 karaktert kell tartalmaznia.</string>
+				<key>id</key>
+				<string>Berisi setidaknya 8 karakter.</string>
+				<key>it</key>
+				<string>Contenere almeno 8 caratteri.</string>
+				<key>ja</key>
+				<string>8文字以上含めてください。</string>
+				<key>ko</key>
+				<string>최소 8개의 문자를 포함해야 합니다.</string>
+				<key>ms</key>
+				<string>Mengandungi sekurang-kurangnya 8 aksara.</string>
+				<key>nb</key>
+				<string>Inneholde minst 8 tegn.</string>
+				<key>nl</key>
+				<string>Moet ten minste 8 tekens bevatten.</string>
+				<key>pl</key>
+				<string>Zawiera minimalną liczbę znaków (8).</string>
+				<key>policyDefaultContentDescription</key>
+				<string>Contain at least 8 characters.</string>
+				<key>pt</key>
+				<string>Conter pelo menos 8 caracteres.</string>
+				<key>pt-PT</key>
+				<string>Conter, pelo menos, 8 caracteres.</string>
+				<key>ro</key>
+				<string>Conține cel puțin 8 caractere.</string>
+				<key>ru</key>
+				<string>Содержит не менее 8 символов.</string>
+				<key>sk</key>
+				<string>Musí obsahovať minimálny počet znakov (8).</string>
+				<key>sv</key>
+				<string>Innehålla minst 8 tecken.</string>
+				<key>th</key>
+				<string>มีอักขระอย่างน้อย 8 ตัว</string>
+				<key>tr</key>
+				<string>En az 8 karakter içermelidir.</string>
+				<key>uk</key>
+				<string>містити щонайменше таку кількість символів: 8.</string>
+				<key>vi</key>
+				<string>Chứa ít nhất 8 ký tự.</string>
+				<key>zh-HK</key>
+				<string>包括至少8個字元。</string>
+				<key>zh-Hans</key>
+				<string>包含至少8个字符。</string>
+				<key>zh-Hant</key>
+				<string>包含至少8個字元。</string>
+			</dict>
+			<key>policyIdentifier</key>
+			<string>ProfilePayload:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA:minLength</string>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '.{8,}+'</string>
+			<key>policyIdentifier</key>
+			<string>Has at least 8 characters</string>
+			<key>policyParameters</key>
+			<dict>
+				<key>minimumLength</key>
+				<integer>8</integer>
+			</dict>
+		</dict>
+		<dict>
+			<key>policyContent</key>
+			<string>policyAttributePassword matches '^(?=.*[0-9])(?=.*[a-zA-Z]).+'</string>
+			<key>policyContentDescription</key>
+			<dict>
+				<key>ar</key>
+				<string>تحتوي على رقم واحد وحرف أبجدي واحد على الأقل.</string>
+				<key>ca</key>
+				<string>Ha de tenir com a mínim un número i un caràcter alfabètic.</string>
+				<key>cs</key>
+				<string>obsahovat alespoň jednu číslici a jeden alfanumerický znak.</string>
+				<key>da</key>
+				<string>Indeholder mindst et tal og et alfabetisk tegn.</string>
+				<key>de</key>
+				<string>Enthält mindestens eine Ziffer und ein alphabetisches Zeichen.</string>
+				<key>el</key>
+				<string>Να περιέχει τουλάχιστον έναν αριθμό και έναν αλφαβητικό χαρακτήρα.</string>
+				<key>en</key>
+				<string>Contain at least one number and one alphabetic character.</string>
+				<key>en-AU</key>
+				<string>Contain at least one number and one alphabetic character.</string>
+				<key>en-GB</key>
+				<string>Contain at least one number and one alphabetic character.</string>
+				<key>es</key>
+				<string>Debe contener al menos un número y un carácter alfabético.</string>
+				<key>es-419</key>
+				<string>Contener al menos un número y un carácter alfabético.</string>
+				<key>fi</key>
+				<string>Sisältää ainakin yhden numeron ja ainakin yhden aakkosten kirjaimen.</string>
+				<key>fr</key>
+				<string>Contenir au moins un nombre et un caractère alphabétique.</string>
+				<key>fr-CA</key>
+				<string>Contenir au moins un nombre et un caractère alphabétique.</string>
+				<key>he</key>
+				<string>להכיל לפחות ספרה אחת ותו אלפביתי אחד.</string>
+				<key>hi</key>
+				<string>कम से कम एक संख्या और एक वर्णमाला वर्ण शामिल होना चाहिए।</string>
+				<key>hr</key>
+				<string>Sadrži najmanje jedan broj i jedan abecedni znak.</string>
+				<key>hu</key>
+				<string>Legalább egy számjegyet és egy betűt kell tartalmaznia.</string>
+				<key>id</key>
+				<string>Berisi setidaknya satu angka dan satu karakter alfabetis.</string>
+				<key>it</key>
+				<string>Contenere almeno un numero e un carattere alfabetico.</string>
+				<key>ja</key>
+				<string>数字と英字をそれぞれ1つ以上含めてください。</string>
+				<key>ko</key>
+				<string>최소 하나의 숫자와 하나의 알파벳 문자가 포함되어야 합니다.</string>
+				<key>ms</key>
+				<string>Mengandungi sekurang-kurangnya satu nombor dan satu aksara abjad.</string>
+				<key>nb</key>
+				<string>Inneholde minst ett tall og ett alfabetisk tegn.</string>
+				<key>nl</key>
+				<string>Moet ten minste één cijfer en één alfabetisch teken bevatten.</string>
+				<key>pl</key>
+				<string>Zawiera co najmniej jedną cyfrę i jedną literę alfabetu.</string>
+				<key>policyDefaultContentDescription</key>
+				<string>Contain at least one number and one alphabetic character.</string>
+				<key>pt</key>
+				<string>Conter pelo menos um número e um caractere do alfabeto.</string>
+				<key>pt-PT</key>
+				<string>Conter, pelo menos, um algarismo e um carácter alfabético.</string>
+				<key>ro</key>
+				<string>Conține cel puțin un număr și un caracter alfabetic.</string>
+				<key>ru</key>
+				<string>Содержит хотя бы одну цифру и одну букву.</string>
+				<key>sk</key>
+				<string>Musí obsahovať najmenej jedno číslo a jeden abecedný znak.</string>
+				<key>sv</key>
+				<string>Innehålla minst en siffra och en bokstav.</string>
+				<key>th</key>
+				<string>มีตัวเลขและอักขระพยัญชนะอย่างน้อยหนึ่งตัว</string>
+				<key>tr</key>
+				<string>En az bir rakam ve bir alfabetik karakter içermelidir.</string>
+				<key>uk</key>
+				<string>містити принаймні одну цифру та одну букву.</string>
+				<key>vi</key>
+				<string>Chứa ít nhất một số và một chữ cái.</string>
+				<key>zh-HK</key>
+				<string>包括至少一個數字和一個英文字元。</string>
+				<key>zh-Hans</key>
+				<string>包含至少1个数字和1个字母字符。</string>
+				<key>zh-Hant</key>
+				<string>包含至少一個數字和一個英文字元。</string>
+			</dict>
+			<key>policyIdentifier</key>
+			<string>ProfilePayload:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA:requireAlphanumeric</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -56,7 +56,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			continue
 		}
 
-		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("")) {
+		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 			secEditResults, err := t.execSecedit(ctx, useMergedPolicy)
 			if err != nil {
 				level.Info(t.logger).Log("msg", "secedit failed", "err", err)

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -71,7 +71,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 		tablehelpers.WithAllowedCharacters(allowedCharacters+`:\= '".`),
 	)
 
-	flattenQueries := tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults(""))
+	flattenQueries := tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*"))
 
 	for _, class := range classes {
 		for _, rawProperties := range properties {


### PR DESCRIPTION
In #666 I moved the if statement  about what happens if no `query` is specified. This inadvertently caused dataflatten to operate with a query of `""`, matching _nothing_ and overriding the default query of `*`. This moves the implicit `*` value to the `tablehelpers.GetConstraints` calls. This is more explicit.

Also add in a test case for pwpolicy