### PR TITLE
Add helper to run a function using setuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/viper v1.2.1 // indirect
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.7.1
 	github.com/theupdateframework/notary v0.6.1
 	go.etcd.io/bbolt v1.3.6
 	go.opencensus.io v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=
 github.com/theupdateframework/notary v0.6.1/go.mod h1:MOfgIfmox8s7/7fduvB2xyPPMJCrjRLRizA8OFwpnKY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -321,9 +321,10 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/pkg/threadas/threadas.go
+++ b/pkg/threadas/threadas.go
@@ -1,10 +1,15 @@
-// Package threadsetuid uses some thread trickery to facilitate
+//go:build darwin
+// +build darwin
+
+// Package threadas uses some thread trickery to facilitate
 // dropping permissions on a single thread. This allows us to call
 // underlying darwin APIs which change behavior based on the userid.
 //
 // Note that this changes permission on a single thread. It cannot
 // change permission on something like osquery (communication is over
-// a socket), and may not do the right thing if you bring in an exec.
+// a socket), and may not do the right thing if you bring in an
+// exec. This also means that if you spawn a new thread, you'll get
+// the parent process permissions.
 //
 // This is based on ideas from:
 //   * https://github.com/golang/go/issues/14592
@@ -13,21 +18,20 @@
 //
 // There's future work in supporting other platforms. Linux may have
 // `syscall(SYS_setresuid, ...)` for this.
-package threadsetuid
+package threadas
 
