### PR TITLE
Add macOS universal builds to GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,12 @@ jobs:
       run: make deps
 
     - name: Build
+      if: ${{ ! contains(matrix.os, 'ubuntu') }}
       run: make -j2 github-build
+
+    - name: Build (No Cross Compiles)
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      run: make -j2 github-build-no-cross
 
     - name: Lipo
       run: make github-lipo

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,22 @@ jobs:
         go-version: ${{env.GOVER}}
       id: go
 
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Go Build Cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - name: Go Mod Cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+
     - name: Get dependencies
       run: make deps
 
@@ -83,6 +99,21 @@ jobs:
       with:
         go-version: ${{env.GOVER}}
       id: go
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Go Build Cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - name: Go Mod Cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - run: make deps
     - id: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Lipo
       run: make lipo_{${{env.RELEASE_TARGETS}}}_${{ matrix.os }}
-      if: matrix.os == "darwin"
+      if: ${{ matrix.os == 'macos-latest' }}
 
     - name: Test
       run: make test
@@ -86,7 +86,6 @@ jobs:
     - name: package
       run: ${{ steps.build.outputs.binary }} make -debug --hostname=localhost --enroll_secret=secret
 
-      	       				  
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single
   # one.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: '**'
 
+env:
+  GOVER: 1.17
+  RELEASE_TARGETS: launcher,osquery-extension.ext,grpc.ext,tables.ext,package-builder
+
 jobs:
   build_and_test:
     name: launcher
@@ -27,14 +31,18 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{env.GOVER}}
       id: go
 
     - name: Get dependencies
       run: make deps
 
     - name: Build
-      run: make -j launcher extension grpc.ext tables.ext package-builder
+      run: make -j2 build_{${{env.RELEASE_TARGETS}}}_${{ matrix.os }}_{amd64,arm64}
+
+    - name: Lipo
+      run: make lipo_{${{env.RELEASE_TARGETS}}}_${{ matrix.os }}
+      if: matrix.os == "darwin"
 
     - name: Test
       run: make test
@@ -69,7 +77,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{env.GOVER}}
       id: go
 
     - run: make deps
@@ -78,7 +86,7 @@ jobs:
     - name: package
       run: ${{ steps.build.outputs.binary }} make -debug --hostname=localhost --enroll_secret=secret
 
-
+      	       				  
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single
   # one.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         fetch-depth: 0 # need a full checkout for `git describe`
 
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{env.GOVER}}
       id: go
@@ -84,6 +84,12 @@ jobs:
       with:
         go-version: ${{env.GOVER}}
       id: go
+
+    - name: Setup Zig
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
+      with:
+        version: 0.9.1
 
     - run: make deps
     - id: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,8 @@ jobs:
     - name: Build (No Cross Compiles)
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: make -j2 github-build-no-cross
+      env:
+        MAKE_DEBUG: true
 
     - name: Lipo
       run: make github-lipo

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,11 +27,17 @@ jobs:
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 
-    - name: Set up Go 1.x
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{env.GOVER}}
       id: go
+
+    - name: Setup Zig
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
+        with:
+          version: 0.10.0
 
     - name: Get dependencies
       run: make deps
@@ -41,7 +47,7 @@ jobs:
 
     - name: Lipo
       run: make github-lipo
-      if: ${{ contains(matrix.os, 'macos-latest') }}
+      if: ${{ contains(matrix.os, 'macos') }}
 
     - name: Test
       run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - name: Check out code
       id: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 
@@ -37,7 +37,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
       with:
-        version: 0.10.0
+        version: 0.9.1
 
     - name: Get dependencies
       run: make deps
@@ -76,11 +76,11 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{env.GOVER}}
       id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Setup Zig
       if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
-        with:
-          version: 0.10.0
+      with:
+        version: 0.10.0
 
     - name: Get dependencies
       run: make deps

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,12 +33,6 @@ jobs:
         go-version: ${{env.GOVER}}
       id: go
 
