### PR TITLE
Code tidy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - ubuntu-latest
+            #- ubuntu-latest # No support for go 1.13
           - macos-latest
           - windows-latest
     steps:

--- a/pkg/dataflatten/examples/flatten/main.go
+++ b/pkg/dataflatten/examples/flatten/main.go
@@ -46,10 +46,7 @@ func main() {
 	opts := []dataflatten.FlattenOpts{
 		dataflatten.WithLogger(logger),
 		dataflatten.WithNestedPlist(),
-	}
-
-	if *flQuery != "" {
-		opts = append(opts, dataflatten.WithQuery(strings.Split(*flQuery, `/`)))
+		dataflatten.WithQuery(strings.Split(*flQuery, `/`)),
 	}
 
 	rows := []dataflatten.Row{}

--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -114,7 +114,7 @@ func WithDebugLogging() FlattenOpts {
 // re-writing arrays into maps, and for filtering. See "Query
 // Specification" for docs.
 func WithQuery(q []string) FlattenOpts {
-	if q == nil || len(q) == 0 {
+	if q == nil || len(q) == 0 || (len(q) == 1 && q[0] == "") {
 		return func(_ *Flattener) {}
 	}
 

--- a/pkg/osquery/tables/dataflattentable/exec.go
+++ b/pkg/osquery/tables/dataflattentable/exec.go
@@ -97,14 +97,9 @@ func (t *Table) exec(ctx context.Context) ([]byte, error) {
 }
 
 func (t *Table) getRowsFromOutput(dataQuery string, execOutput []byte) []map[string]string {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(t.logger))
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	data, err := t.execDataFunc(execOutput, flattenOpts...)

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -100,16 +100,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 func (t *Table) generatePath(filePath string, dataQuery string) ([]map[string]string, error) {
 	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
 		dataflatten.WithNestedPlist(),
-	}
-
-	if t.logger != nil {
-		// dataflatten is noisy, so unless we're not debugging it, filter it to info
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())))
-	}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	data, err := t.dataFunc(filePath, flattenOpts...)

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -52,13 +52,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 		flattenOpts := []dataflatten.FlattenOpts{
+			dataflatten.WithLogger(t.logger),
 			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
-		}
-
-		if t.logger != nil {
-			flattenOpts = append(flattenOpts,
-				dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-			)
 		}
 
 		rows, err := dataflatten.Xml(dismResults, flattenOpts...)

--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -141,16 +141,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 }
 
 func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	return dataflatten.Plist(systemOutput, flattenOpts...)

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -99,16 +99,9 @@ func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflat
 		return nil, errors.Wrap(err, "converting")
 	}
 
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	return dataflatten.Plist(converted, flattenOpts...)

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -114,12 +114,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 					}
 
 					flattenOpts := []dataflatten.FlattenOpts{
+						dataflatten.WithLogger(t.logger),
 						dataflatten.WithQuery(strings.Split(dataQuery, "/")),
-					}
-					if t.logger != nil {
-						flattenOpts = append(flattenOpts,
-							dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-						)
 					}
 
 					flatData, err := dataflatten.PlistFile(outputFile, flattenOpts...)
@@ -144,16 +140,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 }
 
 func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	return dataflatten.Plist(systemOutput, flattenOpts...)

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -70,12 +70,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			}
 
 			flattenOpts := []dataflatten.FlattenOpts{
+				dataflatten.WithLogger(t.logger),
 				dataflatten.WithQuery(strings.Split(dataQuery, "/")),
-			}
-			if t.logger != nil {
-				flattenOpts = append(flattenOpts,
-					dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-				)
 			}
 
 			flatData, err := dataflatten.Plist(pwPolicyOutput, flattenOpts...)

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -80,16 +80,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 }
 
 func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	return dataflatten.Ini(systemOutput, flattenOpts...)

--- a/pkg/osquery/tables/systemprofiler/systemprofiler.go
+++ b/pkg/osquery/tables/systemprofiler/systemprofiler.go
@@ -159,14 +159,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 func (t *Table) getRowsFromOutput(dataQuery, detailLevel string, systemProfilerOutput []byte) []map[string]string {
 	var results []map[string]string
 
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(t.logger))
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	var systemProfilerResults []Result

