### PR TITLE
Simple fc-list table

### DIFF
--- a/pkg/osquery/table/fc-list.go
+++ b/pkg/osquery/table/fc-list.go
@@ -1,0 +1,26 @@
+package table
+
+import "os"
+
+var fcArgs = []string{
+	"--format",
+	"file: %{file}\nfamily: %{family}\nstyle:%{style}\n",
+}
+
+var fcPossiblePaths = []string{
+	"/Xusr/local/bin/fc-list",
+	"/Xusr/bin/fc-list",
+}
+
+// findFcList finds the local fc-list binary. No errors, since we're
+// trying to run this in the TablePlugin create call.
+func fcListCli() []string {
+	for _, b := range fcPossiblePaths {
+		if stat, err := os.Stat(b); err == nil && stat.Mode().IsRegular() {
+			return append([]string{b}, fcArgs...)
+		}
+	}
+
+	// default to returning nothing
+	return nil
+}

--- a/pkg/osquery/table/fc-list.go
+++ b/pkg/osquery/table/fc-list.go
@@ -8,8 +8,8 @@ var fcArgs = []string{
 }
 
 var fcPossiblePaths = []string{
-	"/Xusr/local/bin/fc-list",
-	"/Xusr/bin/fc-list",
+	"/usr/local/bin/fc-list",
+	"/usr/bin/fc-list",
 }
 
 // findFcList finds the local fc-list binary. No errors, since we're

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -45,6 +45,15 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 			"kolide_zerotier_peers", dataflattentable.JsonType, zerotierCli("listpeers")),
 	}
 
+	if fcargs := fcListCli(); fcargs != nil {
+		dataflattentable.TablePluginExec(client, logger,
+			"kolide_fclist",
+			dataflattentable.KeyValueType,
+			fcargs,
+			dataflattentable.WithKVSeparator(":"),
+		)
+	}
+
 	// add in the platform specific ones (as denoted by build tags)
 	tables = append(tables, platformTables(client, logger, currentOsquerydBinaryPath)...)
 


### PR DESCRIPTION
Only installs if there binary is present. This may not be correct. Possible better would be to return no rows if not present.

`fc-list` is low value. I think without a better answer for the missing binary case, I don't want to merge this. But we might pick this up later.

Fixes: #685