### PR TITLE
Allow spaces in gsettings table

### DIFF
--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -27,7 +27,7 @@ import (
 
 const gsettingsPath = "/usr/bin/gsettings"
 
-const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
+const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-. "
 
 type gsettingsExecer func(ctx context.Context, username string, buf *bytes.Buffer) error
 


### PR DESCRIPTION
Linux usernames [are allowed to contain spaces](https://stackoverflow.com/questions/208054/user-names-and-white-spaces so we should not be filtering them in this table. It's possible other allowed characters sets need to be examined for the same assumption, but this one definitely needs to be added.