### PR TITLE
Add Apple Notarization to packagekit

### DIFF
--- a/pkg/packagekit/applenotarization/applenotarization.go
+++ b/pkg/packagekit/applenotarization/applenotarization.go
@@ -1,0 +1,158 @@
+// Package applenotarization is a wrapper around the apple
+// notarization tools.
+//
+// It supports submitting to apple, and recording the uuid. As well as
+// checking on the status.
+package applenotarization
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/groob/plist"
+	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/pkg/errors"
+)
+
+type Notarizer struct {
+	username     string // apple id
+	password     string // application password
+	account      string // This is the itunes account identifier
+	fakeResponse string
+}
+
+func New(
+	username string,
+	password string,
+	account string,
+) *Notarizer {
+	n := &Notarizer{
+		username: username,
+		password: password,
+		account:  account,
+	}
+
+	return n
+
+}
+
+var duplicateSubmitRegexp = regexp.MustCompile(`ERROR ITMS-90732: "The software asset has already been uploaded. The upload ID is ([0-9a-fA-F-]+)"`)
+
+// Submit an file to apple's notarization service. Returns the uuid of
+// the submission
+func (n *Notarizer) Submit(ctx context.Context, filePath string, primaryBundleId string) (string, error) {
+	logger := log.With(ctxlog.FromContext(ctx), "caller", "applenotarization.Submit")
+
+	// TODO check file extension here
+	// zip,pkg,dmg
+
+	response, err := n.runAltool(ctx, []string{
+		"--notarize-app",
+		"--primary-bundle-id", primaryBundleId,
+		"--file", filePath,
+	})
+
+	// duplicate submissions
+	if len(response.ProductErrors) == 1 {
+		matches := duplicateSubmitRegexp.FindStringSubmatch(response.ProductErrors[0].Message)
+		if len(matches) == 2 {
+			return matches[1], nil
+		}
+	}
+
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "error getting notarize-app",
+			"error-messages", fmt.Sprintf("%+v", response.ProductErrors),
+		)
+
+		return "", errors.Wrap(err, "calling notarize")
+	}
+
+	return response.NotarizationUpload.RequestUUID, nil
+}
+
+// Check the notarization status of a uuid
+func (n *Notarizer) Check(ctx context.Context, uuid string) (string, error) {
+	logger := log.With(ctxlog.FromContext(ctx),
+		"caller", "applenotarization.Check",
+		"request-uuid", uuid,
+	)
+
+	response, err := n.runAltool(ctx, []string{"--notarization-info", uuid})
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "error getting notarization-info",
+			"error-messages", fmt.Sprintf("%+v", response.ProductErrors),
+		)
+		return "", errors.Wrap(err, "exec")
+	}
+
+	if response.NotarizationInfo.RequestUUID != uuid {
+		return "", errors.Errorf("Something went wrong. Expected response for %s, but got %s",
+			response.NotarizationInfo.RequestUUID,
+			uuid,
+		)
+	}
+
+	if response.NotarizationInfo.Status != "success" {
+		level.Info(logger).Log(
+			"msg", "Not successful. Examine log",
+			"logfile", response.NotarizationInfo.LogFileURL,
+		)
+	}
+
+	return response.NotarizationInfo.Status, nil
+}
+
+func Staple(ctx context.Context) {
+}
+
+func (n *Notarizer) runAltool(ctx context.Context, cmdArgs []string) (*notarizationResponse, error) {
+	logger := log.With(ctxlog.FromContext(ctx), "caller", "applenotarization.runAltool")
+
+	baseArgs := []string{
+		"altool",
+		"--username", n.username,
+		"--password", "@env:N_PASS",
+		"--asc-provider", n.account,
+		"--output-format", "xml",
+	}
+
+	cmd := exec.CommandContext(ctx, "xcrun", append(baseArgs, cmdArgs...)...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("N_PASS=%s", n.password))
+
+	level.Debug(logger).Log(
+		"msg", "Execing altool as",
+		"cmd", strings.Join(cmd.Args, " "),
+	)
+
+	if n.fakeResponse != "" {
+		response := &notarizationResponse{}
+		if err := plist.NewXMLDecoder(strings.NewReader(n.fakeResponse)).Decode(response); err != nil {
+			return nil, errors.Wrap(err, "plist decode")
+		}
+
+		// This isn't quite right -- we're returng nil, and
+		// not the command error. But it's good enough...
+		return response, nil
+	}
+
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	cmdErr := cmd.Run()
+
+	// So far, we get xml output even in the face of errors. So we may as well try to parse it here.
+	response := &notarizationResponse{}
+	if err := plist.NewXMLDecoder(stdout).Decode(response); err != nil {
+		return nil, errors.Wrap(err, "plist decode")
+	}
+
+	return response, cmdErr
+}

