### PR TITLE
Add another path for `cryptsetup`

### DIFF
--- a/pkg/osquery/tables/cryptsetup/table.go
+++ b/pkg/osquery/tables/cryptsetup/table.go
@@ -14,7 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const cryptsetupPath = "/usr/sbin/cryptsetup"
+var cryptsetupPaths = []string{
+	"/usr/sbin/cryptsetup",
+	"/sbin/cryptsetup",
+}
 
 const allowedNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/_"
 
@@ -51,7 +54,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	}
 
 	for _, name := range requestedNames {
-		output, err := tablehelpers.Exec(ctx, t.logger, 15, []string{cryptsetupPath}, []string{"--readonly", "status", name})
+		output, err := tablehelpers.Exec(ctx, t.logger, 15, cryptsetupPaths, []string{"--readonly", "status", name})
 		if err != nil {
 			level.Debug(t.logger).Log("msg", "Error execing for status", "name", name, "err", err)
 			continue


### PR DESCRIPTION
Digging around my ubuntu machines, it looks like `cryptsetup` is
installed as `/sbin/cryptsetup`. But that `/sbin` is a symlink to
`/usr/sbin`. I don't know if it's always a symlink, so I'm adding both
as a fallback path