### PR TITLE
Adds apple_silicon_security_policy table to capture the boot policies on Apple Silicon Macs

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
 	"github.com/kolide/launcher/pkg/osquery/tables/airport"
 	appicons "github.com/kolide/launcher/pkg/osquery/tables/app-icons"
+	"github.com/kolide/launcher/pkg/osquery/tables/apple_silicon_security_policy"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/filevault"
 	"github.com/kolide/launcher/pkg/osquery/tables/firmwarepasswd"
@@ -91,6 +92,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		kextpolicy.TablePlugin(),
 		filevault.TablePlugin(client, logger),
 		mdmclient.TablePlugin(client, logger),
+		apple_silicon_security_policy.TablePlugin(logger),
 		legacyexec.TablePlugin(),
 		dataflattentable.TablePluginExec(client, logger,
 			"kolide_diskutil_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "list", "-plist"}),

--- a/pkg/osquery/tables/apple_silicon_security_policy/parser.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/parser.go
@@ -1,0 +1,169 @@
+package apple_silicon_security_policy
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// This regexp gets matches for an arbitrary property name, and a four-character code (4CC) sequence
+var fourCharCodeRegexp = regexp.MustCompile(`^((.*) (?:\((.{4})\)))`)
+
+// This regexp gets matches for the volume group UUID following the text "Local policy for volume group"
+var volumeGroupRegexp = regexp.MustCompile("^((?:(?:.*) for volume group))(.*):")
+
+// parseStatus parses the output from `bputil --display-all-policies`.
+// bputil reference: https://keith.github.io/xcode-man-pages/bputil.1.html
+//
+// Decriptions of properties: https://support.apple.com/guide/security/contents-a-localpolicy-file-mac-apple-silicon-secc745a0845/web
+//
+// Example output:
+//
+// sudo bputil -d
+// Password:
+//
+// This utility is not meant for normal users or even sysadmins.
+// It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+// It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+// This tool is not to be used in production environments.
+// It is possible to render your system unbootable with this tool.
+// It should only be used to understand how the security of Apple Silicon Macs works.
+// Use at your own risk!
+//
+// Local policy for volume group 5D0D176D-E8CC-**REDACTED**:
+// OS environment:
+// OS Type                                       : macOS
+// OS Pairing Status                             : Not Paired
+// Local Policy Nonce Hash                 (lpnh): A8D3EC575A03E7F58**REDACTED**
+// Remote Policy Nonce Hash                (rpnh): FAD13B6348B0B0FB0**REDACTED**
+// Recovery OS Policy Nonce Hash           (ronh): F7FDBA24525C17FFA**REDACTED**
+//
+// Local policy:
+// Pairing Integrity                             : Valid
+// Signature Type                                : BAA
+// Unique Chip ID                          (ECID): 0x1D68A**REDACTED**
+// Board ID                                (BORD): 0x24
+// Chip ID                                 (CHIP): 0x8103
+// Certificate Epoch                       (CEPO): 0x1
+// Security Domain                         (SDOM): 0x1
+// Production Status                       (CPRO): 1
+// Security Mode                           (CSEC): 1
+// OS Version                              (love): 21.1.559.0.0,0
+// Volume Group UUID                       (vuid): 8462458F-944E-**REDACTED**
+// KEK Group UUID                          (kuid): 41196911-E654-**REDACTED**
+// Local Policy Nonce Hash                 (lpnh): A8D3EC575A03E7F58**REDACTED**
+// Remote Policy Nonce Hash                (rpnh): FAD13B6348B0B0FB0**REDACTED**
+// Next Stage Image4 Hash                  (nsih): 19F3A3DC16816A9FC**REDACTED**
+// User Authorized Kext List Hash          (auxp): absent
+// Auxiliary Kernel Cache Image4 Hash      (auxi): absent
+// Kext Receipt Hash                       (auxr): absent
+// CustomKC or fuOS Image4 Hash            (coih): absent
+// Security Mode:               Full       (smb0): absent
+// 3rd Party Kexts Status:      Disabled   (smb2): absent
+// User-allowed MDM Control:    Disabled   (smb3): absent
+// DEP-allowed MDM Control:     Disabled   (smb4): absent
+// SIP Status:                  Enabled    (sip0): absent
+// Signed System Volume Status: Enabled    (sip1): absent
+// Kernel CTRR Status:          Enabled    (sip2): absent
+// Boot Args Filtering Status:  Enabled    (sip3): absent
+func parseStatus(rawdata []byte) ([]map[string]string, error) {
+	data := []map[string]string{}
+
+	if len(rawdata) == 0 {
+		return nil, errors.New("No data")
+	}
+
+	var volumeGroup string
+
+	scanner := bufio.NewScanner(bytes.NewReader(rawdata))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Always look first for matches with the volume group regexp
+		// Once found, it will be the volume_group column associated with subsequent rows
+		m := volumeGroupRegexp.FindAllStringSubmatch(line, -1)
+		if len(m) == 1 && len(m[0]) == 3 {
+			volumeGroup = strings.TrimSpace(m[0][2])
+			continue
+		}
+
+		// Skip lines not associated with a volume group (includes header warning text)
+		if len(volumeGroup) == 0 {
+			continue
+		}
+
+		// Some lines have one colon, some have two colons
+		kv := strings.SplitN(line, ": ", 3)
+
+		var property, mode, code, value string
+		switch len(kv) {
+		case 2:
+			property, code, value = parseTwoColumns(kv)
+		case 3:
+			property, mode, code, value = parseThreeColumns(kv)
+		default:
+			// Skip blank lines or other unexpected input
+			continue
+		}
+
+		rowData := map[string]string{
+			"volume_group": volumeGroup,
+			"property":     strings.ReplaceAll(strings.TrimSpace(property), " ", "_"),
+			"mode":         strings.TrimSpace(mode),
+			"code":         code,
+			"value":        strings.TrimSpace(value),
+		}
+
+		data = append(data, rowData)
+	}
+
+	return data, nil
+}
+
+// Parses lines which have two columns of data, for example:
+//
+// Local Policy Nonce Hash                 (lpnh): A8D3EC575A03E7F58**REDACTED**
+//
+// Signature Type                                : BAA
+//
+// returns property, code (optional), value
+func parseTwoColumns(kv []string) (string, string, string) {
+	var property, code, value string
+	matches := fourCharCodeRegexp.FindAllStringSubmatch(kv[0], -1)
+	if len(matches) > 0 && len(matches[0]) == 4 {
+		// matches[0][2] = property name string
+		// matches[0][3] = four-character code (4CC) sequence
+		property = matches[0][2]
+		code = matches[0][3]
+
+	} else {
+		property = kv[0]
+	}
+
+	value = kv[1]
+
+	return property, code, value
+}
+
+// Parses lines which have three columns of data, for example:
+//
+// 3rd Party Kexts Status:      Disabled   (smb2): absent
+//
+// returns property, mode, code, value
+func parseThreeColumns(kv []string) (string, string, string, string) {
+	var property, mode, code, value string
+	matches := fourCharCodeRegexp.FindAllStringSubmatch(kv[1], -1)
+	if len(matches) > 0 && len(matches[0]) == 4 {
+		// matches[0][2] = (Full|Enabled|Disabled)
+		// matches[0][3] = four-character code (4CC) sequence
+		property = kv[0]
+		mode = matches[0][2]
+		code = matches[0][3]
+		value = kv[2]
+	}
+
+	return property, mode, code, value
+}

