### PR TITLE
Move plist table to being universal

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -46,7 +46,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		filevault.TablePlugin(client, logger),
 		mdmclient.TablePlugin(client, logger),
 		legacyexec.TablePlugin(),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_apfs_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "list", "-plist"}),
 		dataflattentable.TablePluginExec(client, logger,

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -36,6 +36,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		dataflattentable.TablePlugin(client, logger, dataflattentable.JsonType),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.XmlType),
 		dataflattentable.TablePlugin(client, logger, dataflattentable.IniType),
+		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_info", dataflattentable.JsonType, zerotierCli("info")),
 		dataflattentable.TablePluginExec(client, logger,


### PR DESCRIPTION
While plist is predominantly a macOS thing, there's no reason the table needs that limitation.