### PR TITLE
When shipping app bundle, ship launcher binary as symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ lipo_%: build/darwin.amd64/% build/darwin.arm64/%
 # TODO: need to add build/Launcher.app/Contents/embedded.provisionprofile
 build/darwin.%/Kolide.app: build/darwin.%/launcher
 	mkdir -p $@/Contents/MacOS
-	cp $@/../launcher $@/Contents/MacOS/
+	mv $@/../launcher $@/Contents/MacOS/
+	ln -s Kolide.app/Contents/MacOS/launcher $@/../
 	mkdir -p $@/Contents/Resources
 	cp tools/images/Kolide.icns $@/Contents/Resources
 	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION}/g' tools/packaging/LauncherTemplate_Info.plist > $@/Contents/Info.plist


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/921.

Instead of shipping `launcher` both at the top level and inside the app bundle, create a symlink at the top level to the binary inside the app bundle.