### PR TITLE
Increase timeout for powershell wlanapi execution

### DIFF
--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -121,7 +121,7 @@ func execPwsh(logger log.Logger) execer {
 		// successful execution code.
 		if err != nil || errOutput != "" {
 			// if there is an error, inspect the contents of stdout
-			level.Debug(logger).Log("msg", "error occured, inspecting stdout contents", "stdout", buf.String())
+			level.Debug(logger).Log("msg", "error occurred, inspecting stdout contents", "stdout", buf.String())
 
 			if err == nil {
 				err = errors.Errorf("exec succeeded, but emitted to stderr")

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -121,7 +121,7 @@ func execPwsh(logger log.Logger) execer {
 		// successful execution code.
 		if err != nil || errOutput != "" {
 			// if there is an error, inspect the contents of stdout
-			level.Debug(logger).Log("msg", "error occurred, inspecting stdout contents", "stdout", buf.String())
+			level.Debug(logger).Log("msg", "error execing, inspecting stdout contents", "stdout", buf.String())
 
 			if err == nil {
 				err = errors.Errorf("exec succeeded, but emitted to stderr")


### PR DESCRIPTION
This commit:
 - increases the timeout for powershell execution of the wlanapi calls

Why?
 - while network interfaces _should_ complete this in under 4 seconds,
 empirically many do not.