### PR TITLE
Rosetta should be installed on more OS versions

### DIFF
--- a/pkg/packaging/assets/preinstall-darwin.sh
+++ b/pkg/packaging/assets/preinstall-darwin.sh
@@ -8,11 +8,6 @@
 # rosetta2 install, but this does not appear to happen during an MDM
 # install. So, we need to trigger than from a preinstall script.
 
-# If we're not Big Sur (build 20x), exit
-if [[ "$(/usr/bin/sw_vers -buildVersion)" != 20* ]]; then
-    exit 0
-fi
-
 # If we're not arm, exit
 if [ "$(/usr/bin/arch)" != "arm64" ]; then
     exit 0


### PR DESCRIPTION
With Monterey shipping, this is clearly wrong. The M1 machines will need rosetta as long as we're not shipping for that platform. This check is clearly incorrect.

It's possible this is going to throw an error on an m1 machine on catalina. But the internet suggests that's not supported. 

Thanks @terracatta for noticing