--- a/pkg/packagekit/applenotarization/applenotarization.go
+++ b/pkg/packagekit/applenotarization/applenotarization.go
@@ -58,21 +58,20 @@ func (n *Notarizer) Submit(ctx context.Context, filePath string, primaryBundleId
 		"--file", filePath,
 	})
 
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "error getting notarize-app",
+			"error-messages", fmt.Sprintf("%+v", response.ProductErrors),
+		)
+		return "", errors.Wrap(err, "calling notarize")
+	}
+
 	// duplicate submissions
 	if len(response.ProductErrors) == 1 {
 		matches := duplicateSubmitRegexp.FindStringSubmatch(response.ProductErrors[0].Message)
 		if len(matches) == 2 {
 			return matches[1], nil
 		}
-	}
-
-	if err != nil {
-		level.Error(logger).Log(
-			"msg", "error getting notarize-app",
-			"error-messages", fmt.Sprintf("%+v", response.ProductErrors),
-		)
-
-		return "", errors.Wrap(err, "calling notarize")
 	}
 
 	return response.NotarizationUpload.RequestUUID, nil

--- a/pkg/packagekit/applenotarization/applenotarization_test.go
+++ b/pkg/packagekit/applenotarization/applenotarization_test.go
@@ -1,0 +1,90 @@
+package applenotarization
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.TODO()
+
+	var tests = []struct {
+		fakeFile       string
+		uuid           string
+		expectedError  bool
+		expectedStatus string
+	}{
+		{
+			fakeFile:       "testdata/info.xml",
+			uuid:           "11111111-2222-3333-4444-f4b2a99e443a",
+			expectedStatus: "success",
+		},
+		{
+			fakeFile:      "testdata/info.xml",
+			uuid:          "mismatched uuid",
+			expectedError: true,
+		},
+		{
+			fakeFile:       "testdata/infoinprogress.xml",
+			uuid:           "77777777-1111-4444-aaaa-111111111111",
+			expectedStatus: "in progress",
+		},
+	}
+
+	for _, tt := range tests {
+		fileBytes, err := ioutil.ReadFile(tt.fakeFile)
+		require.NoError(t, err)
+		n := New("myname@example.com", "123password", "X11111AAAA")
+		n.fakeResponse = string(fileBytes)
+
+		returnedStatus, err := n.Check(ctx, tt.uuid)
+
+		if tt.expectedError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, returnedStatus)
+		}
+	}
+}
+
+func TestSubmit(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	tmpZipFile, err := ioutil.TempFile("", "fake-for-submission.*.zip")
+	require.NoError(t, err)
+	defer os.Remove(tmpZipFile.Name())
+
+	var tests = []struct {
+		fakeFile     string
+		expectedUuid string
+	}{
+		{
+			fakeFile:     "testdata/submit.xml",
+			expectedUuid: "11111111-aaaa-4444-aaaa-bbbbbbbbbbbb",
+		},
+		{
+			fakeFile:     "testdata/submitduplicate.xml",
+			expectedUuid: "22222222-dddd-4444-4444-cccccccccccc",
+		},
+	}
+
+	for _, tt := range tests {
+		fileBytes, err := ioutil.ReadFile(tt.fakeFile)
+		require.NoError(t, err)
+		n := New("myname@example.com", "123password", "X11111AAAA")
+		n.fakeResponse = string(fileBytes)
+
+		returnedUuid, err := n.Submit(ctx, tmpZipFile.Name(), "com.example.testing")
+		require.NoError(t, err)
+		require.Equal(t, tt.expectedUuid, returnedUuid, "Using fake data in %s", tt.fakeFile)
+	}
+
+}