-    - name: Setup Zig
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
-      with:
-        version: 0.9.1
-
     - name: Get dependencies
       run: make deps
 
@@ -49,8 +43,6 @@ jobs:
     - name: Build (No Cross Compiles)
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: make -j2 github-build-no-cross
-      env:
-        MAKE_DEBUG: true
 
     - name: Lipo
       run: make github-lipo
@@ -91,12 +83,6 @@ jobs:
       with:
         go-version: ${{env.GOVER}}
       id: go
-
-    - name: Setup Zig
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      uses: goto-bus-stop/setup-zig@0cee191d0784787b27367e56fb83cde121658bbc
-      with:
-        version: 0.9.1
 
     - run: make deps
     - id: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   GOVER: 1.17
-  RELEASE_TARGETS: launcher,osquery-extension.ext,grpc.ext,tables.ext,package-builder
 
 jobs:
   build_and_test:
@@ -18,7 +17,7 @@ jobs:
       fail-fast: false # Consider changing this sometime
       matrix:
         os:
-          - ubuntu-18.04 # latest has a bunch of version/tool issues
+          - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
@@ -38,11 +37,11 @@ jobs:
       run: make deps
 
     - name: Build
-      run: make -j2 build_{${{env.RELEASE_TARGETS}}}_noop_{amd64,arm64}
+      run: make -j2 github-build
 
     - name: Lipo
-      run: make lipo_{${{env.RELEASE_TARGETS}}}
-      if: ${{ matrix.os == 'macos-latest' }}
+      run: make github-lipo
+      if: ${{ contains(matrix.os, 'macos-latest') }}
 
     - name: Test
       run: make test
@@ -67,7 +66,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-18.04 # latest has a bunch of version/tool issues
+          - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,10 +38,10 @@ jobs:
       run: make deps
 
     - name: Build
-      run: make -j2 build_{${{env.RELEASE_TARGETS}}}_${{ matrix.os }}_{amd64,arm64}
+      run: make -j2 build_{${{env.RELEASE_TARGETS}}}_noop_{amd64,arm64}
 
     - name: Lipo
-      run: make lipo_{${{env.RELEASE_TARGETS}}}_${{ matrix.os }}
+      run: make lipo_{${{env.RELEASE_TARGETS}}}
       if: ${{ matrix.os == 'macos-latest' }}
 
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ fake-launcher: fake_launcher
 ##
 GITHUB_TARGETS=launcher osquery-extension.ext grpc.ext tables.ext package-builder
 GITHUB_ARCHS=amd64 arm64
+github-build-no-cross: $(foreach t, $(GITHUB_TARGETS), build_$(t))
 github-build: $(foreach t, $(GITHUB_TARGETS), $(foreach a, $(GITHUB_ARCHS), build_$(t)_noop_$(a)))
 github-lipo: $(foreach t, $(GITHUB_TARGETS), lipo_$(t))
 

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,13 @@ extension: build_osquery-extension.ext
 grpc.ext: build_grpc.ext
 fake-launcher: fake_launcher
 
+##
+## GitHub Action Helpers
+##
+GITHUB_TARGETS=launcher osquery-extension.ext grpc.ext tables.ext package-builder
+GITHUB_ARCHS=amd64 arm64
+github-build: $(foreach t, $(GITHUB_TARGETS), $(foreach a, $(GITHUB_ARCHS), build_$(t)_noop_$(a)))
+github-lipo: $(foreach t, $(GITHUB_TARGETS), lipo_$(t))
 
 ##
 ## Cross Build targets

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 
 build_%: TARGET =  $(word 2, $(subst _, ,$@))
 build_%: OS = $(word 3, $(subst _, ,$@))
