### PR TITLE
Move tables to using `tablehelpers.Exec`

### DIFF
--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -10,9 +10,7 @@ package mdmclient
 import (
 	"bytes"
 	"context"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -70,7 +68,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 
-			mdmclientOutput, err := t.execMdmclient(ctx, mdmclientCommand)
+			mdmclientOutput, err := tablehelpers.Exec(ctx, t.logger, 30, []string{mdmclientPath}, []string{mdmclientCommand})
 			if err != nil {
 				level.Info(t.logger).Log("msg", "mdmclient failed", "err", err)
 				continue
@@ -105,26 +103,6 @@ func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflat
 	}
 
 	return dataflatten.Plist(converted, flattenOpts...)
-}
-
-func (t *Table) execMdmclient(ctx context.Context, command string) ([]byte, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, mdmclientPath, command)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	level.Debug(t.logger).Log("msg", "calling mdmclient", "args", cmd.Args)
-
-	if err := cmd.Run(); err != nil {
-		return nil, errors.Wrapf(err, "calling mdmclient. Got: %s", string(stderr.Bytes()))
-	}
-
-	return stdout.Bytes(), nil
 }
 
 // transformOutput has some hackish rules to transform the output into a "proper" gnustep plist

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -14,10 +14,8 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -108,8 +106,14 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 						return nil, errors.Errorf("Unknown user argument: %s", user)
 					}
 
-					if _, err := t.execProfiles(ctx, profileArgs); err != nil {
-						level.Info(t.logger).Log("msg", "exec failed", "err", err)
+					output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{profilesPath}, profileArgs)
+					if err != nil {
+						level.Info(t.logger).Log("msg", "ioreg exec failed", "err", err)
+						continue
+					}
+
+					if bytes.Contains(output, []byte("requires root privileges")) {
+						level.Info(t.logger).Log("ioreg requires root privileges")
 						continue
 					}
 
@@ -146,29 +150,4 @@ func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflat
 	}
 
 	return dataflatten.Plist(systemOutput, flattenOpts...)
-}
-
-func (t *Table) execProfiles(ctx context.Context, args []string) ([]byte, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, profilesPath, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	level.Debug(t.logger).Log("msg", "calling profiles", "args", cmd.Args)
-
-	if err := cmd.Run(); err != nil {
-		return nil, errors.Wrapf(err, "calling profiles. Got: %s", string(stderr.Bytes()))
-	}
-
-	// Check for an error about root permissions
-	if bytes.Contains(stdout.Bytes(), []byte("requires root privileges")) {
-		return nil, errors.New("Requires root privileges")
-	}
-
-	return stdout.Bytes(), nil
 }


### PR DESCRIPTION
On the theory that less code is better than the explictness, this
consolidates several exec calls to using `tablehelpers.Exec`.

I did not move the ones that needed special tmp dirs, file handling, or
sudo.