### PR TITLE
James/flakey desktop runner tests

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/consoleuser"
 	"github.com/kolide/launcher/ee/desktop/client"
+	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/shirou/gopsutil/process"
 )
 
@@ -176,7 +177,7 @@ func (r *DesktopUsersProcessesRunner) Interrupt(interruptError error) {
 
 	for uid, proc := range r.uidProcs {
 		client := client.New(r.authToken, proc.socketPath)
-		if err := client.Shutdown(); err != nil {
+		if err := backoff.WaitFor(client.Shutdown, 5*time.Second, 1*time.Second); err != nil {
 			level.Error(r.logger).Log(
 				"msg", "error sending shutdown command to desktop process",
 				"uid", uid,

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -184,7 +184,7 @@ func launcherRootDir(t *testing.T) string {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(path))
+		// require.NoError(t, os.RemoveAll(path))
 	})
 
 	return path

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -184,7 +184,7 @@ func launcherRootDir(t *testing.T) string {
 	}
 
 	t.Cleanup(func() {
-		// require.NoError(t, os.RemoveAll(path))
+		require.NoError(t, os.RemoveAll(path))
 	})
 
 	return path

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -141,7 +141,8 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 				// on windows this will cause an error, so just wait for all the processes to finish
 				for _, p := range r.uidProcs {
 					if processExists(p) {
-						p.process.Wait()
+						state, err := p.process.Wait()
+						require.NoError(t, err, fmt.Sprintf("failed to wait for process: %v", state))
 					}
 				}
 			})

--- a/ee/desktop/server/server.go
+++ b/ee/desktop/server/server.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/backoff"
 )
 
 type DesktopServer struct {
@@ -118,31 +118,7 @@ func (s *DesktopServer) authMiddleware(next http.Handler) http.Handler {
 // shuts down, there is some lag time before the file is release, this can cause errors
 // when trying to delete the file.
 func (s *DesktopServer) removeSocket() error {
-	return waitForFileRemove(s.socketPath, 1*time.Second, 5*time.Second)
-}
-
-func waitForFileRemove(path string, interval, timeout time.Duration) error {
-	intervalTicker := time.NewTicker(interval)
-	defer intervalTicker.Stop()
-	timeoutTimer := time.NewTimer(timeout)
-	defer timeoutTimer.Stop()
-
-	f := func() bool {
-		return os.RemoveAll(path) == nil
-	}
-
-	if f() {
-		return nil
-	}
-
-	for {
-		select {
-		case <-timeoutTimer.C:
-			return fmt.Errorf("timeout waiting for file removal: %s", path)
-		case <-intervalTicker.C:
-			if f() {
-				return nil
-			}
-		}
-	}
+	return backoff.WaitFor(func() error {
+		return os.RemoveAll(s.socketPath)
+	}, 5*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
* uses backoff.WaitFor() to make client request since tests were failing because server hadn't full started before make calls to it
* uses backoff.WaitFor() to remove socket when server shut down