### PR TITLE
Adds dev_table_tooling to capture output of allowed commands

### DIFF
--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/kolide/launcher/pkg/osquery/tables/cryptoinfotable"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/dev_table_tooling"
 	"github.com/kolide/launcher/pkg/osquery/tables/firefox_preferences"
 	"github.com/kolide/launcher/pkg/osquery/tables/osquery_instance_history"
 	"github.com/kolide/launcher/pkg/osquery/tables/tdebug"
@@ -40,6 +41,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		SlackConfig(client, logger),
 		SshKeys(client, logger),
 		cryptoinfotable.TablePlugin(logger),
+		dev_table_tooling.TablePlugin(client, logger),
 		firefox_preferences.TablePlugin(logger),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_info", dataflattentable.JsonType, zerotierCli("info")),

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -41,7 +41,7 @@ func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		SlackConfig(client, logger),
 		SshKeys(client, logger),
 		cryptoinfotable.TablePlugin(logger),
-		dev_table_tooling.TablePlugin(client, logger),
+		dev_table_tooling.TablePlugin(logger),
 		firefox_preferences.TablePlugin(logger),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_zerotier_info", dataflattentable.JsonType, zerotierCli("info")),

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+// +build darwin
+
+package dev_table_tooling
+
+func GetAllowedCommands() map[string]AllowedCommand {
+	cmds := map[string]AllowedCommand{
+		"system_profiler": {
+			binPaths: []string{"/usr/sbin/system_profiler"},
+			args:     []string{"SPSoftwareDataType", "SPNetworkDataType"},
+		},
+		"diskutil": {
+			binPaths: []string{"diskutil"},
+			args:     []string{"info", "-all"},
+		},
+	}
+	return cmds
+}

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -3,6 +3,6 @@
 
 package dev_table_tooling
 