-import(
-	"time"
-	"syscall"
+import (
 	"fmt"
 	"runtime"
+	"syscall"
+	"time"
 )
-
 
 // ThreadAs will run a function, in a "thread", after using setuid to
 // change permissions on that thread. It uses `LockOSThread` so the
 // thread terminates after with the function, this is to clean up from
 // the permissions change.
-func ThreadAs(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  error {
+func ThreadAs(fn func() error, timeout time.Duration, uid uint32, gid uint32) error {
 	// As we only support calling the function once, so we can
 	// buffer a single size. Makes it a bit easier to
 	// sequence starting the child and our listener.
@@ -56,9 +60,9 @@ func ThreadAs(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  
 	}()
 
 	select {
-	case err := <- errChan:
+	case err := <-errChan:
 		return err
-	case <- time.After(timeout):
+	case <-time.After(timeout):
 		return fmt.Errorf("Timeout after %s", timeout)
 	}
 }
@@ -69,15 +73,14 @@ func ThreadAs(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  
 //
 // There is some discussion in the man page that this is not suitable
 // for security isolation. It's recommended you read and understand that.
-func pthread_setugid_np(uid uint32, gid uint32) (error) {
+func pthread_setugid_np(uid uint32, gid uint32) error {
 	// syscall.RawSyscall blocks, while Syscall does not. Since we
 	// don't think this blocks, we can use the _slightly_ more
 	// performant RawSyscall
 	_, _, errNo := syscall.RawSyscall(syscall.SYS_SETTID, uintptr(uid), uintptr(gid), 0)
 	if errNo != 0 {
 		return errNo
-	} 
+	}
 
 	return nil
 }
-

--- a/pkg/threadas/threadas.go
+++ b/pkg/threadas/threadas.go
@@ -28,7 +28,9 @@ import (
 )
 
 const (
-	// KAUTH_UID_NONE and KAUTH_GID_NONE are special values. See the man page
+	// KAUTH_UID_NONE and KAUTH_GID_NONE are special values. When
+	// pthread_setugid_np is called with them, it will revert to
+	// the process credentials.
 	KAUTH_UID_NONE = ^uint32(0) - 100
 	KAUTH_GID_NONE = ^uint32(0) - 100
 )
@@ -77,8 +79,9 @@ func ThreadAs(fn func() error, timeout time.Duration, uid uint32, gid uint32) er
 // which sets the per-thread userid and groupid. We use this, and not
 // syscall.Setuid, because the latter will impact _all_ threads.
 //
-// There is some discussion in the man page that this is not suitable
-// for security isolation. It's recommended you read and understand that.
+// This is not suitable for security isolation. Something in thread
+// can return to parent permissions be either calling with
+// KAUTH_UID_NONE, or simply spawning a new thread.
 func pthread_setugid_np(uid uint32, gid uint32) error {
 	// syscall.RawSyscall blocks, while Syscall does not. Since we
 	// don't think this blocks, we can use the _slightly_ more

--- a/pkg/threadas/threadas.go
+++ b/pkg/threadas/threadas.go
@@ -27,6 +27,12 @@ import (
 	"time"
 )
 
+const (
+	// KAUTH_UID_NONE and KAUTH_GID_NONE are special values. See the man page
+	KAUTH_UID_NONE = ^uint32(0) - 100
+	KAUTH_GID_NONE = ^uint32(0) - 100
+)
+
 // ThreadAs will run a function, in a "thread", after using setuid to
 // change permissions on that thread. It uses `LockOSThread` so the
 // thread terminates after with the function, this is to clean up from

--- a/pkg/threadas/threadas.go
+++ b/pkg/threadas/threadas.go
@@ -117,7 +117,14 @@ func pthread_setugid_np(uid uint32, gid uint32) error {
 	// don't think this blocks, we can use the _slightly_ more
 	// performant RawSyscall
 	if _, _, errno := syscall.RawSyscall(syscall.SYS_SETTID, uintptr(uid), uintptr(gid), 0); errno != 0 {
-		return &NoPermissionsError{Errno: errno}
+		if errno == 1 {
+			return &NoPermissionsError{Errno: errno}
+		}
+
+		// It's not clear when this can happen. It's probably
+		// not indicative of a permissions error. But it's
+		// unclear what it means.
+		return fmt.Errorf("calling pthread_setugid_np: %w", errno)
 	}
 
 	return nil

--- a/pkg/threadas/threadas_test.go
+++ b/pkg/threadas/threadas_test.go
@@ -50,8 +50,6 @@ func TestThreadAs(t *testing.T) {
 	// undermines some of what we're testing
 	for i := 1; i < 100; i++ {
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
-
 			t.Run("baseline", func(t *testing.T) {
 				require.NoError(t, fnMyUidsEqual(), "no thread, matches my uid")
 				require.NoError(t, fnTargetUidsNotEqual(), "no thread, does not match target")
@@ -90,7 +88,7 @@ func TestTimeout(t *testing.T) {
 	require.Error(t, ThreadAs(fn, timeout, uint32(syscall.Getuid()), uint32(syscall.Getgid())))
 }
 
-func TestGoroutineLeaks(t *testing.T) {
+func TestGoroutineLeaks(t *testing.T) { // nolint:paralleltest
 	// Don't parallize this -- it's using the global count of
 	// goroutines, which is going to vary based on what other
 	// tests are running.

--- a/pkg/threadas/threadas_test.go
+++ b/pkg/threadas/threadas_test.go
@@ -4,13 +4,13 @@
 package threadas
 
 import (
-	"testing"
-	"syscall"
-	"time"
 	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 )
 
 const timeout = 100 * time.Millisecond
@@ -37,21 +37,21 @@ func TestThreadAs(t *testing.T) {
 	targetUid := 501
 	targetGid := 20
 
-	targetUids := uidData{ Uid: targetUid, Euid: targetUid, Gid: targetGid, Egid: targetGid}
+	targetUids := uidData{Uid: targetUid, Euid: targetUid, Gid: targetGid, Egid: targetGid}
 	fnTargetUidsEqual := targetUids.GenerateTestFunc(t, "matches target user", assert.Equal)
 	fnTargetUidsNotEqual := targetUids.GenerateTestFunc(t, "does not matches target user", assert.NotEqual)
 
 	myUids := getUidData()
 	fnMyUidsEqual := myUids.GenerateTestFunc(t, "matches my user", assert.Equal)
 	fnMyUidsNotEqual := myUids.GenerateTestFunc(t, "does not matches my user", assert.NotEqual)
-	
+
 	// Be somewhat thoughtful in how parallel works here -- using
 	// t.Parallel will spawn a new thread, which potentially
 	// undermines some of what we're testing
 	for i := 1; i < 100; i++ {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			
+
 			t.Run("baseline", func(t *testing.T) {
 				require.NoError(t, fnMyUidsEqual(), "no thread, matches my uid")
 				require.NoError(t, fnTargetUidsNotEqual(), "no thread, does not match target")
@@ -66,7 +66,7 @@ func TestThreadAs(t *testing.T) {
 				require.NoError(t, ThreadAs(fnTargetUidsNotEqual, timeout, uint32(0), uint32(0)), "not match target")
 				require.NoError(t, ThreadAs(fnMyUidsEqual, timeout, uint32(0), uint32(0)), "matches mine")
 			})
-			
+
 			t.Run("baseline after setuids", func(t *testing.T) {
 				require.NoError(t, fnMyUidsEqual(), "no thread, matches my uid")
 				require.NoError(t, fnTargetUidsNotEqual(), "no thread, does not match target")
@@ -103,7 +103,7 @@ func TestGoroutineLeaks(t *testing.T) {
 
 	fn := func() error {
 		c := runtime.NumGoroutine()
-		require.Equal(t, startCount + 1, c, "go routines should be one more than starting")
+		require.Equal(t, startCount+1, c, "go routines should be one more than starting")
 		return nil
 	}
 
@@ -125,14 +125,14 @@ func TestTestUids(t *testing.T) {
 }
 
 type uidData struct {
-	Uid int
+	Uid  int
 	Euid int
-	Gid int
+	Gid  int
 	Egid int
 }
 
 // GenerateTestFunc generates a function suitable for handing to ThreadAs
-func (ud uidData) GenerateTestFunc(t *testing.T, name string, assertion assert.ComparisonAssertionFunc) func() error{
+func (ud uidData) GenerateTestFunc(t *testing.T, name string, assertion assert.ComparisonAssertionFunc) func() error {
 	return func() error {
 		ud.TestUids(t, name, assertion)
 		return nil
@@ -151,9 +151,9 @@ func (ud uidData) TestUids(t *testing.T, name string, assertion assert.Compariso
 
 func getUidData() uidData {
 	return uidData{
-		Uid: syscall.Getuid(),
+		Uid:  syscall.Getuid(),
 		Euid: syscall.Geteuid(),
-		Gid: syscall.Getgid(),
+		Gid:  syscall.Getgid(),
 		Egid: syscall.Getegid(),
 	}
 }

--- a/pkg/threadas/threadas_test.go
+++ b/pkg/threadas/threadas_test.go
@@ -1,0 +1,159 @@
+//go:build darwin
+// +build darwin
+
+package threadas
+
+import (
+	"testing"
+	"syscall"
+	"time"
+	"runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+)
+
+const timeout = 100 * time.Millisecond
+
+func TestThreadAsNotRoot(t *testing.T) {
+	t.Parallel()
+
+	if syscall.Getuid() == 0 {
+		t.Skip("Skipping -- test requires not-root")
+	}
+
+	uids := getUidData()
+	fn := uids.GenerateTestFunc(t, "expected failure", assert.Equal)
+	require.Error(t, ThreadAs(fn, timeout, uint32(uids.Uid), uint32(uids.Gid)), "Fails when run as non-root")
+}
+
+func TestThreadAs(t *testing.T) {
+	t.Parallel()
+
+	if syscall.Getuid() != 0 {
+		t.Skip("Skipping -- test requires root")
+	}
+
+	targetUid := 501
+	targetGid := 20
+
+	targetUids := uidData{ Uid: targetUid, Euid: targetUid, Gid: targetGid, Egid: targetGid}
+	fnTargetUidsEqual := targetUids.GenerateTestFunc(t, "matches target user", assert.Equal)
+	fnTargetUidsNotEqual := targetUids.GenerateTestFunc(t, "does not matches target user", assert.NotEqual)
+
+	myUids := getUidData()
+	fnMyUidsEqual := myUids.GenerateTestFunc(t, "matches my user", assert.Equal)
+	fnMyUidsNotEqual := myUids.GenerateTestFunc(t, "does not matches my user", assert.NotEqual)
+	
+	// Be somewhat thoughtful in how parallel works here -- using
+	// t.Parallel will spawn a new thread, which potentially
+	// undermines some of what we're testing
+	for i := 1; i < 100; i++ {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			
+			t.Run("baseline", func(t *testing.T) {
+				require.NoError(t, fnMyUidsEqual(), "no thread, matches my uid")
+				require.NoError(t, fnTargetUidsNotEqual(), "no thread, does not match target")
+			})
+
+			t.Run("change to target uid", func(t *testing.T) {
+				require.NoError(t, ThreadAs(fnTargetUidsEqual, timeout, uint32(targetUid), uint32(targetGid)), "match target")
+				require.NoError(t, ThreadAs(fnMyUidsNotEqual, timeout, uint32(targetUid), uint32(targetGid)), "not match mine")
+			})
+
+			t.Run("change to my uid", func(t *testing.T) {
+				require.NoError(t, ThreadAs(fnTargetUidsNotEqual, timeout, uint32(0), uint32(0)), "not match target")
+				require.NoError(t, ThreadAs(fnMyUidsEqual, timeout, uint32(0), uint32(0)), "matches mine")
+			})
+			
+			t.Run("baseline after setuids", func(t *testing.T) {
+				require.NoError(t, fnMyUidsEqual(), "no thread, matches my uid")
+				require.NoError(t, fnTargetUidsNotEqual(), "no thread, does not match target")
+			})
+		})
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+
+	if syscall.Getuid() != 0 {
+		t.Skip("Skipping -- test requires root")
+	}
+
+	fn := func() error {
+		time.Sleep(10 * time.Second)
+		return nil
+	}
+
+	require.Error(t, ThreadAs(fn, timeout, uint32(syscall.Getuid()), uint32(syscall.Getgid())))
+}
+
+func TestGoroutineLeaks(t *testing.T) {
+	// Don't parallize this -- it's using the global count of
+	// goroutines, which is going to vary based on what other
+	// tests are running.
+
+	if syscall.Getuid() != 0 {
+		t.Skip("Skipping -- test requires root")
+	}
+
+	startCount := runtime.NumGoroutine()
+
+	fn := func() error {
+		c := runtime.NumGoroutine()
+		require.Equal(t, startCount + 1, c, "go routines should be one more than starting")
+		return nil
+	}
+
+	require.NoError(t, ThreadAs(fn, timeout, uint32(syscall.Getuid()), uint32(syscall.Getgid())))
+
+	require.Equal(t, startCount, runtime.NumGoroutine(), "go routines should return to normal")
+
+}
+
+// TestTestUids tests that my test harness basically works
+func TestTestUids(t *testing.T) {
+	t.Parallel()
+
+	uids := getUidData()
+	uids.TestUids(t, "bare test", assert.Equal)
+
+	fn := uids.GenerateTestFunc(t, "generated", assert.Equal)
+	require.NoError(t, fn())
+}
+
+type uidData struct {
+	Uid int
+	Euid int
+	Gid int
+	Egid int
+}
+
+// GenerateTestFunc generates a function suitable for handing to ThreadAs
+func (ud uidData) GenerateTestFunc(t *testing.T, name string, assertion assert.ComparisonAssertionFunc) func() error{
+	return func() error {
+		ud.TestUids(t, name, assertion)
+		return nil
+	}
+}
+
+func (ud uidData) TestUids(t *testing.T, name string, assertion assert.ComparisonAssertionFunc) {
+	// Don't use t.Run here, it will spawn a new thread and thus reset any kind of setuid
+	actual := getUidData()
+
+	assertion(t, ud.Uid, actual.Uid, "uid")
+	assertion(t, ud.Euid, actual.Euid, "euid")
+	assertion(t, ud.Gid, actual.Gid, "gid")
+	assertion(t, ud.Egid, actual.Egid, "egid")
+}
+
+func getUidData() uidData {
+	return uidData{
+		Uid: syscall.Getuid(),
+		Euid: syscall.Geteuid(),
+		Gid: syscall.Getgid(),
+		Egid: syscall.Getegid(),
+	}
+}

--- a/pkg/threadas/threadas_test.go
+++ b/pkg/threadas/threadas_test.go
@@ -47,7 +47,9 @@ func TestThreadAs(t *testing.T) {
 
 	// Be somewhat thoughtful in how parallel works here -- using
 	// t.Parallel will spawn a new thread, which potentially
-	// undermines some of what we're testing
+	// undermines some of what we're testing. But we do want the
+	// top level to be parallel, so that we have more thread
+	// churn.
 	for i := 1; i < 100; i++ {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()

--- a/pkg/threadsetuid/threadsetuid.go
+++ b/pkg/threadsetuid/threadsetuid.go
@@ -8,16 +8,18 @@ import(
 )
 
 
-func Runas(fn func() ([]map[string]string, error), timeout time.Duration, uid uint32, gid uint32) ([]map[string]string, error) {
+func Runas(fn func() ([]map[string]interface{}, error), timeout time.Duration, uid uint32, gid uint32) ([]map[string]interface{}, error) {
 	// Only support getting one batch of data, so we can just
 	// buffer a single size. Makes it a bit easier to sequence
 	// starting the child, and handling the data
-	dataChan := make(chan []map[string]string, 1)
+	dataChan := make(chan []map[string]interface{}, 1)
 	errChan := make(chan error, 1)
 
 	go func() {
-		// Calling LockOSThread, without a subsequent Unlock, will
-		// cause the thread to terminate when the goroutine does.
+		// Calling LockOSThread, without a subsequent Unlock,
+		// will cause the thread to terminate when the
+		// goroutine does. This seems simpler than resetting
+		// the thread permissions.
 		runtime.LockOSThread()
 
 		if err := pthread_setugid_np(uid, gid); err != nil {

--- a/pkg/threadsetuid/threadsetuid.go
+++ b/pkg/threadsetuid/threadsetuid.go
@@ -38,6 +38,13 @@ func ThreadAs(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  
 		// will cause the thread to terminate when the
 		// goroutine does. This seems simpler than resetting
 		// the thread permissions.
+		//
+		// An alternate implementation, for darwin, would be
+		// to use `pthread_setugid_np(KAUTH_UID_NONE,
+		// KAUTH_GID_NONE)` to reset permissions
+		// afterwards. See the manpage, or
+		// https://github.com/rfjakob/gocryptfs/blob/master/internal/syscallcompat/sys_darwin.go
+		// for an example.
 		runtime.LockOSThread()
 
 		if err := pthread_setugid_np(uid, gid); err != nil {

--- a/pkg/threadsetuid/threadsetuid.go
+++ b/pkg/threadsetuid/threadsetuid.go
@@ -1,0 +1,57 @@
+package threadsetuid
+
+import(
+	"time"
+	"syscall"
+	"fmt"
+	"runtime"
+)
+
+
+func Runas(fn func() ([]map[string]string, error), timeout time.Duration, uid uint32, gid uint32) ([]map[string]string, error) {
+	// Only support getting one batch of data, so we can just
+	// buffer a single size. Makes it a bit easier to sequence
+	// starting the child, and handling the data
+	dataChan := make(chan []map[string]string, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		// Calling LockOSThread, without a subsequent Unlock, will
+		// cause the thread to terminate when the goroutine does.
+		runtime.LockOSThread()
+
+		if err := pthread_setugid_np(uid, gid); err != nil {
+			errChan <- err
+			return
+		}
+
+		data, err := fn()
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		dataChan <- data
+	}()
+
+	select {
+	case data := <- dataChan:
+		return data, nil
+	case err := <- errChan:
+		return nil, err
+	case <- time.After(timeout):
+		return nil, fmt.Errorf("Timeout after %s", timeout)
+	}
+}
+
+func pthread_setugid_np(uid uint32, gid uint32) (error) {
+	// syscall.RawSyscall blocks, while Syscall does not. Since we
+	// don't know better, we should use Syscall.
+	_, _, e1 := syscall.Syscall(syscall.SYS_SETTID, uintptr(uid), uintptr(gid), 0)
+	if e1 != 0 {
+		return e1
+	} 
+
+	return nil
+}
+

--- a/pkg/threadsetuid/threadsetuid.go
+++ b/pkg/threadsetuid/threadsetuid.go
@@ -1,3 +1,18 @@
+// Package threadsetuid uses some thread trickery to facilitate
+// dropping permissions on a single thread. This allows us to call
+// underlying darwin APIs which change behavior based on the userid.
+//
+// Note that this changes permission on a single thread. It cannot
+// change permission on something like osquery (communication is over
+// a socket), and may not do the right thing if you bring in an exec.
+//
+// This is based on ideas from:
+//   * https://github.com/golang/go/issues/14592
+//   * https://wiki.freebsd.org/Per-Thread%20Credentials
+//   * https://pkg.go.dev/runtime#LockOSThread
+//
+// There's future work in supporting other platforms. Linux may have
+// `syscall(SYS_setresuid, ...)` for this.
 package threadsetuid
 
 import(
@@ -8,10 +23,14 @@ import(
 )
 
 
-func Runas(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  error {
+// ThreadAs will run a function, in a "thread", after using setuid to
+// change permissions on that thread. It uses `LockOSThread` so the
+// thread terminates after with the function, this is to clean up from
+// the permissions change.
+func ThreadAs(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  error {
 	// As we only support calling the function once, so we can
 	// buffer a single size. Makes it a bit easier to
-	// sequence starting the child, and handling the data
+	// sequence starting the child and our listener.
 	errChan := make(chan error, 1)
 
 	go func() {
@@ -37,12 +56,19 @@ func Runas(fn func()  error, timeout time.Duration, uid uint32, gid uint32)  err
 	}
 }
 
+// pthread_setugid_np calls the darwin syscall `pthread_setugid_np`
+// which sets the per-thread userid and groupid. We use this, and not
+// syscall.Setuid, because the latter will impact _all_ threads.
+//
+// There is some discussion in the man page that this is not suitable
+// for security isolation. It's recommended you read and understand that.
 func pthread_setugid_np(uid uint32, gid uint32) (error) {
 	// syscall.RawSyscall blocks, while Syscall does not. Since we
-	// don't know better, we should use Syscall.
-	_, _, e1 := syscall.Syscall(syscall.SYS_SETTID, uintptr(uid), uintptr(gid), 0)
-	if e1 != 0 {
-		return e1
+	// don't think this blocks, we can use the _slightly_ more
+	// performant RawSyscall
+	_, _, errNo := syscall.RawSyscall(syscall.SYS_SETTID, uintptr(uid), uintptr(gid), 0)
+	if errNo != 0 {
+		return errNo
 	} 
 
 	return nil


### PR DESCRIPTION
Some macOS APIs take different actions based on the `uid` of the caller. As such, we need to change our uid to use them. But, the normal mechanisms to change uid effect the _entire_ process.

Luckily, macOS provides a syscall to change permissions only on a single execution thread. And go has a `runtime.LockOsThread` that allows us to ensure our thread  is safe to modify. This is a simple wrapper bundling those together.