### PR TITLE
Fix ioreg table

### DIFF
--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -64,7 +64,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	}
 
 	for _, ioC := range tablehelpers.GetConstraints(queryContext, "c", gcOpts...) {
-		ioregArgs := []string{}
+		// We always need "-a", it's the "archive" output
+		ioregArgs := []string{"-a"}
 
 		if ioC != "" {
 			ioregArgs = append(ioregArgs, "-c", ioC)


### PR DESCRIPTION
In #735 we changed the caller for ioreg, and inadvertently dropped the `-a` flag. Add it back