### PR TITLE
Updates tests to stop occasional failing

### DIFF
--- a/cmd/launcher/internal/updater/updater_test.go
+++ b/cmd/launcher/internal/updater/updater_test.go
@@ -91,7 +91,7 @@ func Test_updaterCmd_execute(t *testing.T) {
 				config: &UpdaterConfig{
 					Logger: log.NewNopLogger(),
 				},
-				runUpdaterRetryInterval: 10 * time.Millisecond,
+				runUpdaterRetryInterval: 1 * time.Second,
 			},
 			updaterRunReturns: []func(opts ...tuf.Option) (stop func(), err error){
 				func(opts ...tuf.Option) (stop func(), err error) {

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -112,8 +112,8 @@ func TestQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest
+			// parallel makes test flakey, probably race condition somewhere
 
 			mockQC := tablehelpers.MockQueryContext(map[string][]string{
 				"class":       []string{tt.class},

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQueries(t *testing.T) { //nolint:paralleltest
+func TestQueries(t *testing.T) {
 	t.Parallel()
 
 	wmiTable := Table{logger: log.NewNopLogger()}
@@ -110,9 +110,9 @@ func TestQueries(t *testing.T) { //nolint:paralleltest
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest
+		t.Run(tt.name, func(t *testing.T) {
 			// making this parallel causing the unit test to occasionally fail
 
 			mockQC := tablehelpers.MockQueryContext(map[string][]string{

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQueries(t *testing.T) {
+func TestQueries(t *testing.T) { //nolint:paralleltest
 	t.Parallel()
 
 	wmiTable := Table{logger: log.NewNopLogger()}
@@ -113,6 +113,7 @@ func TestQueries(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest
+			// making this parallel causing the unit test to occasionally fail
 
 			mockQC := tablehelpers.MockQueryContext(map[string][]string{
 				"class":       []string{tt.class},

--- a/pkg/osquery/tables/wmitable/wmitable_test.go
+++ b/pkg/osquery/tables/wmitable/wmitable_test.go
@@ -113,7 +113,6 @@ func TestQueries(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest
-			// parallel makes test flakey, probably race condition somewhere
 
 			mockQC := tablehelpers.MockQueryContext(map[string][]string{
 				"class":       []string{tt.class},


### PR DESCRIPTION
Updates tests to stop occasional failing

Not sure if the wmitable_test.go failing when parallel is indicative of a race condition somewhere in the code or if it's just affecting the unit test.