### PR TITLE
File read tables should not error on bad files

### DIFF
--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -99,7 +99,12 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 				subresults, err := t.generatePath(filePath, dataQuery)
 				if err != nil {
-					return results, errors.Wrapf(err, "generating for path %s with query", filePath)
+					level.Info(t.logger).Log(
+						"msg", "failed to get data for path",
+						"path", filePath,
+						"err", err,
+					)
+					continue
 				}
 
 				results = append(results, subresults...)


### PR DESCRIPTION
We have a variety of file reading tables that we use to parse configuration
data. Sometimes, we encounter badly formatted data. Instead of hard erroring
out, we should instead return what we can.