### PR TITLE
Go Version changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build_%: ARCHARG = $(if $(ARCH), --arch $(ARCH))
 build_%: GOARG = $(if $(CROSSGOPATH), --go $(CROSSGOPATH))
 build_%: GOBUILD = $(if $(CROSSGOPATH), $(CROSSGOPATH), go)
 build_%: .pre-build
-	go run cmd/make/make.go -targets=$(TARGET) -linkstamp $(OSARG) $(ARCHARG) $(GOARG)
+	$(GOBUILD) run cmd/make/make.go -targets=$(TARGET) -linkstamp $(OSARG) $(ARCHARG) $(GOARG)
 
 fake_%: TARGET =  $(word 2, $(subst _, ,$@))
 fake_%: OS = $(word 3, $(subst _, ,$@))

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ build_%: OSARG = $(if $(OS), --os $(OS))
 build_%: ARCH = $(word 4, $(subst _, ,$@))
 build_%: ARCHARG = $(if $(ARCH), --arch $(ARCH))
 build_%: GOARG = $(if $(CROSSGOPATH), --go $(CROSSGOPATH))
+build_%: GOBUILD = $(if $(CROSSGOPATH), $(CROSSGOPATH), go)
 build_%: .pre-build
 	go run cmd/make/make.go -targets=$(TARGET) -linkstamp $(OSARG) $(ARCHARG) $(GOARG)
 

--- a/pkg/osquery/table/launcher_info.go
+++ b/pkg/osquery/table/launcher_info.go
@@ -10,14 +10,14 @@ import (
 
 func LauncherInfoTable() *table.Plugin {
 	columns := []table.ColumnDefinition{
-		table.TextColumn("version"),
-		table.TextColumn("go_version"),
 		table.TextColumn("branch"),
-		table.TextColumn("revision"),
 		table.TextColumn("build_date"),
 		table.TextColumn("build_user"),
-		table.TextColumn("goos"),
+		table.TextColumn("go_version"),
 		table.TextColumn("goarch"),
+		table.TextColumn("goos"),
+		table.TextColumn("revision"),
+		table.TextColumn("version"),
 	}
 	return table.NewPlugin("kolide_launcher_info", columns, generateLauncherInfoTable())
 }
@@ -26,14 +26,14 @@ func generateLauncherInfoTable() table.GenerateFunc {
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 		results := []map[string]string{
 			map[string]string{
-				"version":    version.Version().Version,
-				"go_version": version.Version().GoVersion,
 				"branch":     version.Version().Branch,
-				"revision":   version.Version().Revision,
 				"build_date": version.Version().BuildDate,
 				"build_user": version.Version().BuildUser,
-				"goos":       runtime.GOOS,
+				"go_version": runtime.Version(),
 				"goarch":     runtime.GOARCH,
+				"goos":       runtime.GOOS,
+				"revision":   version.Version().Revision,
+				"version":    version.Version().Version,
 			},
 		}
 


### PR DESCRIPTION
Move the reporting of the go version in `launcher_info` to being based on runtime. As go is static, I'm not sure what this was meant to do.

Update the Makefile's build targets to use the CROSSGO, if set, to run the build. This is not strictly needed, but should make some of the build encoded things more correct.