### PR TITLE
Adjust timeouts and add health checks to startup

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -143,7 +143,7 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 
 					// Did we timeout? If so, send the error from the healthcheck
 					if limiter.Wait(deadlineCtx) != nil {
-						level.Debug(logger).Log("msg", "Exiting because runner not healthy")
+						level.Debug(logger).Log("msg", "Exiting because runner not healthy", "err", err)
 						return errors.Wrapf(runnerErr, "timeout waiting for runner to be healthy")
 					}
 				}

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -125,9 +125,13 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 					return errors.Wrap(err, "launching osquery instance")
 				}
 
+				// The runner allows querying the osqueryd instance from the extension.
+				// Used by the Enroll method below to get initial enrollment details.
+				ext.SetQuerier(runner)
+
 				// Because the runner starts a bunch
-				// of async threads, we need to make
-				// sure it's healthy before we
+				// of async threads, we need to
+				// make sure it's healthy before we
 				// continue with startup.
 				deadlineCtx, cancel := context.WithTimeout(context.Background(), runnerStartTimeout)
 				defer cancel()
@@ -148,10 +152,6 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 					}
 				}
 				level.Debug(logger).Log("msg", "Runner healthy. Moving on")
-
-				// The runner allows querying the osqueryd instance from the extension.
-				// Used by the Enroll method below to get initial enrollment details.
-				ext.SetQuerier(runner)
 
 				// enroll this launcher with the server
 				_, invalid, err := ext.Enroll(ctx)

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-		"golang.org/x/time/rate"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/actor"
@@ -27,11 +26,11 @@ import (
 	osquerylogger "github.com/osquery/osquery-go/plugin/logger"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
+	"golang.org/x/time/rate"
 )
 
-
 const (
-	runnerStartTimeout = 5 * time.Minute // Total time to wait opening the osquery socket
+	runnerStartTimeout  = 5 * time.Minute  // Total time to wait opening the osquery socket
 	runnerStartInterval = 20 * time.Second // how long to wait between attempts to open osquery socket
 )
 
@@ -137,7 +136,7 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 					level.Debug(logger).Log("msg", "Health checks on runner")
 
 					runnerErr := runner.Healthy()