--- a/pkg/osquery/tables/apple_silicon_security_policy/table.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/table.go
@@ -1,0 +1,59 @@
+//go:build darwin
+// +build darwin
+
+package apple_silicon_security_policy
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const bootPolicyUtilPath = "/usr/bin/bputil"
+const bootPolicyUtilArgs = "--display-all-policies"
+
+type Table struct {
+	logger log.Logger
+}
+
+func TablePlugin(logger log.Logger) *table.Plugin {
+
+	columns := []table.ColumnDefinition{
+		table.TextColumn("volume_group"),
+		table.TextColumn("property"),
+		table.TextColumn("mode"),
+		table.TextColumn("code"),
+		table.TextColumn("value"),
+	}
+
+	tableName := "apple_silicon_security_policy"
+
+	t := &Table{
+		logger: log.With(logger, "table", tableName),
+	}
+
+	return table.NewPlugin(tableName, columns, t.generate)
+}
+
+func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	var results []map[string]string
+
+	output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{bootPolicyUtilPath}, []string{bootPolicyUtilArgs})
+	if err != nil {
+		level.Info(t.logger).Log("msg", "bputil failed", "err", err)
+		return results, err
+	}
+
+	status, err := parseStatus(output)
+	if err != nil {
+		level.Info(t.logger).Log("msg", "Error parsing status", "err", err)
+		return results, err
+	}
+
+	results = status
+
+	return results, nil
+}