--- a/pkg/packagekit/applenotarization/testdata/badauth.xml
+++ b/pkg/packagekit/applenotarization/testdata/badauth.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>product-errors</key>
+	<array>
+		<dict>
+			<key>code</key>
+			<integer>-22938</integer>
+			<key>message</key>
+			<string>Sign in with the app-specific password you generated. If you forgot the app-specific password or need to create a new one, go to appleid.apple.com</string>
+			<key>userInfo</key>
+			<dict>
+				<key>NSLocalizedDescription</key>
+				<string>Sign in with the app-specific password you generated. If you forgot the app-specific password or need to create a new one, go to appleid.apple.com</string>
+				<key>NSLocalizedFailureReason</key>
+				<string>Unable to validate your application.</string>
+			</dict>
+		</dict>
+	</array>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>

--- a/pkg/packagekit/applenotarization/testdata/info.xml
+++ b/pkg/packagekit/applenotarization/testdata/info.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>notarization-info</key>
+	<dict>
+		<key>Date</key>
+		<date>2019-10-04T22:05:48Z</date>
+		<key>LogFileURL</key>
+		<string>https://osxapps-ssl.itunes.apple.com/itunes-assets/Enigma113/v4/5a/20/75/11111111-1111-1111-1111-111111111111/developer_log.json?accessKey=REDACTEDLONGSTRING%3D</string>
+		<key>RequestUUID</key>
+		<string>11111111-2222-3333-4444-f4b2a99e443a</string>
+		<key>Status</key>
+		<string>success</string>
+		<key>Status Code</key>
+		<integer>0</integer>
+		<key>Status Message</key>
+		<string>Package Approved</string>
+	</dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>success-message</key>
+	<string>No errors getting notarization info.</string>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>

--- a/pkg/packagekit/applenotarization/testdata/infobad.xml
+++ b/pkg/packagekit/applenotarization/testdata/infobad.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>product-errors</key>
+	<array>
+		<dict>
+			<key>code</key>
+			<integer>1519</integer>
+			<key>message</key>
+			<string>Could not find the RequestUUID.</string>
+			<key>userInfo</key>
+			<dict>
+				<key>NSLocalizedDescription</key>
+				<string>Could not find the RequestUUID.</string>
+				<key>NSLocalizedFailureReason</key>
+				<string>Apple Services operation failed.</string>
+				<key>NSLocalizedRecoverySuggestion</key>
+				<string>Could not find the RequestUUID.</string>
+			</dict>
+		</dict>
+	</array>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>

--- a/pkg/packagekit/applenotarization/testdata/infoinprogress.xml
+++ b/pkg/packagekit/applenotarization/testdata/infoinprogress.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>notarization-info</key>
+	<dict>
+		<key>Date</key>
+		<date>2019-10-07T17:49:32Z</date>
+		<key>RequestUUID</key>
+		<string>77777777-1111-4444-aaaa-111111111111</string>
+		<key>Status</key>
+		<string>in progress</string>
+	</dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>success-message</key>
+	<string>No errors getting notarization info.</string>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>
+

--- a/pkg/packagekit/applenotarization/testdata/submit.xml
+++ b/pkg/packagekit/applenotarization/testdata/submit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>notarization-upload</key>
+	<dict>
+		<key>RequestUUID</key>
+		<string>11111111-aaaa-4444-aaaa-bbbbbbbbbbbb</string>
+	</dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>success-message</key>
+	<string>No errors uploading '/tmp/file.zip'.</string>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>
+

--- a/pkg/packagekit/applenotarization/testdata/submitduplicate.xml
+++ b/pkg/packagekit/applenotarization/testdata/submitduplicate.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>os-version</key>
+	<string>10.14.6</string>
+	<key>product-errors</key>
+	<array>
+		<dict>
+			<key>code</key>
+			<integer>-18000</integer>
+			<key>message</key>
+			<string>ERROR ITMS-90732: "The software asset has already been uploaded. The upload ID is 22222222-dddd-4444-4444-cccccccccccc" at SoftwareAssets/EnigmaSoftwareAsset</string>
+			<key>userInfo</key>
+			<dict>
+				<key>NSLocalizedDescription</key>
+				<string>ERROR ITMS-90732: "The software asset has already been uploaded. The upload ID is 22222222-dddd-4444-4444-cccccccccccc" at SoftwareAssets/EnigmaSoftwareAsset</string>
+				<key>NSLocalizedFailureReason</key>
+				<string>ERROR ITMS-90732: "The software asset has already been uploaded. The upload ID is 22222222-dddd-4444-4444-cccccccccccc" at SoftwareAssets/EnigmaSoftwareAsset</string>
+				<key>NSLocalizedRecoverySuggestion</key>
+				<string>ERROR ITMS-90732: "The software asset has already been uploaded. The upload ID is 22222222-dddd-4444-4444-cccccccccccc" at SoftwareAssets/EnigmaSoftwareAsset</string>
+			</dict>
+		</dict>
+	</array>
+	<key>tool-path</key>
+	<string>/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework</string>
+	<key>tool-version</key>
+	<string>1.1.1138</string>
+</dict>
+</plist>
+

