### PR TITLE
kills desktop process if initial ping fails

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -248,7 +248,16 @@ func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
 
 		client := client.New(r.authToken, socketPath)
 		if err := backoff.WaitFor(client.Ping, 5*time.Second, 1*time.Second); err != nil {
-			return fmt.Errorf("pinging desktop server: %w", err)
+			if err := cmd.Process.Kill(); err != nil {
+				level.Error(r.logger).Log(
+					"msg", "killing desktop process after startup ping failed",
+					"uid", uid,
+					"pid", cmd.Process.Pid,
+					"path", cmd.Path,
+					"err", err,
+				)
+			}
+			return fmt.Errorf("pinging desktop server after startup: %w", err)
 		}
 
 		level.Debug(r.logger).Log(

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -247,7 +247,7 @@ func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
 		r.waitOnProcessAsync(uid, cmd.Process)
 
 		client := client.New(r.authToken, socketPath)
-		if err := backoff.WaitFor(client.Ping, 5*time.Second, 1*time.Second); err != nil {
+		if err := backoff.WaitFor(client.Ping, 10*time.Second, 1*time.Second); err != nil {
 			if err := cmd.Process.Kill(); err != nil {
 				level.Error(r.logger).Log(
 					"msg", "killing desktop process after startup ping failed",


### PR DESCRIPTION
Addresses a bug where if the initial desktop server ping failed, the process was left running and not added to internal tracking. Now killing the process if initial ping fails.