--- a/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
@@ -2,6 +2,7 @@ package apple_silicon_security_policy
 
 import (
 	"bytes"
+	_ "embed"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,54 +51,14 @@ func Test_ParseBootPoliciesOutputUnexpected(t *testing.T) {
 	}
 }
 
-const oneBootVol = `This utility is not meant for normal users or even sysadmins.
-It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
-It is possible to make your system security much weaker and therefore easier to compromise using this tool.
-This tool is not to be used in production environments.
-It is possible to render your system unbootable with this tool.
-It should only be used to understand how the security of Apple Silicon Macs works.
-Use at your own risk!
+//go:embed test-data/bputil-one-boot-vol.txt
+var oneBootVol string
 
+//go:embed test-data/bputil-multiple-boot-vol.txt
+var multipleBootVol string
 
-Local policy for volume group 1234567890:
-OS environment:
-OS Type                                       : macOS`
-
-const multipleBootVol = `This utility is not meant for normal users or even sysadmins.
-It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
-It is possible to make your system security much weaker and therefore easier to compromise using this tool.
-This tool is not to be used in production environments.
-It is possible to render your system unbootable with this tool.
-It should only be used to understand how the security of Apple Silicon Macs works.
-Use at your own risk!
-
-
-Local policy for volume group 123:
-OS environment:
-Boot Args Filtering Status:  Enabled    (sip3): absent
-
-Local policy for volume group 456:
-OS environment:
-Boot Args Filtering Status:  Enabled    (sip3): absent`
-
-const failedSecondVol = `This utility is not meant for normal users or even sysadmins.
-It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
-It is possible to make your system security much weaker and therefore easier to compromise using this tool.
-This tool is not to be used in production environments.
-It is possible to render your system unbootable with this tool.
-It should only be used to understand how the security of Apple Silicon Macs works.
-Use at your own risk!
-
-
-Local policy for volume group 5D0D176D-E8CC-4E8B-815C-444A679390BD:
-OS environment:
-OS Type                                       : macOS
-
-Local policy:
-Security Domain                         (SDOM): 0x1
-Production Status                       (CPRO): 1
-Can't get local policy for Volume Group UUID 5EADF322-3C85-4DF8-8516-0B556700CD5E
-Failed to display local policy for volume group 5EADF322-3C85-4DF8-8516-0B556700CD5E`
+//go:embed test-data/bputil-failed-second-vol.txt
+var failedSecondVol string
 
 func Test_ParsePoliciesTable(t *testing.T) {
 	t.Parallel()

--- a/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
@@ -1,43 +1,21 @@
 package apple_silicon_security_policy
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ParseStatusErrors(t *testing.T) {
+func Test_ParseBootPoliciesOutputUnexpected(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name           string
 		status         string
 		expectedResult map[string]string
-	}{
-		{
-			name: "no data",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := parseStatus([]byte(tt.status))
-			require.Error(t, err, "parseStatus")
-		})
-	}
-}
-
-func Test_ParseStatusUnexpected(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		status         string
-		expectedResult map[string]string
+		queryClause    []string
 	}{
 		{
 			name:   "bad output",
@@ -66,65 +44,84 @@ func Test_ParseStatusUnexpected(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			data, err := parseStatus([]byte(tt.status))
-			require.NoError(t, err, "parseStatus")
-			require.Empty(t, data)
+			o := parseBootPoliciesOutput(bytes.NewReader([]byte(tt.status)))
+			require.Empty(t, o)
 		})
 	}
 }
 
