### PR TITLE
Simple table over `airport` command

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/knightsc/system_policy/osquery/table/kextpolicy"
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
+	"github.com/kolide/launcher/pkg/osquery/tables/airport"
 	appicons "github.com/kolide/launcher/pkg/osquery/tables/app-icons"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/filevault"
@@ -84,6 +85,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		TouchIDUserConfig(client, logger),
 		TouchIDSystemConfig(client, logger),
 		UserAvatar(logger),
+		airport.TablePlugin(client, logger),
 		ioreg.TablePlugin(client, logger),
 		profiles.TablePlugin(client, logger),
 		kextpolicy.TablePlugin(),

--- a/pkg/osquery/tables/airport/airport.go
+++ b/pkg/osquery/tables/airport/airport.go
@@ -1,0 +1,77 @@
+//go:build darwin
+// +build darwin
+
+package airport
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/dataflatten"
+	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/osquery/osquery-go"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/pkg/errors"
+)
+
+var (
+	allowedOptions = []string{"getinfo", "scan"}
+	airportPaths   = []string{"/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport"}
+)
+
+type Table struct {
+	name   string
+	logger log.Logger
+}
+
+func TablePlugin(_ *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := dataflattentable.Columns(
+		table.TextColumn("option"),
+	)
+
+	t := &Table{
+		name:   "kolide_airport_util",
+		logger: logger,
+	}
+
+	return table.NewPlugin(t.name, columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	options := tablehelpers.GetConstraints(queryContext, "option", tablehelpers.WithAllowedValues(allowedOptions))
+
+	if len(options) == 0 {
+		return results, errors.Errorf("The %s table requires that you specify a constraint for option", t.name)
+	}
+
+	for _, option := range options {
+		airportOutput, err := tablehelpers.Exec(ctx, t.logger, 30, airportPaths, []string{"--" + option, "--xml"})
+		if err != nil {
+			level.Debug(t.logger).Log("msg", "Error execing airport", "option", option, "err", err)
+			continue
+		}
+
+		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
+			flatData, err := dataflatten.Xml(
+				airportOutput,
+				dataflatten.WithLogger(t.logger),
+				dataflatten.WithQuery(strings.Split(dataQuery, "/")),
+			)
+
+			if err != nil {
+				level.Info(t.logger).Log("msg", "flatten failed", "err", err)
+				continue
+			}
+
+			rowData := map[string]string{"option": option}
+			results = append(results, dataflattentable.ToMap(flatData, dataQuery, rowData)...)
+
+		}
+	}
+	return results, nil
+}


### PR DESCRIPTION
This uses the `airport --xml` to display some debugging information and parse it into an EAV.

One issue here -- the xml output seems crashy. On my test machines it will often stop working mid stream, leaving me with unparsable junk