### PR TITLE
Go 1.16 (Build only)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13 # 1.14 has issues with bolt's pointers
+        go-version: 1.16 
       id: go
 
     - name: Get dependencies

--- a/go.mod
+++ b/go.mod
@@ -88,4 +88,4 @@ require (
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Move the automated builds to go 1.16. 

This matches how the builds actually happen