### PR TITLE
Expand Linting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# set line endings got go files. Mostly needed for golang-ci
+*.go text eol=lf
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,10 +34,6 @@ jobs:
     - name: Get dependencies
       run: make deps
 
-    - name: Lint
-      run: make -j lint
-      if: runner.os != 'Windows'
-
     - name: Build
       run: make -j launcher extension grpc.ext tables.ext package-builder
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,11 +37,6 @@ jobs:
     - name: Build
       run: make -j launcher extension grpc.ext tables.ext package-builder
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.42
-      
     - name: Test
       run: make test
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Build
       run: make -j launcher extension grpc.ext tables.ext package-builder
 
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.42
+      
     - name: Test
       run: make test
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        run: golangci-lint run --out-format=colored-line-number
         with:
           version: v1.42

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,9 +26,9 @@ jobs:
       - name: restore path
         if: matrix.os == 'ubuntu-18.04'
         run: |
-          cat ${GITHUB_PATH}
-          perl -pi -e 's{.*/go/bin}{}'
-          cat ${GITHUB_PATH}
+          cat $GITHUB_PATH
+          perl -pi -e 's{.*/go/bin}{}' $GITHUB_PATH
+          cat $GITHUB_PATH
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,9 @@ jobs:
       - run: make deps
       - name: restore path
         if: matrix.os == 'ubuntu-18.04'
-        run: cp ${GITHUB_PATH}.orig ${GITHUB_PATH}.orig
+        run: |
+          cat ${GITHUB_PATH} | grep -v go/bin > ${GITHUB_PATH}.restored
+          mv ${GITHUB_PATH}.restored ${GITHUB_PATH}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: adjust path for bindata
+        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+      - run: make deps
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Work around https://github.com/golangci/golangci-lint-action/issues/362
       - name: don't process annotations
-        run:  echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+        run:  echo "::stop-commands::qwerty66"
 
 
       # Getting this to work outside a normal build is quite

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,8 +33,6 @@ jobs:
 
       - run: make deps
 
-      # Work around https://github.com/golangci/golangci-lint-action/issues/362
-
       # Getting this to work outside a normal build is quite
       # cumbersome. golangci/golangci-lint-action attempts to install
       # go, and use the module cache. In a way that _assumes_ no go
@@ -49,6 +47,7 @@ jobs:
           skip-pkg-cache: true
           skip-go-installation: true
 
+      # Run again as a workaround for https://github.com/golangci/golangci-lint-action/issues/362
       - name: golangci-lint
         if: ${{ always() }}
         #uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04]
-        go-version: [1.16.x]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,13 +22,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
-#      - name: adjust path for generation
-#        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
-#
-#      - name: adjust path for generation (windows)
-#        if: matrix.os == 'windows-latest'
-#        run: echo "${HOME}\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - run: make deps
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-18.04]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,17 @@ jobs:
 
       - name: adjust path for generation
         run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+
+      - name: adjust path for generation (windows)
+        if: matrix.os == 'windows-latest'
+        run: echo "${HOME}\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - run: make deps
+
+      # Work around https://github.com/golangci/golangci-lint-action/issues/362
+      - name: don't process annotations
+        run:  echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+
 
       # Getting this to work outside a normal build is quite
       # cumbersome. golangci/golangci-lint-action attempts to install

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,3 @@
-# Getting this to work outside a normal build is quite
-# cumbersome. golangci/golangci-lint-action attempts to install go,
-# and use the module cache. In a way that _assumes_ no go commands
-# have been run in the workspace. But, this is fundamentally
-# incompatible with our needing to to generate code before
-# linting. Thus the various skip- commands.
-# See https://github.com/golangci/golangci-lint-action/issues/244
-
 name: golangci-lint
 on:
   push:
@@ -31,6 +23,13 @@ jobs:
           echo "${HOME}/go/bin" >> $GITHUB_PATH
           make deps
 
