### PR TITLE
Add a startup delay to the autoupdater,  to avoid interfering with critical work

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -182,6 +182,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			MirrorURL:          opts.MirrorServerURL,
 			NotaryPrefix:       opts.NotaryPrefix,
 			HTTPClient:         httpClient,
+			InitialDelay:       1 * time.Hour,
 			SigChannel:         sigChannel,
 		}
 

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -182,7 +182,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			MirrorURL:          opts.MirrorServerURL,
 			NotaryPrefix:       opts.NotaryPrefix,
 			HTTPClient:         httpClient,
-			InitialDelay:       1 * time.Hour,
+			InitialDelay:       opts.AutoupdateInitialDelay,
 			SigChannel:         sigChannel,
 		}
 

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -62,12 +62,13 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		_                  = flagset.String("config", "", "config file to parse options from (optional)")
 
 		// Autoupdate options
-		flAutoupdate         = flagset.Bool("autoupdate", false, "Whether or not the osquery autoupdater is enabled (default: false)")
-		flNotaryServerURL    = flagset.String("notary_url", autoupdate.DefaultNotary, "The Notary update server (default: https://notary.kolide.co)")
-		flMirrorURL          = flagset.String("mirror_url", autoupdate.DefaultMirror, "The mirror server for autoupdates (default: https://dl.kolide.co)")
-		flAutoupdateInterval = flagset.Duration("autoupdate_interval", 1*time.Hour, "The interval to check for updates (default: once every hour)")
-		flUpdateChannel      = flagset.String("update_channel", "stable", "The channel to pull updates from (options: stable, beta, nightly)")
-		flNotaryPrefix       = flagset.String("notary_prefix", autoupdate.DefaultNotaryPrefix, "The prefix for Notary path that contains the collections (default: kolide/)")
+		flAutoupdate             = flagset.Bool("autoupdate", false, "Whether or not the osquery autoupdater is enabled (default: false)")
+		flNotaryServerURL        = flagset.String("notary_url", autoupdate.DefaultNotary, "The Notary update server (default: https://notary.kolide.co)")
+		flMirrorURL              = flagset.String("mirror_url", autoupdate.DefaultMirror, "The mirror server for autoupdates (default: https://dl.kolide.co)")
+		flAutoupdateInterval     = flagset.Duration("autoupdate_interval", 1*time.Hour, "The interval to check for updates (default: once every hour)")
+		flUpdateChannel          = flagset.String("update_channel", "stable", "The channel to pull updates from (options: stable, beta, nightly)")
+		flNotaryPrefix           = flagset.String("notary_prefix", autoupdate.DefaultNotaryPrefix, "The prefix for Notary path that contains the collections (default: kolide/)")
+		flAutoupdateInitialDelay = flagset.Duration("autoupdater_initial_delay", 1*time.Hour, "Initial autoupdater subprocess delay")
 
 		// Development options
 		flDebug             = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