--- a/pkg/packagekit/applenotarization/types.go
+++ b/pkg/packagekit/applenotarization/types.go
@@ -1,0 +1,29 @@
+package applenotarization
+
+import "time"
+
+// notarizationResponse is the response from altool. It probably only
+// have NotarizationInfo or NotarizationUpload populated.
+type notarizationResponse struct {
+	ProductErrors      []productError   `plist:"product-errors"`
+	NotarizationInfo   notarizationInfo `plist:"notarization-info"`
+	NotarizationUpload notarizationInfo `plist:"notarization-upload"`
+}
+
+type notarizationInfo struct {
+	Date          time.Time `plist:"Date"`
+	LogFileURL    string    `plist:"LogFileURL"`
+	RequestUUID   string    `plist:"RequestUUID"`
+	Status        string    `plist:"Status"`
+	StatusCode    int       `plist:"Status Code"`
+	StatusMessage string    `plist:"Status Message"`
+}
+
+type notarizationUpload struct {
+	ProductErrors []productError `plist:"product-errors"`
+}
+
+type productError struct {
+	Code    int    `plist:"code"`
+	Message string `plist:"message"`
+}

--- a/pkg/packagekit/context.go
+++ b/pkg/packagekit/context.go
@@ -18,15 +18,15 @@ const (
 // for data smuggling. Not the simplest way to move data around, but
 // it allows us not to adjust all the returns.
 func InitContext(ctx context.Context) context.Context {
-	var strPointer *string
-	s := ""
-	strPointer = &s
-
 	for _, key := range []contextKey{
 		ContextNotarizationUuidKey,
 		ContextLauncherVersionKey,
 		ContextOsqueryVersionKey,
 	} {
+		var strPointer *string
+		s := ""
+		strPointer = &s
+
 		ctx = context.WithValue(ctx, key, strPointer)
 	}
 

--- a/pkg/packagekit/context.go
+++ b/pkg/packagekit/context.go
@@ -1,0 +1,52 @@
+package packagekit
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+type contextKey int
+
+const (
+	ContextNotarizationUuidKey contextKey = iota
+	ContextLauncherVersionKey
+	ContextOsqueryVersionKey
+)
+
+// InitContext adds several pointers to the context to allow
+// for data smuggling. Not the simplest way to move data around, but
+// it allows us not to adjust all the returns.
+func InitContext(ctx context.Context) context.Context {
+	var strPointer *string
+	s := ""
+	strPointer = &s
+
+	for _, key := range []contextKey{
+		ContextNotarizationUuidKey,
+		ContextLauncherVersionKey,
+		ContextOsqueryVersionKey,
+	} {
+		ctx = context.WithValue(ctx, key, strPointer)
+	}
+
+	return ctx
+}
+
+func setInContext(ctx context.Context, key contextKey, val string) {
+	// If there's no pointer, then there's no point in setting
+	// this. It won't get back to the caller.
+	ptr, ok := ctx.Value(key).(*string)
+	if !ok || ptr == nil {
+		return
+	}
+	*ptr = val
+}
+
+func GetFromContext(ctx context.Context, key contextKey) (string, error) {
+	ptr, ok := ctx.Value(key).(*string)
+	if !ok {
+		return "", errors.New("Context didn't have a string pointer")
+	}
+	return *ptr, nil
+}

--- a/pkg/packagekit/context_test.go
+++ b/pkg/packagekit/context_test.go
@@ -1,0 +1,68 @@
+package packagekit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kolide/kit/ulid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextError(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetFromContext(context.Background(), ContextNotarizationUuidKey)
+	require.Error(t, err)
+}
+
+func TestContextBlanks(t *testing.T) {
+	t.Parallel()
+
+	ctx := InitContext(context.Background())
+
+	actual, err := GetFromContext(ctx, ContextNotarizationUuidKey)
+	require.NoError(t, err)
+	require.Empty(t, actual)
+
+}
+
+func TestContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := InitContext(context.Background())
+
+	var contextPairs = []struct {
+		name string
+		key  contextKey
+		val  string
+	}{
+		{
+			name: "notarization uuid",
+			key:  ContextNotarizationUuidKey,
+			val:  ulid.New(),
+		},
+		{
+			name: "launcher version",
+			key:  ContextLauncherVersionKey,
+			val:  ulid.New(),
+		},
+		{
+			name: "osquery version",
+			key:  ContextOsqueryVersionKey,
+			val:  ulid.New(),
+		},
+	}
+
+	for _, pair := range contextPairs {
+		setInContext(ctx, pair.key, pair.val)
+	}
+
+	for _, pair := range contextPairs {
+		t.Run(pair.name, func(t *testing.T) {
+			actual, err := GetFromContext(ctx, pair.key)
+			require.NoError(t, err)
+			require.Equal(t, pair.val, actual)
+		})
+	}
+
+}

--- a/pkg/packagekit/package.go
+++ b/pkg/packagekit/package.go
@@ -12,9 +12,12 @@ type PackageOptions struct {
 
 	DisableService bool // Whether to install a system service in a disabled state
 
-	AppleSigningKey     string   // apple signing key
-	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
-	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key
+	AppleNotarizeAccountId   string   // The 10 character apple account id
+	AppleNotarizeAppPassword string   // app password for notarization service
+	AppleNotarizeUserId      string   // User id to authenticate to the notarization service with
+	AppleSigningKey          string   // apple signing key
+	WindowsSigntoolArgs      []string // Extra args for signtool. May be needed for finding a key
+	WindowsUseSigntool       bool     // whether to use signtool.exe on windows
 
 	WixPath        string // path to wix installation
 	WixUI          bool   //include the wix ui or not

--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -166,5 +166,7 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 		return errors.Wrap(err, "copying output")
 	}
 
+	setInContext(ctx, ContextLauncherVersionKey, po.Version)
+
 	return nil
 }

