### PR TITLE
For exec tables, don't error for missing binaries

### DIFF
--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -4,6 +4,7 @@ package filevault
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -38,6 +39,11 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	output, err := tablehelpers.Exec(ctx, t.logger, 10, []string{fdesetupPath}, []string{"status"})
 	if err != nil {
 		level.Info(t.logger).Log("msg", "fdesetup failed", "err", err)
+
+		// Don't error out if the binary isn't found
+		if os.IsNotExist(errors.Cause(err)) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "calling fdesetup")
 	}
 

--- a/pkg/osquery/tables/tablehelpers/exec.go
+++ b/pkg/osquery/tables/tablehelpers/exec.go
@@ -53,5 +53,5 @@ func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, possibleBi
 
 	}
 	// Getting here means no binary was found
-	return nil, errors.Errorf("No binary found is specified paths: %v", possibleBins)
+	return nil, errors.Wrapf(os.ErrNotExist, "No binary found is specified paths: %v", possibleBins)
 }

--- a/pkg/osquery/tables/zfs/tables.go
+++ b/pkg/osquery/tables/zfs/tables.go
@@ -62,6 +62,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	output, err := tablehelpers.Exec(ctx, t.logger, 15, []string{t.cmd}, t.args)
 	if err != nil {
 		level.Info(t.logger).Log("msg", "failed to get zfs info", "err", err)
+
 		// Don't error out if the binary isn't found
 		if os.IsNotExist(errors.Cause(err)) {
 			return nil, nil

--- a/pkg/osquery/tables/zfs/tables.go
+++ b/pkg/osquery/tables/zfs/tables.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"os"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -11,6 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -60,6 +62,10 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	output, err := tablehelpers.Exec(ctx, t.logger, 15, []string{t.cmd}, t.args)
 	if err != nil {
 		level.Info(t.logger).Log("msg", "failed to get zfs info", "err", err)
+		// Don't error out if the binary isn't found
+		if os.IsNotExist(errors.Cause(err)) {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
When an exec table is missing a binary, this condition should be treated as a warning, not an error. This way the table can be included in larger check queries and simply ignored.