+      # Getting this to work outside a normal build is quite
+      # cumbersome. golangci/golangci-lint-action attempts to install
+      # go, and use the module cache. In a way that _assumes_ no go
+      # commands have been run in the workspace. But, this is
+      # fundamentally incompatible with our needing to to generate
+      # code before linting. Thus the various skip- commands.  See
+      # https://github.com/golangci/golangci-lint-action/issues/244
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         skip-pkg-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,8 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: adjust path for bindata
-        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+        run: |
+          cp $GITHUB_PATH ${GITHUB_PATH}.orig
+          echo "${HOME}/go/bin" >> $GITHUB_PATH
       - run: make deps
+      - name: restore path
+        run: cp ${GITHUB_PATH}.orig ${GITHUB_PATH}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,13 +16,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: deps
+
+      - name: adjust path for bindata
         if: matrix.os == 'ubuntu-18.04'
         run: |
           cp $GITHUB_PATH ${GITHUB_PATH}.orig
           echo "${HOME}/go/bin" >> $GITHUB_PATH
-          make deps
-          cp ${GITHUB_PATH}.orig ${GITHUB_PATH}
+      - run: make deps
+      - name: restore path
+        if: matrix.os == 'ubuntu-18.04'
+        run: cp ${GITHUB_PATH}.orig ${GITHUB_PATH}.orig
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: adjust path for generation
         run: echo "${HOME}/go/bin" >> $GITHUB_PATH
-      - name: make deps
+      - run: make deps
 
       # Getting this to work outside a normal build is quite
       # cumbersome. golangci/golangci-lint-action attempts to install

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,8 +26,9 @@ jobs:
       - name: restore path
         if: matrix.os == 'ubuntu-18.04'
         run: |
-          cat ${GITHUB_PATH} | grep -v go/bin > ${GITHUB_PATH}.restored
-          mv ${GITHUB_PATH}.restored ${GITHUB_PATH}
+          cat ${GITHUB_PATH}
+          perl -pi -e 's{.*/go/bin}{}'
+          cat ${GITHUB_PATH}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,12 +19,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: adjust path for generation
-        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
 
-      - name: adjust path for generation (windows)
-        if: matrix.os == 'windows-latest'
-        run: echo "${HOME}\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: adjust path for generation
+#        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+#
+#      - name: adjust path for generation (windows)
+#        if: matrix.os == 'windows-latest'
+#        run: echo "${HOME}\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - run: make deps
 
@@ -42,6 +47,7 @@ jobs:
         with:
           version: v1.42
           skip-pkg-cache: true
+          skip-go-installation: true
 
       - name: golangci-lint
         if: ${{ always() }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        run: golangci-lint run --out-format=colored-line-number
+        skip-pkg-cache: true
         with:
           version: v1.42

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,11 @@
+# Getting this to work outside a normal build is quite
+# cumbersome. golangci/golangci-lint-action attempts to install go,
+# and use the module cache. In a way that _assumes_ no go commands
+# have been run in the workspace. But, this is fundamentally
+# incompatible with our needing to to generate code before
+# linting. Thus the various skip- commands.
+# See https://github.com/golangci/golangci-lint-action/issues/244
+
 name: golangci-lint
 on:
   push:
@@ -17,6 +25,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
+      - name: deps and generate
+        run: |
+          echo "${HOME}/go/bin" >> $GITHUB_PATH
+          make deps
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         skip-pkg-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,6 +32,6 @@ jobs:
       # https://github.com/golangci/golangci-lint-action/issues/244
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        skip-pkg-cache: true
         with:
           version: v1.42
+          skip-pkg-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: adjust path for bindata
+      - name: deps
+        if: matrix.os == 'ubuntu-18.04'
         run: |
           cp $GITHUB_PATH ${GITHUB_PATH}.orig
           echo "${HOME}/go/bin" >> $GITHUB_PATH
-      - run: make deps
-      - name: restore path
-        run: cp ${GITHUB_PATH}.orig ${GITHUB_PATH}
+          make deps
+          cp ${GITHUB_PATH}.orig ${GITHUB_PATH}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,6 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.15.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - master
+  pull_request:
+jobs:
+  golangci:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    name: lint
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.42

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04]
+        go-version: [1.16.x]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,10 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: deps and generate
-        run: |
-          echo "${HOME}/go/bin" >> $GITHUB_PATH
-          make deps
+      - name: adjust path for generation
+        run: echo "${HOME}/go/bin" >> $GITHUB_PATH
+      - name: make deps
 
       # Getting this to work outside a normal build is quite
       # cumbersome. golangci/golangci-lint-action attempts to install

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,26 +10,13 @@ on:
 jobs:
   golangci:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-
