### PR TITLE
Exec table for SecureBoot status

### DIFF
--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/cryptsetup"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/gsettings"
+	"github.com/kolide/launcher/pkg/osquery/tables/mokutil"
 	"github.com/kolide/launcher/pkg/osquery/tables/xrdb"
 	osquery "github.com/kolide/osquery-go"
 	"github.com/kolide/osquery-go/plugin/table"
@@ -17,6 +18,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		cryptsetup.TablePlugin(client, logger),
 		gsettings.Settings(client, logger),
 		gsettings.Metadata(client, logger),
+		mokutil.StatusTablePlugin(client, logger),
 		xrdb.TablePlugin(client, logger),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_nmcli_wifi", dataflattentable.KeyValueType,

--- a/pkg/osquery/tables/mokutil/status.go
+++ b/pkg/osquery/tables/mokutil/status.go
@@ -1,0 +1,60 @@
+package mokutil
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/kolide/osquery-go"
+	"github.com/kolide/osquery-go/plugin/table"
+)
+
+var mokutilLocations = []string{
+	"/usr/bin/mokutil",
+	"/usr/sbin/mokutil",
+}
+
+var (
+	enabledBytes  = []byte("SecureBoot enabled")
+	disabledBytes = []byte("SecureBoot disabled")
+)
+
+type Table struct {
+	logger log.Logger
+}
+
+func StatusTablePlugin(_client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("secureboot"),
+		table.TextColumn("_error"),
+	}
+
+	t := &Table{
+		logger: logger,
+	}
+
+	return table.NewPlugin("kolide_mokutil_status", columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	output, err := tablehelpers.Exec(ctx, t.logger, 2, mokutilLocations, []string{"--sb-state"})
+	if err != nil {
+		level.Info(t.logger).Log("msg", "mokutil failed", "err", err)
+		row := map[string]string{"_error": err.Error()}
+		return []map[string]string{row}, nil
+	}
+
+	status := "unknown"
+
+	switch {
+	case bytes.HasPrefix(output, enabledBytes):
+		status = "enabled"
+	case bytes.HasPrefix(output, disabledBytes):
+		status = "disabled"
+	}
+
+	row := map[string]string{"secureboot": status}
+	return []map[string]string{row}, nil
+}


### PR DESCRIPTION
This wraps mokutil's status command to return the SecureBoot status.

As an experiment, it inlines the errors. This should allow it to succeed in larger join operations, but still provides a hook for debugging. Not sure I like it yet.

I'm flexible on table and column names.