### PR TITLE
Add Get-Bitlocker cmdlet exec based table

### DIFF
--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -16,6 +16,8 @@ import (
 
 func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
+		dataflattentable.TablePluginExec(client, logger,
+			"kolide_bitlocker_volumes", dataflattentable.JsonType, []string{"Get-BitlockerVolume", "|", "ConvertTo-Json"}),
 		ProgramIcons(),
 		dsim_default_associations.TablePlugin(client, logger),
 		secedit.TablePlugin(client, logger),


### PR DESCRIPTION
## What is the purpose of this PR?

Adds a new table `kolide_bitlocker_volumes` which prints a dataflatten type JSON array of mounted volumes and their respective Bitlocker configuration status:

Example output of the cmdlet is pasted below with sensitive fields redacted with `***` characters

```JSON
{
    "ComputerName":  "Test-Device",
    "MountPoint":  "C:",
    "EncryptionMethod":  6,
    "AutoUnlockEnabled":  null,
    "AutoUnlockKeyStored":  false,
    "MetadataVersion":  2,
    "VolumeStatus":  1,
    "ProtectionStatus":  1,
    "LockStatus":  0,
    "EncryptionPercentage":  100,
    "WipePercentage":  0,
    "VolumeType":  0,
    "CapacityGB":  220.694336,
    "KeyProtector":  [
                         {
                             "KeyProtectorId":  "{******-******-49B4-A548-2BB8F4812FF6}",
                             "AutoUnlockProtector":  null,
                             "KeyProtectorType":  3,
                             "KeyFileName":  "",
                             "RecoveryPassword":  "******-******-******-******-******-******-******-******",
                             "KeyCertificateType":  null,
                             "Thumbprint":  ""
                         },
                         {
                             "KeyProtectorId":  "{******-******-4CE5-B540-176BD6C95424}",
                             "AutoUnlockProtector":  null,
                             "KeyProtectorType":  1,
                             "KeyFileName":  "",
                             "RecoveryPassword":  "",
                             "KeyCertificateType":  null,
                             "Thumbprint":  ""
                         }
                     ]
}
```

## Why is this table necessary?

The existing `bitlocker_info` table in osquery does not return the state of KeyProtectors and whether any have been configured. This cmdlet is capable of returning any identified KeyProtectors.

This information is beneficial in identifying the fully/partially configured state of Bitlocker for a given disk.

## Possible concerns / necessitated changes

In my testing the output of this cmdlet _*CAN*_ print the Bitlocker Recovery Key in clear-text. This does not always occur, but I have seen it twice already. 

This output can be avoided at the SQL-writing stage by omitting any row where the `key` is labeled `RecoveryPassword`. However, this may not be sufficient from a privacy standpoint for other contributors. I can imagine a scenario in which it would be beneficial for an IT administrator to have access to this Recovery Password, however, I am not sure that outweighs the potential risk for an employee who enrolls a personal device.

I think playing it safe would mean amending the exec to exclude or redact that key/value when it is present. Curious to hear @directionless's thoughts...