### PR TITLE
Add macOS preinstall script to install rosetta2

### DIFF
--- a/pkg/packaging/internal/assets/preinstall-darwin.sh
+++ b/pkg/packaging/internal/assets/preinstall-darwin.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# As of the Big Sur general release, Apple M1 machines no longer ship
+# Rosetta 2. Instead, this must be installed manually. As osquery does
+# not yet ship a universal binary, launcher requires rosetta2.
+#
+# During an interactive install, the user is prompted to okay a
+# rosetta2 install, but this does not appear to happen during an MDM
+# install. So, we need to trigger than from a preinstall script.
+
+# If we're not Big Sur (build 20x), exit
+if [[ "$(/usr/bin/sw_vers -buildVersion)" != 20* ]]; then
+    exit 0
+fi
+
+# If we're not arm, exit
+if [ "$(/usr/bin/arch)" != "arm64" ]; then
+    exit 0
+fi
+
+# If it's already installed, exit.  If this check misfires, we'll
+# invoke software update an extra time, which should be okay.
+if [[ -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
+    exit 0
+fi
+
+# report errors
+set -e
+
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -278,6 +278,10 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 		return errors.Wrapf(err, "setup init script for %s", p.target.String())
 	}
 
+	if err := p.setupPreinst(ctx); err != nil {
+		return errors.Wrapf(err, "setup preinst for %s", p.target.String())
+	}
+
 	if err := p.setupPostinst(ctx); err != nil {
 		return errors.Wrapf(err, "setup postInst for %s", p.target.String())
 	}
@@ -587,6 +591,22 @@ func (p *PackageOptions) setupPrerm(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (p *PackageOptions) setupPreinst(ctx context.Context) error {
+	if p.target.Platform != Darwin {
+		return nil
+	}
+
+	preinstallContent, err := internal.Asset("internal/assets/preinstall-darwin.sh")
+	if err != nil {
+		return errors.Wrap(err, "getting template for preinstall")
+	}
+
+	return errors.Wrap(
+		ioutil.WriteFile(filepath.Join(p.scriptRoot, "preinstall"), preinstallContent, 0755),
+		"writing preinstall file",
+	)
 }
 
 func (p *PackageOptions) setupPostinst(ctx context.Context) error {


### PR DESCRIPTION
As of the Big Sur general release, Apple M1 machines no longer ship
Rosetta 2. Instead, this must be installed manually. As osquery does
not yet ship a universal binary, launcher requires rosetta2.

During an interactive install, the user is prompted to okay a
rosetta2 install, but this does not appear to happen during an MDM
install. So, we need to trigger than from a preinstall script.

For internet discussion see:
- https://www.alansiu.net/2020/12/02/installing-rosetta-2-on-m1-apple-silicon-macs/
- https://derflounder.wordpress.com/2020/11/17/installing-rosetta-2-on-apple-silicon-macs/
- https://grahamgilbert.com/blog/2020/11/13/installing-rosetta-2-on-apple-silicon-macs/