### PR TITLE
Simple certificate info

### DIFF
--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -37,6 +37,7 @@ package dataflatten
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -460,6 +461,9 @@ func stringify(data interface{}) (string, error) {
 		return strconv.FormatInt(v.Unix(), 10), nil
 	case howett.UID:
 		return strconv.FormatUint(uint64(v), 10), nil
+	case fmt.Stringer:
+		return v.String(), nil
+
 	default:
 		// spew.Dump(data)
 		return "", errors.Errorf("unknown type on %v", data)

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -33,10 +33,6 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		OnePasswordAccounts(client, logger),
 		SlackConfig(client, logger),
 		SshKeys(client, logger),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.JsonType),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.XmlType),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.IniType),
-		dataflattentable.TablePlugin(client, logger, dataflattentable.PlistType),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_info", dataflattentable.JsonType, zerotierCli("info")),
 		dataflattentable.TablePluginExec(client, logger,
@@ -44,6 +40,9 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_peers", dataflattentable.JsonType, zerotierCli("listpeers")),
 	}
+
+	// Ever growing list of file parsers
+	tables = append(tables, dataflattentable.FileTables(client, logger)...)
 
 	// add in the platform specific ones (as denoted by build tags)
 	tables = append(tables, platformTables(client, logger, currentOsquerydBinaryPath)...)

--- a/pkg/osquery/tables/dataflattentable/certificates.go
+++ b/pkg/osquery/tables/dataflattentable/certificates.go
@@ -1,0 +1,125 @@
+package dataflattentable
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"io/ioutil"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/kolide/launcher/pkg/dataflatten"
+	"github.com/pkg/errors"
+)
+
+type certExtract struct {
+	CRLDistributionPoints       []string
+	DNSNames                    []string
+	EmailAddresses              []string
+	ExcludedDNSDomains          []string
+	ExcludedEmailAddresses      []string
+	ExcludedIPRanges            []*net.IPNet
+	ExcludedURIDomains          []string
+	IPAddresses                 []net.IP
+	IssuerRaw                   pkix.Name
+	Issuer                      string
+	IssuingCertificateURL       []string
+	KeyUsage                    []string
+	NotBefore, NotAfter         time.Time
+	OCSPServer                  []string
+	PermittedDNSDomains         []string
+	PermittedDNSDomainsCritical bool
+	PermittedEmailAddresses     []string
+	PermittedIPRanges           []*net.IPNet
+	PermittedURIDomains         []string
+	PublicKeyAlgorithm          string
+	SerialNumber                string
+	SignatureAlgorithm          string
+	SubjectRaw                  pkix.Name
+	Subject                     string
+	URIs                        []*url.URL
+	Version                     int
+}
+
+// flattenCertificate reads a certificate at path, and returns a
+// flattened form. It's suitable for handing to the generalized table
+// flattener.
+func flattenCertificate(certpath string, _opts ...dataflatten.FlattenOpts) ([]dataflatten.Row, error) {
+	certBytes, err := ioutil.ReadFile(certpath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading %s", certpath)
+	}
+
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return nil, errors.Errorf("Unable to read pem from %s", certpath)
+	}
+
+	rawCerts, err := x509.ParseCertificates(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "x509 parsing %s", certpath)
+	}
+
+	certs := make([]certExtract, len(rawCerts))
+	for i, c := range rawCerts {
+		certs[i] = certExtract{
+			CRLDistributionPoints: c.CRLDistributionPoints,
+			DNSNames:              c.DNSNames,
+			EmailAddresses:        c.EmailAddresses,
+			IPAddresses:           c.IPAddresses,
+			IssuerRaw:             c.Issuer,
+			Issuer:                c.Issuer.String(),
+			IssuingCertificateURL: c.IssuingCertificateURL,
+			KeyUsage:              keyUsageToStrings(c.KeyUsage),
+			NotAfter:              c.NotAfter,
+			NotBefore:             c.NotBefore,
+			OCSPServer:            c.OCSPServer,
+			PublicKeyAlgorithm:    c.PublicKeyAlgorithm.String(),
+			SerialNumber:          c.SerialNumber.String(),
+			SignatureAlgorithm:    c.SignatureAlgorithm.String(),
+			SubjectRaw:            c.Subject,
+			Subject:               c.Subject.String(),
+			URIs:                  c.URIs,
+			Version:               c.Version,
+		}
+	}
+
+	// Bounce through json, because it's the simplest way to marshal the deep nested things like Subject
+	certsJson, err := json.Marshal(certs)
+	if err != nil {
+		return nil, errors.Wrap(err, "json marshal")
+	}
+
+	rows, err := dataflatten.Json(certsJson)
+	if err != nil {
+		return nil, errors.Wrap(err, "flatten")
+	}
+
+	return rows, nil
+
+}
+
+var keyUsageBits = map[x509.KeyUsage]string{
+	x509.KeyUsageContentCommitment: "Content Commitment",
+	x509.KeyUsageKeyEncipherment:   "Key Encipherment",
+	x509.KeyUsageDataEncipherment:  "Data Encipherment",
+	x509.KeyUsageKeyAgreement:      "Key Agreement",
+	x509.KeyUsageCertSign:          "Certificate Sign",
+	x509.KeyUsageCRLSign:           "CRL Sign",
+	x509.KeyUsageEncipherOnly:      "Encipher Only",
+	x509.KeyUsageDecipherOnly:      "Decipher Only",
+}
+
+func keyUsageToStrings(k x509.KeyUsage) []string {
+	var usage []string
+
+	for usageBit, usageMeaning := range keyUsageBits {
+		if k&usageBit != 0 {
+			usage = append(usage, usageMeaning)
+		}
+	}
+
+	return usage
+}

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -23,6 +23,7 @@ const (
 	XmlType
 	IniType
 	KeyValueType
+	CertType
 )
 
 type Table struct {
@@ -36,6 +37,17 @@ type Table struct {
 	execArgs     []string
 
 	keyValueSeparator string
+}
+
+// FileTables is a helper to return the expected file parsers.
+func FileTables(client *osquery.ExtensionManagerClient, logger log.Logger) []*table.Plugin {
+	return []*table.Plugin{
+		TablePlugin(client, logger, JsonType),
+		TablePlugin(client, logger, XmlType),
+		TablePlugin(client, logger, IniType),
+		TablePlugin(client, logger, PlistType),
+		TablePlugin(client, logger, CertType),
+	}
 }
 
 func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, dataSourceType DataSourceType) *table.Plugin {
@@ -60,6 +72,9 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 	case IniType:
 		t.dataFunc = dataflatten.IniFile
 		t.tableName = "kolide_ini"
+	case CertType:
+		t.dataFunc = flattenCertificate
+		t.tableName = "kolide_cert"
 	default:
 		panic("Unknown data source type")
 	}


### PR DESCRIPTION
Simple certificate parser. Reads pems, uses dataflatten.

Not currently designed to match the osquery `certificates` table, but maybe it should be?