### PR TITLE
Improve localserver id fetch timing

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/ee/desktop/runtime/runner_darwin.go
+++ b/ee/desktop/runtime/runner_darwin.go
@@ -75,7 +75,7 @@ func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
 	r.procsWg.Add(1)
 	go func(uid string, proc *os.Process) {
 		defer r.procsWg.Done()
-		// if the desktop proccess dies, the parent must clean up otherwise we get a zombie process
+		// if the desktop process dies, the parent must clean up otherwise we get a zombie process
 		// waiting here gives the parent a chance to clean up
 		_, err := proc.Wait()
 		if err != nil {

--- a/ee/desktop/runtime/runner_test.go
+++ b/ee/desktop/runtime/runner_test.go
@@ -20,7 +20,7 @@ import (
 func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 	t.Parallel()
 
-	// When running this using the golang test harness, it will leave behind proccess if you do not build the binary first.
+	// When running this using the golang test harness, it will leave behind process if you do not build the binary first.
 	// On mac os you can find these by setting the executable path to an empty string before running the tests, then search
 	// the processes in a terminal using: ps aux -o ppid | runtime.test after the tests have completed, you'll also see the
 	// CPU consumtion go way up.

--- a/ee/localserver/request-id.go
+++ b/ee/localserver/request-id.go
@@ -24,12 +24,16 @@ type requestIdsResponse struct {
 	Timestamp time.Time
 }
 
+const (
+	idSQL = "select instance_id, osquery_info.uuid, hardware_serial from osquery_info, system_info"
+)
+
 func (ls *localServer) updateIdFields() error {
 	if ls.querier == nil {
 		return errors.New("no querier set")
 	}
 
-	results, err := ls.querier.Query("select instance_id, osquery_info.uuid, hardware_serial from osquery_info, system_info")
+	results, err := ls.querier.Query(idSQL)
 	if err != nil {
 		return fmt.Errorf("id query failed: %w", err)
 	}

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -158,7 +158,7 @@ func (ls *localServer) runAsyncdWorkers() time.Time {
 func (ls *localServer) Start() error {
 	// Spawn background workers. This loop is a bit weird on startup. We want to populate this data as soon as we can, but because the underlying launcher
 	// run group isn't ordered, this is likely to happen before querier is ready. So we retry at a frequent interval for a couple of minutes, then we drop
-	// back to a slower poll interval. Note that this polling is mearly a check against time, we don't repopulate this data nearly so often. (But we poll
+	// back to a slower poll interval. Note that this polling is merely a check against time, we don't repopulate this data nearly so often. (But we poll
 	// frequently to account for the difference between wall clock time, and sleep time)
 	const (
 		initialPollInterval = 10 * time.Second


### PR DESCRIPTION
To account for startup sequencing, we want to do the initial id structure population quickly. But it can slow down after an initial success. This expands the logic around how localserver to handle that case. 