### PR TITLE
Fix the duplicate GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: '**'
+    branches: [main, master]
   pull_request:
     branches: '**'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,11 @@
 name: golangci-lint
+
 on:
   push:
-    tags:
-      - v*
-    branches:
-      - '**'
+    branches: [main, master]
   pull_request:
+    branches: '**'
+
 jobs:
   golangci:
     strategy:


### PR DESCRIPTION
I noticed that we were running twice the number of GitHub actions as expected. I believe this is because both the `push` and the `pull_request` triggers were active. This shifts them so the `push` is only on the main branches