### PR TITLE
Add support for `uint8` to dataflatten

### DIFF
--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -462,6 +462,8 @@ func stringify(data interface{}) (string, error) {
 		return base64.StdEncoding.EncodeToString(v), nil
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10), nil
 	case uint32:
 		return strconv.FormatUint(uint64(v), 10), nil
 	case uint64:
@@ -472,6 +474,10 @@ func stringify(data interface{}) (string, error) {
 		return strconv.FormatFloat(v, 'f', -1, 64), nil
 	case int:
 		return strconv.Itoa(v), nil
+	case int8:
+		return strconv.FormatInt(int64(v), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(v), 10), nil
 	case int32:
 		return strconv.FormatInt(int64(v), 10), nil
 	case int64:

--- a/pkg/dataflatten/flatten.go
+++ b/pkg/dataflatten/flatten.go
@@ -460,6 +460,8 @@ func stringify(data interface{}) (string, error) {
 			return s, nil
 		}
 		return base64.StdEncoding.EncodeToString(v), nil
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10), nil
 	case uint32:
 		return strconv.FormatUint(uint64(v), 10), nil
 	case uint64:


### PR DESCRIPTION
We've now seen `uint8` in flatten input.