--- a/pkg/osquery/tables/systemprofiler/systemprofiler.go
+++ b/pkg/osquery/tables/systemprofiler/systemprofiler.go
@@ -193,7 +193,7 @@ func (t *Table) getRowsFromOutput(dataQuery, detailLevel string, systemProfilerO
 }
 
 func (t *Table) execSystemProfiler(ctx context.Context, detailLevel string, subcommands []string) ([]byte, error) {
-	timeout := 30 * time.Second
+	timeout := 45 * time.Second
 	if detailLevel == "full" {
 		timeout = 5 * time.Minute
 	}

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -52,7 +52,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	if err := t.getBytes(ctx, &output); err != nil {
 		return results, errors.Wrap(err, "getting raw data")
 	}
-	rows, err := dataflatten.Json(output.Bytes(), dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())))
+	rows, err := dataflatten.Json(output.Bytes(), dataflatten.WithLogger(t.logger))
 	if err != nil {
 		return results, errors.Wrap(err, "flattening json output")
 	}

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
@@ -120,16 +120,9 @@ func (t *Table) searchLocale(locale string, queryContext table.QueryContext) ([]
 }
 
 func (t *Table) flattenOutput(dataQuery string, searchResults interface{}) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts,
-			dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())),
-		)
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	// dataflatten won't parse the raw searchResults. As a workaround,

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTable(t *testing.T) {
-	t.parallel()
+	t.Parallel()
 
 	var tests = []struct {
 		name      string

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +33,7 @@ func TestTable(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 
-			rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
+			rows, err := table.generate(ctx, tablehelpers.MockQueryContext(nil))
 			require.NoError(t, err, "generate")
 			require.Greater(t, len(rows), 5, "got at least 5 rows")
 

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -1,0 +1,45 @@
+// +build windows
+
+package windowsupdatetable
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdatesTable(t *testing.T) {
+	t.parallel()
+
+	table := Table{
+		logger:    log.NewNopLogger(),
+		queryFunc: queryUpdates,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
+	require.NoError(t, err, "generate")
+	require.Greater(t, len(rows), 5, "got at least 5 rows")
+}
+
+func TestHistoryTable(t *testing.T) {
+	t.parallel()
+
+	table := Table{
+		logger:    log.NewNopLogger(),
+		queryFunc: queryHistory,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
+	require.NoError(t, err, "generate")
+	require.Greater(t, len(rows), 5, "got at least 5 rows")
+
+}

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -33,10 +33,9 @@ func TestTable(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 
-			rows, err := table.generate(ctx, tablehelpers.MockQueryContext(nil))
+			// ci doesn;t return data, but we can, at least, check that the underlying API doesn't error.
+			_, err := table.generate(ctx, tablehelpers.MockQueryContext(nil))
 			require.NoError(t, err, "generate")
-			require.Greater(t, len(rows), 5, "got at least 5 rows")
-
 		})
 	}
 

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -11,35 +11,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUpdatesTable(t *testing.T) {
+func TestTable(t *testing.T) {
 	t.parallel()
 
-	table := Table{
-		logger:    log.NewNopLogger(),
-		queryFunc: queryUpdates,
+	var tests = []struct {
+		name      string
+		queryFunc queryFuncType
+	}{
+		{name: "updates", queryFunc: queryUpdates},
+		{name: "history", queryFunc: queryHistory},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-	defer cancel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := Table{
+				logger:    log.NewNopLogger(),
+				queryFunc: tt.queryFunc,
+			}
 
-	rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
-	require.NoError(t, err, "generate")
-	require.Greater(t, len(rows), 5, "got at least 5 rows")
-}
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
 
-func TestHistoryTable(t *testing.T) {
-	t.parallel()
+			rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
+			require.NoError(t, err, "generate")
+			require.Greater(t, len(rows), 5, "got at least 5 rows")
 
-	table := Table{
-		logger:    log.NewNopLogger(),
-		queryFunc: queryHistory,
+		})
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-	defer cancel()
-
-	rows, err := table.generate(ctx.tablehelpers.MockQueryContext(nil))
-	require.NoError(t, err, "generate")
-	require.Greater(t, len(rows), 5, "got at least 5 rows")
 
 }

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -122,14 +122,9 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 }
 
 func (t *Table) flattenRowsFromWmi(dataQuery string, wmiResults []map[string]interface{}, wmiClass, wmiProperties, wmiNamespace, whereClause string) []map[string]string {
-	flattenOpts := []dataflatten.FlattenOpts{}
-
-	if dataQuery != "" {
-		flattenOpts = append(flattenOpts, dataflatten.WithQuery(strings.Split(dataQuery, "/")))
-	}
-
-	if t.logger != nil {
-		flattenOpts = append(flattenOpts, dataflatten.WithLogger(level.NewFilter(t.logger, level.AllowInfo())))
+	flattenOpts := []dataflatten.FlattenOpts{
+		dataflatten.WithLogger(t.logger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 
 	// wmi.Query returns []map[string]interface{}, but dataflatten


### PR DESCRIPTION
Batching several small changes

1. Remove CI builder, which is now too new for go 1.13
2. Use the `comshim` library for wmi
3. Update dataflatten to accept a logger, and apply the info filter internally
4. Update dataflatten callers to have fewer if blocks (dataflatten duplicates that internally)