### PR TITLE
Add `lsblk` table

### DIFF
--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -17,7 +17,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_nmcli_wifi", dataflattentable.KeyValueType, []string{"/usr/bin/nmcli", "--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
-
 		dataflattentable.TablePluginExec(client, logger, "kolide_lsblk", dataflattentable.JsonType, []string{"/usr/bin/lsblk", "-J"}),
 	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -15,8 +15,12 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		gsettings.Settings(client, logger),
 		gsettings.Metadata(client, logger),
 		dataflattentable.TablePluginExec(client, logger,
-			"kolide_nmcli_wifi", dataflattentable.KeyValueType, []string{"/usr/bin/nmcli", "--mode=multiline", "--fields=all", "device", "wifi", "list"},
+			"kolide_nmcli_wifi", dataflattentable.KeyValueType,
+			[]string{"/usr/bin/nmcli", "--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
-		dataflattentable.TablePluginExec(client, logger, "kolide_lsblk", dataflattentable.JsonType, []string{"/usr/bin/lsblk", "-J"}),
+		dataflattentable.TablePluginExec(client, logger, "kolide_lsblk", dataflattentable.JsonType,
+			[]string{"lsblk", "-J"},
+			dataflattentable.WithBinDirs("/usr/bin", "/bin"),
+		),
 	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -17,5 +17,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_nmcli_wifi", dataflattentable.KeyValueType, []string{"/usr/bin/nmcli", "--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
+
+		dataflattentable.TablePluginExec(client, logger, "kolide_lsblk", dataflattentable.JsonType, []string{"/usr/bin/lsblk", "-J"}),
 	}
 }

--- a/pkg/osquery/tables/dataflattentable/exec.go
+++ b/pkg/osquery/tables/dataflattentable/exec.go
@@ -118,8 +118,9 @@ func (t *Table) exec(ctx context.Context) ([]byte, error) {
 		// success!
 		return stdout.Bytes(), nil
 	}
-	// Shouldn't be possible to get here.
-	return nil, errors.New("Impossible Error: No possible exec")
+
+	// None of the possible execs were found
+	return nil, errors.Errorf("Unable to exec '%s'. No binary found is specified paths", t.execArgs[0])
 }
 
 func (t *Table) getRowsFromOutput(dataQuery string, execOutput []byte) []map[string]string {

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -34,6 +34,7 @@ type Table struct {
 
 	execDataFunc func([]byte, ...dataflatten.FlattenOpts) ([]dataflatten.Row, error)
 	execArgs     []string
+	binDirs      []string
 
 	keyValueSeparator string
 }


### PR DESCRIPTION
Very simple `kolide_lsblk` table. I'm not sure that it adds data that isn't in the native osquery tables, but it presents it in a different way. Seems valuable in diagnosing linux disk setups.

To handle different locations on different linux distributions, this also introduces a `dataflattentable.WithBinDirs` option to exec table