-var allowedCommands = map[string]AllowedCommand{
+var allowedCommands = map[string]allowedCommand{
 	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -9,3 +9,6 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
+
+// Platform-specific test data
+var echoHelloOutput = "hello\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -9,6 +9,3 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
-
-// Platform-specific test data
-var echoHelloOutput = "hello\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -3,9 +3,6 @@
 
 package dev_table_tooling
 
-func GetAllowedCommands() map[string]AllowedCommand {
-	cmds := map[string]AllowedCommand{
-		// Add allowed commands here
-	}
-	return cmds
+var allowedCommands = map[string]AllowedCommand{
+	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -4,5 +4,8 @@
 package dev_table_tooling
 
 var allowedCommands = map[string]allowedCommand{
-	// Add allowed commands here
+	"echo": {
+		binPaths: []string{"echo"},
+		args:     []string{"hello"},
+	},
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_darwin.go
@@ -5,14 +5,7 @@ package dev_table_tooling
 
 func GetAllowedCommands() map[string]AllowedCommand {
 	cmds := map[string]AllowedCommand{
-		"system_profiler": {
-			binPaths: []string{"/usr/sbin/system_profiler"},
-			args:     []string{"SPSoftwareDataType", "SPNetworkDataType"},
-		},
-		"diskutil": {
-			binPaths: []string{"diskutil"},
-			args:     []string{"info", "-all"},
-		},
+		// Add allowed commands here
 	}
 	return cmds
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -5,10 +5,7 @@ package dev_table_tooling
 
 func GetAllowedCommands() map[string]AllowedCommand {
 	cmds := map[string]AllowedCommand{
-		"ifconfig": {
-			binPaths: []string{"ifconfig"},
-			args:     []string{},
-		},
+		// Add allowed commands here
 	}
 	return cmds
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -3,6 +3,6 @@
 
 package dev_table_tooling
 
-var allowedCommands = map[string]AllowedCommand{
+var allowedCommands = map[string]allowedCommand{
 	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -9,3 +9,6 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
+
+// Platform-specific test data
+var echoHelloOutput = "hello\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -9,6 +9,3 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
-
-// Platform-specific test data
-var echoHelloOutput = "hello\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package dev_table_tooling
+
+func GetAllowedCommands() map[string]AllowedCommand {
+	cmds := map[string]AllowedCommand{
+		"ifconfig": {
+			binPaths: []string{"ifconfig"},
+			args:     []string{},
+		},
+	}
+	return cmds
+}

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -3,9 +3,6 @@
 
 package dev_table_tooling
 
-func GetAllowedCommands() map[string]AllowedCommand {
-	cmds := map[string]AllowedCommand{
-		// Add allowed commands here
-	}
-	return cmds
+var allowedCommands = map[string]AllowedCommand{
+	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_linux.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_linux.go
@@ -4,5 +4,8 @@
 package dev_table_tooling
 
 var allowedCommands = map[string]allowedCommand{
-	// Add allowed commands here
+	"echo": {
+		binPaths: []string{"echo"},
+		args:     []string{"hello"},
+	},
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package dev_table_tooling
+
+func GetAllowedCommands() map[string]AllowedCommand {
+	cmds := map[string]AllowedCommand{
+		"hostname": {
+			binPaths: []string{"hostname"},
+			args:     []string{},
+		},
+	}
+	return cmds
+}

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -9,3 +9,6 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
+
+// Platform-specific test data
+var echoHelloOutput = "hello\r\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -9,6 +9,3 @@ var allowedCommands = map[string]allowedCommand{
 		args:     []string{"hello"},
 	},
 }
-
-// Platform-specific test data
-var echoHelloOutput = "hello\r\n"

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -3,6 +3,6 @@
 
 package dev_table_tooling
 
-var allowedCommands = map[string]AllowedCommand{
+var allowedCommands = map[string]allowedCommand{
 	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -5,10 +5,7 @@ package dev_table_tooling
 
 func GetAllowedCommands() map[string]AllowedCommand {
 	cmds := map[string]AllowedCommand{
-		"hostname": {
-			binPaths: []string{"hostname"},
-			args:     []string{},
-		},
+		// Add allowed commands here
 	}
 	return cmds
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -3,9 +3,6 @@
 
 package dev_table_tooling
 
-func GetAllowedCommands() map[string]AllowedCommand {
-	cmds := map[string]AllowedCommand{
-		// Add allowed commands here
-	}
-	return cmds
+var allowedCommands = map[string]AllowedCommand{
+	// Add allowed commands here
 }

--- a/pkg/osquery/tables/dev_table_tooling/commands_windows.go
+++ b/pkg/osquery/tables/dev_table_tooling/commands_windows.go
@@ -4,5 +4,8 @@
 package dev_table_tooling
 
 var allowedCommands = map[string]allowedCommand{
-	// Add allowed commands here
+	"echo": {
+		binPaths: []string{"echo"},
+		args:     []string{"hello"},
+	},
 }

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -48,7 +48,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			continue
 		}
 
-		cmd, ok := GetAllowedCommands()[name]
+		cmd, ok := allowedCommands[name]
 
 		if !ok {
 			level.Info(t.logger).Log("msg", "Command not allowed", "name", name)

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -3,6 +3,7 @@ package dev_table_tooling
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -27,6 +28,7 @@ type Table struct {
 func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("name"),
+		table.TextColumn("args"),
 		table.TextColumn("output"),
 	}
 
@@ -61,6 +63,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			} else {
 				results = append(results, map[string]string{
 					"name":   name,
+					"args":   strings.Join(cmd.args, " "),
 					"output": base64.StdEncoding.EncodeToString(output),
 				})
 			}

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -20,7 +19,6 @@ type allowedCommand struct {
 }
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -58,7 +58,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 		output, err := tablehelpers.Exec(ctx, t.logger, 30, cmd.binPaths, cmd.args)
 		if err != nil {
-			level.Info(t.logger).Log("msg", "dev_table_tooling failed", "name", name, "err", err)
+			level.Info(t.logger).Log("msg", "execution failed", "name", name, "err", err)
 			continue
 		}
 

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -1,0 +1,87 @@
+package dev_table_tooling
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/osquery/osquery-go"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func GetAllowedCommandNameList() []string {
+	cmds := GetAllowedCommands()
+	keys := make([]string, len(cmds))
+
+	i := 0
+	for k := range cmds {
+		keys[i] = k
+		i++
+	}
+
+	return keys
+}
+
+// Encapsulates the binary path(s) of a command allowed to execute
+// along with a strict list of arguments.
+type AllowedCommand struct {
+	binPaths []string
+	args     []string
+}
+
+type Table struct {
+	client    *osquery.ExtensionManagerClient
+	logger    log.Logger
+	tableName string
+}
+
+func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+	columns := dataflattentable.Columns(
+		table.TextColumn("name"),
+		table.TextColumn("output"),
+	)
+
+	t := &Table{
+		client:    client,
+		logger:    logger,
+		tableName: "kolide_dev_table_tooling",
+	}
+
+	return table.NewPlugin(t.tableName, columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	for _, name := range tablehelpers.GetConstraints(queryContext, "name", tablehelpers.WithAllowedValues(GetAllowedCommandNameList()), tablehelpers.WithDefaults("")) {
+		if name == "" {
+			level.Info(t.logger).Log("msg", "Command not allowed", "name", name)
+			continue
+		}
+
+		// The ConstraintOps should have already filtered out disallowed command names
+		// If the cmd is not found, this could indicate a logic error
+		cmd, found := GetAllowedCommands()[name]
+
+		if !found {
+			level.Info(t.logger).Log("msg", "Command not allowed", "name", name)
+			continue
+		} else {
+			output, err := tablehelpers.Exec(ctx, t.logger, 30, cmd.binPaths, cmd.args)
+			if err != nil {
+				level.Info(t.logger).Log("msg", "dev_table_tooling failed", "name", name, "err", err)
+				continue
+			} else {
+				results = append(results, map[string]string{
+					"name":   name,
+					"output": base64.StdEncoding.EncodeToString(output),
+				})
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -20,9 +20,8 @@ type allowedCommand struct {
 }
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
-	logger    log.Logger
-	tableName string
+	client *osquery.ExtensionManagerClient
+	logger log.Logger
 }
 
 func TablePlugin(logger log.Logger) *table.Plugin {

--- a/pkg/osquery/tables/dev_table_tooling/table_test.go
+++ b/pkg/osquery/tables/dev_table_tooling/table_test.go
@@ -26,9 +26,9 @@ func Test_generate(t *testing.T) {
 			commandName: []string{"ransomware.exe"},
 		},
 		{
-			name:           "should-always-work happy path",
+			name:           "should always work happy path",
 			commandName:    []string{"echo"},
-			expectedResult: []map[string]string{{"name": "echo", "args": "hello", "output": base64.StdEncoding.EncodeToString([]byte("hello\n"))}},
+			expectedResult: []map[string]string{{"name": "echo", "args": "hello", "output": base64.StdEncoding.EncodeToString([]byte(echoHelloOutput))}},
 		},
 	}
 

--- a/pkg/osquery/tables/dev_table_tooling/table_test.go
+++ b/pkg/osquery/tables/dev_table_tooling/table_test.go
@@ -2,6 +2,7 @@ package dev_table_tooling
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -23,6 +24,11 @@ func Test_generate(t *testing.T) {
 		{
 			name:        "malware",
 			commandName: []string{"ransomware.exe"},
+		},
+		{
+			name:           "should-always-work happy path",
+			commandName:    []string{"echo"},
+			expectedResult: []map[string]string{{"name": "echo", "args": "hello", "output": base64.StdEncoding.EncodeToString([]byte("hello\n"))}},
 		},
 	}
 

--- a/pkg/osquery/tables/dev_table_tooling/table_test.go
+++ b/pkg/osquery/tables/dev_table_tooling/table_test.go
@@ -1,0 +1,44 @@
+package dev_table_tooling
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		commandName    []string
+		expectedResult []map[string]string
+	}{
+		{
+			name: "no command name",
+		},
+		{
+			name:        "malware",
+			commandName: []string{"ransomware.exe"},
+		},
+	}
+
+	table := Table{logger: log.NewNopLogger()}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			constraints := make(map[string][]string)
+			constraints["name"] = tt.commandName
+
+			got, _ := table.generate(context.Background(), tablehelpers.MockQueryContext(constraints))
+
+			assert.ElementsMatch(t, tt.expectedResult, got)
+		})
+	}
+}

--- a/pkg/osquery/tables/dev_table_tooling/table_test.go
+++ b/pkg/osquery/tables/dev_table_tooling/table_test.go
@@ -17,7 +17,7 @@ func Test_generate(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		commandName    []string
+		commandName    string
 		expectedResult []map[string]string
 	}{
 		{
@@ -25,11 +25,11 @@ func Test_generate(t *testing.T) {
 		},
 		{
 			name:        "malware",
-			commandName: []string{"ransomware.exe"},
+			commandName: "ransomware.exe",
 		},
 		{
 			name:           "should always work happy path",
-			commandName:    []string{"echo"},
+			commandName:    "echo",
 			expectedResult: []map[string]string{{"name": "echo", "args": "hello", "output": "hello"}},
 		},
 	}
@@ -42,16 +42,16 @@ func Test_generate(t *testing.T) {
 			t.Parallel()
 
 			constraints := make(map[string][]string)
-			constraints["name"] = tt.commandName
+			constraints["name"] = []string{tt.commandName}
 
 			got, _ := table.generate(context.Background(), tablehelpers.MockQueryContext(constraints))
 
 			if len(tt.expectedResult) <= 0 {
-				assert.ElementsMatch(t, tt.expectedResult, got)
+				assert.Empty(t, got)
 				return
 			}
 
-			// test for expected results
+			// Test for expected results
 			assert.Equal(t, tt.expectedResult[0]["name"], got[0]["name"])
 			assert.Equal(t, tt.expectedResult[0]["args"], got[0]["args"])
 

--- a/pkg/osquery/tables/dev_table_tooling/table_test.go
+++ b/pkg/osquery/tables/dev_table_tooling/table_test.go
@@ -46,21 +46,23 @@ func Test_generate(t *testing.T) {
 
 			got, _ := table.generate(context.Background(), tablehelpers.MockQueryContext(constraints))
 
-			if len(tt.expectedResult) > 0 {
-				assert.Equal(t, tt.expectedResult[0]["name"], got[0]["name"])
-				assert.Equal(t, tt.expectedResult[0]["args"], got[0]["args"])
-
-				// To verify output, let's convert back to utf8
-				decodedOutput, _ := base64.StdEncoding.DecodeString(got[0]["output"])
-				scanner := bufio.NewScanner(bytes.NewReader(decodedOutput))
-				for scanner.Scan() {
-					// Scanner "normalizes" the output by removing platform-specific newline characters
-					firstLine := scanner.Text()
-					assert.Equal(t, tt.expectedResult[0]["output"], firstLine)
-					break
-				}
-			} else {
+			if len(tt.expectedResult) <= 0 {
 				assert.ElementsMatch(t, tt.expectedResult, got)
+				return
+			}
+
+			// test for expected results
+			assert.Equal(t, tt.expectedResult[0]["name"], got[0]["name"])
+			assert.Equal(t, tt.expectedResult[0]["args"], got[0]["args"])
+
+			// To verify output, let's convert back to utf8
+			decodedOutput, _ := base64.StdEncoding.DecodeString(got[0]["output"])
+			scanner := bufio.NewScanner(bytes.NewReader(decodedOutput))
+			for scanner.Scan() {
+				// Scanner "normalizes" the output by removing platform-specific newline characters
+				firstLine := scanner.Text()
+				assert.Equal(t, tt.expectedResult[0]["output"], firstLine)
+				break
 			}
 		})
 	}


### PR DESCRIPTION
This PR addresses #876.

- `kolide_dev_table_tooling` table has a `name`, `args`, and `output` column
- Each platform has a hard-coded set of named allowed commands, which correspond to a strict list of binaries and arguments
- A test exercises the cases where a command name isn't provided, or is unrecognized
- I've supplied some hard-coded allowed commands purely as an example of how they would be specified in the code, these can be replaced with more suitable options, or removed entirely, prior to merging