### PR TITLE
Add `launcher_gc_info` table

### DIFF
--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -3,6 +3,7 @@ package table
 import (
 	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/tdebug"
 	"github.com/kolide/launcher/pkg/osquery/tables/zfs"
 
 	"github.com/go-kit/kit/log"
@@ -11,7 +12,8 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-// LauncherTables returns launcher-specific tables
+// LauncherTables returns launcher-specific tables. They're based
+// around _launcher_ things thus do not make sense in tables.ext
 func LauncherTables(db *bbolt.DB, opts *launcher.Options) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		LauncherConfigTable(db),
@@ -41,6 +43,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 			"kolide_zerotier_networks", dataflattentable.JsonType, zerotierCli("listnetworks")),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_peers", dataflattentable.JsonType, zerotierCli("listpeers")),
+		tdebug.LauncherGcInfo(client, logger),
 		zfs.ZfsPropertiesPlugin(client, logger),
 		zfs.ZpoolPropertiesPlugin(client, logger),
 	}

--- a/pkg/osquery/tables/tdebug/doc.go
+++ b/pkg/osquery/tables/tdebug/doc.go
@@ -1,0 +1,4 @@
+// Package tdebug contains various debugging oriented tables. These are
+// intended to remotely debug the state of launcher and may not make
+// any kind of sense in a broader context.
+package tdebug

--- a/pkg/osquery/tables/tdebug/gc.go
+++ b/pkg/osquery/tables/tdebug/gc.go
@@ -1,0 +1,71 @@
+package tdebug
+
+import (
+	"context"
+	"encoding/json"
+	"runtime/debug"
+	"strings"
+
+	"github.com/kolide/launcher/pkg/dataflatten"
+	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/pkg/errors"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/osquery/osquery-go"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const (
+	gcTableName = "launcher_gc_info"
+)
+
+type gcTable struct {
+	logger log.Logger
+	stats  debug.GCStats
+}
+
+func LauncherGcInfo(_client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := dataflattentable.Columns()
+
+	t := &gcTable{
+		logger: logger,
+	}
+
+	return table.NewPlugin(gcTableName, columns, t.generate)
+}
+
+func (t *gcTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	debug.ReadGCStats(&t.stats)
+
+	// Make sure the history arrays aren't too large
+	if len(t.stats.Pause) > 100 {
+		t.stats.Pause = t.stats.Pause[:100]
+	}
+	if len(t.stats.PauseEnd) > 100 {
+		t.stats.PauseEnd = t.stats.PauseEnd[:100]
+	}
+
+	for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
+		// bounce through json to serialize GCStats
+		jsonBytes, err := json.Marshal(t.stats)
+		if err != nil {
+			return nil, errors.Wrap(err, "json")
+		}
+
+		flatData, err := dataflatten.Json(
+			jsonBytes,
+			dataflatten.WithLogger(t.logger),
+			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
+		)
+		if err != nil {
+			level.Info(t.logger).Log("msg", "gc flatten failed", "err", err)
+			continue
+		}
+		results = append(results, dataflattentable.ToMap(flatData, dataQuery, nil)...)
+	}
+	return results, nil
+}


### PR DESCRIPTION
This adds a table that exposes launcher's GC runs. I don't believe this
is sensitive, and it should help some remote debugging