-build_%: OSARG = $(if $(OS), --os $(OS))
+build_%: OSARG = $(if $(filter-out noop, $(OS)), --os $(OS))
 build_%: ARCH = $(word 4, $(subst _, ,$@))
 build_%: ARCHARG = $(if $(ARCH), --arch $(ARCH))
 build_%: GOARG = $(if $(CROSSGOPATH), --go $(CROSSGOPATH))

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ fake-launcher: fake_launcher
 ##
 GITHUB_TARGETS=launcher osquery-extension.ext grpc.ext tables.ext package-builder
 GITHUB_ARCHS=amd64 arm64
+# linux cross compiles aren't working. Disable for now
 github-build-no-cross: $(foreach t, $(GITHUB_TARGETS), build_$(t))
 github-build: $(foreach t, $(GITHUB_TARGETS), $(foreach a, $(GITHUB_ARCHS), build_$(t)_noop_$(a)))
 github-lipo: $(foreach t, $(GITHUB_TARGETS), lipo_$(t))

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -158,7 +158,7 @@ func New(opts ...Option) *Builder {
 
 	// Setup zig as cross compiler for linux
 	// (This is mostly to support fscrypt on linux)
-	if runtime.GOOS == "linux" && (b.os != runtime.GOOS || b.arch != runtime.GOARCH) {
+	if b.os == "linux" && (b.os != runtime.GOOS || b.arch != runtime.GOARCH) {
 		cwd, err := os.Getwd()
 		if err != nil {
 			// panic here feels a little uncouth, but the

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -138,11 +138,21 @@ func New(opts ...Option) *Builder {
 	cmdEnv = append(cmdEnv, fmt.Sprintf("GOOS=%s", b.os))
 	cmdEnv = append(cmdEnv, fmt.Sprintf("GOARCH=%s", b.arch))
 
-	if b.cgo {
-		if b.os == "windows" {
-			// See https://github.com/kolide/launcher/pull/776
-			panic("Windows and CGO are not friends")
-		}
+	// CGO...
+	switch {
+
+	// https://github.com/kolide/launcher/pull/776 has a theory
+	// that windows and cgo aren't friends. This might be wrong,
+	// but I don't want to change it yet.
+	case b.cgo && b.os == "windows":
+		panic("Windows and CGO are not friends")
+
+	// cgo is intentionally enabled
+	case b.cgo:
+		cmdEnv = append(cmdEnv, "CGO_ENABLED=1")
+
+	// When cross compiling for ARCH, cgo is not automatically detected. So we force it here.
+	case b.arch != runtime.GOARCH:
 		cmdEnv = append(cmdEnv, "CGO_ENABLED=1")
 	}
 

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -156,9 +156,9 @@ func New(opts ...Option) *Builder {
 		cmdEnv = append(cmdEnv, "CGO_ENABLED=1")
 	}
 
-	// Setup zig as cross compiler
+	// Setup zig as cross compiler for linux
 	// (This is mostly to support fscrypt on linux)
-	if b.os != runtime.GOOS {
+	if runtime.GOOS == "linux" {
 		cwd, err := os.Getwd()
 		if err != nil {
 			// panic here feels a little uncouth, but the

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -158,7 +158,7 @@ func New(opts ...Option) *Builder {
 
 	// Setup zig as cross compiler for linux
 	// (This is mostly to support fscrypt on linux)
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" && (b.os != runtime.GOOS || b.arch != runtime.GOARCH) {
 		cwd, err := os.Getwd()
 		if err != nil {
 			// panic here feels a little uncouth, but the


### PR DESCRIPTION
This configures GitHub actions to build the `amd64` and the `arm64` binaries, and on macOS, stitch them into a universal binary.

We do not build `arm64` on linux, because I can't get the cross compile to work properly. As the main goal here is universal mac binaries, I simply disabled that. It would be nice to loop back in the future.

There's some bonus spring cleaning around the actions file:
* Updates the go build version to match what I'm using locally
* updates some action versions
* updates the linux build machine
* Adds caching to the go dependancies (As described by the [flipt project](https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/))

Fixes: #821