-      - name: adjust path for bindata
-        if: matrix.os == 'ubuntu-18.04'
-        run: |
-          cp $GITHUB_PATH ${GITHUB_PATH}.orig
-          echo "${HOME}/go/bin" >> $GITHUB_PATH
-      - run: make deps
-      - name: restore path
-        if: matrix.os == 'ubuntu-18.04'
-        run: |
-          cat $GITHUB_PATH
-          perl -pi -e 's{.*/go/bin}{}' $GITHUB_PATH
-          cat $GITHUB_PATH
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,9 +28,6 @@ jobs:
       - run: make deps
 
       # Work around https://github.com/golangci/golangci-lint-action/issues/362
-      - name: don't process annotations
-        run:  echo "::stop-commands::qwerty66"
-
 
       # Getting this to work outside a normal build is quite
       # cumbersome. golangci/golangci-lint-action attempts to install
@@ -44,3 +41,8 @@ jobs:
         with:
           version: v1.42
           skip-pkg-cache: true
+
+      - name: golangci-lint
+        if: ${{ always() }}
+        #uses: golangci/golangci-lint-action@v2
+        run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   skip-dirs:
     - test-cmds
+  timeout: 2m
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,17 +7,27 @@ linters:
     - bodyclose
     - deadcode
     - gofmt
-    - gosec
     - govet
-    - interfacer
-    - maligned
     - misspell
     - nakedret
-    - noctx
     - sqlclosecheck
     - unconvert
+  disable:
+    - errcheck
+    - gosec
+    - gosimple
+    - ineffassign
+    - interfacer
+    - maligned
+    - noctx
+    - staticcheck
+    - structcheck
     - unused
+    - varcheck
 
 linters-settings:
   errcheck:
     ignore: github.com/go-kit/kit/log:Log
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  skip-dirs:
+    - test-cmds
+
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - gofmt
+    - gosec
+    - govet
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - noctx
+    - sqlclosecheck
+    - unconvert
+    - unused
+
+linters-settings:
+  errcheck:
+    ignore: github.com/go-kit/kit/log:Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,5 +29,4 @@ linters-settings:
   errcheck:
     ignore: github.com/go-kit/kit/log:Log
   gofmt:
-    # simplify code: gofmt with `-s` option, true by default
     simplify: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ run:
   skip-dirs:
     - test-cmds
   timeout: 2m
+  out-format: colored-line-number
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   skip-dirs:
     - test-cmds
-  timeout: 2m
+  timeout: 5m
   out-format: colored-line-number
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
   skip-dirs:
     - test-cmds
   timeout: 5m
-  out-format: colored-line-number
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ test: generate
 ##
 
 lint:
+	# Requires golangci-lint installed, see https://golangci-lint.run/usage/install#local-installation
 	golangci-lint -j3 run
 
 ##

--- a/Makefile
+++ b/Makefile
@@ -214,37 +214,8 @@ test: generate
 ## Lint
 ##
 
