### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/launcher/internal/install_ca_certs_test.go
+++ b/cmd/launcher/internal/install_ca_certs_test.go
@@ -14,9 +14,7 @@ import (
 func TestInstallCaCerts(t *testing.T) {
 	t.Parallel()
 
-	tempDir, err := os.MkdirTemp("", "test-install-certs")
-	require.NoError(t, err, "mktemp dir")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	installedPath1, err := InstallCaCerts(tempDir)
 	require.NoError(t, err, "install certs one")

--- a/cmd/launcher/internal/record_launcher_version_test.go
+++ b/cmd/launcher/internal/record_launcher_version_test.go
@@ -35,9 +35,7 @@ func TestRecordLauncherVersion(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 
-			tempDir, err := os.MkdirTemp("", "record-launcher-version")
-			require.NoError(t, err, "making temp dir")
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			// Make additional files
 			for i := 0; i < tt.additionalVerFiles; i++ {

--- a/pkg/augeas/augeas_test.go
+++ b/pkg/augeas/augeas_test.go
@@ -12,9 +12,7 @@ import (
 func TestInstallLenses(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "TestInstallLenses")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	require.NoError(t, InstallLenses(tmpDir), "install lenses")
 

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -19,8 +19,7 @@ import (
 func TestCreateTUFRepoDirectory(t *testing.T) {
 	t.Parallel()
 
-	localTUFRepoPath, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	localTUFRepoPath := t.TempDir()
 
 	u := &Updater{logger: log.NewNopLogger()}
 	require.NoError(t, u.createTUFRepoDirectory(localTUFRepoPath, "pkg/autoupdate/assets", AssetDir))
@@ -40,7 +39,7 @@ func TestCreateTUFRepoDirectory(t *testing.T) {
 
 	for _, knownFilePath := range knownFilePaths {
 		fullFilePath := filepath.Join(localTUFRepoPath, knownFilePath)
-		_, err = os.Stat(fullFilePath)
+		_, err := os.Stat(fullFilePath)
 		require.NoError(t, err, "stat file")
 
 		jsonBytes, err := ioutil.ReadFile(fullFilePath)
@@ -63,7 +62,7 @@ func TestCreateTUFRepoDirectory(t *testing.T) {
 	// And retest
 	for _, knownFilePath := range knownFilePaths {
 		fullFilePath := filepath.Join(localTUFRepoPath, knownFilePath)
-		_, err = os.Stat(fullFilePath)
+		_, err := os.Stat(fullFilePath)
 		require.NoError(t, err, "stat file")
 
 		jsonBytes, err := ioutil.ReadFile(fullFilePath)
@@ -230,9 +229,7 @@ func TestFindCurrentUpdate(t *testing.T) {
 	}
 
 	// Setup the tests
-	tmpDir, err := ioutil.TempDir("", "test-autoupdate-findCurrentUpdate")
-	defer os.RemoveAll(tmpDir)
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	updater := Updater{
 		binaryName:       "binary",

--- a/pkg/autoupdate/helpers_test.go
+++ b/pkg/autoupdate/helpers_test.go
@@ -1,7 +1,6 @@
 package autoupdate
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,9 +16,7 @@ func TestCheckExecutablePermissions(t *testing.T) {
 	require.Error(t, checkExecutablePermissions("/random/path/should/not/exist"), "passing non-existent file path")
 
 	// Setup the tests
-	tmpDir, err := ioutil.TempDir("", "test-autoupdate-check-executable")
-	defer os.RemoveAll(tmpDir)
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	require.Error(t, checkExecutablePermissions(tmpDir), "directory should not be executable")
 

--- a/pkg/log/checkpoint/files_test.go
+++ b/pkg/log/checkpoint/files_test.go
@@ -13,12 +13,7 @@ import (
 func TestFilesFound(t *testing.T) {
 	t.Parallel()
 
-	tempDir, err := os.MkdirTemp("", "log-checkpoint-files-test")
-	require.NoError(t, err, "making temp dir")
-
-	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
-	})
+	tempDir := t.TempDir()
 
 	var tests = []struct {
 		name         string

--- a/pkg/osquery/runtime/history/history_test.go
+++ b/pkg/osquery/runtime/history/history_test.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -189,13 +188,14 @@ func TestNoDbError(t *testing.T) {
 
 // newTestBoltDb creates a new boltdb instance and seeds it with the given instances.
 func newTestBoltDb(t *testing.T, seedInstances ...*Instance) *bbolt.DB {
-
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	db, err := bbolt.Open(filepath.Join(dir, "osquery_instance_history_test.db"), 0600, &bbolt.Options{
 		Timeout: 1 * time.Second,
+	})
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
 	})
 
 	require.NoError(t, err, "expect no error opening bolt db")

--- a/pkg/osquery/runtime/history/history_test.go
+++ b/pkg/osquery/runtime/history/history_test.go
@@ -173,9 +173,7 @@ func TestLatestInstance(t *testing.T) { // nolint:paralleltest
 	}
 }
 
-func TestNoDbError(t *testing.T) {
-	t.Parallel()
-
+func TestNoDbError(t *testing.T) { // nolint:paralleltest
 	err := InitHistory(nil)
 	assert.ErrorIs(t, err, NoDbError{})
 

--- a/pkg/osquery/runtime/history/instance_test.go
+++ b/pkg/osquery/runtime/history/instance_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInstance_Connected(t *testing.T) {
-	t.Parallel()
-
+func TestInstance_Connected(t *testing.T) { // nolint:paralleltest
 	// have to declare this up here to use later in comparison
 	queryError := errors.New("some query error")
 
@@ -51,11 +49,9 @@ func TestInstance_Connected(t *testing.T) {
 			wantErrReturn: ExpectedAtLeastOneRowError{},
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:paralleltest
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			require.NoError(t, InitHistory(newTestBoltDb(t)))
 
 			i := &Instance{}
@@ -77,9 +73,7 @@ func TestInstance_Connected(t *testing.T) {
 	}
 }
 
-func TestInstance_Exited(t *testing.T) {
-	t.Parallel()
-
+func TestInstance_Exited(t *testing.T) { // nolint:paralleltest
 	type args struct {
 		exitError error
 	}
@@ -99,11 +93,9 @@ func TestInstance_Exited(t *testing.T) {
 			wantErr: "some error",
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:paralleltest
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			require.NoError(t, InitHistory(newTestBoltDb(t)))
 
 			i := &Instance{}

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -6,7 +6,6 @@ package authenticode
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -36,9 +35,7 @@ func TestSign(t *testing.T) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer ctxCancel()
 
-	tmpDir, err := ioutil.TempDir("", "packagekit-authenticode-signing")
-	defer os.RemoveAll(tmpDir)
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	testExe := filepath.Join(tmpDir, "test.exe")
 

--- a/pkg/packagekit/package_test.go
+++ b/pkg/packagekit/package_test.go
@@ -18,8 +18,7 @@ func TestPackageTrivial(t *testing.T) {
 		t.Skip("No packaging tools")
 	}
 
-	inputDir, err := ioutil.TempDir("", "packaging-input")
-	require.NoError(t, err)
+	inputDir := t.TempDir()
 
 	po := &PackageOptions{
 		Name:            "test-empty",
@@ -28,7 +27,7 @@ func TestPackageTrivial(t *testing.T) {
 		AppleSigningKey: "Developer ID Installer: Kolide Inc (YZ3EM74M78)",
 	}
 
-	err = PackageFPM(context.TODO(), ioutil.Discard, po, AsTar())
+	err := PackageFPM(context.TODO(), ioutil.Discard, po, AsTar())
 	require.NoError(t, err)
 
 	err = PackageFPM(context.TODO(), ioutil.Discard, po, AsDeb())

--- a/pkg/packagekit/wix/wix_test.go
+++ b/pkg/packagekit/wix/wix_test.go
@@ -33,11 +33,9 @@ func TestWixPackage(t *testing.T) {
 
 	ctx = ctxlog.NewContext(ctx, logger)
 
-	packageRoot, err := ioutil.TempDir("", "packaging-root")
-	require.NoError(t, err)
-	defer os.RemoveAll(packageRoot)
+	packageRoot := t.TempDir()
 
-	err = setupPackageRoot(packageRoot)
+	err := setupPackageRoot(packageRoot)
 	require.NoError(t, err)
 
 	mainWxsContent, err := testdata.ReadFile("product.wxs")

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -3,7 +3,6 @@ package packaging
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -57,25 +56,28 @@ func TestInitStuff(t *testing.T) {
 	}
 
 	for _, target := range testedTargets() {
-		testPackageRoot, err := ioutil.TempDir("", fmt.Sprintf("test-packaging-root-%s", target.String()))
-		require.NoError(t, err)
+		target := target
 
-		testScriptDir, err := ioutil.TempDir("", fmt.Sprintf("test-packaging-script-%s", target.String()))
-		require.NoError(t, err)
+		t.Run(target.String(), func(t *testing.T) {
+			t.Parallel()
 
-		p := &PackageOptions{
-			target:      target,
-			Identifier:  "test",
-			initFile:    "/usr/bin/true",
-			scriptRoot:  testScriptDir,
-			packageRoot: testPackageRoot,
-			initOptions: initOptions,
-		}
+			testPackageRoot := t.TempDir()
+			testScriptDir := t.TempDir()
 
-		// TODO we're creating here, but we should check the output
-		require.NoError(t, p.setupInit(ctx))
-		require.NoError(t, p.setupPostinst(ctx))
-		require.NoError(t, p.setupPrerm(ctx))
+			p := &PackageOptions{
+				target:      target,
+				Identifier:  "test",
+				initFile:    "/usr/bin/true",
+				scriptRoot:  testScriptDir,
+				packageRoot: testPackageRoot,
+				initOptions: initOptions,
+			}
+
+			// TODO we're creating here, but we should check the output
+			require.NoError(t, p.setupInit(ctx))
+			require.NoError(t, p.setupPostinst(ctx))
+			require.NoError(t, p.setupPrerm(ctx))
+		})
 	}
 }
 


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```