### PR TITLE
Disable macOS version compatible strings

### DIFF
--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -182,6 +182,14 @@ func (opts *osqueryOptions) createOsquerydCommand(osquerydBinary string, paths *
 		fmt.Sprintf("--config_plugin=%s", opts.configPluginFlag),
 	)
 
+	// On darwin, run osquery using a magic macOS variable to ensure we
+	// get proper versions strings back. I'm not totally sure why apple
+	// did this, but reading SystemVersion.plist is different when this is set.
+	// See:
+	// https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
+	// https://github.com/osquery/osquery/pull/6824
+	cmd.Env = append(cmd.Env, "SYSTEM_VERSION_COMPAT=0")
+
 	return cmd, nil
 }
 


### PR DESCRIPTION
For reasons unknown, apple changes the content of `SystemVersion.plist`
based on the environment variables set in the caller.

Empiracally, it looks like the 10.16 nomenclature is dropping the .x.
So, force versions to use the 11.x.x format.

See:
 * https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
 * https://github.com/osquery/osquery/pull/6824