### PR TITLE
Add `mergeable` targets to github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
 
 
   package_builder_test:
-    name: Package Builder
+    name: package_builder
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -77,3 +77,15 @@ jobs:
       run: make package-builder
     - name: package
       run: ${{ steps.build.outputs.binary }} make -debug --hostname=localhost --enroll_secret=secret
+
+
+  # This job is here as a github status check -- it allows us to move
+  # the merge dependency from being on all the jobs to this single
+  # one.
+  mergeable:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+    needs:
+      - package_builder
+      - launcher

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,5 +87,5 @@ jobs:
     steps:
       - run: true
     needs:
-      - package_builder
-      - launcher
+      - build_and_test
+      - package_builder_test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -53,5 +53,4 @@ jobs:
     steps:
       - run: true
     needs:
-      - lint
-      - lint
+      - golangci

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -44,3 +44,14 @@ jobs:
         if: ${{ always() }}
         #uses: golangci/golangci-lint-action@v2
         run: golangci-lint run
+
+  # This job is here as a github status check -- it allows us to move
+  # the merge dependency from being on all the jobs to this single
+  # one.
+  mergeable:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+    needs:
+      - lint
+      - lint


### PR DESCRIPTION
When gating mergability on github actions, you must explicitly list all checks. This is surprisingly cumbersome. Instead, create a target to act as an aggregator.