-# These are escape newlines, looks super weird. Allows these to run in
-# parallel with `make -j`
-lint: \
-	lint-go-deadcode \
-	lint-misspell \
-	lint-go-vet \
-	lint-go-nakedret \
-	lint-go-fmt
-
-lint-go-deadcode: deps-go
-	deadcode cmd/ pkg/
-
-lint-misspell: deps-go
-	git ls-files \
-	  | grep -v pkg/simulator/testdata/bad_symlink \
-	  | grep -v assets.go$ \
-	  | xargs misspell -error -f 'misspell: {{ .Filename }}:{{ .Line }}:{{ .Column }}:corrected {{ printf "%q" .Original }} to {{ printf "%q" .Corrected }}'
-
-lint-go-vet:
-	go vet ./cmd/... ./pkg/...
-
-lint-go-nakedret: deps-go
-	nakedret ./pkg/... ./cmd/...
-
-# This is ugly. since go-fmt doesn't have a simple exit code, we use
-# some make trickery to handle failing if there;s output.
-lint-go-fmt: $(foreach c,$(shell gofmt -l ./pkg/ ./cmd/ | grep -vE 'assets.go|bindata.go'),fmt-fail/$(c))
-lint-go-fmt: deps-go
-fmt-fail/%:
-	@echo fmt failure in: $*
-	@false
+lint:
+	golangci-lint -j3 run
 
 ##
 ## Docker Tooling

--- a/cmd/launcher-pummel/launcher-pummel.go
+++ b/cmd/launcher-pummel/launcher-pummel.go
@@ -189,7 +189,7 @@ func main() {
 		"msg", "all hosts started",
 	)
 
-	sig := make(chan os.Signal)
+	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)
 	<-sig
 }

--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/launcher/control_windows.go
+++ b/cmd/launcher/control_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -336,6 +336,7 @@ func reportNotaryPing(
 	} else {
 		keyvals = append(keyvals, "response_code", resp.StatusCode)
 	}
+	defer resp.Body.Close()
 	logger.Log(keyvals...)
 	return nil
 }

--- a/cmd/launcher/runsocket.go
+++ b/cmd/launcher/runsocket.go
@@ -44,7 +44,7 @@ func runSocket(args []string) error {
 	fmt.Println(*flPath)
 
 	// Wait forever
-	sig := make(chan os.Signal)
+	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, os.Kill, syscall.Signal(15))
 	<-sig
 

--- a/cmd/launcher/svc.go
+++ b/cmd/launcher/svc.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/launcher/updater-finalizer.go
+++ b/cmd/launcher/updater-finalizer.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/launcher/updater-finalizer_windows.go
+++ b/cmd/launcher/updater-finalizer_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/osquery-extension/osquery-extension.go
+++ b/cmd/osquery-extension/osquery-extension.go
@@ -29,7 +29,7 @@ func main() {
 
 	go monitorForParent()
 
-	sig := make(chan os.Signal)
+	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)
 	<-sig
 }

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -40,6 +40,7 @@
 // While some functions can be unit tested, integration is tightly
 // coupled to TUF. One of the simplest ways to test this, is by
 // attaching to the `nightly` channel, and causing frequent updates.
