### PR TITLE
Updates around socket handling

### DIFF
--- a/cmd/grpc.ext/grpc.go
+++ b/cmd/grpc.ext/grpc.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	var (
 		flSocketPath = flag.String("socket", "", "")
-		flTimeout    = flag.Int("timeout", 0, "")
+		flTimeout    = flag.Int("timeout", 2, "")
 		flVerbose    = flag.Bool("verbose", false, "")
 		flVersion    = flag.Bool("version", false, "Print Launcher version and exit")
 

--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	var (
 		flSocketPath = flag.String("socket", "", "")
-		flTimeout    = flag.Int("timeout", 0, "")
+		flTimeout    = flag.Int("timeout", 2, "")
 		flVerbose    = flag.Bool("verbose", false, "")
 		flVersion    = flag.Bool("version", false, "Print  version and exit")
 		_            = flag.Int("interval", 0, "")

--- a/cmd/osquery-extension/osquery-extension.go
+++ b/cmd/osquery-extension/osquery-extension.go
@@ -14,9 +14,9 @@ func main() {
 	var (
 		_         = flag.Bool("verbose", false, "")
 		_         = flag.Int("interval", 0, "")
-		_         = flag.Int("timeout", 0, "")
+		_         = flag.Int("timeout", 2, "")
 		_         = flag.String("socket", "", "")
-		flVersion = flag.Bool("version", false, "Print  version and exit")
+		flVersion = flag.Bool("version", false, "Print version and exit")
 	)
 	flag.Parse()
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5
+	github.com/osquery/osquery-go v0.0.0-20220317165851-954ac78f381f
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,9 @@ github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea/go.mod h1:N5eJIl14
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/apache/thrift v0.13.1-0.20200603211036-eac4d0c79a5f h1:33BV5v3u8I6dA2dEoPuXWCsAaHHOJfPtdxZhAMQV4uo=
 github.com/apache/thrift v0.13.1-0.20200603211036-eac4d0c79a5f/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
+github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bugsnag/bugsnag-go v1.3.2 h1:8bcRylldQKQiAx9/KPu9+1iLZwgK1eN1Ib3SROSXfIY=
@@ -68,6 +69,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -161,8 +163,9 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5 h1:E275nJIUAvIK/RSN8cq9MAcRLk23jaZq+s24B0I8bEw=
 github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5/go.mod h1:JKR5QhjsYdnIPY7hakgas5sxf8qlA/9wQnLqaMfWdcg=
+github.com/osquery/osquery-go v0.0.0-20220317165851-954ac78f381f h1:FrIbNt88ZvH8RoqEXCJF0mWylKrojqhJVOs6CqAzODw=
+github.com/osquery/osquery-go v0.0.0-20220317165851-954ac78f381f/go.mod h1:0KzmMhe0PL19cdYq6nd1cT9/5bMMJBTssAfuEgM2i34=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
@@ -222,6 +225,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -232,6 +236,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -281,7 +286,9 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191025023517-2077df36852e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -849,6 +849,8 @@ func (r *Runner) launchOsqueryInstance() error {
 						failed = false
 						break
 					}
+
+					time.Sleep(1 * time.Second)
 				}
 				if failed {
 					return errors.Wrap(err, "health check failed")

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -744,11 +744,12 @@ func (r *Runner) launchOsqueryInstance() error {
 	// Kill osquery process on shutdown
 	o.errgroup.Go(func() error {
 		<-o.doneCtx.Done()
+		level.Debug(o.logger).Log("msg", "Starting osquery shutdown")
 		if o.cmd.Process != nil {
 			// kill osqueryd and children
 			if err := killProcessGroup(o.cmd); err != nil {
 				if strings.Contains(err.Error(), "process already finished") || strings.Contains(err.Error(), "no such process") {
-					level.Debug(o.logger).Log("process already gone")
+					level.Debug(o.logger).Log("msg", "tried to stop osquery, but process already gone")
 				} else {
 					level.Info(o.logger).Log("msg", "killing osquery process", "err", err)
 				}
@@ -813,6 +814,7 @@ func (r *Runner) launchOsqueryInstance() error {
 	// Cleanup extension manager server on shutdown
 	o.errgroup.Go(func() error {
 		<-o.doneCtx.Done()
+		level.Debug(o.logger).Log("msg", "Starting extension shutdown")
 		if err := o.extensionManagerServer.Shutdown(context.TODO()); err != nil {
 			level.Info(o.logger).Log(
 				"msg", "Got error while shutting down extension server",
@@ -832,6 +834,7 @@ func (r *Runner) launchOsqueryInstance() error {
 				return o.doneCtx.Err()
 			case <-ticker.C:
 				if err := o.Healthy(); err != nil {
+					level.Info(o.logger).Log("msg", "Health check failed", "err", err)
 					return errors.Wrap(err, "health check failed")
 				}
 			}

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -844,11 +844,11 @@ func (r *Runner) launchOsqueryInstance() error {
 						level.Info(o.logger).Log("msg", "Health check failed", "attempt", i, "err", err)
 						failed = true
 
+					} else {
+						// err was nil, clear failed
+						failed = false
+						break
 					}
-
-					// err was nil, clear failed
-					failed = false
-					break
 				}
 				if failed {
 					return errors.Wrap(err, "health check failed")

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -838,22 +838,22 @@ func (r *Runner) launchOsqueryInstance() error {
 				// down. This is pretty simple, it
 				// hardcodes the timing. Might be
 				// better for a Limiter
-				failed := false
-				for i := 0; i <= 5; i++ {
+				maxHealthChecks := 5
+				for i := 1; i <= maxHealthChecks; i++ {
 					if err := o.Healthy(); err != nil {
 						level.Info(o.logger).Log("msg", "Health check failed", "attempt", i, "err", err)
-						failed = true
+
+						if i == maxHealthChecks {
+							return errors.Wrap(err, "health check failed")
+						}
+
+						time.Sleep(1 * time.Second)
 
 					} else {
 						// err was nil, clear failed
-						failed = false
 						break
 					}
 
-					time.Sleep(1 * time.Second)
-				}
-				if failed {
-					return errors.Wrap(err, "health check failed")
 				}
 			}
 		}

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -815,7 +815,7 @@ func (r *Runner) launchOsqueryInstance() error {
 		<-o.doneCtx.Done()
 		if err := o.extensionManagerServer.Shutdown(context.TODO()); err != nil {
 			level.Info(o.logger).Log(
-				"msg", "shutting down extension server",
+				"msg", "Got error while shutting down extension server",
 				"err", err,
 			)
 		}

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -846,7 +846,7 @@ func (r *Runner) launchOsqueryInstance() error {
 							return errors.Wrap(err, "health check failed")
 						}
 
-						level.Info(o.logger).Log("msg", "Health check failed. Will retry", "attempt", i, "err", err)
+						level.Debug(o.logger).Log("msg", "Health check failed. Will retry", "attempt", i, "err", err)
 						time.Sleep(1 * time.Second)
 
 					} else {

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -841,16 +841,20 @@ func (r *Runner) launchOsqueryInstance() error {
 				maxHealthChecks := 5
 				for i := 1; i <= maxHealthChecks; i++ {
 					if err := o.Healthy(); err != nil {
-						level.Info(o.logger).Log("msg", "Health check failed", "attempt", i, "err", err)
-
 						if i == maxHealthChecks {
+							level.Info(o.logger).Log("msg", "Health check failed. Giving up", "attempt", i, "err", err)
 							return errors.Wrap(err, "health check failed")
 						}
 
+						level.Info(o.logger).Log("msg", "Health check failed. Will retry", "attempt", i, "err", err)
 						time.Sleep(1 * time.Second)
 
 					} else {
 						// err was nil, clear failed
+						if i > 1 {
+							level.Debug(o.logger).Log("msg", "Health check passed. Clearing error", "attempt", i)
+						}
+
 						break
 					}
 


### PR DESCRIPTION
This has several small things to try to fix a socket issue I've been started seeing. 

1. Upgrades osquery-go, to upgrade thrift. This is a bit of a long shot, but seems reasonable
2. Sets better default timeouts to the optional tools we build (Not quite relevant, but seems reasonable in debugging)
3. Improve logging on the code paths that are likely in play
4. Add some simple retry logic to the health check code path