-func Test_ParseStatus(t *testing.T) {
+const oneBootVol = `This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 1234567890:
+OS environment:
+OS Type                                       : macOS`
+
+const multipleBootVol = `This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 123:
+OS environment:
+Boot Args Filtering Status:  Enabled    (sip3): absent
+
+Local policy for volume group 456:
+OS environment:
+Boot Args Filtering Status:  Enabled    (sip3): absent`
+
+const failedSecondVol = `This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 5D0D176D-E8CC-4E8B-815C-444A679390BD:
+OS environment:
+OS Type                                       : macOS
+
+Local policy:
+Security Domain                         (SDOM): 0x1
+Production Status                       (CPRO): 1
+Can't get local policy for Volume Group UUID 5EADF322-3C85-4DF8-8516-0B556700CD5E
+Failed to display local policy for volume group 5EADF322-3C85-4DF8-8516-0B556700CD5E`
+
+func Test_ParsePoliciesTable(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name           string
 		status         string
-		expectedResult []map[string]string
+		expectedResult map[string]interface{}
+		queryClause    []string
 	}{
 		{
-			name: "one boot volume",
-			status: `This utility is not meant for normal users or even sysadmins.
-			It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
-			It is possible to make your system security much weaker and therefore easier to compromise using this tool.
-			This tool is not to be used in production environments.
-			It is possible to render your system unbootable with this tool.
-			It should only be used to understand how the security of Apple Silicon Macs works.
-			Use at your own risk!
-			
-			
-			Local policy for volume group 1234567890:
-			OS environment:
-			OS Type                                       : macOS
-			Local Policy Nonce Hash                 (lpnh): 0987654321
-			User-allowed MDM Control:    Disabled   (smb3): absent`,
-			expectedResult: []map[string]string{
-				{"volume_group": "1234567890", "property": "OS_Type", "mode": "", "code": "", "value": "macOS"},
-				{"volume_group": "1234567890", "property": "Local_Policy_Nonce_Hash", "mode": "", "code": "lpnh", "value": "0987654321"},
-				{"volume_group": "1234567890", "property": "User-allowed_MDM_Control", "mode": "Disabled", "code": "smb3", "value": "absent"},
-			},
+			name:           "one boot volume",
+			status:         oneBootVol,
+			expectedResult: map[string]interface{}{"1234567890": []map[string]interface{}{{"OS_Type": map[string]interface{}{"code": "", "mode": "", "value": "macOS"}}}},
 		},
 		{
-			name: "multiple boot volumes",
-			status: `This utility is not meant for normal users or even sysadmins.
-			It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
-			It is possible to make your system security much weaker and therefore easier to compromise using this tool.
-			This tool is not to be used in production environments.
-			It is possible to render your system unbootable with this tool.
-			It should only be used to understand how the security of Apple Silicon Macs works.
-			Use at your own risk!
-			
-			
-			Local policy for volume group 123:
-			OS environment:
-			Boot Args Filtering Status:  Enabled    (sip3): absent
-			
-			Local policy for volume group 456:
-			OS environment:
-			Boot Args Filtering Status:  Enabled    (sip3): absent`,
-			expectedResult: []map[string]string{
-				{"volume_group": "123", "property": "Boot_Args_Filtering_Status", "mode": "Enabled", "code": "sip3", "value": "absent"},
-				{"volume_group": "456", "property": "Boot_Args_Filtering_Status", "mode": "Enabled", "code": "sip3", "value": "absent"},
-			},
+			name:           "multiple boot volumes",
+			status:         multipleBootVol,
+			expectedResult: map[string]interface{}{"123": []map[string]interface{}{{"Boot_Args_Filtering_Status": map[string]interface{}{"code": "sip3", "mode": "Enabled", "value": "absent"}}}, "456": []map[string]interface{}{{"Boot_Args_Filtering_Status": map[string]interface{}{"code": "sip3", "mode": "Enabled", "value": "absent"}}}},
+		},
+		{
+			name:           "failed second volumes",
+			status:         failedSecondVol,
+			expectedResult: map[string]interface{}{"5D0D176D-E8CC-4E8B-815C-444A679390BD": []map[string]interface{}{{"OS_Type": map[string]interface{}{"code": "", "mode": "", "value": "macOS"}}, {"Security_Domain": map[string]interface{}{"code": "SDOM", "mode": "", "value": "0x1"}}, {"Production_Status": map[string]interface{}{"code": "CPRO", "mode": "", "value": "1"}}}},
 		},
 	}
 
@@ -133,10 +130,65 @@ func Test_ParseStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			data, err := parseStatus([]byte(tt.status))
-			require.NoError(t, err, "parseStatus")
+			result := parseBootPoliciesOutput(bytes.NewReader([]byte(tt.status)))
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
 
-			assert.Equal(t, tt.expectedResult, data)
+func Test_ParsePolicyRow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		line           string
+		expectedResult map[string]interface{}
+	}{
+		{
+			name: "empty line",
+		},
+		{
+			name: "no columns",
+			line: "data with no colon separators",
+		},
+		{
+			name: "only one column",
+			line: "Policy:",
+		},
+		{
+			name:           "two columns",
+			line:           "Signature Type                                : BAA",
+			expectedResult: map[string]interface{}{"Signature_Type": map[string]interface{}{"value": "BAA", "mode": "", "code": ""}},
+		},
+		{
+			name:           "two columns with code",
+			line:           "Local Policy Nonce Hash                 (lpnh): A8D3EC575A03E7F58**REDACTED**",
+			expectedResult: map[string]interface{}{"Local_Policy_Nonce_Hash": map[string]interface{}{"value": "A8D3EC575A03E7F58**REDACTED**", "mode": "", "code": "lpnh"}},
+		},
+		{
+			name:           "two columns with code missing last value",
+			line:           "Auxiliary Kernel Cache Image4 Hash      (auxi): ",
+			expectedResult: map[string]interface{}{"Auxiliary_Kernel_Cache_Image4_Hash": map[string]interface{}{"value": "", "mode": "", "code": "auxi"}},
+		},
+		{
+			name:           "three columns",
+			line:           "3rd Party Kexts Status:      Disabled   (smb2): absent",
+			expectedResult: map[string]interface{}{"3rd_Party_Kexts_Status": map[string]interface{}{"value": "absent", "mode": "Disabled", "code": "smb2"}},
+		},
+		{
+			name:           "three columns missing last value",
+			line:           "Security Mode:               Full       (smb0): ",
+			expectedResult: map[string]interface{}{"Security_Mode": map[string]interface{}{"value": "", "mode": "Full", "code": "smb0"}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := parsePolicyRow(tt.line)
+			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
 }

--- a/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/table_test.go
@@ -1,0 +1,142 @@
+package apple_silicon_security_policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseStatusErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		status         string
+		expectedResult map[string]string
+	}{
+		{
+			name: "no data",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseStatus([]byte(tt.status))
+			require.Error(t, err, "parseStatus")
+		})
+	}
+}
+
+func Test_ParseStatusUnexpected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		status         string
+		expectedResult map[string]string
+	}{
+		{
+			name:   "bad output",
+			status: "\n\n\n\n",
+		},
+		{
+			name:   "no volume group",
+			status: "This utility is not meant for normal users or even sysadmins.",
+		},
+		{
+			name: "only volume group",
+			status: `Use at your own risk!
+			Local policy for volume group 5D0D176D-E8CC-**REDACTED**:`,
+		},
+		{
+			name: "no column data",
+			status: `Use at your own risk!
+			Local policy for volume group 5D0D176D-E8CC-**REDACTED**:
+			OS Policy:
+			Environment:`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := parseStatus([]byte(tt.status))
+			require.NoError(t, err, "parseStatus")
+			require.Empty(t, data)
+		})
+	}
+}
+
+func Test_ParseStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		status         string
+		expectedResult []map[string]string
+	}{
+		{
+			name: "one boot volume",
+			status: `This utility is not meant for normal users or even sysadmins.
+			It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+			It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+			This tool is not to be used in production environments.
+			It is possible to render your system unbootable with this tool.
+			It should only be used to understand how the security of Apple Silicon Macs works.
+			Use at your own risk!
+			
+			
+			Local policy for volume group 1234567890:
+			OS environment:
+			OS Type                                       : macOS
+			Local Policy Nonce Hash                 (lpnh): 0987654321
+			User-allowed MDM Control:    Disabled   (smb3): absent`,
+			expectedResult: []map[string]string{
+				{"volume_group": "1234567890", "property": "OS_Type", "mode": "", "code": "", "value": "macOS"},
+				{"volume_group": "1234567890", "property": "Local_Policy_Nonce_Hash", "mode": "", "code": "lpnh", "value": "0987654321"},
+				{"volume_group": "1234567890", "property": "User-allowed_MDM_Control", "mode": "Disabled", "code": "smb3", "value": "absent"},
+			},
+		},
+		{
+			name: "multiple boot volumes",
+			status: `This utility is not meant for normal users or even sysadmins.
+			It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+			It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+			This tool is not to be used in production environments.
+			It is possible to render your system unbootable with this tool.
+			It should only be used to understand how the security of Apple Silicon Macs works.
+			Use at your own risk!
+			
+			
+			Local policy for volume group 123:
+			OS environment:
+			Boot Args Filtering Status:  Enabled    (sip3): absent
+			
+			Local policy for volume group 456:
+			OS environment:
+			Boot Args Filtering Status:  Enabled    (sip3): absent`,
+			expectedResult: []map[string]string{
+				{"volume_group": "123", "property": "Boot_Args_Filtering_Status", "mode": "Enabled", "code": "sip3", "value": "absent"},
+				{"volume_group": "456", "property": "Boot_Args_Filtering_Status", "mode": "Enabled", "code": "sip3", "value": "absent"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := parseStatus([]byte(tt.status))
+			require.NoError(t, err, "parseStatus")
+
+			assert.Equal(t, tt.expectedResult, data)
+		})
+	}
+}

