### PR TITLE
Build launcher app bundle in build/darwin.<arch>/

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,7 +69,7 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') }}
     
     - name: App Bundle
-      run: make launcher-app
+      run: make github-launcherapp
       if: ${{ contains(matrix.os, 'macos') }}
 
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,12 @@ lipo_%: build/darwin.amd64/% build/darwin.arm64/%
 
 # Build an app bundle for macOS
 # TODO: need to add build/Launcher.app/Contents/embedded.provisionprofile
-launcherapp_%: ARCH = $(word 2, $(subst _, ,$@))
-launcherapp_%: build/darwin.%/launcher
-	mkdir -p build/darwin.$(ARCH)/Kolide.app/Contents/MacOS
-	cp build/darwin.$(ARCH)/launcher build/darwin.$(ARCH)/Kolide.app/Contents/MacOS/
-	mkdir -p build/darwin.$(ARCH)/Kolide.app/Contents/Resources
-	cp tools/images/Kolide.icns build/darwin.$(ARCH)/Kolide.app/Contents/Resources
-	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION}/g' tools/packaging/LauncherTemplate_Info.plist > build/darwin.$(ARCH)/Kolide.app/Contents/Info.plist
+build/darwin.%/Kolide.app: build/darwin.%/launcher
+	mkdir -p $@/Contents/MacOS
+	cp $@/../launcher $@/Contents/MacOS/
+	mkdir -p $@/Contents/Resources
+	cp tools/images/Kolide.icns $@/Contents/Resources
+	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION}/g' tools/packaging/LauncherTemplate_Info.plist > $@/Contents/Info.plist
 
 # pointers, mostly for convenience reasons
 launcher: build_launcher
@@ -84,7 +83,7 @@ GITHUB_ARCHS=amd64 arm64
 github-build-no-cross: $(foreach t, $(GITHUB_TARGETS), build_$(t))
 github-build: $(foreach t, $(GITHUB_TARGETS), $(foreach a, $(GITHUB_ARCHS), build_$(t)_noop_$(a)))
 github-lipo: $(foreach t, $(GITHUB_TARGETS), lipo_$(t))
-github-launcherapp: $(foreach a, $(GITHUB_ARCHS) universal, launcherapp_$(a))
+github-launcherapp: $(foreach a, $(GITHUB_ARCHS) universal, build/darwin.$(a)/Kolide.app)
 
 ##
 ## Cross Build targets
@@ -109,7 +108,7 @@ rel-arm64: $(foreach target, $(RELEASE_TARGETS), $(foreach os, $(ARM64_OSES), bu
 
 rel-lipo: $(foreach target, $(RELEASE_TARGETS), lipo_$(target))
 
-rel-launcherapp: $(foreach arch, $(DARWIN_ARCHES), launcherapp_$(arch))
+rel-launcherapp: $(foreach arch, $(DARWIN_ARCHES), build/darwin.$(arch)/Kolide.app)
 
 ##
 ## Release Process Stuff


### PR DESCRIPTION
Instead of creating the app bundle in `build/`, create one in each of `build/darwin.arm64`, `build/darwin.amd64`, `build/darwin.universal`.

See it in GitHub Actions: https://github.com/kolide/launcher/actions/runs/3346890067/jobs/5544250723