### PR TITLE
address performance issue caused by re instantiating new ticker in for loop condition

### DIFF
--- a/cmd/launcher/desktop/desktop.go
+++ b/cmd/launcher/desktop/desktop.go
@@ -41,7 +41,9 @@ func handleSignals() {
 
 // continuously monitor for ppid and exit if parent process terminates
 func exitWhenParentGone() {
-	for ; true; <-time.NewTicker(2 * time.Second).C {
+	ticker := time.NewTicker(2 * time.Second)
+
+	for ; true; <-ticker.C {
 		ppid := os.Getppid()
 
 		if ppid <= 1 {


### PR DESCRIPTION
declares exitWhenParentGone() ticker out side of for loop condition, declaring in condition was causing causes ticker to be continuously recreated