### PR TITLE
Move the augeas lens assets to using `fsutil.CopyFSToDisk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc
-	github.com/kolide/kit v0.0.0-20220822193427-0680b087f9bd
+	github.com/kolide/kit v0.0.0-20220920212810-17eca5d2e6d2
 	github.com/kolide/krypto v0.0.0-20220830180245-7cb3a3940071
 	github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80
 	github.com/kr/pty v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc h1:g2S0GQ
 github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc/go.mod h1:5e34JEkxWsOeAd9jvcxkz01tAY/JAGFuabGnNBJ6TT4=
 github.com/kolide/kit v0.0.0-20220822193427-0680b087f9bd h1:/z9eL7GqXuM8po3JN4QaOGX2nSkFubhZqrsDbauwKmw=
 github.com/kolide/kit v0.0.0-20220822193427-0680b087f9bd/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=
+github.com/kolide/kit v0.0.0-20220920212810-17eca5d2e6d2 h1:wp1mWNZ2tb2Nq9uCa7g19PrYVHzBUb3RxU1aZCVuQGY=
+github.com/kolide/kit v0.0.0-20220920212810-17eca5d2e6d2/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=
 github.com/kolide/krypto v0.0.0-20220830180245-7cb3a3940071 h1:CMQwFVCVQR3ziaje/2TaW62CsTQrGybilNTkOWBadwA=
 github.com/kolide/krypto v0.0.0-20220830180245-7cb3a3940071/go.mod h1:Xdw3V8Z6rsebg2tliGb1xU46QDOxhcwS2dz49qFtIwc=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=

--- a/pkg/augeas/augeas.go
+++ b/pkg/augeas/augeas.go
@@ -21,8 +21,8 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
+
+	"github.com/kolide/kit/fsutil"
 )
 
 //go:embed assets/*
@@ -31,45 +31,11 @@ var assets embed.FS
 const lensSubdir = "assets/lenses"
 
 func InstallLenses(targetDir string) error {
+
 	lensesFS, err := fs.Sub(assets, lensSubdir)
 	if err != nil {
 		return fmt.Errorf("reading lenses subdirectory %s: %w", lensSubdir, err)
 	}
 
-	if err := fs.WalkDir(lensesFS, ".", genCopyLensToDiskFunc(lensesFS, targetDir)); err != nil {
-		return fmt.Errorf("walking lenes directory: %w", err)
-	}
-
-	return nil
-}
-
-// genCopyLensToDiskFunc returns fs.WalkDirFunc function that will
-// copy files to disk in a given location.
-func genCopyLensToDiskFunc(srcFS fs.FS, targetdir string) fs.WalkDirFunc {
-	return func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// Should be impossible for embed https://github.com/golang/go/issues/45815
-			return fmt.Errorf("Impossible error from embed: %w", err)
-		}
-
-		if path == lensSubdir || path == "." {
-			return nil
-		}
-
-		if d.IsDir() {
-			return fmt.Errorf("Lenses can only be files, %s is a directory", path)
-		}
-
-		data, err := fs.ReadFile(srcFS, path)
-		if err != nil {
-			// Should be impossible for embded https://github.com/golang/go/issues/45815
-			return fmt.Errorf("Impossible error from embed: %w", err)
-		}
-
-		if err := os.WriteFile(filepath.Join(targetdir, path), data, 0644); err != nil {
-			return fmt.Errorf("writing lens %s, got: %w", path, err)
-		}
-
-		return nil
-	}
+	return fsutil.CopyFSToDisk(lensesFS, targetDir, fsutil.CommonFileMode)
 }


### PR DESCRIPTION
This PR moves the lenses asset bundling to a common walk function. Perhaps silly, but I find that kind of recursion somewhat hard to read, and more valuable in a shared location.