### PR TITLE
Adding clang format file for local use

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+---
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: true
+# AlignConsecutiveAssignments: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: false # differs
+AllowShortBlocksOnASingleLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false # differs
+AllowShortLoopsOnASingleLine: false # differs
+AllowShortFunctionsOnASingleLine: Empty
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: true
+BreakBeforeBinaryOperators: false # differs
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BinPackParameters: false
+BinPackArguments: false
+ColumnLimit: 80
+ConstructorInitializerIndentWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerAlignment: false
+DerivePointerBinding: true
+IndentCaseLabels: false #differs
+IndentWrappedFunctionNames: false
+IndentFunctionDeclarationAfterType: false
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+PointerBindsToType: true
+SpacesBeforeTrailingComments: 1 #differs
+Cpp11BracedListStyle: true
+Standard: Cpp11
+IndentWidth: 2
+TabWidth: 8
+UseTab: Never
+SpaceAfterControlStatementKeyword: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+ContinuationIndentWidth: 4
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+...


### PR DESCRIPTION
I copied this file directly from osquery: https://github.com/osquery/osquery/blob/master/.clang-format

We have very little C/C++/Objective-C at the moment (~2% of the repository), but it doesn't hurt to stick with a consistent format.

At the moment, the effort to incorporate this into our CI/linting doesn't feel justified, however this enables us to all use the same clang format file for local use.