### PR TITLE
Revert "When shipping app bundle, ship launcher binary as symlink"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ lipo_%: build/darwin.amd64/% build/darwin.arm64/%
 # TODO: need to add build/Launcher.app/Contents/embedded.provisionprofile
 build/darwin.%/Kolide.app: build/darwin.%/launcher
 	mkdir -p $@/Contents/MacOS
-	mv $@/../launcher $@/Contents/MacOS/
-	ln -s Kolide.app/Contents/MacOS/launcher $@/../
+	cp $@/../launcher $@/Contents/MacOS/
 	mkdir -p $@/Contents/Resources
 	cp tools/images/Kolide.icns $@/Contents/Resources
 	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION}/g' tools/packaging/LauncherTemplate_Info.plist > $@/Contents/Info.plist


### PR DESCRIPTION
Reverts kolide/launcher#929

It turns out that github's upload-artifacts doesn't really [support this as expected](https://github.com/actions/upload-artifact/issues/93), so this change will have to happen later in the pipeline -- no point in doing it here.