### PR TITLE
Add support for remotectl + parsing results

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -11,6 +11,7 @@ import (
 	appicons "github.com/kolide/launcher/pkg/osquery/tables/app-icons"
 	"github.com/kolide/launcher/pkg/osquery/tables/apple_silicon_security_policy"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/execparsers/remotectl"
 	"github.com/kolide/launcher/pkg/osquery/tables/filevault"
 	"github.com/kolide/launcher/pkg/osquery/tables/firmwarepasswd"
 	"github.com/kolide/launcher/pkg/osquery/tables/ioreg"
@@ -114,5 +115,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		systemprofiler.TablePlugin(client, logger),
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, []string{`/usr/libexec/remotectl`, `dumpstate`}),
 	}
 }

--- a/pkg/osquery/tables/execparsers/remotectl/parse.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse.go
@@ -1,0 +1,128 @@
+//go:build darwin
+// +build darwin
+
+package remotectl
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// parseDumpstate parses the result of /usr/libexec/remotectl into a map that can be flattened by dataflatten.
+// We expect results in the following format, with empty newlines separating devices:
+//
+//	<device name>
+//			Key: Value
+//			Properties: {
+//				Key => Value
+//			}
+//			Services:
+//				service1
+//				service2
+func parseDumpstate(reader io.Reader) (any, error) {
+	results := make(map[string]map[string]interface{})
+
+	currentDeviceName := ""
+	insidePropertiesDictionary := false
+	insideServicesArray := false
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// We need a device name to proceed -- if present, initialize its data in `results` and move on
+		if isDeviceName(line) {
+			currentDeviceName = extractDeviceName(line)
+			results[currentDeviceName] = make(map[string]interface{})
+			results[currentDeviceName]["Properties"] = make(map[string]interface{})
+			results[currentDeviceName]["Services"] = make([]string, 0)
+			continue
+		}
+
+		if currentDeviceName == "" {
+			return nil, fmt.Errorf("no device name(s) given in remotectl dumpstate output")
+		}
+
+		if isDeviceDelimiter(line) {
+			// We've reached a new device -- reset state and continue
+			currentDeviceName = ""
+			insidePropertiesDictionary = false
+			insideServicesArray = false
+			continue
+		}
+
+		line = strings.TrimSpace(line)
+
+		if insidePropertiesDictionary {
+			if line == "}" {
+				insidePropertiesDictionary = false
+				continue
+			}
+
+			propertyKey, propertyValue, err := extractPropertyKeyValue(line)
+			if err != nil {
+				return nil, err
+			}
+
+			properties := results[currentDeviceName]["Properties"].(map[string]interface{})
+			properties[propertyKey] = propertyValue
+		} else if insideServicesArray {
+			services := results[currentDeviceName]["Services"].([]string)
+			services = append(services, line)
+			results[currentDeviceName]["Services"] = services
+		} else {
+			if strings.HasPrefix(line, "Properties:") {
+				insidePropertiesDictionary = true
+			} else if strings.HasPrefix(line, "Services:") {
+				insideServicesArray = true
+			} else {
+				// We have a top-level key with a value we should extract to store in `results`
+				propertyKey, propertyValue, err := extractTopLevelKeyValue(line)
+				if err != nil {
+					return nil, err
+				}
+				results[currentDeviceName][propertyKey] = propertyValue
+			}
+		}
+	}
+
+	return results, nil
+}
+
+func isDeviceName(line string) bool {
+	// If the line is not indented (i.e. top-level), we have a device name
+	return !strings.HasPrefix(line, "\t")
+}
+
+func extractDeviceName(line string) string {
+	// Devices (besides "Local device") are identified as `Found <name> (<type>)` -- strip "Found"
+	return strings.TrimSpace(strings.TrimPrefix(line, "Found"))
+}
+
+func isDeviceDelimiter(line string) bool {
+	// A newline indicates a new device's information is coming next
+	return strings.TrimSpace(line) == ""
+}
+
+func extractPropertyKeyValue(line string) (string, string, error) {
+	// key-value pairs in the `Properties` dictionary are in the format `key => value`
+	extracted := strings.Split(line, "=>")
+	if len(extracted) != 2 {
+		return "", "", errors.New("key/value pair in properties in remotectl output is in an unexpected format")
+	}
+
+	return strings.TrimSpace(extracted[0]), strings.TrimSpace(extracted[1]), nil
+}
+
+func extractTopLevelKeyValue(line string) (string, string, error) {
+	// Top-level key-value pairs are in the format `key: value`
+	extracted := strings.Split(line, ":")
+	if len(extracted) != 2 {
+		return "", "", errors.New("top-level key/value pair in remotectl output is in an unexpected format")
+	}
+
+	return strings.TrimSpace(extracted[0]), strings.TrimSpace(extracted[1]), nil
+}