-					
+
 					if runnerErr == nil {
 						break
 					}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -296,7 +296,7 @@ func isNodeInvalidErr(err error) bool {
 // be returned. To force re-enrollment, use RequireReenroll.
 func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	level.Debug(e.logger).Log("msg", "Beginning enrollment")
-	
+
 	// If we already have a successful enrollment (perhaps from another
 	// thread), no need to do anything else.
 	if e.NodeKey != "" {

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -295,6 +295,8 @@ func isNodeInvalidErr(err error) bool {
 // identification. If the host is already enrolled, the existing node key will
 // be returned. To force re-enrollment, use RequireReenroll.
 func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
+	level.Debug(e.logger).Log("msg", "Beginning enrollment")
+	
 	// If we already have a successful enrollment (perhaps from another
 	// thread), no need to do anything else.
 	if e.NodeKey != "" {
@@ -786,6 +788,9 @@ func (e *Extension) writeResultsWithReenroll(ctx context.Context, results []dist
 }
 
 func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
+	if client == nil {
+		panic("SEPH")
+	}
 	query := `
 	SELECT
 		osquery_info.version as osquery_version,

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -807,6 +807,7 @@ func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
 	var details service.EnrollmentDetails
 	resp, err := client.Query(query)
 	if err != nil {
+		// seph, here.
 		return details, errors.Wrap(err, "query enrollment details")
 	}
 

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -295,16 +295,16 @@ func isNodeInvalidErr(err error) bool {
 // identification. If the host is already enrolled, the existing node key will
 // be returned. To force re-enrollment, use RequireReenroll.
 func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
-	// Only one thread should ever be allowed to attempt enrollment at the
-	// same time.
-	e.enrollMutex.Lock()
-	defer e.enrollMutex.Unlock()
-
 	// If we already have a successful enrollment (perhaps from another
 	// thread), no need to do anything else.
 	if e.NodeKey != "" {
 		return e.NodeKey, false, nil
 	}
+
+	// Only one thread should ever be allowed to attempt enrollment at the
+	// same time.
+	e.enrollMutex.Lock()
+	defer e.enrollMutex.Unlock()
 
 	// Look up a node key cached in the local store
 	key, err := NodeKeyFromDB(e.db)

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -470,7 +470,7 @@ func (r *Runner) Healthy() error {
 }
 
 const (
-	socketOpenTimeout = 5 * time.Minute // Total time to wait opening the osquery socket
+	socketOpenTimeout  = 5 * time.Minute  // Total time to wait opening the osquery socket
 	socketOpenInterval = 10 * time.Second // how long to wait between attempts to open osquery socket
 )
 
@@ -811,8 +811,8 @@ func (r *Runner) launchOsqueryInstance() error {
 	for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
 		plugins = append(plugins, t)
 	}
-	o.extensionManagerServer.RegisterPlugin(plugins...)	
-	
+	o.extensionManagerServer.RegisterPlugin(plugins...)
+
 	o.extensionManagerClient, err = osquery.NewClient(paths.extensionSocketPath, 5*time.Second)
 	if err != nil {
 		return errors.Wrap(err, "could not create an extension client")
@@ -931,7 +931,7 @@ func (o *OsqueryInstance) Healthy() error {
 func (o *OsqueryInstance) Query(query string) ([]map[string]string, error) {
 	o.clientLock.Lock()
 	defer o.clientLock.Unlock()
-	
+
 	resp, err := o.extensionManagerClient.Query(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not query the extension manager client")

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -470,8 +470,8 @@ func (r *Runner) Healthy() error {
 
 // timeout and interval values for the various limiters
 const (
-	healthyInterval     = 1 * time.Second
-	healthyTimeout      = 30 * time.Second
+	healthyInterval     = 5 * time.Second
+	healthyTimeout      = 5 * time.Minute // Should be longer than any query that might be running
 	serverStartInterval = 10 * time.Second
 	serverStartTimeout  = 5 * time.Minute
 	socketOpenInterval  = 10 * time.Second

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -803,10 +803,6 @@ func (r *Runner) launchOsqueryInstance() error {
 	}
 	level.Debug(o.logger).Log("msg", "Successfully connected server to osquery")
 
-	if err := o.stats.Connected(o); err != nil {
-		level.Info(o.logger).Log("msg", "osquery instance history", "error", err)
-	}
-
 	plugins := o.opts.extensionPlugins
 	for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
 		plugins = append(plugins, t)
@@ -816,6 +812,10 @@ func (r *Runner) launchOsqueryInstance() error {
 	o.extensionManagerClient, err = osquery.NewClient(paths.extensionSocketPath, 5*time.Second)
 	if err != nil {
 		return errors.Wrap(err, "could not create an extension client")
+	}
+
+	if err := o.stats.Connected(o); err != nil {
+		level.Info(o.logger).Log("msg", "osquery instance history", "error", err)
 	}
 
 	// Launch the extension manager server asynchronously. Note

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -75,17 +75,17 @@ type OsqueryInstance struct {
 	logger log.Logger
 	// the following are instance artifacts that are created and held as a result
 	// of launching an osqueryd process
-	errgroup               *errgroup.Group
-	doneCtx                context.Context
-	cancel                 context.CancelFunc
-	cmd                    *exec.Cmd
+	errgroup                *errgroup.Group
+	doneCtx                 context.Context
+	cancel                  context.CancelFunc
+	cmd                     *exec.Cmd
 	extensionManagerServers []*osquery.ExtensionManagerServer
-	extensionManagerClient *osquery.ExtensionManagerClient
-	clientLock             sync.Mutex
-	paths                  *osqueryFilePaths
-	rmRootDirectory        func()
-	usingTempDir           bool
-	stats                  *history.Instance
+	extensionManagerClient  *osquery.ExtensionManagerClient
+	clientLock              sync.Mutex
+	paths                   *osqueryFilePaths
+	rmRootDirectory         func()
+	usingTempDir            bool
+	stats                   *history.Instance
 }
 
 // osqueryFilePaths is a struct which contains the relevant file paths needed to
@@ -470,12 +470,10 @@ func (r *Runner) Healthy() error {
 
 // timeout and interval values for the various limiters
 const (
-	healthyInterval     = 5 * time.Second
-	healthyTimeout      = 5 * time.Minute // Should be longer than any query that might be running
-	serverStartInterval = 10 * time.Second
-	serverStartTimeout  = 5 * time.Minute
-	socketOpenInterval  = 10 * time.Second
-	socketOpenTimeout   = 5 * time.Minute
+	healthyInterval    = 5 * time.Second
+	healthyTimeout     = 5 * time.Minute // Should be longer than any query that might be running
+	socketOpenInterval = 10 * time.Second
+	socketOpenTimeout  = 5 * time.Minute
 )
 
 // LaunchInstance will launch an instance of osqueryd via a very configurable
@@ -794,7 +792,7 @@ func (r *Runner) launchOsqueryInstance() error {
 	// enrollment. *But* there's been a lot of racy behaviors,
 	// likely due to time spent registering tables, and subtle
 	// ordering issues.
-	
+
 	// Start an extension manager for the extensions that osquery
 	// needs for config/log/etc
 	if len(o.opts.extensionPlugins) > 0 {
@@ -805,7 +803,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		}
 	}
 
-	
 	// Now spawn an extension manage to for the tables. We need to
 	// start this one in the background, because the runner.Start
 	// function needs to return promptly enough for osquery to use
@@ -819,21 +816,19 @@ func (r *Runner) launchOsqueryInstance() error {
 			plugins = append(plugins, t)
 		}
 
-		if err := r.startOsqueryExtensionManagerServer(		"kolide",		paths.extensionSocketPath,		plugins	); err != nil {
+		if err := r.startOsqueryExtensionManagerServer("kolide", paths.extensionSocketPath, plugins); err != nil {
 			level.Info(o.logger).Log("msg", "Unable to create tables extension server. Stopping", "err", err)
 			return errors.Wrap(err, "could not create a table extension server")
 		}
 		return nil
 	})
 
-	
 	// getting stats requires the Client already be instantiated
 	go func() {
 		if err := o.stats.Connected(o); err != nil {
 			level.Info(o.logger).Log("msg", "osquery instance history", "error", err)
 		}
 	}()
-		
 
 	// Health check on interval
 	o.errgroup.Go(func() error {
@@ -865,7 +860,7 @@ func (r *Runner) launchOsqueryInstance() error {
 }
 
 // startOsqueryExtensionManagerServer takes a set of plugins, creates
-// an osquery.NewExtensionManagerServer for them, and then starts it. 
+// an osquery.NewExtensionManagerServer for them, and then starts it.
 func (r *Runner) startOsqueryExtensionManagerServer(name string, socketPath string, plugins []osquery.OsqueryPlugin) error {
 	o := r.instance
 
@@ -888,7 +883,7 @@ func (r *Runner) startOsqueryExtensionManagerServer(name string, socketPath stri
 	}
 
 	extensionManagerServer.RegisterPlugin(plugins...)
-	
+
 	o.extensionManagerServers = append(o.extensionManagerServers, extensionManagerServer)
 
 	// Start!
@@ -899,7 +894,6 @@ func (r *Runner) startOsqueryExtensionManagerServer(name string, socketPath stri
 		}
 		return errors.New("extension manager server exited")
 	})
-
 
 	// register a shutdown routine
 	o.errgroup.Go(func() error {
@@ -927,7 +921,7 @@ func (o *OsqueryInstance) Healthy() error {
 		return errors.New("instance not started")
 	}
 
-	for _, srv := range( o.extensionManagerServers) {
+	for _, srv := range o.extensionManagerServers {
 		serverStatus, err := srv.Ping(context.TODO())
 		if err != nil {
 			return errors.Wrap(err, "could not ping extension server")

--- a/pkg/osquery/runtime/runtime.go
+++ b/pkg/osquery/runtime/runtime.go
@@ -818,7 +818,9 @@ func (r *Runner) launchOsqueryInstance() error {
 		return errors.Wrap(err, "could not create an extension client")
 	}
 
-	// Launch the extension manager server asynchronously. Because this is async...
+	// Launch the extension manager server asynchronously. Note
+	// that this is async, which can cause subtle ordering issues
+	// FIXME: before merge -- does this need to lock the thrift socket
 	o.errgroup.Go(func() error {
 		// We see the extension manager being slow to start. Implement a simple re-try routine
 		backoff := backoff.New()

--- a/pkg/osquery/runtime/waitfor.go
+++ b/pkg/osquery/runtime/waitfor.go
@@ -1,0 +1,38 @@
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+)
+
+// WaitFor is a wrapper over the stock go limiter pattern. It can be
+// used to retry things until the timeout is reached, with a delay in
+// between attempts. It does not implement an exponential backoff, and
+// is intended for simple startup logic.
+//
+// Contrary to documentation, it appears go will always retry
+// once. Even if the interval exceeds the timeout.
+func WaitFor(fn func() error, timeout, interval time.Duration) error {
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	limiter := rate.NewLimiter(rate.Every(interval), 1)
+	counter := 0
+	for {
+		counter += 1
+
+		err := fn()
+
+		if err == nil {
+			return nil
+		}
+
+		// Did we timeout? If so, send the error
+		if limiter.Wait(deadlineCtx) != nil {
+			return errors.Wrapf(err, "timeout after %s (%d attempts)", timeout, counter)
+		}
+	}
+}

--- a/pkg/osquery/runtime/waitfor.go
+++ b/pkg/osquery/runtime/waitfor.go
@@ -8,14 +8,14 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// WaitFor is a wrapper over the stock go limiter pattern. It can be
+// waitFor is a wrapper over the stock go limiter pattern. It can be
 // used to retry things until the timeout is reached, with a delay in
 // between attempts. It does not implement an exponential backoff, and
 // is intended for simple startup logic.
 //
 // Contrary to documentation, it appears go will always retry
 // once. Even if the interval exceeds the timeout.
-func WaitFor(fn func() error, timeout, interval time.Duration) error {
+func waitFor(fn func() error, timeout, interval time.Duration) error {
 	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/osquery/runtime/waitfor_test.go
+++ b/pkg/osquery/runtime/waitfor_test.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitFor(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name               string
+		innerFn            func() error
+		errorAssertion     require.ErrorAssertionFunc
+		testifyExpectation func(require.TestingT, func() bool, time.Duration, time.Duration, ...interface{})
+		errorContains      []string
+
+		interval time.Duration
+		timeout  time.Duration
+	}{
+		{
+			name:               "never returns",
+			innerFn:            innerFuncGenerator(30*time.Millisecond, nil),
+			errorAssertion:     require.NoError,
+			testifyExpectation: require.Never,
+			interval:           2 * time.Millisecond,
+			timeout:            5 * time.Millisecond,
+		},
+		{
+			name:               "fast returns",
+			innerFn:            innerFuncGenerator(1*time.Millisecond, nil),
+			errorAssertion:     require.NoError,
+			testifyExpectation: require.Eventually,
+			interval:           2 * time.Millisecond,
+			timeout:            5 * time.Millisecond,
+		},
+		{
+			name:               "fast errors",
+			innerFn:            innerFuncGenerator(1*time.Millisecond, errors.New("sentinal")),
+			errorAssertion:     require.Error,
+			testifyExpectation: require.Eventually,
+			errorContains:      []string{"sentinal", "timeout", "3 attempts"},
+			interval:           2 * time.Millisecond,
+			timeout:            5 * time.Millisecond,
+		},
+		{
+			name:               "slow errors",
+			innerFn:            innerFuncGenerator(9*time.Millisecond, errors.New("sentinal")),
+			errorAssertion:     require.Error,
+			testifyExpectation: require.Eventually,
+			errorContains:      []string{"sentinal", "timeout", "2 attempts"},
+			interval:           4 * time.Millisecond,
+			timeout:            10 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Construct a test function, and a suitable
+			// comparison function for require.Never / require.Eventually
+			fn := func() bool {
+				err := WaitFor(tt.innerFn, tt.timeout, tt.interval)
+				tt.errorAssertion(t, err)
+
+				for _, s := range tt.errorContains {
+					assert.ErrorContains(t, err, s)
+				}
+
+				// This return is what causes Never or Eventual to Succeed or Fail.
+				return true
+			}
+
+			tt.testifyExpectation(t, fn, 30*time.Millisecond, 2*time.Millisecond)
+		})
+	}
+}
+
+func innerFuncGenerator(t time.Duration, err error) func() error {
+	return func() error {
+		time.Sleep(t)
+		return err
+	}
+}

--- a/pkg/osquery/runtime/waitfor_test.go
+++ b/pkg/osquery/runtime/waitfor_test.go
@@ -66,7 +66,7 @@ func TestWaitFor(t *testing.T) {
 			// Construct a test function, and a suitable
 			// comparison function for require.Never / require.Eventually
 			fn := func() bool {
-				err := WaitFor(tt.innerFn, tt.timeout, tt.interval)
+				err := waitFor(tt.innerFn, tt.timeout, tt.interval)
 				tt.errorAssertion(t, err)
 
 				for _, s := range tt.errorContains {


### PR DESCRIPTION
Continuing to track down the Monterey enrollment issue, I'm pretty sure there's a race condition around the async startup. 

This PR attempts to address that via several mechanisms:
1. Adjusts some timeouts. A bit of a long shot, but I think these were too aggressive before
2. Adds a health check between starting up, and trying to do anything