### PR TITLE
Correct macOS check in kolide_macos_software_update

### DIFF
--- a/pkg/osquery/table/sus_darwin.go
+++ b/pkg/osquery/table/sus_darwin.go
@@ -42,7 +42,7 @@ void softwareUpdate(
 		*doesAppStoreAutoUpdates = 1;
 	}
 
-	// before 10.13 (build ver 17 (build ver 18) it's called doesMacOSAutoUpdate.
+	// before 10.13 (build ver 17) it's called doesMacOSAutoUpdate.
 	if (os_version >= 18) {
 		val = [manager doesMacOSAutoUpdate];
 		if (val) {


### PR DESCRIPTION
This PR corrects the version check in the CGO of the software update table. The previous version relied on the old version scheme for macOS (ex: 10.15, 10.16) and failed when os_version reported something like "11.1" for Big Sur.

We now use a more robust method which is to look at the first two digits of the build number.