@@ -147,31 +148,32 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	}
 
 	opts := &launcher.Options{
-		Autoupdate:          *flAutoupdate,
-		AutoupdateInterval:  *flAutoupdateInterval,
-		CertPins:            certPins,
-		Control:             *flControl,
-		ControlServerURL:    *flControlServerURL,
-		Debug:               *flDebug,
-		DebugLogFile:        *flDebugLogFile,
-		DisableControlTLS:   *flDisableControlTLS,
-		EnableInitialRunner: *flInitialRunner,
-		EnrollSecret:        *flEnrollSecret,
-		EnrollSecretPath:    *flEnrollSecretPath,
-		InsecureTLS:         *flInsecureTLS,
-		InsecureTransport:   *flInsecureTransport,
-		KolideServerURL:     *flKolideServerURL,
-		LoggingInterval:     *flLoggingInterval,
-		MirrorServerURL:     *flMirrorURL,
-		NotaryPrefix:        *flNotaryPrefix,
-		NotaryServerURL:     *flNotaryServerURL,
-		OsqueryFlags:        flOsqueryFlags,
-		OsqueryVerbose:      *flOsqueryVerbose,
-		OsquerydPath:        osquerydPath,
-		RootDirectory:       *flRootDirectory,
-		RootPEM:             *flRootPEM,
-		Transport:           *flTransport,
-		UpdateChannel:       updateChannel,
+		Autoupdate:             *flAutoupdate,
+		AutoupdateInterval:     *flAutoupdateInterval,
+		AutoupdateInitialDelay: *flAutoupdateInitialDelay,
+		CertPins:               certPins,
+		Control:                *flControl,
+		ControlServerURL:       *flControlServerURL,
+		Debug:                  *flDebug,
+		DebugLogFile:           *flDebugLogFile,
+		DisableControlTLS:      *flDisableControlTLS,
+		EnableInitialRunner:    *flInitialRunner,
+		EnrollSecret:           *flEnrollSecret,
+		EnrollSecretPath:       *flEnrollSecretPath,
+		InsecureTLS:            *flInsecureTLS,
+		InsecureTransport:      *flInsecureTransport,
+		KolideServerURL:        *flKolideServerURL,
+		LoggingInterval:        *flLoggingInterval,
+		MirrorServerURL:        *flMirrorURL,
+		NotaryPrefix:           *flNotaryPrefix,
+		NotaryServerURL:        *flNotaryServerURL,
+		OsqueryFlags:           flOsqueryFlags,
+		OsqueryVerbose:         *flOsqueryVerbose,
+		OsquerydPath:           osquerydPath,
+		RootDirectory:          *flRootDirectory,
+		RootPEM:                *flRootPEM,
+		Transport:              *flTransport,
+		UpdateChannel:          updateChannel,
 	}
 	return opts, nil
 }

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -102,16 +102,17 @@ func getArgsAndResponse() (map[string]string, *launcher.Options) {
 	}
 
 	opts := &launcher.Options{
-		Control:            true,
-		OsquerydPath:       windowsAddExe("/dev/null"),
-		KolideServerURL:    randomHostname,
-		LoggingInterval:    time.Duration(randomInt) * time.Second,
-		AutoupdateInterval: 48 * time.Hour,
-		NotaryServerURL:    "https://notary.kolide.co",
-		MirrorServerURL:    "https://dl.kolide.co",
-		NotaryPrefix:       "kolide",
-		UpdateChannel:      "stable",
-		Transport:          "grpc",
+		Control:                true,
+		OsquerydPath:           windowsAddExe("/dev/null"),
+		KolideServerURL:        randomHostname,
+		LoggingInterval:        time.Duration(randomInt) * time.Second,
+		AutoupdateInterval:     48 * time.Hour,
+		AutoupdateInitialDelay: 1 * time.Hour,
+		NotaryServerURL:        "https://notary.kolide.co",
+		MirrorServerURL:        "https://dl.kolide.co",
+		NotaryPrefix:           "kolide",
+		UpdateChannel:          "stable",
+		Transport:              "grpc",
 	}
 
 	return args, opts

--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -21,6 +21,7 @@ type updaterConfig struct {
 	RootDirectory      string // launcher's root dir. use for holding tuf staging and updates
 	AutoupdateInterval time.Duration
 	UpdateChannel      autoupdate.UpdateChannel
+	InitialDelay       time.Duration // start delay, to avoid whomping critical early data
 
 	NotaryURL    string
 	MirrorURL    string
@@ -64,6 +65,15 @@ func createUpdater(
 
 	return &actor.Actor{
 		Execute: func() error {
+			// When launcher first starts, we'd like the
+			// Saas side to start recieving data
+			// immediately. But, if updater is trying to
+			// run, this creates an awkward pause for restart.
+			// So, delay starting updates by an hour or two.
+			if config.InitialDelay != 0 {
+				time.Sleep(config.InitialDelay)
+			}
+
 			// Failing to start the updater is not a fatal launcher
 			// error. If there's a problem, sleep and try
 			// again. Implementing this is a bit gnarly. In the event of a

--- a/cmd/launcher/updater.go
+++ b/cmd/launcher/updater.go
@@ -66,7 +66,7 @@ func createUpdater(
 	return &actor.Actor{
 		Execute: func() error {
 			// When launcher first starts, we'd like the
-			// Saas side to start recieving data
+			// server to start receiving data
 			// immediately. But, if updater is trying to
 			// run, this creates an awkward pause for restart.
 			// So, delay starting updates by an hour or two.

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -54,6 +54,8 @@ type Options struct {
 	UpdateChannel autoupdate.UpdateChannel
 	// NotaryPrefix is the path prefix used to store launcher and osqueryd binaries on the Notary server
 	NotaryPrefix string
+	// AutoupdateInitialDelay set an initial startup delay on the autoupdater process.
+	AutoupdateInitialDelay time.Duration
 
 	// Debug enables debug logging.
 	Debug bool


### PR DESCRIPTION
When launcher first enrolls with a server, it often begins fetching key data.  However, the autoupdater _also_ starts. And if there's a pending update, this has the effect of pre-empting that early data. 

This introduces a simple option to delay the autoupdater to allow key data to come in first. This option defaults to an hour.