### PR TITLE
Add flag to adjust `LogMaxBytesPerBatch`

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -54,11 +54,15 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 		RunDifferentialQueriesImmediately: opts.EnableInitialRunner,
 	}
 
-	// We have a MaxBytesPerBatch set low enough to support GRPC's
-	// hardcoded 4mb limit. We don't need that for jsonrpc, so
-	// bump it up to 10 MB
+	// Setting MaxBytesPerBatch is a tradeoff. If it's too low, we
+	// can never send a large result. But if it's too high, we may
+	// not be able to send the data over a low bandwidth
+	// connection before the connection is timed out.
+	//
+	// It defaults to 3mb, to support GRPC's hardcoded 4MB
+	// limit. But jsonrpc can be a little higher. Set it to 5MB
 	if opts.Transport == "jsonrpc" {
-		extOpts.MaxBytesPerBatch = 10 << 20
+		extOpts.MaxBytesPerBatch = 5 << 20
 	}
 
 	// create the extension

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -61,7 +61,15 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 	//
 	// It defaults to 3mb, to support GRPC's hardcoded 4MB
 	// limit. But jsonrpc can be a little higher. Set it to 5MB
-	if opts.Transport == "jsonrpc" {
+	if opts.LogMaxBytesPerBatch != 0 {
+		if opts.Transport == "grpc" && opts.LogMaxBytesPerBatch > 3 {
+			level.Info(logger).Log(
+				"msg", "LogMaxBytesPerBatch is set above the grpc recommended maximum of 3. Expect errors",
+				"LogMaxBytesPerBatch", opts.LogMaxBytesPerBatch,
+			)
+		}
+		extOpts.MaxBytesPerBatch = opts.LogMaxBytesPerBatch << 20
+	} else if opts.Transport == "jsonrpc" {
 		extOpts.MaxBytesPerBatch = 5 << 20
 	}
 

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -59,8 +59,10 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 	// not be able to send the data over a low bandwidth
 	// connection before the connection is timed out.
 	//
-	// It defaults to 3mb, to support GRPC's hardcoded 4MB
-	// limit. But jsonrpc can be a little higher. Set it to 5MB
+	// The logic for setting this is spread out. The underlying
+	// extension defaults to 3mb, to support GRPC's hardcoded 4MB
+	// limit. But as we're transport aware here. we can set it to
+	// 5MB for others.
 	if opts.LogMaxBytesPerBatch != 0 {
 		if opts.Transport == "grpc" && opts.LogMaxBytesPerBatch > 3 {
 			level.Info(logger).Log(
@@ -69,7 +71,9 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 			)
 		}
 		extOpts.MaxBytesPerBatch = opts.LogMaxBytesPerBatch << 20
-	} else if opts.Transport == "jsonrpc" {
+	} else if opts.Transport == "grpc" {
+		extOpts.MaxBytesPerBatch = 3 << 20
+	} else if opts.Transport != "grpc" {
 		extOpts.MaxBytesPerBatch = 5 << 20
 	}
 

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -45,21 +45,22 @@ func parseOptions(args []string) (*launcher.Options, error) {
 
 	var (
 		// Primary options
-		flCertPins         = flagset.String("cert_pins", "", "Comma separated, hex encoded SHA256 hashes of pinned subject public key info")
-		flControl          = flagset.Bool("control", false, "Whether or not the control server is enabled (default: false)")
-		flControlServerURL = flagset.String("control_hostname", "", "The hostname of the control server")
-		flEnrollSecret     = flagset.String("enroll_secret", "", "The enroll secret that is used in your environment")
-		flEnrollSecretPath = flagset.String("enroll_secret_path", "", "Optionally, the path to your enrollment secret")
-		flInitialRunner    = flagset.Bool("with_initial_runner", false, "Run differential queries from config ahead of scheduled interval.")
-		flKolideServerURL  = flagset.String("hostname", "", "The hostname of the gRPC server")
-		flTransport        = flagset.String("transport", "grpc", "The transport protocol that should be used to communicate with remote (default: grpc)")
-		flLoggingInterval  = flagset.Duration("logging_interval", 60*time.Second, "The interval at which logs should be flushed to the server")
-		flOsquerydPath     = flagset.String("osqueryd_path", "", "Path to the osqueryd binary to use (Default: find osqueryd in $PATH)")
-		flRootDirectory    = flagset.String("root_directory", "", "The location of the local database, pidfiles, etc.")
-		flRootPEM          = flagset.String("root_pem", "", "Path to PEM file including root certificates to verify against")
-		flVersion          = flagset.Bool("version", false, "Print Launcher version and exit")
-		flOsqueryFlags     arrayFlags // set below with flagset.Var
-		_                  = flagset.String("config", "", "config file to parse options from (optional)")
+		flCertPins            = flagset.String("cert_pins", "", "Comma separated, hex encoded SHA256 hashes of pinned subject public key info")
+		flControl             = flagset.Bool("control", false, "Whether or not the control server is enabled (default: false)")
+		flControlServerURL    = flagset.String("control_hostname", "", "The hostname of the control server")
+		flEnrollSecret        = flagset.String("enroll_secret", "", "The enroll secret that is used in your environment")
+		flEnrollSecretPath    = flagset.String("enroll_secret_path", "", "Optionally, the path to your enrollment secret")
+		flInitialRunner       = flagset.Bool("with_initial_runner", false, "Run differential queries from config ahead of scheduled interval.")
+		flKolideServerURL     = flagset.String("hostname", "", "The hostname of the gRPC server")
+		flTransport           = flagset.String("transport", "grpc", "The transport protocol that should be used to communicate with remote (default: grpc)")
+		flLoggingInterval     = flagset.Duration("logging_interval", 60*time.Second, "The interval at which logs should be flushed to the server")
+		flOsquerydPath        = flagset.String("osqueryd_path", "", "Path to the osqueryd binary to use (Default: find osqueryd in $PATH)")
+		flRootDirectory       = flagset.String("root_directory", "", "The location of the local database, pidfiles, etc.")
+		flRootPEM             = flagset.String("root_pem", "", "Path to PEM file including root certificates to verify against")
+		flVersion             = flagset.Bool("version", false, "Print Launcher version and exit")
+		flLogMaxBytesPerBatch = flagset.Int("log_max_bytes_per_batch", 0, "Maximum size of a batch of logs. Recommend leaving unset, and launcher will determine")
+		flOsqueryFlags        arrayFlags // set below with flagset.Var
+		_                     = flagset.String("config", "", "config file to parse options from (optional)")
 
 		// Autoupdate options
 		flAutoupdate             = flagset.Bool("autoupdate", false, "Whether or not the osquery autoupdater is enabled (default: false)")
@@ -163,6 +164,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		InsecureTLS:            *flInsecureTLS,
 		InsecureTransport:      *flInsecureTransport,
 		KolideServerURL:        *flKolideServerURL,
+		LogMaxBytesPerBatch:    *flLogMaxBytesPerBatch,
 		LoggingInterval:        *flLoggingInterval,
 		MirrorServerURL:        *flMirrorURL,
 		NotaryPrefix:           *flNotaryPrefix,
@@ -187,7 +189,7 @@ func shortUsage(flagset *flag.FlagSet) {
 
 	printOpt := func(opt string) {
 		fmt.Fprintf(os.Stderr, "  --%s", opt)
-		for i := 0; i < 22-len(opt); i++ {
+		for i := 0; i < 24-len(opt); i++ {
 			fmt.Fprintf(os.Stderr, " ")
 		}
 		fmt.Fprintf(os.Stderr, "%s\n", launcherFlags[opt])
@@ -202,6 +204,7 @@ func shortUsage(flagset *flag.FlagSet) {
 	printOpt("hostname")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("transport")
+	printOpt("log_max_bytes_per_batch")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("enroll_secret")
 	printOpt("enroll_secret_path")

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -35,6 +35,10 @@ type Options struct {
 	// Transport the transport that should be used for remote
 	// communication.
 	Transport string
+	// MaxBytesPerBatch sets the maximum bytes allowed in a batch
+	// of log files. When blank, launcher will pick a value
+	// appropraite for the transport.
+	LogMaxBytesPerBatch int
 
 	// Control enables the remote control functionality.
 	Control bool

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -35,9 +35,9 @@ type Options struct {
 	// Transport the transport that should be used for remote
 	// communication.
 	Transport string
-	// MaxBytesPerBatch sets the maximum bytes allowed in a batch
-	// of log files. When blank, launcher will pick a value
-	// appropraite for the transport.
+	// LogMaxBytesPerBatch sets the maximum bytes allowed in a batch
+	// of log. When blank, launcher will pick a value
+	// appropriate for the transport.
 	LogMaxBytesPerBatch int
 
 	// Control enables the remote control functionality.


### PR DESCRIPTION
## Problem

Setting MaxBytesPerBatch is a tradeoff. If it's too low, we can never send a large result. But if it's too high, we may not be able to send the data over a low bandwidth connection before the connection is timed out.

We originally had it at 2MB. But bumped it to 10MB for a specific use case. But I'm now seeing issues with low bandwidth clients.

## Solution

Lower it to 5MB, and allow it to be set in a launcher flag. 