--- a/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-failed-second-vol.txt
+++ b/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-failed-second-vol.txt
@@ -1,0 +1,18 @@
+This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 5D0D176D-E8CC-4E8B-815C-444A679390BD:
+OS environment:
+OS Type                                       : macOS
+
+Local policy:
+Security Domain                         (SDOM): 0x1
+Production Status                       (CPRO): 1
+Can't get local policy for Volume Group UUID 5EADF322-3C85-4DF8-8516-0B556700CD5E
+Failed to display local policy for volume group 5EADF322-3C85-4DF8-8516-0B556700CD5E

--- a/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-multiple-boot-vol.txt
+++ b/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-multiple-boot-vol.txt
@@ -1,0 +1,16 @@
+This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 123:
+OS environment:
+Boot Args Filtering Status:  Enabled    (sip3): absent
+
+Local policy for volume group 456:
+OS environment:
+Boot Args Filtering Status:  Enabled    (sip3): absent

--- a/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-one-boot-vol.txt
+++ b/pkg/osquery/tables/apple_silicon_security_policy/test-data/bputil-one-boot-vol.txt
@@ -1,0 +1,12 @@
+This utility is not meant for normal users or even sysadmins.
+It provides unabstracted access to capabilities which are normally handled for the user automatically when changing the security policy through GUIs such as the Startup Security Utility in macOS Recovery ("recoveryOS").
+It is possible to make your system security much weaker and therefore easier to compromise using this tool.
+This tool is not to be used in production environments.
+It is possible to render your system unbootable with this tool.
+It should only be used to understand how the security of Apple Silicon Macs works.
+Use at your own risk!
+
+
+Local policy for volume group 1234567890:
+OS environment:
+OS Type                                       : macOS


