### PR TITLE
Detect and fix improper file ownership on launch

### DIFF
--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -524,6 +524,14 @@ func (r *Runner) launchOsqueryInstance() error {
 		return errors.Wrap(err, "could not calculate osquery file paths")
 	}
 
+	err = ensureProperPermissions(o, paths)
+	if err != nil {
+		level.Info(o.logger).Log(
+			"msg", "unable to ensure proper permissions",
+			"err", err,
+		)
+	}
+
 	// Populate augeas lenses, if requested
 	if o.opts.augeasLensFunc != nil {
 		if err := os.MkdirAll(paths.augeasPath, 0755); err != nil {
@@ -586,17 +594,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		o.opts.binaryPath,
 		autoupdate.DeleteOldUpdates(),
 	)
-
-	// The extensions file should be owned by the process's UID or by root.
-	// Osquery will refuse to load the extension otherwise. Also ensure osqueryd
-	// is owned by root or current uid.
-	err = ensureProperPermissions(o, []string{paths.extensionPath, currentOsquerydBinaryPath})
-	if err != nil {
-		level.Info(o.logger).Log(
-			"msg", "unable to ensure proper permissions",
-			"err", err,
-		)
-	}
 
 	// Now that we have accepted options from the caller and/or determined what
 	// they should be due to them not being set, we are ready to create and start

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -526,8 +526,7 @@ func (r *Runner) launchOsqueryInstance() error {
 
 	// The extensions file should be owned by the process's UID or by root.
 	// Osquery will refuse to load the extension otherwise.
-	err = ensureProperPermissions(o, paths.extensionPath)
-	if err != nil {
+	if err := ensureProperPermissions(o, paths.extensionPath); err != nil {
 		level.Info(o.logger).Log(
 			"msg", "unable to ensure proper permissions on extension path",
 			"err", err,

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -543,7 +543,10 @@ func (r *Runner) launchOsqueryInstance() error {
 				"event", "BCJ_",
 				"msg", "unsafe permissions detected on extension binary")
 
-			// chown the file
+			// chown the file. This could potentially be insecure, since we're
+			// basically chown-ing whatever is there to root, but a certain
+			// level of privilege is needed to place something in the launcher
+			// root directory.
 			err := os.Chown(paths.extensionPath, os.Getuid(), os.Getgid())
 			if err != nil {
 				return errors.Wrap(err, "attempting to chown extension binary")

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -524,14 +524,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		return errors.Wrap(err, "could not calculate osquery file paths")
 	}
 
-	err = ensureProperPermissions(o, paths)
-	if err != nil {
-		level.Info(o.logger).Log(
-			"msg", "unable to ensure proper permissions",
-			"err", err,
-		)
-	}
-
 	// Populate augeas lenses, if requested
 	if o.opts.augeasLensFunc != nil {
 		if err := os.MkdirAll(paths.augeasPath, 0755); err != nil {
@@ -594,6 +586,17 @@ func (r *Runner) launchOsqueryInstance() error {
 		o.opts.binaryPath,
 		autoupdate.DeleteOldUpdates(),
 	)
+
+	// The extensions file should be owned by the process's UID or by root.
+	// Osquery will refuse to load the extension otherwise. Also ensure osqueryd
+	// is owned by root or current uid.
+	err = ensureProperPermissions(o, []string{paths.extensionPath, currentOsquerydBinaryPath})
+	if err != nil {
+		level.Info(o.logger).Log(
+			"msg", "unable to ensure proper permissions",
+			"err", err,
+		)
+	}
 
 	// Now that we have accepted options from the caller and/or determined what
 	// they should be due to them not being set, we are ready to create and start

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -524,10 +524,12 @@ func (r *Runner) launchOsqueryInstance() error {
 		return errors.Wrap(err, "could not calculate osquery file paths")
 	}
 
-	err = ensureProperPermissions(o, paths)
+	// The extensions file should be owned by the process's UID or by root.
+	// Osquery will refuse to load the extension otherwise.
+	err = ensureProperPermissions(o, paths.extensionPath)
 	if err != nil {
 		level.Info(o.logger).Log(
-			"msg", "unable to ensure proper permissions",
+			"msg", "unable to ensure proper permissions on extension path",
 			"err", err,
 		)
 	}

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -36,31 +36,31 @@ func isExitOk(err error) bool {
 	return false
 }
 
-func ensureProperPermissions(o *OsqueryInstance, paths []string) error {
-	for _, p := range paths {
-		fd, err := os.Stat(p)
+func ensureProperPermissions(o *OsqueryInstance, paths *osqueryFilePaths) error {
+	// The extensions file should be owned by the process's UID or the file
+	// should be owned by root. Osquery will refuse to load the extension
+	// otherwise
+	fd, err := os.Stat(paths.extensionPath)
+	if err != nil {
+		return errors.Wrap(err, "stat-ing extension path")
+	}
+	sys := fd.Sys().(*syscall.Stat_t)
+	isRootOwned := (sys.Uid == 0)
+	isProcOwned := (sys.Uid == uint32(os.Geteuid()))
+
+	if !(isRootOwned || isProcOwned) {
+		level.Info(o.logger).Log(
+			"msg", "unsafe permissions detected on extension binary",
+			"path", paths.extensionPath)
+
+		// chown the extension binary. This could potentially be insecure, since
+		// we're basically chown-ing whatever is there to root, but a certain
+		// level of privilege is needed to place something in the launcher root
+		// directory.
+		err := os.Chown(paths.extensionPath, os.Getuid(), os.Getgid())
 		if err != nil {
-			return errors.Wrap(err, "stat-ing extension path")
+			return errors.Wrap(err, "attempting to chown extension binary")
 		}
-		sys := fd.Sys().(*syscall.Stat_t)
-		isRootOwned := (sys.Uid == 0)
-		isProcOwned := (sys.Uid == uint32(os.Geteuid()))
-
-		if !(isRootOwned || isProcOwned) {
-			level.Info(o.logger).Log(
-				"msg", "unsafe permissions detected for file",
-				"path", p)
-
-			// chown the provided file. This could potentially be insecure,
-			// since we're basically chown-ing whatever is there to root, but a
-			// certain level of privilege is needed to place something in the
-			// launcher root directory.
-			err := os.Chown(p, os.Getuid(), os.Getgid())
-			if err != nil {
-				return errors.Wrapf(err, "attempting to chown file %s", p)
-			}
-		}
-
 	}
 	return nil
 }

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -36,31 +36,31 @@ func isExitOk(err error) bool {
 	return false
 }
 
-func ensureProperPermissions(o *OsqueryInstance, paths *osqueryFilePaths) error {
-	// The extensions file should be owned by the process's UID or the file
-	// should be owned by root. Osquery will refuse to load the extension
-	// otherwise
-	fd, err := os.Stat(paths.extensionPath)
-	if err != nil {
-		return errors.Wrap(err, "stat-ing extension path")
-	}
-	sys := fd.Sys().(*syscall.Stat_t)
-	isRootOwned := (sys.Uid == 0)
-	isProcOwned := (sys.Uid == uint32(os.Geteuid()))
-
-	if !(isRootOwned || isProcOwned) {
-		level.Info(o.logger).Log(
-			"msg", "unsafe permissions detected on extension binary",
-			"path", paths.extensionPath)
-
-		// chown the extension binary. This could potentially be insecure, since
-		// we're basically chown-ing whatever is there to root, but a certain
-		// level of privilege is needed to place something in the launcher root
-		// directory.
-		err := os.Chown(paths.extensionPath, os.Getuid(), os.Getgid())
+func ensureProperPermissions(o *OsqueryInstance, paths []string) error {
+	for _, p := range paths {
+		fd, err := os.Stat(p)
 		if err != nil {
-			return errors.Wrap(err, "attempting to chown extension binary")
+			return errors.Wrap(err, "stat-ing extension path")
 		}
+		sys := fd.Sys().(*syscall.Stat_t)
+		isRootOwned := (sys.Uid == 0)
+		isProcOwned := (sys.Uid == uint32(os.Geteuid()))
+
+		if !(isRootOwned || isProcOwned) {
+			level.Info(o.logger).Log(
+				"msg", "unsafe permissions detected for file",
+				"path", p)
+
+			// chown the provided file. This could potentially be insecure,
+			// since we're basically chown-ing whatever is there to root, but a
+			// certain level of privilege is needed to place something in the
+			// launcher root directory.
+			err := os.Chown(p, os.Getuid(), os.Getgid())
+			if err != nil {
+				return errors.Wrapf(err, "attempting to chown file %s", p)
+			}
+		}
+
 	}
 	return nil
 }

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -45,19 +45,22 @@ func ensureProperPermissions(o *OsqueryInstance, path string) error {
 	isRootOwned := (sys.Uid == 0)
 	isProcOwned := (sys.Uid == uint32(os.Geteuid()))
 
-	if !(isRootOwned || isProcOwned) {
-		level.Info(o.logger).Log(
-			"msg", "unsafe permissions detected on path",
-			"path", path)
+	if isRootOwned || isProcOwned {
+		return nil
+	}
 
-		// chown the path. This could potentially be insecure, since
-		// we're basically chown-ing whatever is there to root, but a certain
-		// level of privilege is needed to place something in the launcher root
-		// directory.
-		err := os.Chown(path, os.Getuid(), os.Getgid())
-		if err != nil {
-			return errors.Wrap(err, "attempting to chown path")
-		}
+	level.Info(o.logger).Log(
+		"msg", "unsafe permissions detected on path",
+		"path", path,
+	)
+
+	// chown the path. This could potentially be insecure, since
+	// we're basically chown-ing whatever is there to root, but a certain
+	// level of privilege is needed to place something in the launcher root
+	// directory.
+	err = os.Chown(path, os.Getuid(), os.Getgid())
+	if err != nil {
+		return errors.Wrap(err, "attempting to chown path")
 	}
 	return nil
 }

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -58,8 +58,7 @@ func ensureProperPermissions(o *OsqueryInstance, path string) error {
 	// we're basically chown-ing whatever is there to root, but a certain
 	// level of privilege is needed to place something in the launcher root
 	// directory.
-	err = os.Chown(path, os.Getuid(), os.Getgid())
-	if err != nil {
+	if err = os.Chown(path, os.Getuid(), os.Getgid()); err != nil {
 		return errors.Wrap(err, "attempting to chown path")
 	}
 	return nil

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -3,10 +3,12 @@
 package runtime
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 )
 
@@ -32,4 +34,33 @@ func platformArgs() []string {
 
 func isExitOk(err error) bool {
 	return false
+}
+
+func ensureProperPermissions(o *OsqueryInstance, paths *osqueryFilePaths) error {
+	// The extensions file should be owned by the process's UID or the file
+	// should be owned by root. Osquery will refuse to load the extension
+	// otherwise
+	fd, err := os.Stat(paths.extensionPath)
+	if err != nil {
+		return errors.Wrap(err, "stat-ing extension path")
+	}
+	sys := fd.Sys().(*syscall.Stat_t)
+	isRootOwned := (sys.Uid == 0)
+	isProcOwned := (sys.Uid == uint32(os.Geteuid()))
+
+	if !(isRootOwned || isProcOwned) {
+		level.Info(o.logger).Log(
+			"msg", "unsafe permissions detected on extension binary",
+			"path", paths.extensionPath)
+
+		// chown the extension binary. This could potentially be insecure, since
+		// we're basically chown-ing whatever is there to root, but a certain
+		// level of privilege is needed to place something in the launcher root
+		// directory.
+		err := os.Chown(paths.extensionPath, os.Getuid(), os.Getgid())
+		if err != nil {
+			return errors.Wrap(err, "attempting to chown extension binary")
+		}
+	}
+	return nil
 }

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -60,3 +60,7 @@ func isExitOk(err error) bool {
 	}
 	return false
 }
+
+func ensureProperPermissions(o *OsqueryInstance, paths *osqueryFilePaths) error {
+	return nil
+}

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -61,6 +61,6 @@ func isExitOk(err error) bool {
 	return false
 }
 
-func ensureProperPermissions(o *OsqueryInstance, paths *osqueryFilePaths) error {
+func ensureProperPermissions(o *OsqueryInstance, path string) error {
 	return nil
 }


### PR DESCRIPTION
This commit:
 - detects a subset of what osquery will consider improper file
 perms/ownership on the extension binary
 - tries to fix those errors

We could and perhaps should apply this to the entire root directory,
and this doesn't yet work on windows.