+//nolint:typecheck // parts of this come from bindata, so lint fails
 package autoupdate
 
 import (

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -64,10 +64,9 @@ import (
 type UpdateChannel string
 
 const (
-	Stable   UpdateChannel = "stable"
-	Beta                   = "beta"
-	Nightly                = "nightly"
-	localDev               = "development"
+	Stable  UpdateChannel = "stable"
+	Beta                  = "beta"
+	Nightly               = "nightly"
 )
 
 const (

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -1,3 +1,4 @@
+//nolint:typecheck // parts of this come from bindata, so lint fails
 package autoupdate
 
 import (

--- a/pkg/autoupdate/helpers.go
+++ b/pkg/autoupdate/helpers.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package autoupdate

--- a/pkg/autoupdate/helpers_windows.go
+++ b/pkg/autoupdate/helpers_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package autoupdate

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package debug
 
 import (

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -113,7 +113,7 @@ func authHandler(token string, logger log.Logger) http.HandlerFunc {
 }
 
 func registerAuthHandler(token string, mux *http.ServeMux, logger log.Logger) {
-	mux.Handle(debugPrefix, http.StripPrefix(debugPrefix, http.HandlerFunc(authHandler(token, logger))))
+	mux.Handle(debugPrefix, http.StripPrefix(debugPrefix, authHandler(token, logger)))
 }
 
 var indexTmpl = template.Must(template.New("index").Parse(`<html>

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 //nolint:bodyclose

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,5 +1,6 @@
 // +build !windows
 
+//nolint:bodyclose
 package debug
 
 import (
@@ -73,13 +74,13 @@ func TestAttachDebugHandler(t *testing.T) {
 	resp, err := http.Get(url)
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	// Stop server
 	syscall.Kill(syscall.Getpid(), debugSignal)
 	time.Sleep(1 * time.Second)
 
-	resp, err = http.Get(url)
+	_, err = http.Get(url)
 	require.NotNil(t, err)
 
 	// Start server
@@ -89,7 +90,7 @@ func TestAttachDebugHandler(t *testing.T) {
 	newUrl := getDebugURL(t, tokenFile.Name())
 	assert.NotEqual(t, url, newUrl)
 
-	resp, err = http.Get(newUrl)
+	_, err = http.Get(newUrl)
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
@@ -98,6 +99,6 @@ func TestAttachDebugHandler(t *testing.T) {
 	syscall.Kill(syscall.Getpid(), debugSignal)
 	time.Sleep(1 * time.Second)
 
-	resp, err = http.Get(url)
+	_, err = http.Get(url)
 	require.NotNil(t, err)
 }

--- a/pkg/debug/signal_debug.go
+++ b/pkg/debug/signal_debug.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package debug

--- a/pkg/debug/signal_debug_windows.go
+++ b/pkg/debug/signal_debug_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package debug

--- a/pkg/execwrapper/exec.go
+++ b/pkg/execwrapper/exec.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package execwrapper

--- a/pkg/execwrapper/exec_windows.go
+++ b/pkg/execwrapper/exec_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package execwrapper

--- a/pkg/log/eventlog/eventlog.go
+++ b/pkg/log/eventlog/eventlog.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package eventlog

--- a/pkg/log/eventlog/eventlog_windows.go
+++ b/pkg/log/eventlog/eventlog_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventlog

--- a/pkg/log/eventlog/writer.go
+++ b/pkg/log/eventlog/writer.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package eventlog

--- a/pkg/log/eventlog/writer_windows.go
+++ b/pkg/log/eventlog/writer_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package eventlog

--- a/pkg/osquery/extension_serial.go
+++ b/pkg/osquery/extension_serial.go
@@ -1,3 +1,4 @@
+//go:build !fakeserial
 // +build !fakeserial
 
 package osquery

--- a/pkg/osquery/extension_serial_fakeserial.go
+++ b/pkg/osquery/extension_serial_fakeserial.go
@@ -1,3 +1,4 @@
+//go:build fakeserial
 // +build fakeserial
 
 package osquery

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package runtime

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package runtime

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package runtime

--- a/pkg/osquery/table/corefoundation_helpers_darwin.go
+++ b/pkg/osquery/table/corefoundation_helpers_darwin.go
@@ -1,3 +1,4 @@
+//nolint:unconvert
 package table
 
 /*

--- a/pkg/osquery/table/mdfind_darwin.go
+++ b/pkg/osquery/table/mdfind_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin || !cgo
 // +build darwin !cgo
 
 package table

--- a/pkg/osquery/table/mdm_test.go
+++ b/pkg/osquery/table/mdm_test.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package table

--- a/pkg/osquery/table/platform_tables.go
+++ b/pkg/osquery/table/platform_tables.go
@@ -1,3 +1,4 @@
+//go:build !darwin && !windows && !linux
 // +build !darwin,!windows,!linux
 
 package table

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package table

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package table

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package table

--- a/pkg/osquery/table/spotlight.go
+++ b/pkg/osquery/table/spotlight.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package table

--- a/pkg/osquery/table/user_avatar_darwin.go
+++ b/pkg/osquery/table/user_avatar_darwin.go
@@ -80,7 +80,7 @@ func (t *userAvatarTable) generateAvatars(ctx context.Context, queryContext tabl
 	} else {
 		usernamesString := C.LocalUsers()
 		for _, posixName := range strings.Split(C.GoString(usernamesString), " ") {
-			usernames = append(usernames, string(posixName))
+			usernames = append(usernames, posixName)
 		}
 	}
 

--- a/pkg/osquery/table/zerotier.go
+++ b/pkg/osquery/table/zerotier.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package table

--- a/pkg/osquery/table/zerotier_windows.go
+++ b/pkg/osquery/table/zerotier_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package table

--- a/pkg/osquery/tables/app-icons/app_icons_darwin.go
+++ b/pkg/osquery/tables/app-icons/app_icons_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package appicons

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package dsim_default_associations

--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package filevault

--- a/pkg/osquery/tables/fscrypt_info/fscrypt_linux.go
+++ b/pkg/osquery/tables/fscrypt_info/fscrypt_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package fscrypt_info

--- a/pkg/osquery/tables/fscrypt_info/generate.go
+++ b/pkg/osquery/tables/fscrypt_info/generate.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package fscrypt_info

--- a/pkg/osquery/tables/fscrypt_info/generate_linux.go
+++ b/pkg/osquery/tables/fscrypt_info/generate_linux.go
@@ -11,6 +11,10 @@ import (
 	"github.com/kolide/osquery-go/plugin/table"
 )
 
+const (
+	allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-_.+"
+)
+
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	paths := tablehelpers.GetConstraints(queryContext, "path", tablehelpers.WithAllowedCharacters(allowedCharacters))
 	if len(paths) < 1 {
@@ -42,4 +46,12 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	}
 
 	return results, nil
+}
+
+func boolToRow(v bool) string {
+	if v {
+		return "1"
+	}
+
+	return "0"
 }

--- a/pkg/osquery/tables/fscrypt_info/generate_linux.go
+++ b/pkg/osquery/tables/fscrypt_info/generate_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package fscrypt_info

--- a/pkg/osquery/tables/fscrypt_info/table.go
+++ b/pkg/osquery/tables/fscrypt_info/table.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-_.+"
-	tableName         = "kolide_fscrypt_info"
+	tableName = "kolide_fscrypt_info"
 )
 
 type Table struct {
@@ -30,12 +29,4 @@ func TablePlugin(logger log.Logger) *table.Plugin {
 		logger: logger,
 	}
 	return table.NewPlugin(tableName, columns, t.generate)
-}
-
-func boolToRow(v bool) string {
-	if v {
-		return "1"
-	}
-
-	return "0"
 }

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package gsettings

--- a/pkg/osquery/tables/gsettings/gsettings_test.go
+++ b/pkg/osquery/tables/gsettings/gsettings_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package gsettings

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package gsettings

--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 // Package ioreg provides a table wrapper around the `ioreg` macOS
 // command.

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -1,4 +1,6 @@
+//go:build !windows
 // +build !windows
+
 // (skip building windows, since the newline replacement doesn't work there)
 
 // Package mdmclient provides a table that parses the mdmclient

--- a/pkg/osquery/tables/mdmclient/mdmclient_test.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient_test.go
@@ -1,4 +1,6 @@
+//go:build !windows
 // +build !windows
+
 // (skip building windows, since the newline replacement doesn't work there)
 
 package mdmclient

--- a/pkg/osquery/tables/munki/munki.go
+++ b/pkg/osquery/tables/munki/munki.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package munki

--- a/pkg/osquery/tables/munki/munki_test.go
+++ b/pkg/osquery/tables/munki/munki_test.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package munki

--- a/pkg/osquery/tables/osquery_user_exec_table/table.go
+++ b/pkg/osquery/tables/osquery_user_exec_table/table.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Package osquery_exec_table provides a table generator that will

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 // Package profiles provides a table wrapper around the various
 // profiles options.

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 // Package pwpolicy provides a table wrapper around the `pwpolicy` macOS
 // command.

--- a/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy_test.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package pwpolicy
 

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package secedit

--- a/pkg/osquery/tables/systemprofiler/systemprofiler.go
+++ b/pkg/osquery/tables/systemprofiler/systemprofiler.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 // Package systemprofiler provides a suite table wrapper around
 // `system_profiler` macOS command. It supports some basic arguments

--- a/pkg/osquery/tables/tablehelpers/exec_test.go
+++ b/pkg/osquery/tables/tablehelpers/exec_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package tablehelpers

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wifi_networks

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
@@ -165,7 +165,7 @@ func getSearcher(locale string) (*windowsupdate.IUpdateSearcher, string, int, er
 		return nil, locale, isDefaultLocale, errors.Wrap(err, "getlocale")
 	}
 	if strconv.FormatUint(uint64(getLocale), 10) != locale && isDefaultLocale == 0 {
-		return nil, locale, isDefaultLocale, errors.Wrapf(err, "set locale(%s) doesn't match returned locale(%d) sqlite will filter", locale, uint32(getLocale))
+		return nil, locale, isDefaultLocale, errors.Wrapf(err, "set locale(%s) doesn't match returned locale(%d) sqlite will filter", locale, getLocale)
 	} else {
 		locale = strconv.FormatUint(uint64(getLocale), 10)
 	}

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsupdatetable

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsupdatetable

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmitable

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmitable

--- a/pkg/osquery/tables/xrdb/xrdb.go
+++ b/pkg/osquery/tables/xrdb/xrdb.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package xrdb

--- a/pkg/osquery/tables/xrdb/xrdb_test.go
+++ b/pkg/osquery/tables/xrdb/xrdb_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package xrdb

--- a/pkg/packagekit/applenotarization/types.go
+++ b/pkg/packagekit/applenotarization/types.go
@@ -19,6 +19,8 @@ type notarizationInfo struct {
 	StatusMessage string    `plist:"Status Message"`
 }
 
+// this is eventually used by callers in other repos
+//nolint:deadcode
 type notarizationUpload struct {
 	ProductErrors []productError `plist:"product-errors"`
 }

--- a/pkg/packagekit/authenticode/authenticode_dummy.go
+++ b/pkg/packagekit/authenticode/authenticode_dummy.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package authenticode

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package authenticode

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Authenticode is a light wrapper around signing code under windows.

--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -129,5 +129,4 @@ func (so *signtoolOptions) signtoolSign(ctx context.Context, file string, args .
 		// Fallthrough to catch errors unrelated to timeouts
 		return errors.Wrap(err, "calling signtool")
 	}
-	return errors.New("How did you get here? Some logic bug")
 }

--- a/pkg/packagekit/render_launchd_test.go
+++ b/pkg/packagekit/render_launchd_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package packagekit

--- a/pkg/packagekit/render_upstart_test.go
+++ b/pkg/packagekit/render_upstart_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // These tests fail on windows, due to what looks like line ending

--- a/pkg/ptycmd/command.go
+++ b/pkg/ptycmd/command.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package ptycmd

--- a/pkg/ptycmd/command_windows.go
+++ b/pkg/ptycmd/command_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package ptycmd

--- a/pkg/service/dial_test.go
+++ b/pkg/service/dial_test.go
@@ -52,6 +52,7 @@ func startServer(t *testing.T, conf *tls.Config) func() {
 	return grpcServer.Stop
 }
 
+//nolint:deadcode
 const (
 	badCert = "testdata/bad-cert.pem"
 	badKey  = "testdata/bad-key.pem"

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -9,8 +9,5 @@ For additional documentation on the topic:
 package tools
 
 import (
-	_ "github.com/alexkohler/nakedret"
-	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/go-bindata/go-bindata/go-bindata"
-	_ "github.com/tsenart/deadcode"
 )

--- a/pkg/windows/windowsupdate/iupdate.go
+++ b/pkg/windows/windowsupdate/iupdate.go
@@ -358,6 +358,7 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 	return iUpdate, nil
 }
 
+//nolint:deadcode
 func toIUpdateCollection(updates []*IUpdate) (*ole.IDispatch, error) {
 	unknown, err := oleutil.CreateObject("Microsoft.Update.UpdateColl")
 	if err != nil {

--- a/pkg/wmi/wmi.go
+++ b/pkg/wmi/wmi.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Package wmi provides a basic interface for querying against

--- a/pkg/wmi/wmi_test.go
+++ b/pkg/wmi/wmi_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmi

--- a/tools/autoupdate-v1-tests/main.go
+++ b/tools/autoupdate-v1-tests/main.go
@@ -15,9 +15,6 @@ type thingy struct {
 	stagedFile string
 }
 
-const serviceName = "upgradetest"
-const serviceDesc = "Launcher Auto Upgrade Testing"
-
 type processNotes struct {
 	Pid     int
 	Path    string

--- a/tools/autoupdate-v1-tests/main.go
+++ b/tools/autoupdate-v1-tests/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/kardianos/osext"
-	"github.com/kolide/kit/fs"
 	"github.com/pkg/errors"
 )
 
@@ -74,38 +73,6 @@ func main() {
 	}
 
 	fmt.Printf("Finished Main (pid %d)\n", ProcessNotes.Pid)
-
-}
-
-func oldShit() {
-
-	fmt.Printf("\n\nStarting a new thread. Pid: %d\n", os.Getpid())
-	time.Sleep(1 * time.Second)
-
-	binaryName, err := osext.Executable()
-	if err != nil {
-		panic(errors.Wrap(err, "osext.Executable"))
-	}
-
-	// Should this get a random append?
-	stagedFile := fmt.Sprintf("%s-staged", binaryName)
-
-	// To emulate a new version, just copy the current binary to the staged location
-	fmt.Println("fs.CopyFile")
-	if err := fs.CopyFile(binaryName, stagedFile); err != nil {
-		panic(errors.Wrap(err, "fs.CopyFile"))
-	}
-
-	b := &thingy{
-		binaryName: binaryName,
-		stagedFile: stagedFile,
-	}
-
-	if err := b.rename(); err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("BAD BAD BAD old thread! (pid %d)\n", os.Getpid())
 
 }
 

--- a/tools/autoupdate-v1-tests/svc-manager_windows.go
+++ b/tools/autoupdate-v1-tests/svc-manager_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/tools/autoupdate-v1-tests/svc.go
+++ b/tools/autoupdate-v1-tests/svc.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/tools/autoupdate-v1-tests/svc_windows.go
+++ b/tools/autoupdate-v1-tests/svc_windows.go
@@ -18,6 +18,11 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
+const (
+	serviceName = "upgradetest"
+	serviceDesc = "Launcher Auto Upgrade Testing"
+)
+
 func runWindowsSvc(args []string) error {
 	eventLogWriter, err := eventlog.NewWriter(serviceName)
 	if err != nil {

--- a/tools/autoupdate-v1-tests/svc_windows.go
+++ b/tools/autoupdate-v1-tests/svc_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main


### PR DESCRIPTION
`golangci-lint` seems common. This moves our linting to using it. New github job, and cleanup on some of the weird tools pattern.

To support this, there's also a bunch of tiny bits of code cleanup. (And lint ignores)
