### PR TITLE
Improvements to the zfs tables

### DIFF
--- a/pkg/osquery/tables/zfs/tables.go
+++ b/pkg/osquery/tables/zfs/tables.go
@@ -60,7 +60,7 @@ func ZpoolPropertiesPlugin(client *osquery.ExtensionManagerClient, logger log.Lo
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	// Generate ZFS commands.
 	//
-	// keys are comma seperated. Default to `all` to get everything
+	// keys are comma separated. Default to `all` to get everything
 	// names are args. Default to none to get everything
 	//
 	// These commands all work:


### PR DESCRIPTION
As I've seen machines with broken ZFS in the wild, don't return on errors.

Pass the query context to the underlying zfs command. This allows a tremendous performance improvement when there are numerous snapshots.