### PR TITLE
Add exec table for diskutil without apfs flag

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -47,6 +47,8 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		mdmclient.TablePlugin(client, logger),
 		legacyexec.TablePlugin(),
 		dataflattentable.TablePluginExec(client, logger,
+			"kolide_diskutil_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "list", "-plist"}),
+		dataflattentable.TablePluginExec(client, logger,
 			"kolide_apfs_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "list", "-plist"}),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_apfs_users", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "listUsers", "/", "-plist"}),


### PR DESCRIPTION
### What is the purpose of this PR?
We currently have two diskutil exec tables which collect data about the apfs info of various disks/containers. We do not have the plain (non-apfs) invocation of `disktuil list`. This PR adds that missing exec as a new table.

### Why is this added table necessary?
The existing osquery and launcher tables return only partial data when it comes to the names of mounted disks, which ultimately results in data that is either unclear or misleading.

Let's take a look at the existing `block_devices` table:
```markdown
  osquery> SELECT name, model, label FROM block_devices;
  +--------------+-------------------+-------------------------------+
  | name         | model             | label                         |
  +--------------+-------------------+-------------------------------+
  | /dev/disk0   | Sabrent           | Sabrent Media                 |
  | /dev/disk0s1 | Sabrent           | EFI System Partition          |
##| /dev/disk0s2 | Sabrent           | Untitled 2                    | <-----
  | /dev/disk1   | APPLE SSD AP1024M | APPLE SSD AP1024M Media       |
  | /dev/disk1s1 | APPLE SSD AP1024M | EFI System Partition          |
  | /dev/disk1s2 | APPLE SSD AP1024M | Untitled 2                    |
  | /dev/disk2   | APPLE SSD AP1024M | AppleAPFSMedia                |
  | /dev/disk2s1 | APPLE SSD AP1024M | Macintosh HD - Data           |
  | /dev/disk2s2 | APPLE SSD AP1024M | Preboot                       |
  | /dev/disk2s3 | APPLE SSD AP1024M | Recovery                      |
  | /dev/disk2s4 | APPLE SSD AP1024M | VM                            |
  | /dev/disk2s5 | APPLE SSD AP1024M | Macintosh HD                  |
  | /dev/disk3   | My Passport 25E2  | WD My Passport 25E2 Media     |
  | /dev/disk3s1 | My Passport 25E2  | EFI System Partition          |
##| /dev/disk3s2 | My Passport 25E2  | Untitled 2                    | <-----
  | /dev/disk3s3 | My Passport 25E2  | Booter                        |
  | /dev/disk4   | Portable SSD T5   | Samsung Portable SSD T5 Media |
  | /dev/disk4s1 | Portable SSD T5   | EFI System Partition          |
##| /dev/disk4s2 | Portable SSD T5   | Untitled 2                    | <-----
  | /dev/disk6   | Ext HDD 1021      | WD Ext HDD 1021 Media         |
##| /dev/disk6s1 | Ext HDD 1021      | Untitled 1                    | <-----
  +--------------+-------------------+-------------------------------+
```

Now let's take a look at the built-in macOS GUI representation: 

![image](https://user-images.githubusercontent.com/931724/112755124-5732e700-8fad-11eb-9ae5-1aff518c1876.png)

As we can see there are a number of mislabeled rows which are incorrectly reporting a label of `'Untitled...'`

Unfortunately, this data does not appear to be available via iOKit/iORegistry and thus cannot be retrieved using the method that the underlying osquery table relies upon.

### How does this new table address this issue?
The diskutil output can be collected via this new table and returned to provide the appropriate volume names:

```markdown
  +--------------------------------------+----------------------+---------------+---------------------+--------------------------------------+--------------+-------------------+
  | disk_uuid                            | mount_point          | size          | volume_name         | volume_uuid                          | content      | device_identifier |
  +--------------------------------------+----------------------+---------------+---------------------+--------------------------------------+--------------+-------------------+
  | 53623F23-DEFD-45A4-AC8E-4EA90F1F7774 |                      | 209715200     | EFI                 | 0E239BC6-F960-3107-89CF-1C97F78BB46B | EFI          | disk0s1           |
##| 06324AB6-396F-4A65-8758-93E466C8D9B2 | /Volumes/Jeyi        | 1023865569280 | Jeyi                | 8B1762E2-E84D-3F8D-901F-65259C2A55EF | Apple_HFS    | disk0s2           | <-------
  | 08BF6B16-4B16-4696-A5CD-3593688AE41B |                      | 314572800     | EFI                 | E783267B-A4C3-3556-B751-DBED770EB996 | EFI          | disk1s1           |
  | DC311620-BDEC-40EC-9329-C172D333BD82 | /System/Volumes/Data | 1000240963584 | Macintosh HD - Data | DC311620-BDEC-40EC-9329-C172D333BD82 |              | disk2s1           |
  | FFC488C5-DD0D-420B-BEC2-8AB9B34A033C |                      | 1000240963584 | Preboot             | FFC488C5-DD0D-420B-BEC2-8AB9B34A033C |              | disk2s2           |
  | A7405C6A-2D9A-435B-8877-AB28BB767F60 |                      | 1000240963584 | Recovery            | A7405C6A-2D9A-435B-8877-AB28BB767F60 |              | disk2s3           |
  | 92E31DE7-E6FB-4537-90C7-E8EBCF258139 | /private/var/vm      | 1000240963584 | VM                  | 92E31DE7-E6FB-4537-90C7-E8EBCF258139 |              | disk2s4           |
  | F2099E1B-164B-4970-9208-2F441A69AAD2 | /                    | 1000240963584 | Macintosh HD        | F2099E1B-164B-4970-9208-2F441A69AAD2 |              | disk2s5           |
  | EAB711C1-F546-4AA8-B45F-F738931C28E6 |                      | 209715200     | EFI                 | 0E239BC6-F960-3107-89CF-1C97F78BB46B | EFI          | disk3s1           |
##| 3D4D25A4-7927-4511-8688-D5286BE4C9FB | /Volumes/My Passport | 4000408625152 | My Passport         | 23B590E7-BD3A-3AAC-B2ED-3553507A55FC | Apple_HFS    | disk3s2           | <-------
  | 389D597D-A736-40C4-AF3E-0EAF937170B4 |                      | 209715200     | EFI                 | 0E239BC6-F960-3107-89CF-1C97F78BB46B | EFI          | disk4s1           |
##| CCDBD7BF-5E12-4911-B2A2-13088037964D | /Volumes/Samsung-SSD | 999860912128  | Samsung-SSD         | 57904C94-ECF8-33A6-BCA9-4E60D8D67D3C | Apple_HFS    | disk4s2           | <-------
##|                                      | /Volumes/Elements    | 2000395698176 | Elements            | 79C16A2A-0B74-47DF-A367-E5F537DC39F7 | Windows_NTFS | disk6s1           | <-------
  +--------------------------------------+----------------------+---------------+---------------------+--------------------------------------+--------------+-------------------+
```



### What other alternatives should be considered long-term?
Patching the vanilla osquery disk tables (looking at you `block_devices`) to return accurate information.