### PR TITLE
Allow slightly larger logs

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -52,6 +52,13 @@ func createExtensionRuntime(ctx context.Context, db *bolt.DB, launcherClient ser
 		RunDifferentialQueriesImmediately: opts.EnableInitialRunner,
 	}
 
+	// We have a MaxBytesPerBatch set low enough to support GRPC's
+	// hardcoded 4mb limit. We don't need that for jsonrpc, so
+	// bump it up to 10 MB
+	if opts.Transport == "jsonrpc" {
+		extOpts.MaxBytesPerBatch = 10 << 20
+	}
+
 	// create the extension
 	ext, err := osquery.NewExtension(launcherClient, db, extOpts)
 	if err != nil {

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -76,10 +76,10 @@ const (
 	configKey = "config"
 
 	// Default maximum number of bytes per batch (used if not specified in
-	// options). This 2MB limit is chosen based on the default grpc-go
+	// options). This 3MB limit is chosen based on the default grpc-go
 	// limit specified in https://github.com/grpc/grpc-go/blob/master/server.go#L51
-	// which is 4MB. We use 2MB to be conservative.
-	defaultMaxBytesPerBatch = 2 << 20
+	// which is 4MB. We use 3MB to be conservative.
+	defaultMaxBytesPerBatch = 3 << 20
 	// Default logging interval (used if not specified in
 	// options)
 	defaultLoggingInterval = 60 * time.Second
@@ -549,6 +549,7 @@ func (e *Extension) writeBufferedLogsForType(typ logger.LogType) error {
 					"msg", "dropped log",
 					"size", len(v),
 					"limit", e.Opts.MaxBytesPerBatch,
+					"header", string(v)[0:100],
 				)
 			} else if totalBytes+len(v) > e.Opts.MaxBytesPerBatch {
 				// Buffer is filled

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -545,11 +545,12 @@ func (e *Extension) writeBufferedLogsForType(typ logger.LogType) error {
 		for totalBytes := 0; k != nil; {
 			if len(v) > e.Opts.MaxBytesPerBatch {
 				// Discard logs that are too big
+				logheadSize := minInt(len(v), 100)
 				level.Info(e.Opts.Logger).Log(
 					"msg", "dropped log",
 					"size", len(v),
 					"limit", e.Opts.MaxBytesPerBatch,
-					"loghead", string(v)[0:100],
+					"loghead", string(v)[0:logheadSize],
 				)
 			} else if totalBytes+len(v) > e.Opts.MaxBytesPerBatch {
 				// Buffer is filled
@@ -977,4 +978,12 @@ func (i *initialRunner) cacheRanQueries(known map[string]struct{}) error {
 		return nil
 	})
 	return errors.Wrap(err, "caching known initial result queries")
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
 }

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -549,7 +549,7 @@ func (e *Extension) writeBufferedLogsForType(typ logger.LogType) error {
 					"msg", "dropped log",
 					"size", len(v),
 					"limit", e.Opts.MaxBytesPerBatch,
-					"header", string(v)[0:100],
+					"loghead", string(v)[0:100],
 				)
 			} else if totalBytes+len(v) > e.Opts.MaxBytesPerBatch {
 				// Buffer is filled


### PR DESCRIPTION
Because grpc has a 4mb limit, we've usually used a 2mb log limit. This
raises that to 3mb, and includes a log snippet when logging about it
being too large.