--- a/pkg/osquery/tables/execparsers/remotectl/parse.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse.go
@@ -240,17 +240,16 @@ func (p *parser) getCurrentIndentationLevel() int {
 
 func extractPropertyKeyValue(line string) (string, string, error) {
 	// key-value pairs in the `Properties` dictionary are in the format `key => value`
-	extracted := strings.Split(line, "=>")
-	if len(extracted) != 2 {
-		return "", "", errors.New("key/value pair in properties in remotectl output is in an unexpected format")
-	}
-
-	return strings.TrimSpace(extracted[0]), strings.TrimSpace(extracted[1]), nil
+	return extractKeyValue(line, "=>")
 }
 
 func extractTopLevelKeyValue(line string) (string, string, error) {
 	// Top-level key-value pairs are in the format `key: value`
-	extracted := strings.Split(line, ":")
+	return extractKeyValue(line, ":")
+}
+
+func extractKeyValue(line, delimiter string) (string, string, error) {
+	extracted := strings.Split(line, delimiter)
 	if len(extracted) != 2 {
 		return "", "", errors.New("top-level key/value pair in remotectl output is in an unexpected format")
 	}

--- a/pkg/osquery/tables/execparsers/remotectl/parse.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse.go
@@ -21,90 +21,162 @@ import (
 //			}
 //			Services:
 //				service1
+//					Version: 1
+//					Properties: {
+//						Key => Value
+//					}
 //				service2
-func parseDumpstate(reader io.Reader) (any, error) {
+//				service3
+//			Local Services:
+//				service4
+func (p *parser) parseDumpstate(reader io.Reader) (any, error) {
 	results := make(map[string]map[string]interface{})
 
-	currentDeviceName := ""
-	insidePropertiesDictionary := false
-	insideServicesArray := false
+	p.scanner = bufio.NewScanner(reader)
+	for p.scanner.Scan() {
+		p.lastReadLine = p.scanner.Text()
 
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// We need a device name to proceed -- if present, initialize its data in `results` and move on
-		if isDeviceName(line) {
-			currentDeviceName = extractDeviceName(line)
-			results[currentDeviceName] = make(map[string]interface{})
-			results[currentDeviceName]["Properties"] = make(map[string]interface{})
-			results[currentDeviceName]["Services"] = make([]string, 0)
-			continue
-		}
-
-		if currentDeviceName == "" {
-			return nil, fmt.Errorf("no device name(s) given in remotectl dumpstate output")
-		}
-
-		if isDeviceDelimiter(line) {
-			// We've reached a new device -- reset state and continue
-			currentDeviceName = ""
-			insidePropertiesDictionary = false
-			insideServicesArray = false
-			continue
-		}
-
-		line = strings.TrimSpace(line)
-
-		if insidePropertiesDictionary {
-			if line == "}" {
-				insidePropertiesDictionary = false
-				continue
-			}
-
-			propertyKey, propertyValue, err := extractPropertyKeyValue(line)
+		// Process each device
+		if p.isDeviceName() {
+			currentDeviceName := p.extractDeviceName()
+			currentDeviceResults, err := p.parseDevice()
 			if err != nil {
 				return nil, err
 			}
-
-			properties := results[currentDeviceName]["Properties"].(map[string]interface{})
-			properties[propertyKey] = propertyValue
-		} else if insideServicesArray {
-			services := results[currentDeviceName]["Services"].([]string)
-			services = append(services, line)
-			results[currentDeviceName]["Services"] = services
-		} else {
-			if strings.HasPrefix(line, "Properties:") {
-				insidePropertiesDictionary = true
-			} else if strings.HasPrefix(line, "Services:") {
-				insideServicesArray = true
-			} else {
-				// We have a top-level key with a value we should extract to store in `results`
-				propertyKey, propertyValue, err := extractTopLevelKeyValue(line)
-				if err != nil {
-					return nil, err
-				}
-				results[currentDeviceName][propertyKey] = propertyValue
-			}
+			results[currentDeviceName] = currentDeviceResults
+			continue
 		}
+
+		return nil, fmt.Errorf("no device name(s) given in remotectl dumpstate output")
 	}
 
 	return results, nil
 }
 
-func isDeviceName(line string) bool {
+func (p *parser) isDeviceName() bool {
 	// If the line is not indented (i.e. top-level), we have a device name
-	return !strings.HasPrefix(line, "\t")
+	return !strings.HasPrefix(p.lastReadLine, "\t")
 }
 
-func extractDeviceName(line string) string {
+func (p *parser) extractDeviceName() string {
 	// Devices (besides "Local device") are identified as `Found <name> (<type>)` -- strip "Found"
-	return strings.TrimSpace(strings.TrimPrefix(line, "Found"))
+	return strings.TrimSpace(strings.TrimPrefix(p.lastReadLine, "Found"))
 }
 
-func isDeviceDelimiter(line string) bool {
+func (p *parser) parseDevice() (map[string]interface{}, error) {
+	deviceResults := make(map[string]interface{})
+
+	for p.scanner.Scan() {
+		p.lastReadLine = p.scanner.Text()
+
+		if strings.HasPrefix(strings.TrimSpace(p.lastReadLine), "Heartbeat:") || strings.HasPrefix(strings.TrimSpace(p.lastReadLine), "Services:") {
+			arrayName, _, _ := strings.Cut(strings.TrimSpace(p.lastReadLine), ":")
+			arrayItems, eof, err := p.parseArray()
+			if err != nil {
+				return nil, err
+			}
+			deviceResults[arrayName] = arrayItems
+
+			// If we've reached the end of the command output ("Services" is sometimes the end), then return.
+			// Otherwise, proceed with parsing p.lastReadLine, since arrays do not have ending delimiters.
+			if eof {
+				return deviceResults, nil
+			}
+		}
+
+		// We handle Local Services separately from the above, to allow us to go directly from Services into Local Services
+		if strings.HasPrefix(strings.TrimSpace(p.lastReadLine), "Local Services:") {
+			localServices, eof, err := p.parseArray()
+			if err != nil {
+				return nil, err
+			}
+			deviceResults["Local Services"] = localServices
+
+			// If we've reached the end of the command output ("Local Services" is sometimes the end), then return.
+			// Otherwise, proceed with parsing p.lastReadLine, since arrays do not have ending delimiters.
+			if eof {
+				return deviceResults, nil
+			}
+		}
+
+		if strings.HasPrefix(strings.TrimSpace(p.lastReadLine), "Properties:") {
+			deviceProperties, err := p.parseDictionary()
+			if err != nil {
+				return nil, err
+			}
+			deviceResults["Properties"] = deviceProperties
+			continue
+		}
+
+		if p.isDeviceDelimiter() {
+			return deviceResults, nil
+		}
+
+		// We have a top-level key with a value we should extract to store in `results`
+		propertyKey, propertyValue, err := extractTopLevelKeyValue(p.lastReadLine)
+		if err != nil {
+			return nil, err
+		}
+		deviceResults[propertyKey] = propertyValue
+	}
+
+	return deviceResults, nil
+}
+
+func (p *parser) isDeviceDelimiter() bool {
 	// A newline indicates a new device's information is coming next
-	return strings.TrimSpace(line) == ""
+	return strings.TrimSpace(p.lastReadLine) == ""
+}
+
+func (p *parser) parseDictionary() (map[string]interface{}, error) {
+	dictionaryResults := make(map[string]interface{})
+
+	for p.scanner.Scan() {
+		p.lastReadLine = strings.TrimSpace(p.scanner.Text())
+
+		// Exiting dictionary
+		if p.lastReadLine == "}" {
+			return dictionaryResults, nil
+		}
+
+		propertyKey, propertyValue, err := extractPropertyKeyValue(p.lastReadLine)
+		if err != nil {
+			return nil, err
+		}
+
+		dictionaryResults[propertyKey] = propertyValue
+	}
+
+	return nil, errors.New("unexpected end to dictionary")
+}
+
+func (p *parser) parseArray() ([]string, bool, error) {
+	arrayResults := make([]string, 0)
+	eof := false
+
+	startingIndentationLevel := p.getCurrentIndentationLevel()
+	for p.scanner.Scan() {
+		p.lastReadLine = p.scanner.Text()
+
+		currentIndentationLevel := p.getCurrentIndentationLevel()
+
+		// Exiting array
+		if currentIndentationLevel <= startingIndentationLevel {
+			return arrayResults, eof, nil
+		}
+
+		// Ignore everything not at the top level
+		if currentIndentationLevel == startingIndentationLevel+1 {
+			arrayResults = append(arrayResults, strings.TrimSpace(p.lastReadLine))
+		}
+	}
+
+	eof = true
+	return arrayResults, eof, nil
+}
+
+func (p *parser) getCurrentIndentationLevel() int {
+	return strings.LastIndex(p.lastReadLine, "\t")
 }
 
 func extractPropertyKeyValue(line string) (string, string, error) {

--- a/pkg/osquery/tables/execparsers/remotectl/parse_test.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse_test.go
@@ -5,9 +5,8 @@ package remotectl
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
-	"os"
-	"path"
 	"regexp"
 	"strings"
 	"testing"
@@ -16,38 +15,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//go:embed test-data/single_device_dumpstate.txt
+var single_device_dumpstate string
+
+//go:embed test-data/multiple_devices_dumpstate.txt
+var multiple_devices_dumpstate string
+
+//go:embed test-data/malformed_dumpstate_at_top_level.txt
+var malformed_dumpstate_at_top_level string
+
+//go:embed test-data/malformed_dumpstate_in_properties.txt
+var malformed_dumpstate_in_properties string
+
 func TestParse(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {
-		name        string
-		input       []byte
-		expectedErr bool
+		name                string
+		input               []byte
+		expectedDeviceCount int
+		expectedValueCount  int
+		expectedErr         bool
 	}{
 		{
-			name:        "empty input",
-			input:       []byte("\n"),
-			expectedErr: false,
+			name:                "empty input",
+			input:               []byte("\n"),
+			expectedDeviceCount: 0,
+			expectedValueCount:  0,
+			expectedErr:         false,
 		},
 		{
-			name:        "dumpstate with single device in output",
-			input:       readTestFile(t, path.Join("test-data", "single_device_dumpstate.txt")),
-			expectedErr: false,
+			name:                "dumpstate with single device in output",
+			input:               []byte(single_device_dumpstate),
+			expectedDeviceCount: 1,
+			expectedValueCount:  54,
+			expectedErr:         false,
 		},
 		{
-			name:        "dumpstate with multiple devices in output",
-			input:       readTestFile(t, path.Join("test-data", "multiple_devices_dumpstate.txt")),
-			expectedErr: false,
+			name:                "dumpstate with multiple devices in output",
+			input:               []byte(multiple_devices_dumpstate),
+			expectedDeviceCount: 3,
+			expectedValueCount:  164,
+			expectedErr:         false,
 		},
 		{
-			name:        "malformed dumpstate output -- malformed top-level property",
-			input:       readTestFile(t, path.Join("test-data", "malformed_dumpstate_at_top_level.txt")),
-			expectedErr: true,
+			name:                "malformed dumpstate output -- malformed top-level property",
+			input:               []byte(malformed_dumpstate_at_top_level),
+			expectedDeviceCount: 0,
+			expectedValueCount:  0,
+			expectedErr:         true,
 		},
 		{
-			name:        "malformed dumpstate output -- malformed item in Properties dict",
-			input:       readTestFile(t, path.Join("test-data", "malformed_dumpstate_in_properties.txt")),
-			expectedErr: true,
+			name:                "malformed dumpstate output -- malformed item in Properties dict",
+			input:               []byte(malformed_dumpstate_in_properties),
+			expectedDeviceCount: 0,
+			expectedValueCount:  0,
+			expectedErr:         true,
 		},
 	}
 
@@ -55,7 +78,8 @@ func TestParse(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := parseDumpstate(bytes.NewReader(tt.input))
+			p := New()
+			result, err := p.parseDumpstate(bytes.NewReader(tt.input))
 			if tt.expectedErr {
 				assert.Error(t, err)
 				assert.Nil(t, result)
@@ -66,7 +90,13 @@ func TestParse(t *testing.T) {
 
 			resultMap := result.(map[string]map[string]interface{})
 
+			// Count the number of devices and the total number of data in the result, to confirm we extracted all the information we meant to
+			actualDeviceCount := 0
+			actualValueCount := 0
 			for deviceName, deviceValues := range resultMap {
+				if deviceName != "" && len(deviceValues) != 0 {
+					actualDeviceCount += 1
+				}
 				validateItemInCommandOutput(t, deviceName, tt.input)
 				// Confirm that we stripped "Found" from the front of the device name
 				assert.False(t, strings.HasPrefix(deviceName, "Found"), fmt.Sprintf("device name not extracted correctly: got %s", deviceName))
@@ -75,26 +105,26 @@ func TestParse(t *testing.T) {
 					if topLevelKey == "Properties" {
 						properties := topLevelValue.(map[string]interface{})
 						for propertyKey, propertyValue := range properties {
+							actualValueCount += 1
 							validateKeyValueInCommandOutput(t, propertyKey, propertyValue.(string), tt.input)
 						}
-					} else if topLevelKey == "Services" {
+					} else if topLevelKey == "Services" || topLevelKey == "Local Services" || topLevelKey == "Heartbeat" {
 						services := topLevelValue.([]string)
 						for _, service := range services {
+							actualValueCount += 1
 							validateItemInCommandOutput(t, service, tt.input)
 						}
 					} else {
+						actualValueCount += 1
 						validateKeyValueInCommandOutput(t, topLevelKey, topLevelValue.(string), tt.input)
 					}
 				}
 			}
+
+			assert.Equal(t, tt.expectedDeviceCount, actualDeviceCount)
+			assert.Equal(t, tt.expectedValueCount, actualValueCount)
 		})
 	}
-}
-
-func readTestFile(t *testing.T, filepath string) []byte {
-	b, err := os.ReadFile(filepath)
-	require.NoError(t, err)
-	return b
 }
 
 func validateKeyValueInCommandOutput(t *testing.T, key, val string, commandOutput []byte) {

--- a/pkg/osquery/tables/execparsers/remotectl/parse_test.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse_test.go
@@ -1,0 +1,113 @@
+//go:build darwin
+// +build darwin
+
+package remotectl
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name        string
+		input       []byte
+		expectedErr bool
+	}{
+		{
+			name:        "empty input",
+			input:       []byte("\n"),
+			expectedErr: false,
+		},
+		{
+			name:        "dumpstate with single device in output",
+			input:       readTestFile(t, path.Join("test-data", "single_device_dumpstate.txt")),
+			expectedErr: false,
+		},
+		{
+			name:        "dumpstate with multiple devices in output",
+			input:       readTestFile(t, path.Join("test-data", "multiple_devices_dumpstate.txt")),
+			expectedErr: false,
+		},
+		{
+			name:        "malformed dumpstate output -- malformed top-level property",
+			input:       readTestFile(t, path.Join("test-data", "malformed_dumpstate_at_top_level.txt")),
+			expectedErr: true,
+		},
+		{
+			name:        "malformed dumpstate output -- malformed item in Properties dict",
+			input:       readTestFile(t, path.Join("test-data", "malformed_dumpstate_in_properties.txt")),
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseDumpstate(bytes.NewReader(tt.input))
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+
+			resultMap := result.(map[string]map[string]interface{})
+
+			for deviceName, deviceValues := range resultMap {
+				validateItemInCommandOutput(t, deviceName, tt.input)
+				// Confirm that we stripped "Found" from the front of the device name
+				assert.False(t, strings.HasPrefix(deviceName, "Found"), fmt.Sprintf("device name not extracted correctly: got %s", deviceName))
+
+				for topLevelKey, topLevelValue := range deviceValues {
+					if topLevelKey == "Properties" {
+						properties := topLevelValue.(map[string]interface{})
+						for propertyKey, propertyValue := range properties {
+							validateKeyValueInCommandOutput(t, propertyKey, propertyValue.(string), tt.input)
+						}
+					} else if topLevelKey == "Services" {
+						services := topLevelValue.([]string)
+						for _, service := range services {
+							validateItemInCommandOutput(t, service, tt.input)
+						}
+					} else {
+						validateKeyValueInCommandOutput(t, topLevelKey, topLevelValue.(string), tt.input)
+					}
+				}
+			}
+		})
+	}
+}
+
+func readTestFile(t *testing.T, filepath string) []byte {
+	b, err := os.ReadFile(filepath)
+	require.NoError(t, err)
+	return b
+}
+
+func validateKeyValueInCommandOutput(t *testing.T, key, val string, commandOutput []byte) {
+	// First, confirm that the key and value both exists in the original output
+	validateItemInCommandOutput(t, key, commandOutput)
+	validateItemInCommandOutput(t, val, commandOutput)
+
+	// Validate that the key and value were associated with each other
+	regexFmt := `\Q%s\E.+\Q%s\E` // match key, then any delimiter, then value, on one line
+	re := regexp.MustCompile(fmt.Sprintf(regexFmt, key, val))
+	assert.True(t, re.Match(commandOutput), fmt.Sprintf("expected to see %s : %s in original command output but did not", key, val))
+}
+
+func validateItemInCommandOutput(t *testing.T, item string, commandOutput []byte) {
+	assert.True(t, bytes.Contains(commandOutput, []byte(item)))
+}

--- a/pkg/osquery/tables/execparsers/remotectl/parse_test.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse_test.go
@@ -108,32 +108,48 @@ func TestParse(t *testing.T) {
 							actualValueCount += 1
 							validateKeyValueInCommandOutput(t, propertyKey, propertyValue.(string), tt.input)
 						}
-					} else if topLevelKey == "Heartbeat" {
+
+						continue
+					}
+
+					if topLevelKey == "Heartbeat" {
 						for _, heartbeat := range topLevelValue.([]string) {
 							actualValueCount += 1
 							validateItemInCommandOutput(t, heartbeat, tt.input)
 						}
-					} else if topLevelKey == "Services" || topLevelKey == "Local Services" {
+
+						continue
+					}
+
+					if topLevelKey == "Services" || topLevelKey == "Local Services" {
 						for _, service := range topLevelValue.([]map[string]interface{}) {
 							for serviceKey, serviceValue := range service {
 								if serviceKey == "Name" {
 									actualValueCount += 1
 									validateItemInCommandOutput(t, serviceValue.(string), tt.input)
-								} else if serviceKey == "Properties" {
+
+									continue
+								}
+
+								if serviceKey == "Properties" {
 									for servicePropertyKey, servicePropertyValue := range serviceValue.(map[string]interface{}) {
 										actualValueCount += 1
 										validateKeyValueInCommandOutput(t, servicePropertyKey, servicePropertyValue.(string), tt.input)
 									}
-								} else {
-									actualValueCount += 1
-									validateKeyValueInCommandOutput(t, serviceKey, serviceValue.(string), tt.input)
+
+									continue
 								}
+
+								actualValueCount += 1
+								validateKeyValueInCommandOutput(t, serviceKey, serviceValue.(string), tt.input)
 							}
 						}
-					} else {
-						actualValueCount += 1
-						validateKeyValueInCommandOutput(t, topLevelKey, topLevelValue.(string), tt.input)
+
+						continue
 					}
+
+					actualValueCount += 1
+					validateKeyValueInCommandOutput(t, topLevelKey, topLevelValue.(string), tt.input)
 				}
 			}
 

--- a/pkg/osquery/tables/execparsers/remotectl/parse_test.go
+++ b/pkg/osquery/tables/execparsers/remotectl/parse_test.go
@@ -55,7 +55,7 @@ func TestParse(t *testing.T) {
 			name:                "dumpstate with multiple devices in output",
 			input:               []byte(multiple_devices_dumpstate),
 			expectedDeviceCount: 3,
-			expectedValueCount:  164,
+			expectedValueCount:  188,
 			expectedErr:         false,
 		},
 		{
@@ -108,11 +108,27 @@ func TestParse(t *testing.T) {
 							actualValueCount += 1
 							validateKeyValueInCommandOutput(t, propertyKey, propertyValue.(string), tt.input)
 						}
-					} else if topLevelKey == "Services" || topLevelKey == "Local Services" || topLevelKey == "Heartbeat" {
-						services := topLevelValue.([]string)
-						for _, service := range services {
+					} else if topLevelKey == "Heartbeat" {
+						for _, heartbeat := range topLevelValue.([]string) {
 							actualValueCount += 1
-							validateItemInCommandOutput(t, service, tt.input)
+							validateItemInCommandOutput(t, heartbeat, tt.input)
+						}
+					} else if topLevelKey == "Services" || topLevelKey == "Local Services" {
+						for _, service := range topLevelValue.([]map[string]interface{}) {
+							for serviceKey, serviceValue := range service {
+								if serviceKey == "Name" {
+									actualValueCount += 1
+									validateItemInCommandOutput(t, serviceValue.(string), tt.input)
+								} else if serviceKey == "Properties" {
+									for servicePropertyKey, servicePropertyValue := range serviceValue.(map[string]interface{}) {
+										actualValueCount += 1
+										validateKeyValueInCommandOutput(t, servicePropertyKey, servicePropertyValue.(string), tt.input)
+									}
+								} else {
+									actualValueCount += 1
+									validateKeyValueInCommandOutput(t, serviceKey, serviceValue.(string), tt.input)
+								}
+							}
 						}
 					} else {
 						actualValueCount += 1

--- a/pkg/osquery/tables/execparsers/remotectl/remotectl.go
+++ b/pkg/osquery/tables/execparsers/remotectl/remotectl.go
@@ -3,16 +3,22 @@
 
 package remotectl
 
-import "io"
+import (
+	"bufio"
+	"io"
+)
 
-type parser struct{}
+type parser struct {
+	scanner      *bufio.Scanner
+	lastReadLine string
+}
 
 var Parser = New()
 
-func New() parser {
-	return parser{}
+func New() *parser {
+	return &parser{}
 }
 
-func (p parser) Parse(reader io.Reader) (any, error) {
-	return parseDumpstate(reader)
+func (p *parser) Parse(reader io.Reader) (any, error) {
+	return p.parseDumpstate(reader)
 }

--- a/pkg/osquery/tables/execparsers/remotectl/remotectl.go
+++ b/pkg/osquery/tables/execparsers/remotectl/remotectl.go
@@ -1,0 +1,18 @@
+//go:build darwin
+// +build darwin
+
+package remotectl
+
+import "io"
+
+type parser struct{}
+
+var Parser = New()
+
+func New() parser {
+	return parser{}
+}
+
+func (p parser) Parse(reader io.Reader) (any, error) {
+	return parseDumpstate(reader)
+}

--- a/pkg/osquery/tables/execparsers/remotectl/test-data/malformed_dumpstate_at_top_level.txt
+++ b/pkg/osquery/tables/execparsers/remotectl/test-data/malformed_dumpstate_at_top_level.txt
@@ -1,0 +1,7 @@
+Local device
+	UUID = 4D259086-B8CF-4A99-A2FB-**REDACTED**
+	Properties: {
+		AppleInternal => false
+	}
+	Services:
+		com.apple.sysdiagnose.remote

--- a/pkg/osquery/tables/execparsers/remotectl/test-data/malformed_dumpstate_in_properties.txt
+++ b/pkg/osquery/tables/execparsers/remotectl/test-data/malformed_dumpstate_in_properties.txt
@@ -1,0 +1,5 @@
+Local device
+	UUID: 4D259086-B8CF-4A99-A2FB-**REDACTED**
+	Properties: {
+		AppleInternal: false
+	}

--- a/pkg/osquery/tables/execparsers/remotectl/test-data/multiple_devices_dumpstate.txt
+++ b/pkg/osquery/tables/execparsers/remotectl/test-data/multiple_devices_dumpstate.txt
@@ -1,0 +1,93 @@
+Local device
+	UUID: 4D259086-B8CF-4A99-A2FB-**REDACTED**
+	Messaging Protocol Version: 2
+	Product Type: iMacPro1,1
+	OS Build: 11.6 (20G165)
+	Properties: {
+		AppleInternal => false
+		CPUArchitecture => x86_64h
+		EffectiveProductionStatusSEP => false
+		EthernetMacAddress => d0:81:**REDACTED**
+		HWModel => J137AP
+		HasSEP => true
+		IsUIBuild => true
+		DeviceSupportsLockdown => false
+		EffectiveSecurityModeAp => false
+		SigningFuse => true
+		BuildVersion => 20G165
+		OSVersion => 11.6
+		BridgeVersion => 18.16.14759.0.1,0
+		SensitivePropertiesVisible => true
+		ProductType => iMacPro1,1
+		SerialNumber => C02V**REDACTED**
+		BootSessionUUID => A7C32508-8D2C-**REDACTED**
+		DeviceColor => unknown
+		EffectiveProductionStatusAp => false
+		EffectiveSecurityModeSEP => false
+		UniqueChipID => 14531085**REDACTED**
+		UniqueDeviceID => e664d52b5fbc5a68**REDACTED**
+		RemoteXPCVersionFlags => 7205759**REDACTED**
+		CertificateProductionStatus => false
+		CertificateSecurityMode => false
+		DeviceEnclosureColor => unknown
+		SecurityDomain => 1
+		OSInstallEnvironment => false
+		Image4Supported => false
+	}
+	Services:
+		com.apple.sysdiagnose.remote
+		com.apple.mobile.storage_mounter_proxy.bridge
+		com.apple.osanalytics.logRelay
+		com.apple.corecaptured.remoteservice
+		com.apple.mobile.storage_mounter_proxy.bridge.macOS
+
+Found localbridge (bridge)
+	State: connected (connectable)
+	UUID: 37D16267-478D-4B4D-**REDACTED**
+	Product Type: iBridge2,1
+	OS Build: 5.5 (18P4759a)
+	Messaging Protocol Version: 2
+	Heartbeat:
+		Last successful heartbeat sent 6.643s ago, received 6.639s ago (took 0.004s)
+		69363 heartbeats sent, 0 received
+	Properties: {
+		AppleInternal => false
+		CPUArchitecture => arm64
+		ChipID => 32786
+		EffectiveProductionStatusSEP => true
+		EthernetMacAddress => d0:81:**REDACTED**
+		HWModel => J137AP
+		HasSEP => true
+		LocationID => 2148**REDACTED**
+		IsUIBuild => true
+		RegionInfo => LL/A
+		DeviceSupportsLockdown => false
+		EffectiveSecurityModeAp => true
+		SigningFuse => true
+		BuildVersion => 18P4759a
+		OSVersion => 5.5
+		BridgeVersion => 18.16.14759.0.1,0
+		SensitivePropertiesVisible => true
+		BoardRevision => 9
+		Image4CryptoHashMethod => sha2-384
+		ProductType => iBridge2,1
+		SerialNumber => C02V**REDACTED**
+		BootSessionUUID => 6696D9BB-C1B0-**REDACTED**
+		BoardId => 10
+		DeviceColor => unknown
+		EffectiveProductionStatusAp => true
+		EffectiveSecurityModeSEP => true
+		UniqueChipID => 145310**REDACTED**
+		UniqueDeviceID => 00008012-**REDACTED**
+		RemoteXPCVersionFlags => 7205759**REDACTED**
+		CertificateProductionStatus => true
+		CertificateSecurityMode => true
+		DeviceEnclosureColor => unknown
+		ModelNumber => MQ2Y2
+		RegionCode => LL
+		SecurityDomain => 1
+		OSInstallEnvironment => false
+		InterfaceIndex => 9
+		HardwarePlatform => t8012
+		Image4Supported => true
+	}

--- a/pkg/osquery/tables/execparsers/remotectl/test-data/multiple_devices_dumpstate.txt
+++ b/pkg/osquery/tables/execparsers/remotectl/test-data/multiple_devices_dumpstate.txt
@@ -1,93 +1,226 @@
 Local device
-	UUID: 4D259086-B8CF-4A99-A2FB-**REDACTED**
-	Messaging Protocol Version: 2
-	Product Type: iMacPro1,1
-	OS Build: 11.6 (20G165)
+	UUID: 384B6869-AAAA-BBBB-CCCC-DEADBEEFCAFE
+	Messaging Protocol Version: 3
+	Product Type: MacBookPro18,1
+	OS Build: 12.6 (21G115)
 	Properties: {
 		AppleInternal => false
-		CPUArchitecture => x86_64h
-		EffectiveProductionStatusSEP => false
-		EthernetMacAddress => d0:81:**REDACTED**
-		HWModel => J137AP
-		HasSEP => true
-		IsUIBuild => true
-		DeviceSupportsLockdown => false
-		EffectiveSecurityModeAp => false
-		SigningFuse => true
-		BuildVersion => 20G165
-		OSVersion => 11.6
-		BridgeVersion => 18.16.14759.0.1,0
-		SensitivePropertiesVisible => true
-		ProductType => iMacPro1,1
-		SerialNumber => C02V**REDACTED**
-		BootSessionUUID => A7C32508-8D2C-**REDACTED**
-		DeviceColor => unknown
-		EffectiveProductionStatusAp => false
-		EffectiveSecurityModeSEP => false
-		UniqueChipID => 14531085**REDACTED**
-		UniqueDeviceID => e664d52b5fbc5a68**REDACTED**
-		RemoteXPCVersionFlags => 7205759**REDACTED**
-		CertificateProductionStatus => false
-		CertificateSecurityMode => false
-		DeviceEnclosureColor => unknown
-		SecurityDomain => 1
-		OSInstallEnvironment => false
-		Image4Supported => false
-	}
-	Services:
-		com.apple.sysdiagnose.remote
-		com.apple.mobile.storage_mounter_proxy.bridge
-		com.apple.osanalytics.logRelay
-		com.apple.corecaptured.remoteservice
-		com.apple.mobile.storage_mounter_proxy.bridge.macOS
-
-Found localbridge (bridge)
-	State: connected (connectable)
-	UUID: 37D16267-478D-4B4D-**REDACTED**
-	Product Type: iBridge2,1
-	OS Build: 5.5 (18P4759a)
-	Messaging Protocol Version: 2
-	Heartbeat:
-		Last successful heartbeat sent 6.643s ago, received 6.639s ago (took 0.004s)
-		69363 heartbeats sent, 0 received
-	Properties: {
-		AppleInternal => false
-		CPUArchitecture => arm64
-		ChipID => 32786
+		CPUArchitecture => arm64e
+		ChipID => 24576
 		EffectiveProductionStatusSEP => true
-		EthernetMacAddress => d0:81:**REDACTED**
-		HWModel => J137AP
+		HWModel => J316sAP
 		HasSEP => true
-		LocationID => 2148**REDACTED**
 		IsUIBuild => true
 		RegionInfo => LL/A
+		RestoreLongVersion => 21.7.115.0.0,0
 		DeviceSupportsLockdown => false
 		EffectiveSecurityModeAp => true
 		SigningFuse => true
-		BuildVersion => 18P4759a
-		OSVersion => 5.5
-		BridgeVersion => 18.16.14759.0.1,0
+		BuildVersion => 21G115
+		OSVersion => 12.6
+		BridgeVersion => 19.16.16067.0.0,0
 		SensitivePropertiesVisible => true
-		BoardRevision => 9
 		Image4CryptoHashMethod => sha2-384
-		ProductType => iBridge2,1
-		SerialNumber => C02V**REDACTED**
-		BootSessionUUID => 6696D9BB-C1B0-**REDACTED**
+		MobileDeviceMinimumVersion => 1351
+		ProductName => macOS
+		ProductType => MacBookPro18,1
+		SerialNumber => 1234567890
+		BootSessionUUID => 00AE31FA-AAAA-BBBB-CCCC-DEADBEEFCAFE
 		BoardId => 10
 		DeviceColor => unknown
 		EffectiveProductionStatusAp => true
 		EffectiveSecurityModeSEP => true
-		UniqueChipID => 145310**REDACTED**
-		UniqueDeviceID => 00008012-**REDACTED**
-		RemoteXPCVersionFlags => 7205759**REDACTED**
+		UniqueChipID => 6789012345678900
+		UniqueDeviceID => 11111111-012345789ABCDEF0
+		RemoteXPCVersionFlags => 72057594037927942
 		CertificateProductionStatus => true
 		CertificateSecurityMode => true
-		DeviceEnclosureColor => unknown
-		ModelNumber => MQ2Y2
+		DeviceClass => Mac
+		DeviceEnclosureColor => 2
+		ModelNumber => Z14W00105
 		RegionCode => LL
 		SecurityDomain => 1
 		OSInstallEnvironment => false
-		InterfaceIndex => 9
-		HardwarePlatform => t8012
+		HardwarePlatform => t6000
 		Image4Supported => true
 	}
+	Services:
+		com.apple.remote.installcoordination_proxy
+		com.apple.sysdiagnose.remote
+		com.apple.osanalytics.logRelay
+		com.apple.corecaptured.remoteservice
+		com.apple.mobile.storage_mounter_proxy.bridge
+		com.apple.dt.testmanagerd.remote.automation
+		com.apple.mobile.storage_mounter_proxy.bridge.macOS
+		com.apple.mobile.notification_proxy.remote
+		com.apple.dt.remoteFetchSymbols
+		com.apple.CSCSupportd
+		ssh
+
+Found ncm-0 (ncm-device)
+	State: connected (connectable)
+	UUID: 2C2D2409-AAAA-BBBB-CCCC-DEADBEEFCAFE
+	Product Type: iPhone12,3
+	OS Build: 15.3.1 (19D52)
+	Messaging Protocol Version: 3
+	Heartbeat:
+		0 heartbeats sent, 0 received
+	Properties: {
+		AppleInternal => false
+		CPUArchitecture => arm64e
+		ChipID => 32816
+		EffectiveProductionStatusSEP => true
+		EthernetMacAddress => cc:d2:81:11:22:33
+		HWModel => D421AP
+		HasSEP => true
+		LocationID => 33333333
+		IsUIBuild => true
+		RegionInfo => LL/A
+		DeviceSupportsLockdown => true
+		EffectiveSecurityModeAp => true
+		SigningFuse => true
+		BuildVersion => 19D52
+		OSVersion => 15.3.1
+		SensitivePropertiesVisible => true
+		Image4CryptoHashMethod => sha2-384
+		MobileDeviceMinimumVersion => 1351
+		ProductName => iPhone OS
+		ProductType => iPhone12,3
+		SerialNumber => 1234567890XX
+		BootSessionUUID => D4053160-AAAA-BBBB-CCCC-DEADBEEFCAFE
+		BoardId => 6
+		DeviceColor => 1
+		EffectiveProductionStatusAp => true
+		EffectiveSecurityModeSEP => true
+		StoreDemoMode => false
+		UniqueChipID => 7890123456789ABC
+		UniqueDeviceID => 11111111-0123456789ABCDF0
+		RemoteXPCVersionFlags => 72057594037927942
+		CertificateProductionStatus => true
+		CertificateSecurityMode => true
+		DeviceClass => iPhone
+		DeviceEnclosureColor => 1
+		ModelNumber => MWA12
+		RegionCode => LL
+		SecurityDomain => 1
+		OSInstallEnvironment => false
+		InterfaceIndex => 28
+		HardwarePlatform => t8030
+		Image4Supported => true
+	}
+	Services:
+		com.apple.mobile.insecure_notification_proxy.shim.remote
+		com.apple.mobile.insecure_notification_proxy.remote
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+		com.apple.osanalytics.logTransfer
+			Properties: {
+				UsesRemoteXPC => true
+			}
+		com.apple.fusion.remote.service
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+		com.apple.mobile.lockdown.remote.untrusted
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+		com.apple.sysdiagnose.remote
+			Properties: {
+				UsesRemoteXPC => true
+			}
+	Local Services:
+		com.apple.osanalytics.logRelay
+
+Found ncm-1 (ncm-device)
+	State: connected (connectable)
+	UUID: AAF6DCC0-AAAA-BBBB-CCCC-DEADBEEFCAFE
+	Product Type: iPhone14,2
+	OS Build: 16.0.2 (20A380)
+	Messaging Protocol Version: 3
+	Heartbeat:
+		0 heartbeats sent, 0 received
+	Properties: {
+		AppleInternal => false
+		CPUArchitecture => arm64e
+		ChipID => 33040
+		EffectiveProductionStatusSEP => true
+		EthernetMacAddress => dc:53:92:11:22:33
+		HWModel => D63AP
+		HasSEP => true
+		ThinningProductType => iPhone14,2
+		LocationID => 17825792
+		IsUIBuild => true
+		RegionInfo => LL/A
+		RestoreLongVersion => 20.1.380.0.0,0
+		DeviceSupportsLockdown => true
+		EffectiveSecurityModeAp => true
+		SigningFuse => true
+		BuildVersion => 20A380
+		OSVersion => 16.0.2
+		SensitivePropertiesVisible => true
+		Image4CryptoHashMethod => sha2-384
+		MobileDeviceMinimumVersion => 1400
+		ProductName => iPhone OS
+		ProductType => iPhone14,2
+		SerialNumber => HRHX035W72
+		BootSessionUUID => B8B27D90-AAAA-BBBB-CCCC-DEADBEEFCAFE
+		BoardId => 12
+		DeviceColor => 1
+		EffectiveProductionStatusAp => true
+		EffectiveSecurityModeSEP => true
+		StoreDemoMode => false
+		UniqueChipID => 67890ABCDEF1234
+		UniqueDeviceID => 88888888-AABBCCDDEEFF0011
+		OSInstallEnvironment => false
+		RemoteXPCVersionFlags => 72057594037927942
+		CertificateProductionStatus => true
+		CertificateSecurityMode => true
+		DeviceClass => iPhone
+		DeviceEnclosureColor => 1
+		ModelNumber => MLTW3
+		RegionCode => LL
+		SecurityDomain => 1
+		InterfaceIndex => 30
+		HardwarePlatform => t8110
+		Image4Supported => true
+	}
+	Services:
+		com.apple.mobile.lockdown.remote.untrusted
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+		com.apple.mobile.insecure_notification_proxy.shim.remote
+		com.apple.mobile.insecure_notification_proxy.remote
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+		com.apple.osanalytics.logTransfer
+			Properties: {
+				UsesRemoteXPC => true
+			}
+		com.apple.internal.dt.coredevice.untrusted.tunnelservice
+			Version: 2
+			Properties: {
+				ServiceVersion => 2
+				UsesRemoteXPC => true
+			}
+		com.apple.fusion.remote.service
+			Version: 1
+			Properties: {
+				ServiceVersion => 1
+				UsesRemoteXPC => true
+			}
+	Local Services:
+		com.apple.osanalytics.logRelay

--- a/pkg/osquery/tables/execparsers/remotectl/test-data/single_device_dumpstate.txt
+++ b/pkg/osquery/tables/execparsers/remotectl/test-data/single_device_dumpstate.txt
@@ -1,0 +1,58 @@
+Local device
+	UUID: 65978F15-D653-49DF-B0E5-DEADBEEFCAFE
+	Messaging Protocol Version: 3
+	Product Type: MacBookPro18,1
+	OS Build: 12.6 (21G115)
+	Properties: {
+		AppleInternal => false
+		CPUArchitecture => arm64e
+		ChipID => 24576
+		EffectiveProductionStatusSEP => true
+		HWModel => J316sAP
+		HasSEP => true 
+		IsUIBuild => true
+		RegionInfo => LL/A
+		RestoreLongVersion => 21.7.115.0.0,0
+		DeviceSupportsLockdown => false
+		EffectiveSecurityModeAp => true
+		SigningFuse => true
+		BuildVersion => 21G115
+		OSVersion => 12.6
+		BridgeVersion => 19.16.16067.0.0,0
+		SensitivePropertiesVisible => true
+		Image4CryptoHashMethod => sha2-384
+		MobileDeviceMinimumVersion => 1351
+		ProductName => macOS
+		ProductType => MacBookPro18,1
+		SerialNumber => JMV3**REDACTED**
+		BootSessionUUID => AADCDB34-9A1C-4646-9D50-DEADBEEFCAFE
+		BoardId => 10
+		DeviceColor => unknown
+		EffectiveProductionStatusAp => true
+		EffectiveSecurityModeSEP => true
+		UniqueChipID => 6773**REDACTED**
+		UniqueDeviceID => 00006000-**REDACTED**
+		RemoteXPCVersionFlags => 7205**REDACTED**
+		CertificateProductionStatus => true
+		CertificateSecurityMode => true
+		DeviceClass => Mac
+		DeviceEnclosureColor => 2
+		ModelNumber => Z14V0016E
+		RegionCode => LL
+		SecurityDomain => 1
+		OSInstallEnvironment => false
+		HardwarePlatform => t6000
+		Image4Supported => true
+	}
+	Services:
+		com.apple.mobile.storage_mounter_proxy.bridge.macOS
+		com.apple.osanalytics.logRelay
+		com.apple.mobile.storage_mounter_proxy.bridge
+		com.apple.sysdiagnose.remote
+		com.apple.remote.installcoordination_proxy
+		com.apple.mobile.notification_proxy.remote
+		com.apple.dt.remoteFetchSymbols
+		com.apple.dt.testmanagerd.remote.automation
+		com.apple.CSCSupportd
+		com.apple.corecaptured.remoteservice
+		ssh


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/763

Adds a parser to parse `remotectl` output.

Example output from querying:

```
osquery> select * from kolide_remotectl where query = 'Local device/UUID';
+-------------------+--------------+------+--------------------------------------+-------------------+
| fullkey           | parent       | key  | value                                | query             |
+-------------------+--------------+------+--------------------------------------+-------------------+
| Local device/UUID | Local device | UUID | 65978F15-D653-49DF-B0E5-REDACTED     | Local device/UUID |
+-------------------+--------------+------+--------------------------------------+-------------------+
```