### PR TITLE
Use different names for different CI jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,7 +82,7 @@ jobs:
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single
   # one.
-  mergeable:
+  ci_mergeable:
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -48,7 +48,7 @@ jobs:
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single
   # one.
-  mergeable:
+  lint_mergeable:
     runs-on: ubuntu-latest
     steps:
       - run: true


### PR DESCRIPTION
Apparently github can't differenciate between jobs with the same name. So rename these