### PR TITLE
Use two `ExtensionManagerServer` threads

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -361,7 +361,6 @@ func (r *Runner) launchOsqueryInstance() error {
 	// Start an extension manager for the extensions that osquery
 	// needs for config/log/etc
 	if len(o.opts.extensionPlugins) > 0 {
-		// time.Sleep(2 * time.Second)
 		if err := o.StartOsqueryExtensionManagerServer("kolide_initial", paths.extensionSocketPath, o.opts.extensionPlugins); err != nil {
 			level.Info(o.logger).Log("msg", "Unable to create initial extension server. Stopping", "err", err)
 			return errors.Wrap(err, "could not create an extension server")
@@ -388,6 +387,10 @@ func (r *Runner) launchOsqueryInstance() error {
 		var plugins []osquery.OsqueryPlugin
 		for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
 			plugins = append(plugins, t)
+		}
+
+		if len(plugins) == 0 {
+			return nil
 		}
 
 		if err := o.StartOsqueryExtensionManagerServer("kolide", paths.extensionSocketPath, plugins); err != nil {

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -384,10 +384,7 @@ func (r *Runner) launchOsqueryInstance() error {
 	// TODO: Consider chunking, if we find we can only have so
 	// many tables per extension manager
 	o.errgroup.Go(func() error {
-		var plugins []osquery.OsqueryPlugin
-		for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
-			plugins = append(plugins, t)
-		}
+		plugins := table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath)
 
 		if len(plugins) == 0 {
 			return nil

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/autoupdate"
-	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/osquery/table"
@@ -21,7 +20,6 @@ import (
 	"github.com/osquery/osquery-go/plugin/distributed"
 	"github.com/osquery/osquery-go/plugin/logger"
 	"github.com/pkg/errors"
-	"golang.org/x/time/rate"
 )
 
 // How long to wait before erroring because we cannot open the osquery
@@ -347,37 +345,28 @@ func (r *Runner) launchOsqueryInstance() error {
 		return o.doneCtx.Err()
 	})
 
-	// Because we "invert" the control of the osquery process and the
-	// extension (we are running the extension from the process that starts
-	// osquery, rather than the other way around), we don't know exactly
-	// when osquery will have the extension socket open. Because of this,
-	// we want to try opening the socket until we are successful (with a
-	// timeout if something goes wrong).
-	deadlineCtx, cancel := context.WithTimeout(context.Background(), socketOpenTimeout)
-	defer cancel()
-	limiter := rate.NewLimiter(rate.Every(socketOpenInterval), 1)
-	for {
-		level.Debug(o.logger).Log("msg", "Starting server connection attempts to osquery")
+	// Here be dragons
+	//
+	// There are two thorny issues. First, we "invert" control of
+	// the osquery process. We don't really know when osquery will
+	// be running, so we need a bunch of retries on these connections
+	//
+	// Second, because launcher supplements the enroll
+	// information, this Start function must return fast enough
+	// that osquery can use the registered tables for
+	// enrollment. *But* there's been a lot of racy behaviors,
+	// likely due to time spent registering tables, and subtle
+	// ordering issues.
 
-		// Create the extension server and register all custom osquery
-		// plugins
-		o.extensionManagerServer, err = osquery.NewExtensionManagerServer(
-			"kolide",
-			paths.extensionSocketPath,
-			osquery.ServerTimeout(2*time.Second),
-		)
-		if err == nil {
-			break
-		}
-
-		if limiter.Wait(deadlineCtx) != nil {
-			// This means that our timeout expired. Return the
-			// error from creating the server, not the error from
-			// the timeout expiration.
-			return errors.Wrapf(err, "could not create extension manager server at %s", paths.extensionSocketPath)
+	// Start an extension manager for the extensions that osquery
+	// needs for config/log/etc
+	if len(o.opts.extensionPlugins) > 0 {
+		// time.Sleep(2 * time.Second)
+		if err := o.StartOsqueryExtensionManagerServer("kolide_initial", paths.extensionSocketPath, o.opts.extensionPlugins); err != nil {
+			level.Info(o.logger).Log("msg", "Unable to create initial extension server. Stopping", "err", err)
+			return errors.Wrap(err, "could not create an extension server")
 		}
 	}
-	level.Debug(o.logger).Log("msg", "Successfully connected server to osquery")
 
 	o.extensionManagerClient, err = osquery.NewClient(paths.extensionSocketPath, 5*time.Second)
 	if err != nil {
@@ -388,32 +377,24 @@ func (r *Runner) launchOsqueryInstance() error {
 		level.Info(o.logger).Log("msg", "osquery instance history", "error", err)
 	}
 
-	plugins := o.opts.extensionPlugins
-	for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
-		plugins = append(plugins, t)
-	}
-	o.extensionManagerServer.RegisterPlugin(plugins...)
-
-	// Launch the extension manager server asynchronously.
+	// Now spawn an extension manage to for the tables. We need to
+	// start this one in the background, because the runner.Start
+	// function needs to return promptly enough for osquery to use
+	// it to enroll. Very racy
+	//
+	// TODO: Consider chunking, if we find we can only have so
+	// many tables per extension manager
 	o.errgroup.Go(func() error {
-		// We see the extension manager being slow to start. Retry a few times
-		if err := backoff.WaitFor(o.extensionManagerServer.Start, 2*time.Minute, 10*time.Second); err != nil {
-			return errors.Wrap(err, "running extension server")
+		var plugins []osquery.OsqueryPlugin
+		for _, t := range table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath) {
+			plugins = append(plugins, t)
 		}
-		return errors.New("extension manager server exited")
-	})
 
-	// Cleanup extension manager server on shutdown
-	o.errgroup.Go(func() error {
-		<-o.doneCtx.Done()
-		level.Debug(o.logger).Log("msg", "Starting extension shutdown")
-		if err := o.extensionManagerServer.Shutdown(context.TODO()); err != nil {
-			level.Info(o.logger).Log(
-				"msg", "Got error while shutting down extension server",
-				"err", err,
-			)
+		if err := o.StartOsqueryExtensionManagerServer("kolide", paths.extensionSocketPath, plugins); err != nil {
+			level.Info(o.logger).Log("msg", "Unable to create tables extension server. Stopping", "err", err)
+			return errors.Wrap(err, "could not create a table extension server")
 		}
-		return o.doneCtx.Err()
+		return nil
 	})
 
 	// Health check on interval

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -30,7 +30,7 @@ const (
 	screenlockQuery    = "select enabled, grace_period from screenlock"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
+func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	munki := munki.New()
 
 	// This table uses undocumented APIs, There is some discussion at the
@@ -68,7 +68,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 			table.TextColumn("path"),
 		})
 
-	return []*table.Plugin{
+	return []osquery.OsqueryPlugin{
 		keychainAclsTable,
 		keychainItemsTable,
 		Airdrop(client),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -15,8 +15,8 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
-	return []*table.Plugin{
+func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+	return []osquery.OsqueryPlugin{
 		cryptsetup.TablePlugin(client, logger),
 		gsettings.Settings(client, logger),
 		gsettings.Metadata(client, logger),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/secureboot"
 	"github.com/kolide/launcher/pkg/osquery/tables/xrdb"
 	osquery "github.com/osquery/osquery-go"
-	"github.com/osquery/osquery-go/plugin/table"
 )
 
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	osquery "github.com/osquery/osquery-go"
-	"github.com/osquery/osquery-go/plugin/table"
 )
 
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -15,8 +15,8 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
-	return []*table.Plugin{
+func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+	return []osquery.OsqueryPlugin{
 		ProgramIcons(),
 		dsim_default_associations.TablePlugin(client, logger),
 		secedit.TablePlugin(client, logger),

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	osquery "github.com/osquery/osquery-go"
-	"github.com/osquery/osquery-go/plugin/table"
 	"go.etcd.io/bbolt"
 )
 
@@ -28,9 +27,9 @@ func LauncherTables(db *bbolt.DB, opts *launcher.Options) []osquery.OsqueryPlugi
 }
 
 // PlatformTables returns all tables for the launcher build platform.
-func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []*table.Plugin {
+func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	// Common tables to all platforms
-	tables := []*table.Plugin{
+	tables := []osquery.OsqueryPlugin{
 		BestPractices(client),
 		ChromeLoginDataEmails(client, logger),
 		ChromeUserProfiles(client, logger),

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -40,8 +40,8 @@ type Table struct {
 }
 
 // AllTablePlugins is a helper to return all the expected flattening tables.
-func AllTablePlugins(client *osquery.ExtensionManagerClient, logger log.Logger) []*table.Plugin {
-	return []*table.Plugin{
+func AllTablePlugins(client *osquery.ExtensionManagerClient, logger log.Logger) []osquery.OsqueryPlugin {
+	return []osquery.OsqueryPlugin{
 		TablePlugin(client, logger, JsonType),
 		TablePlugin(client, logger, XmlType),
 		TablePlugin(client, logger, IniType),
@@ -49,7 +49,7 @@ func AllTablePlugins(client *osquery.ExtensionManagerClient, logger log.Logger) 
 	}
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, dataSourceType DataSourceType) *table.Plugin {
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, dataSourceType DataSourceType) osquery.OsqueryPlugin {
 
 	columns := Columns(table.TextColumn("path"))
 


### PR DESCRIPTION
(This is a somewhat speculative change, and extracted from #818)

Tracking down various startup race conditions, I _think_ one of the issues is that more tables means the extension manager takes longer to start. This is a speculative change to split it in two. One extension manager is for the grpc communication, needed for initial enrollment. The other is for all the tables. 