--- a/pkg/packagekit/package_pkg.go
+++ b/pkg/packagekit/package_pkg.go
@@ -13,8 +13,15 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/kolide/launcher/pkg/packagekit/applenotarization"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+)
+
+type contextKey int
+
+const (
+	ContextNotarizationUuidKey contextKey = iota
 )
 
 func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
@@ -42,6 +49,10 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
 		return errors.Wrap(err, "running productbuild")
 	}
 
+	if err := runNotarize(ctx, distributionPkgPath, po); err != nil {
+		return errors.Wrap(err, "running notarize")
+	}
+
 	outputFH, err := os.Open(distributionPkgPath)
 	if err != nil {
 		return errors.Wrap(err, "opening resultant output file")
@@ -51,6 +62,61 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
 	if _, err := io.Copy(w, outputFH); err != nil {
 		return errors.Wrap(err, "copying output")
 	}
+
+	return nil
+}
+
+func InitContextForNotarizationUuid(ctx context.Context) context.Context {
+	var strPointer *string
+	s := ""
+	strPointer = &s
+
+	return context.WithValue(ctx, ContextNotarizationUuidKey, strPointer)
+}
+
+func setNotarizationUuidInContext(ctx context.Context, uuid string) {
+	ptr, ok := ctx.Value(ContextNotarizationUuidKey).(*string)
+	if !ok || ptr == nil {
+		return
+	}
+	*ptr = uuid
+}
+
+func GetNotarizationUuidFromContext(ctx context.Context) (string, error) {
+	ptr, ok := ctx.Value(ContextNotarizationUuidKey).(*string)
+	if !ok {
+		return "", errors.New("Wasn't a string pointer")
+	}
+	return *ptr, nil
+}
+
+// runNotarize takes a given input, and notarizes it
+func runNotarize(ctx context.Context, file string, po *PackageOptions) error {
+	if po.AppleNotarizeUserId == "" || po.AppleNotarizeAppPassword == "" {
+		return nil
+	}
+
+	ctx, span := trace.StartSpan(ctx, "packagekit.runNotarize")
+	defer span.End()
+
+	logger := log.With(ctxlog.FromContext(ctx), "method", "packagekit.runNotarize")
+
+	bundleid := fmt.Sprintf("com.%s.launcher", po.Identifier)
+	notarizer := applenotarization.New(po.AppleNotarizeUserId, po.AppleNotarizeAppPassword, po.AppleNotarizeAccountId)
+	uuid, err := notarizer.Submit(ctx, file, bundleid)
+	if err != nil {
+		return errors.Wrap(err, "submitting file for notarization")
+	}
+
+	level.Debug(logger).Log(
+		"msg", "Got uuid",
+		"uuid", uuid,
+	)
+
+	// Passing data back through a pointer in context is kind of
+	// abhorrent. But, I'm not sure there's a simple way short of
+	// refactoring everything. So, here we are.
+	setNotarizationUuidInContext(ctx, uuid)
 
 	return nil
 }

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -162,6 +162,8 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 		return errors.Wrap(err, "copying output")
 	}
 