### PR DESCRIPTION
Fixes https://github.com/kolide/launcher/issues/785

This table implementation parses the output of the `bputil --display-all-policies` command. The output has some columns which only apply to certain properties, so most of the complexity involved is parsing those values. A LocalPolicy exists for each bootable OS installation, so the root key is volume group the policy is associated with.

The keys are defined as:

- `volume_group`: The UUID of the bootable volume group the policy applies to
- `property`: The property name
- `mode`: (optional) Either Full, Enabled, or Disabled
- `code`: (optional) The four-character code (4CC) sequence
- `value`: The property value

Example table output in osquery:

```
osquery> select fullkey, key, value from apple_silicon_security_policy;
+----------------------------------------------------------------------------------+-------+--------------------------------------------------------------------------------------------------+
| fullkey                                                                          | key   | value                                                                                            |
+----------------------------------------------------------------------------------+-------+--------------------------------------------------------------------------------------------------+
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/0/OS_Type/value                             | value | macOS                                                                                            |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/0/OS_Type/mode                              | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/0/OS_Type/code                              | code  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/1/OS_Pairing_Status/code                    | code  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/1/OS_Pairing_Status/value                   | value | Not Paired                                                                                       |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/1/OS_Pairing_Status/mode                    | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/2/Local_Policy_Nonce_Hash/code              | code  | lpnh                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/2/Local_Policy_Nonce_Hash/value             | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/2/Local_Policy_Nonce_Hash/mode              | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/3/Remote_Policy_Nonce_Hash/value            | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/3/Remote_Policy_Nonce_Hash/mode             | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/3/Remote_Policy_Nonce_Hash/code             | code  | rpnh                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/4/Recovery_OS_Policy_Nonce_Hash/value       | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/4/Recovery_OS_Policy_Nonce_Hash/mode        | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/4/Recovery_OS_Policy_Nonce_Hash/code        | code  | ronh                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/5/Pairing_Integrity/code                    | code  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/5/Pairing_Integrity/value                   | value | Valid                                                                                            |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/5/Pairing_Integrity/mode                    | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/6/Signature_Type/value                      | value | BAA                                                                                              |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/6/Signature_Type/mode                       | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/6/Signature_Type/code                       | code  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/7/Unique_Chip_ID/value                      | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/7/Unique_Chip_ID/mode                       | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/7/Unique_Chip_ID/code                       | code  | ECID                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/8/Board_ID/value                            | value | 0xA                                                                                              |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/8/Board_ID/mode                             | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/8/Board_ID/code                             | code  | BORD                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/9/Chip_ID/value                             | value | 0x6000                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/9/Chip_ID/mode                              | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/9/Chip_ID/code                              | code  | CHIP                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/10/Certificate_Epoch/value                  | value | 0x1                                                                                              |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/10/Certificate_Epoch/mode                   | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/10/Certificate_Epoch/code                   | code  | CEPO                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/11/Security_Domain/value                    | value | 0x1                                                                                              |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/11/Security_Domain/mode                     | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/11/Security_Domain/code                     | code  | SDOM                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/12/Production_Status/value                  | value | 1                                                                                                |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/12/Production_Status/mode                   | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/12/Production_Status/code                   | code  | CPRO                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/13/Security_Mode/value                      | value | 1                                                                                                |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/13/Security_Mode/mode                       | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/13/Security_Mode/code                       | code  | CSEC                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/14/OS_Version/value                         | value | 21.7.83.0.0,0                                                                                    |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/14/OS_Version/mode                          | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/14/OS_Version/code                          | code  | love                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/15/Volume_Group_UUID/mode                   | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/15/Volume_Group_UUID/code                   | code  | vuid                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/15/Volume_Group_UUID/value                  | value | 5D0D176D-E8CC-4E8B-815C-444A679390BD                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/16/KEK_Group_UUID/value                     | value | CA500BD4-2948-275D-F274-222560D3CB80                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/16/KEK_Group_UUID/mode                      | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/16/KEK_Group_UUID/code                      | code  | kuid                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/17/Local_Policy_Nonce_Hash/mode             | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/17/Local_Policy_Nonce_Hash/code             | code  | lpnh                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/17/Local_Policy_Nonce_Hash/value            | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/18/Remote_Policy_Nonce_Hash/value           | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/18/Remote_Policy_Nonce_Hash/mode            | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/18/Remote_Policy_Nonce_Hash/code            | code  | rpnh                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/19/Next_Stage_Image4_Hash/mode              | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/19/Next_Stage_Image4_Hash/code              | code  | nsih                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/19/Next_Stage_Image4_Hash/value             | value | **REDACTED**                                                                                     |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/20/User_Authorized_Kext_List_Hash/value     | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/20/User_Authorized_Kext_List_Hash/mode      | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/20/User_Authorized_Kext_List_Hash/code      | code  | auxp                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/21/Auxiliary_Kernel_Cache_Image4_Hash/mode  | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/21/Auxiliary_Kernel_Cache_Image4_Hash/code  | code  | auxi                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/21/Auxiliary_Kernel_Cache_Image4_Hash/value | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/22/Kext_Receipt_Hash/value                  | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/22/Kext_Receipt_Hash/mode                   | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/22/Kext_Receipt_Hash/code                   | code  | auxr                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/23/CustomKC_or_fuOS_Image4_Hash/value       | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/23/CustomKC_or_fuOS_Image4_Hash/mode        | mode  |                                                                                                  |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/23/CustomKC_or_fuOS_Image4_Hash/code        | code  | coih                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/24/Security_Mode/value                      | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/24/Security_Mode/mode                       | mode  | Full                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/24/Security_Mode/code                       | code  | smb0                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/25/3rd_Party_Kexts_Status/value             | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/25/3rd_Party_Kexts_Status/mode              | mode  | Disabled                                                                                         |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/25/3rd_Party_Kexts_Status/code              | code  | smb2                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/26/User-allowed_MDM_Control/value           | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/26/User-allowed_MDM_Control/mode            | mode  | Disabled                                                                                         |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/26/User-allowed_MDM_Control/code            | code  | smb3                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/27/DEP-allowed_MDM_Control/value            | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/27/DEP-allowed_MDM_Control/mode             | mode  | Disabled                                                                                         |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/27/DEP-allowed_MDM_Control/code             | code  | smb4                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/28/SIP_Status/code                          | code  | sip0                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/28/SIP_Status/value                         | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/28/SIP_Status/mode                          | mode  | Enabled                                                                                          |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/29/Signed_System_Volume_Status/value        | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/29/Signed_System_Volume_Status/mode         | mode  | Enabled                                                                                          |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/29/Signed_System_Volume_Status/code         | code  | sip1                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/30/Kernel_CTRR_Status/mode                  | mode  | Enabled                                                                                          |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/30/Kernel_CTRR_Status/code                  | code  | sip2                                                                                             |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/30/Kernel_CTRR_Status/value                 | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/31/Boot_Args_Filtering_Status/value         | value | absent                                                                                           |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/31/Boot_Args_Filtering_Status/mode          | mode  | Enabled                                                                                          |
| 5D0D176D-E8CC-4E8B-815C-444A679390BD/31/Boot_Args_Filtering_Status/code          | code  | sip3                                                                                             |
+----------------------------------------------------------------------------------+-------+--------------------------------------------------------------------------------------------------+
osquery> 
```