### PR TITLE
pkg/simulator: fix clobbered error

### DIFF
--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -63,6 +63,9 @@ func (h *HostSimulation) Enroll() error {
 	enrollmentAttempts := 5
 
 	var err error
+	var nodeKey string
+	var invalid bool
+
 	for currentAttempt := 1; currentAttempt <= enrollmentAttempts; currentAttempt++ {
 		if currentAttempt != 1 {
 			level.Debug(h.logger).Log(
@@ -71,7 +74,7 @@ func (h *HostSimulation) Enroll() error {
 			)
 			time.Sleep(time.Duration(math.Pow(2, float64(currentAttempt))) * time.Second)
 		}
-		nodeKey, invalid, err := h.state.serviceClient.RequestEnrollment(context.Background(), h.enrollSecret, h.uuid, service.EnrollmentDetails{})
+		nodeKey, invalid, err = h.state.serviceClient.RequestEnrollment(context.Background(), h.enrollSecret, h.uuid, service.EnrollmentDetails{})
 		if err != nil {
 			level.Debug(h.logger).Log(
 				"msg", "transport error in enrollment",


### PR DESCRIPTION
This fixes an `err` that was being declared outside of a loop but then re-declared inside with a `:=`.