### PR TITLE
bumps to go 1.19.2 to address tar vuln

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
     branches: '**'
 
 env:
-  GOVER: 1.19.1
+  GOVER: 1.19.2
 
 jobs:
   build_and_test:


### PR DESCRIPTION
bumping to 1.19.2 addresses https://pkg.go.dev/vuln/GO-2022-1037