### PR TITLE
Rename the initial kolide plugin to `kolide_grpc`

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -366,9 +366,9 @@ func (r *Runner) launchOsqueryInstance() error {
 	// ordering issues.
 
 	// Start an extension manager for the extensions that osquery
-	// needs for config/log/etc
+	// needs for config/log/etc. It's called `kolide_grpc` for mostly historic reasons
 	if len(o.opts.extensionPlugins) > 0 {
-		if err := o.StartOsqueryExtensionManagerServer("kolide_initial", paths.extensionSocketPath, o.opts.extensionPlugins); err != nil {
+		if err := o.StartOsqueryExtensionManagerServer("kolide_grpc", paths.extensionSocketPath, o.opts.extensionPlugins); err != nil {
 			level.Info(o.logger).Log("msg", "Unable to create initial extension server. Stopping", "err", err)
 			return errors.Wrap(err, "could not create an extension server")
 		}


### PR DESCRIPTION
Testing with v0.12.0, I'm running into some issues. I'm pretty sure they're because the extension registers as `kolide_initial`, but various things are configured to use `kolide_grpc`. (Which is kinda :shrug: since there are sub extensions with that name. But who knows)

Renaming this to kolide_grpc feels like the quickest way. It seems to work in some testing, but I want to get it a bit wider