### PR TITLE
Offset the autoupdate

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -173,7 +173,27 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 
 	// If the autoupdater is enabled, enable it for both osquery and launcher
 	if opts.Autoupdate {
-		config := &updaterConfig{
+		osqueryUpdaterconfig := &updaterConfig{
+			Logger:             logger,
+			RootDirectory:      rootDirectory,
+			AutoupdateInterval: opts.AutoupdateInterval,
+			UpdateChannel:      opts.UpdateChannel,
+			NotaryURL:          opts.NotaryServerURL,
+			MirrorURL:          opts.MirrorServerURL,
+			NotaryPrefix:       opts.NotaryPrefix,
+			HTTPClient:         httpClient,
+			InitialDelay:       opts.AutoupdateInitialDelay + opts.AutoupdateInterval/2,
+			SigChannel:         sigChannel,
+		}
+
+		// create an updater for osquery
+		osqueryUpdater, err := createUpdater(ctx, opts.OsquerydPath, runnerRestart, osqueryUpdaterconfig)
+		if err != nil {
+			return errors.Wrap(err, "create osquery updater")
+		}
+		runGroup.Add(osqueryUpdater.Execute, osqueryUpdater.Interrupt)
+
+		launcherUpdaterconfig := &updaterConfig{
 			Logger:             logger,
 			RootDirectory:      rootDirectory,
 			AutoupdateInterval: opts.AutoupdateInterval,
@@ -186,13 +206,6 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			SigChannel:         sigChannel,
 		}
 
-		// create an updater for osquery
-		osqueryUpdater, err := createUpdater(ctx, opts.OsquerydPath, runnerRestart, config)
-		if err != nil {
-			return errors.Wrap(err, "create osquery updater")
-		}
-		runGroup.Add(osqueryUpdater.Execute, osqueryUpdater.Interrupt)
-
 		// create an updater for launcher
 		launcherPath, err := os.Executable()
 		if err != nil {
@@ -202,7 +215,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			ctx,
 			launcherPath,
 			updateFinalizer(logger, runnerShutdown),
-			config,
+			launcherUpdaterconfig,
 		)
 		if err != nil {
 			return errors.Wrap(err, "create launcher updater")


### PR DESCRIPTION
The osquery and launcher updaters run as seperate goroutines. If they
happen to trigger at the same time, it can get messy. One will restart,
before the other is done downloading, and this an update is missed.

The correct fix for this is to rearchtect away from this goroutine and
callback, but this might be a simple fix to reduce likelihood of errors.

This offsets one of the updaters, using the initial delay. As our
internvals are about an hour, this offset should reduce the likelihood
of this happening.

Relates to: #728