### PR TITLE
Add kolide_filevault table

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
 	appicons "github.com/kolide/launcher/pkg/osquery/tables/app-icons"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/filevault"
 	"github.com/kolide/launcher/pkg/osquery/tables/firmwarepasswd"
 	"github.com/kolide/launcher/pkg/osquery/tables/ioreg"
 	"github.com/kolide/launcher/pkg/osquery/tables/munki"
@@ -41,6 +42,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		ioreg.TablePlugin(client, logger),
 		profiles.TablePlugin(client, logger),
 		kextpolicy.TablePlugin(),
+		filevault.TablePlugin(client, logger),
 		legacyexec.TablePlugin(),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
 		dataflattentable.TablePluginExec(client, logger,

--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -1,0 +1,56 @@
+// +build darwin
+
+package filevault
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+const fdesetupPath = "/usr/bin/fdesetup"
+
+type Table struct {
+	client *osquery.ExtensionManagerClient
+	logger log.Logger
+}
+
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("status"),
+	}
+
+	t := &Table{
+		client: client,
+		logger: logger,
+	}
+
+	return table.NewPlugin("kolide_filevault", columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	// Read the system's fdesetup configuration
+	var stdout bytes.Buffer
+	stdout.Reset()
+	cmd := exec.CommandContext(ctx, fdesetupPath, "status")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrap(err, "calling fdesetup")
+	}
+	output := string(stdout.Bytes())
+	status := strings.TrimSuffix(output, "\n")
+	result := map[string]string{
+		"status": status,
+	}
+	results = append(results, result)
+
+	return results, nil
+}

--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/osquery-go"
@@ -39,8 +40,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	// Read the system's fdesetup configuration
 	var stdout bytes.Buffer
-	stdout.Reset()
 	cmd := exec.CommandContext(ctx, fdesetupPath, "status")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
 		return nil, errors.Wrap(err, "calling fdesetup")


### PR DESCRIPTION
This PR adds a simple table that simply displays the output of `fdesetup status`. Unfortunately this tool does not provide any structured output, but as far as I an tell (through disassembling the binary in hopper) it will only produce a simple message.

Looking at dissambled binary, when the command is not run in verbose mode it will produce between 1 - 3 lines of output. The first line will always contain the following output.

* FileVault is On
* FileVault is On, but needs to be restarted to finish
* FileVault is Off.
* FileVault is Off, but will be enabled after the next restart.
* FileVault is Off, but needs to be restarted to finish.

The second line or third line, if shown, can contain one of the following strings:

* FileVault master keychain appears to be installed.
* Decryption in progress: Percent completed = 
* Encryption in progress: Percent completed =
* Decryption in progress: Pending
* Encryption in progress: Pending

None of these strings appear to be localized, they are all hardcoded.

I've opted to not get too smart about parsing the output other than trimming the last newline, since we want to leave it up to the caller