### PR TITLE
Auto Repair the local TUF repo

### DIFF
--- a/pkg/autoupdate/mocklogger_test.go
+++ b/pkg/autoupdate/mocklogger_test.go
@@ -1,0 +1,25 @@
+package autoupdate
+
+import (
+	"sync"
+)
+
+type mockLogger struct {
+	count int
+	mx    sync.Mutex
+}
+
+func (l *mockLogger) Log(keyvals ...interface{}) error {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+
+	l.count = l.count + 1
+	return nil
+}
+
+func (l *mockLogger) Count() int {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+
+	return l.count
+}


### PR DESCRIPTION
We've seen the local TUF repo get corrupt. This adds some simple local repairs when that happens.

I've seen the TUF repo get corrupt. The cases I've seen are benign, and I believe due to some error handling in the [updater](https://github.com/kolide/updater). I think it's reasonable to detect and repair these. First, we're replacing the bad local copy with an expected good one from the compiled assets. Second, what else do we expect to happen?

Testing this on my machine, it does recover from these states. 