### PR TITLE
Fix typo in error output of exec function

### DIFF
--- a/pkg/osquery/tables/tablehelpers/exec.go
+++ b/pkg/osquery/tables/tablehelpers/exec.go
@@ -53,5 +53,5 @@ func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, possibleBi
 
 	}
 	// Getting here means no binary was found
-	return nil, errors.Wrapf(os.ErrNotExist, "No binary found is specified paths: %v", possibleBins)
+	return nil, errors.Wrapf(os.ErrNotExist, "No binary found in specified paths: %v", possibleBins)
 }


### PR DESCRIPTION
1 character change `is` to `in`