+	setInContext(ctx, ContextLauncherVersionKey, po.Version)
+
 	return nil
 }
 

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -57,9 +57,12 @@ type PackageOptions struct {
 	WixSkipCleanup    bool
 	DisableService    bool
 
-	AppleSigningKey     string   // apple signing key
-	WindowsUseSigntool  bool     // whether to use signtool.exe on windows
-	WindowsSigntoolArgs []string // Extra args for signtool. May be needed for finding a key
+	AppleNotarizeAccountId   string   // The 10 character apple account id
+	AppleNotarizeAppPassword string   // app password for notarization service
+	AppleNotarizeUserId      string   // User id to authenticate to the notarization service with
+	AppleSigningKey          string   // apple signing key
+	WindowsSigntoolArgs      []string // Extra args for signtool. May be needed for finding a key
+	WindowsUseSigntool       bool     // whether to use signtool.exe on windows
 
 	target        Target                     // Target build platform
 	initOptions   *packagekit.InitOptions    // options we'll pass to the packagekit renderers
@@ -284,19 +287,22 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 	}
 
 	p.packagekitops = &packagekit.PackageOptions{
-		Name:                "launcher",
-		Identifier:          p.Identifier,
-		Root:                p.packageRoot,
-		Scripts:             p.scriptRoot,
-		AppleSigningKey:     p.AppleSigningKey,
-		WindowsUseSigntool:  p.WindowsUseSigntool,
-		WindowsSigntoolArgs: p.WindowsSigntoolArgs,
-		Version:             p.PackageVersion,
-		FlagFile:            p.canonicalizePath(flagFilePath),
-		WixPath:             p.WixPath,
-		WixUI:               p.MSIUI,
-		WixSkipCleanup:      p.WixSkipCleanup,
-		DisableService:      p.DisableService,
+		Name:                     "launcher",
+		Identifier:               p.Identifier,
+		Root:                     p.packageRoot,
+		Scripts:                  p.scriptRoot,
+		AppleNotarizeAccountId:   p.AppleNotarizeAccountId,
+		AppleNotarizeAppPassword: p.AppleNotarizeAppPassword,
+		AppleNotarizeUserId:      p.AppleNotarizeUserId,
+		AppleSigningKey:          p.AppleSigningKey,
+		WindowsUseSigntool:       p.WindowsUseSigntool,
+		WindowsSigntoolArgs:      p.WindowsSigntoolArgs,
+		Version:                  p.PackageVersion,
+		FlagFile:                 p.canonicalizePath(flagFilePath),
+		WixPath:                  p.WixPath,
+		WixUI:                    p.MSIUI,
+		WixSkipCleanup:           p.WixSkipCleanup,
+		DisableService:           p.DisableService,
 	}
 
 	if err := p.makePackage(ctx); err != nil {


### PR DESCRIPTION
Add the apple notarization tools to launcher's packagekit. This open sources the backend end I've been using for notarization. Note that this is only a library, it is not plumbed through these command line tools.

This also adds some variable smuggling to context, as a way to pass data around during the notarization process.