### PR TITLE
ioutil deprecation

### DIFF
--- a/cmd/launcher-pummel/launcher-pummel.go
+++ b/cmd/launcher-pummel/launcher-pummel.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strconv"
@@ -111,7 +110,7 @@ func main() {
 	if *flEnrollSecret != "" {
 		enrollSecret = *flEnrollSecret
 	} else if *flEnrollSecretPath != "" {
-		content, err := ioutil.ReadFile(*flEnrollSecretPath)
+		content, err := os.ReadFile(*flEnrollSecretPath)
 		if err != nil {
 			logutil.Fatal(logger, "err", fmt.Errorf("could not read enroll_secret_path: %w", err), "enroll_secret_path", *flEnrollSecretPath)
 		}

--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -54,7 +53,7 @@ func createExtensionRuntime(ctx context.Context, db *bbolt.DB, launcherClient se
 	if opts.EnrollSecret != "" {
 		enrollSecret = opts.EnrollSecret
 	} else if opts.EnrollSecretPath != "" {
-		content, err := ioutil.ReadFile(opts.EnrollSecretPath)
+		content, err := os.ReadFile(opts.EnrollSecretPath)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not read enroll_secret_path: %s: %w", opts.EnrollSecretPath, err)
 		}

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -286,7 +285,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 }
 
 func writePidFile(path string) error {
-	if err := ioutil.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
 		return fmt.Errorf("writing pidfile: %w", err)
 	}
 	return nil

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -112,7 +112,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	var rootPool *x509.CertPool
 	if opts.RootPEM != "" {
 		rootPool = x509.NewCertPool()
-		pemContents, err := ioutil.ReadFile(opts.RootPEM)
+		pemContents, err := os.ReadFile(opts.RootPEM)
 		if err != nil {
 			return fmt.Errorf("reading root certs PEM at path: %s: %w", opts.RootPEM, err)
 		}

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -61,7 +60,7 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 
 	testArgs, expectedOpts := getArgsAndResponse()
 
-	flagFile, err := ioutil.TempFile("", "flag-file")
+	flagFile, err := os.CreateTemp("", "flag-file")
 	require.NoError(t, err)
 	defer os.Remove(flagFile.Name())
 

--- a/cmd/launcher/run_query.go
+++ b/cmd/launcher/run_query.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -40,7 +39,7 @@ func runQuery(args []string) error {
 	var queries queryFile
 
 	if _, err := os.Stat(*flQueries); err == nil {
-		data, err := ioutil.ReadFile(*flQueries)
+		data, err := os.ReadFile(*flQueries)
 		if err != nil {
 			return fmt.Errorf("reading supplied queries file: %w", err)
 		}

--- a/cmd/launcher/run_query.go
+++ b/cmd/launcher/run_query.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"time"
@@ -49,7 +50,7 @@ func runQuery(args []string) error {
 	}
 
 	if *flQueries == "" {
-		stdinQueries, err := ioutil.ReadAll(os.Stdin)
+		stdinQueries, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("reading stdin: %w", err)
 		}

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -222,7 +221,7 @@ func runMake(args []string) error {
 	cacheDir := *flCacheDir
 	var err error
 	if cacheDir == "" {
-		cacheDir, err = ioutil.TempDir("", "download_cache")
+		cacheDir, err = os.MkdirTemp("", "download_cache")
 		if err != nil {
 			return fmt.Errorf("could not create temp dir for caching files: %w", err)
 		}
@@ -263,7 +262,7 @@ func runMake(args []string) error {
 	// NOTE: if you are using docker-for-mac, you probably need to set the TMPDIR env to /tmp
 	if outputDir == "" {
 		var err error
-		outputDir, err = ioutil.TempDir("", fmt.Sprintf("launcher-package"))
+		outputDir, err = os.MkdirTemp("", fmt.Sprintf("launcher-package"))
 		if err != nil {
 			return fmt.Errorf("making output dir: %w", err)
 		}

--- a/docs/package-builder.md
+++ b/docs/package-builder.md
@@ -164,7 +164,7 @@ To display the list of support targets, invoke `package-builder list-targets`
 #### Docker Temp Directories
 
 Packaging for linux used `fpm` via a docker container. This operates
-on files in a directory created by golang's `ioutil.TempFile`. On osx,
+on files in a directory created by golang's `os.CreateTemp`. On osx,
 the default temp directory is in `/var`, which is not accessible to
 docker.
 
@@ -178,7 +178,7 @@ You can configure shared paths from Docker -> Preferences... -> File Sharing.
 See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
 ```
 
-As `ioutil.TempFile` respects the `TMPDIR` environmental variable, there is a simple workaround:
+As `os.CreateTemp` respects the `TMPDIR` environmental variable, there is a simple workaround:
 
 ``` shell
 export TMPDIR=/tmp

--- a/pkg/augeas/augeas_test.go
+++ b/pkg/augeas/augeas_test.go
@@ -1,7 +1,6 @@
 package augeas
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestInstallLenses(t *testing.T) {
 
 	require.NoError(t, InstallLenses(tmpDir), "install lenses")
 
-	files, err := ioutil.ReadDir(tmpDir)
+	files, err := os.ReadDir(tmpDir)
 	require.NoError(t, err)
 
 	require.Greater(t, len(files), 5, "Has enough files")
@@ -26,7 +25,7 @@ func TestInstallLenses(t *testing.T) {
 
 	// Replace missing files
 	require.NoError(t, InstallLenses(tmpDir), "reinstall lenses")
-	files2, err := ioutil.ReadDir(tmpDir)
+	files2, err := os.ReadDir(tmpDir)
 	require.NoError(t, err)
 
 	require.Equal(t, len(files), len(files2))

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -47,7 +47,6 @@ package autoupdate
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -217,7 +216,7 @@ func (u *Updater) createTUFRepoDirectory(localPath string, currentAssetPath stri
 			if err != nil {
 				return fmt.Errorf("could not get asset: %w", err)
 			}
-			if err := ioutil.WriteFile(fullLocalPath, asset, 0644); err != nil {
+			if err := os.WriteFile(fullLocalPath, asset, 0644); err != nil {
 				return fmt.Errorf("could not write file: %w", err)
 			}
 			continue

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -4,7 +4,6 @@ package autoupdate
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,7 +51,7 @@ func TestCreateTUFRepoDirectory(t *testing.T) {
 		os.Remove(filepath.Join(localTUFRepoPath, knownFilePaths[0])),
 		"remove a tuf file")
 	require.NoError(t,
-		ioutil.WriteFile(filepath.Join(localTUFRepoPath, knownFilePaths[1]), nil, 0644),
+		os.WriteFile(filepath.Join(localTUFRepoPath, knownFilePaths[1]), nil, 0644),
 		"truncate a tuf file")
 
 	// Attempt to re-create

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -41,7 +41,7 @@ func TestCreateTUFRepoDirectory(t *testing.T) {
 		_, err := os.Stat(fullFilePath)
 		require.NoError(t, err, "stat file")
 
-		jsonBytes, err := ioutil.ReadFile(fullFilePath)
+		jsonBytes, err := os.ReadFile(fullFilePath)
 		require.NoError(t, err, "read file")
 
 		require.True(t, json.Valid(jsonBytes), "file is json")
@@ -64,7 +64,7 @@ func TestCreateTUFRepoDirectory(t *testing.T) {
 		_, err := os.Stat(fullFilePath)
 		require.NoError(t, err, "stat file")
 
-		jsonBytes, err := ioutil.ReadFile(fullFilePath)
+		jsonBytes, err := os.ReadFile(fullFilePath)
 		require.NoError(t, err, "read file")
 
 		require.True(t, json.Valid(jsonBytes), "file is json")

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -122,7 +122,7 @@ func TestValidLocalFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			testFile, err := ioutil.TempFile("", "TestValidLocalFile")
+			testFile, err := os.CreateTemp("", "TestValidLocalFile")
 			require.NoError(t, err)
 			defer os.Remove(testFile.Name())
 

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -196,7 +196,7 @@ func TestFindNewestCleanup(t *testing.T) {
 	}
 
 	{
-		updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+		updatesOnDisk, err := os.ReadDir(updatesDir)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(updatesOnDisk))
 		require.Equal(t, expectedNewest, FindNewest(ctx, binaryPath), "Should find number 5")
@@ -204,7 +204,7 @@ func TestFindNewestCleanup(t *testing.T) {
 
 	{
 		_ = FindNewest(ctx, binaryPath, DeleteOldUpdates())
-		updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+		updatesOnDisk, err := os.ReadDir(updatesDir)
 		require.NoError(t, err)
 		require.Equal(t, expectedNewest, FindNewest(ctx, binaryPath), "Should find number 5")
 		require.Equal(t, 2, len(updatesOnDisk), "after delete")
@@ -228,7 +228,7 @@ func TestCheckExecutableCorruptCleanup(t *testing.T) {
 	}
 
 	{
-		updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+		updatesOnDisk, err := os.ReadDir(updatesDir)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(updatesOnDisk))
 		require.Equal(t, expectedNewest, FindNewest(ctx, binaryPath), "Should find number 3")
@@ -236,7 +236,7 @@ func TestCheckExecutableCorruptCleanup(t *testing.T) {
 
 	{
 		_ = FindNewest(ctx, binaryPath, DeleteCorruptUpdates())
-		updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+		updatesOnDisk, err := os.ReadDir(updatesDir)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(updatesOnDisk), "after cleaning corruption")
 		require.Equal(t, expectedNewest, FindNewest(ctx, binaryPath), "Should find number 3")
@@ -475,7 +475,7 @@ func TestBuildTimestamp(t *testing.T) {
 				DeleteOldUpdates(),
 			)
 
-			updatesOnDisk, err := ioutil.ReadDir(updatesDir)
+			updatesOnDisk, err := os.ReadDir(updatesDir)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedOnDisk, len(updatesOnDisk), "remaining updates on disk")
 

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -412,7 +411,7 @@ func TestCheckExecutableTruncated(t *testing.T) {
 	t.Parallel()
 
 	// First make a broken truncated binary. Lots of setup for this.
-	truncatedBinary, err := ioutil.TempFile("", "test-autoupdate-check-executable-truncation")
+	truncatedBinary, err := os.CreateTemp("", "test-autoupdate-check-executable-truncation")
 	require.NoError(t, err, "make temp file")
 	defer os.Remove(truncatedBinary.Name())
 	truncatedBinary.Close()

--- a/pkg/dataflatten/flatten_test.go
+++ b/pkg/dataflatten/flatten_test.go
@@ -2,7 +2,7 @@ package dataflatten
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -21,7 +21,7 @@ type flattenTestCase struct {
 func TestFlatten_Complex2(t *testing.T) {
 	t.Parallel()
 
-	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "complex2.json"))
+	dataRaw, err := os.ReadFile(filepath.Join("testdata", "complex2.json"))
 	require.NoError(t, err, "reading file")
 	var dataIn interface{}
 	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")
@@ -73,7 +73,7 @@ func TestFlatten_Complex2(t *testing.T) {
 func TestFlatten_NestingBug(t *testing.T) {
 	t.Parallel()
 
-	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "nested.json"))
+	dataRaw, err := os.ReadFile(filepath.Join("testdata", "nested.json"))
 	require.NoError(t, err, "reading file")
 	var dataIn interface{}
 	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")
@@ -119,7 +119,7 @@ func TestFlatten_Complex(t *testing.T) {
 	t.Parallel()
 
 	// Do the unmarshaling here, so we don't keep doing it again and again
-	dataRaw, err := ioutil.ReadFile(filepath.Join("testdata", "animals.json"))
+	dataRaw, err := os.ReadFile(filepath.Join("testdata", "animals.json"))
 	require.NoError(t, err, "reading file")
 	var dataIn interface{}
 	require.NoError(t, json.Unmarshal(dataRaw, &dataIn), "unmarshalling json")

--- a/pkg/dataflatten/ini_test.go
+++ b/pkg/dataflatten/ini_test.go
@@ -1,7 +1,7 @@
 package dataflatten
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -64,7 +64,7 @@ func TestIniFile(t *testing.T) {
 func TestIni(t *testing.T) {
 	t.Parallel()
 
-	fileBytes, err := ioutil.ReadFile(iniTestFilePath)
+	fileBytes, err := os.ReadFile(iniTestFilePath)
 	require.NoError(t, err)
 
 	rows, err := Ini(fileBytes)

--- a/pkg/dataflatten/json.go
+++ b/pkg/dataflatten/json.go
@@ -3,11 +3,11 @@ package dataflatten
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func JsonFile(file string, opts ...FlattenOpts) ([]Row, error) {
-	rawdata, err := ioutil.ReadFile(file)
+	rawdata, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dataflatten/plist.go
+++ b/pkg/dataflatten/plist.go
@@ -2,13 +2,13 @@ package dataflatten
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"howett.net/plist"
 )
 
 func PlistFile(file string, opts ...FlattenOpts) ([]Row, error) {
-	rawdata, err := ioutil.ReadFile(file)
+	rawdata, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -6,11 +6,11 @@ package debug
 import (
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net"
 	"net/http"
 	nhpprof "net/http/pprof"
 	"net/url"
+	"os"
 	"runtime/pprof"
 	"strings"
 
@@ -56,7 +56,7 @@ func startDebugServer(addrPath string, logger log.Logger) (*http.Server, error) 
 	}
 	addr := url.String()
 	// Write the address to a file for easy access by users
-	if err := ioutil.WriteFile(addrPath, []byte(addr), 0600); err != nil {
+	if err := os.WriteFile(addrPath, []byte(addr), 0600); err != nil {
 		return nil, fmt.Errorf("writing debug address: %w", err)
 	}
 

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -18,7 +19,7 @@ import (
 )
 
 func getDebugURL(t *testing.T, tokenPath string) string {
-	url, err := ioutil.ReadFile(tokenPath)
+	url, err := os.ReadFile(tokenPath)
 	require.Nil(t, err)
 	return string(url)
 }

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -6,7 +6,6 @@ package debug
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"syscall"
@@ -26,7 +25,7 @@ func getDebugURL(t *testing.T, tokenPath string) string {
 
 func TestStartDebugServer(t *testing.T) {
 	t.Parallel()
-	tokenFile, err := ioutil.TempFile("", "kolide_debug_test")
+	tokenFile, err := os.CreateTemp("", "kolide_debug_test")
 	require.Nil(t, err)
 
 	serv, err := startDebugServer(tokenFile.Name(), log.NewNopLogger())
@@ -44,7 +43,7 @@ func TestStartDebugServer(t *testing.T) {
 
 func TestDebugServerUnauthorized(t *testing.T) {
 	t.Parallel()
-	tokenFile, err := ioutil.TempFile("", "kolide_debug_test")
+	tokenFile, err := os.CreateTemp("", "kolide_debug_test")
 	require.Nil(t, err)
 
 	serv, err := startDebugServer(tokenFile.Name(), log.NewNopLogger())
@@ -63,7 +62,7 @@ func TestDebugServerUnauthorized(t *testing.T) {
 func TestAttachDebugHandler(t *testing.T) {
 	t.Parallel()
 
-	tokenFile, err := ioutil.TempFile("", "kolide_debug_test")
+	tokenFile, err := os.CreateTemp("", "kolide_debug_test")
 	require.Nil(t, err)
 
 	AttachDebugHandler(tokenFile.Name(), log.NewNopLogger())

--- a/pkg/keyidentifier/keyidentifier.go
+++ b/pkg/keyidentifier/keyidentifier.go
@@ -8,7 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -61,7 +61,7 @@ func (kIdentifer *KeyIdentifier) IdentifyFile(path string) (*KeyInfo, error) {
 		"file", path,
 	)
 
-	keyBytes, err := ioutil.ReadFile(path)
+	keyBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}

--- a/pkg/keyidentifier/keyidentifier_test.go
+++ b/pkg/keyidentifier/keyidentifier_test.go
@@ -2,7 +2,7 @@ package keyidentifier
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,7 +36,7 @@ func TestIdentifyFiles(t *testing.T) {
 
 func testIdentifyFile(t *testing.T, kIdentifer *KeyIdentifier, specFilePath string) {
 	// load the json file
-	data, err := ioutil.ReadFile(specFilePath)
+	data, err := os.ReadFile(specFilePath)
 	require.NoError(t, err, "reading spec file")
 	var expected spec
 	err = json.Unmarshal(data, &expected)

--- a/pkg/log/locallogger/locallogger_test.go
+++ b/pkg/log/locallogger/locallogger_test.go
@@ -3,7 +3,6 @@ package locallogger
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,7 +51,7 @@ func TestKitLogging(t *testing.T) {
 	//	expectedJson, err := json.Marshal(expected)
 	//require.NoError(t, err, "json marshal expected")
 
-	tmpfile, err := ioutil.TempFile("", "test-locallogger")
+	tmpfile, err := os.CreateTemp("", "test-locallogger")
 	require.NoError(t, err, "make temp file")
 	defer os.Remove(tmpfile.Name())
 

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -364,7 +363,7 @@ func (b *Builder) GenerateTUF(ctx context.Context) error {
 	// are present (Asset, AssetDir, etc). Once the symbols are present, we can run
 	// the generate_tuf.go tool to generate actual TUF metadata. Finally, we recreate
 	// the bindata file with the real TUF metadata.
-	dir, err := ioutil.TempDir("", "bootstrap-launcher-bindata")
+	dir, err := os.MkdirTemp("", "bootstrap-launcher-bindata")
 	if err != nil {
 		return fmt.Errorf("create empty dir for bindata: %w", err)
 	}

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -24,7 +23,7 @@ import (
 )
 
 func makeTempDB(t *testing.T) (db *bbolt.DB, cleanup func()) {
-	file, err := ioutil.TempFile("", "kolide_launcher_test")
+	file, err := os.CreateTemp("", "kolide_launcher_test")
 	if err != nil {
 		t.Fatalf("creating temp file: %s", err.Error())
 	}
@@ -51,7 +50,7 @@ func TestNewExtensionEmptyEnrollSecret(t *testing.T) {
 func TestNewExtensionDatabaseError(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "kolide_launcher_test")
+	file, err := os.CreateTemp("", "kolide_launcher_test")
 	if err != nil {
 		t.Fatalf("creating temp file: %s", err.Error())
 	}

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -593,7 +592,7 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 }
 
 func osqueryTempDir() (string, func(), error) {
-	tempPath, err := ioutil.TempDir("", "")
+	tempPath, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", func() {}, fmt.Errorf("could not make temp path: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +42,7 @@ type ChromeLoginDataEmailsTable struct {
 }
 
 func (c *ChromeLoginDataEmailsTable) generateForPath(ctx context.Context, file userFileInfo) ([]map[string]string, error) {
-	dir, err := ioutil.TempDir("", "kolide_chrome_login_data_emails")
+	dir, err := os.MkdirTemp("", "kolide_chrome_login_data_emails")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_data_emails tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ type ChromeLoginKeychain struct {
 }
 
 func (c *ChromeLoginKeychain) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := ioutil.TempDir("", "kolide_chrome_login_keychain")
+	dir, err := os.MkdirTemp("", "kolide_chrome_login_keychain")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_keychain tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/chrome_user_profiles.go
+++ b/pkg/osquery/table/chrome_user_profiles.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -58,7 +58,7 @@ type chromeProfileInfo struct {
 
 func (c *chromeUserProfilesTable) generateForPath(ctx context.Context, fileInfo userFileInfo) ([]map[string]string, error) {
 	var results []map[string]string
-	data, err := ioutil.ReadFile(fileInfo.path)
+	data, err := os.ReadFile(fileInfo.path)
 	if err != nil {
 		return nil, fmt.Errorf("reading chrome local state file: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ type gdrive struct {
 }
 
 func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := ioutil.TempDir("", "kolide_gdrive_sync_config")
+	dir, err := os.MkdirTemp("", "kolide_gdrive_sync_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -38,7 +37,7 @@ type GDriveSyncHistory struct {
 // GDriveSyncHistoryGenerate will be called whenever the table is queried. It should return
 // a full table scan.
 func (g *GDriveSyncHistory) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := ioutil.TempDir("", "kolide_gdrive_sync_history")
+	dir, err := os.MkdirTemp("", "kolide_gdrive_sync_history")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_history tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -54,7 +53,7 @@ type onePasswordAccountsTable struct {
 // generate the onepassword account info results given the path to a
 // onepassword sqlite DB
 func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo userFileInfo) ([]map[string]string, error) {
-	dir, err := ioutil.TempDir("", "kolide_onepassword_accounts")
+	dir, err := os.MkdirTemp("", "kolide_onepassword_accounts")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_onepassword_accounts tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -64,7 +64,7 @@ type slackTeamsFile map[string]struct {
 
 func (t *SlackConfigTable) generateForPath(ctx context.Context, file userFileInfo) ([]map[string]string, error) {
 	var results []map[string]string
-	data, err := ioutil.ReadFile(file.path)
+	data, err := os.ReadFile(file.path)
 	if err != nil {
 		return results, fmt.Errorf("Reading slack teams file: %w", err)
 	}

--- a/pkg/osquery/table/table_util.go
+++ b/pkg/osquery/table/table_util.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -58,7 +57,7 @@ func findFileInUserDirs(pattern string, logger log.Logger, opts ...FindFileOpt) 
 	if ff.username == "" {
 		for _, possibleHome := range homedirRoots {
 
-			userDirs, err := ioutil.ReadDir(possibleHome)
+			userDirs, err := os.ReadDir(possibleHome)
 			if err != nil {
 				// This possibleHome doesn't exist. Move on
 				continue

--- a/pkg/osquery/tables/cryptsetup/parser_test.go
+++ b/pkg/osquery/tables/cryptsetup/parser_test.go
@@ -1,7 +1,7 @@
 package cryptsetup
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -113,7 +113,7 @@ func TestParseStatus(t *testing.T) {
 		t.Run(tt.infile, func(t *testing.T) {
 			t.Parallel()
 
-			input, err := ioutil.ReadFile(filepath.Join("testdata", tt.infile))
+			input, err := os.ReadFile(filepath.Join("testdata", tt.infile))
 			require.NoError(t, err, "read input file")
 
 			data, err := parseStatus(input)

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -98,7 +98,7 @@ func (t *Table) execDism(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("calling dism. Got: %s: %w", stderr.String(), err)
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(dir, dstFile))
+	data, err := os.ReadFile(filepath.Join(dir, dstFile))
 	if err != nil {
 		return nil, fmt.Errorf("error reading dism output file: %s: %w", err, err)
 	}

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 func (t *Table) execDism(ctx context.Context) ([]byte, error) {
 	// dism.exe outputs xml, but with weird intermingled status. So
 	// instead, we dump it to a temp file.
-	dir, err := ioutil.TempDir("", "kolide_dism")
+	dir, err := os.MkdirTemp("", "kolide_dism")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_dism tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -97,7 +96,7 @@ func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output
 
 	cmd := exec.CommandContext(ctx, "/usr/sbin/firmwarepasswd", subcommand)
 
-	dir, err := ioutil.TempDir("", "osq-firmwarepasswd")
+	dir, err := os.MkdirTemp("", "osq-firmwarepasswd")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
@@ -2,7 +2,7 @@ package firmwarepasswd
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +52,7 @@ func TestParser(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()
 
-			inputBytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.input))
+			inputBytes, err := os.ReadFile(filepath.Join("testdata", tt.input))
 			require.NoError(t, err, "read file %s", tt.input)
 
 			inputBuffer := bytes.NewBuffer(inputBytes)

--- a/pkg/osquery/tables/fscrypt_info/fscrypt_linux.go
+++ b/pkg/osquery/tables/fscrypt_info/fscrypt_linux.go
@@ -5,7 +5,7 @@ package fscrypt_info
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/google/fscrypt/actions"
@@ -29,7 +29,7 @@ func GetInfo(dirpath string) (*Info, error) {
 	defer func() {
 		log.SetOutput(origLog)
 	}()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	fsctx, err := actions.NewContextFromPath(dirpath, nil)
 	if err != nil {

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -123,7 +122,7 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "osq-gsettings")
+	dir, err := os.MkdirTemp("", "osq-gsettings")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -91,7 +90,7 @@ type keyDescription struct {
 func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema string) ([]keyDescription, error) {
 	var descriptions []keyDescription
 
-	dir, err := ioutil.TempDir("", fmt.Sprintf("osq-gsettings-metadata-%s", schema))
+	dir, err := os.MkdirTemp("", fmt.Sprintf("osq-gsettings-metadata-%s", schema))
 	if err != nil {
 		return descriptions, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/mdmclient/mdmclient_test.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient_test.go
@@ -6,7 +6,7 @@
 package mdmclient
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestTransformOutput(t *testing.T) {
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 
-			input, err := ioutil.ReadFile(filepath.Join("testdata", tt.in))
+			input, err := os.ReadFile(filepath.Join("testdata", tt.in))
 			require.NoError(t, err, "read input file")
 
 			output, err := table.flattenOutput("", input)

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 					// for some subset of the profiles command. I've reported it
 					// to apple (feedback FB8962811), and while it may someday
 					// be fixed, we need to support it where it is.
-					dir, err := ioutil.TempDir("", "kolide_profiles")
+					dir, err := os.MkdirTemp("", "kolide_profiles")
 					if err != nil {
 						return nil, fmt.Errorf("creating kolide_profiles tmp dir: %w", err)
 					}

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -131,7 +132,7 @@ func (t *Table) execSecedit(ctx context.Context, mergedPolicy bool) ([]byte, err
 	// By default, secedit outputs files encoded in UTF16 Little Endian. Sadly the Go INI parser
 	// cannot read this format by default, therefore we decode the bytes into UTF-8
 	rd := transform.NewReader(file, unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder())
-	data, err := ioutil.ReadAll(rd)
+	data, err := io.ReadAll(rd)
 	if err != nil {
 		return nil, fmt.Errorf("error reading secedit output file: %s: %w", dst, err)
 	}

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,7 +94,7 @@ func (t *Table) execSecedit(ctx context.Context, mergedPolicy bool) ([]byte, err
 	// The secedit.exe binary does not support outputting the data we need to stdout
 	// Instead we create a tmp directory and pass it to secedit to write the data we need
 	// in INI format.
-	dir, err := ioutil.TempDir("", "kolide_secedit_config")
+	dir, err := os.MkdirTemp("", "kolide_secedit_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_secedit_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
+++ b/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -42,7 +41,7 @@ func ExecOsqueryLaunchctl(ctx context.Context, logger log.Logger, timeoutSeconds
 		query,
 	)
 
-	dir, err := ioutil.TempDir("", "osq-launchctl")
+	dir, err := os.MkdirTemp("", "osq-launchctl")
 	if err != nil {
 		return nil, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,7 +81,7 @@ func execPwsh(logger log.Logger) execer {
 		// write the c# code to a file, so the powershell script can load it
 		// from there. This works around a size limit on args passed to
 		// powershell.exe
-		dir, err := ioutil.TempDir("", "nativewifi")
+		dir, err := os.MkdirTemp("", "nativewifi")
 		if err != nil {
 			return fmt.Errorf("creating nativewifi tmp dir: %w", err)
 		}

--- a/pkg/osquery/tables/xrdb/xrdb.go
+++ b/pkg/osquery/tables/xrdb/xrdb.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -127,7 +126,7 @@ func execXRDB(ctx context.Context, displayNum, username string, buf *bytes.Buffe
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "osq-xrdb")
+	dir, err := os.MkdirTemp("", "osq-xrdb")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/zfs/tables_test.go
+++ b/pkg/osquery/tables/zfs/tables_test.go
@@ -1,7 +1,7 @@
 package zfs
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestParseColumns(t *testing.T) {
 		t.Run(tt.infile, func(t *testing.T) {
 			t.Parallel()
 
-			input, err := ioutil.ReadFile(filepath.Join("testdata", tt.infile))
+			input, err := os.ReadFile(filepath.Join("testdata", tt.infile))
 			require.NoError(t, err, "read input file")
 
 			rows, err := parseColumns(input)

--- a/pkg/packagekit/applenotarization/applenotarization_test.go
+++ b/pkg/packagekit/applenotarization/applenotarization_test.go
@@ -2,7 +2,6 @@ package applenotarization
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestSubmit(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpZipFile, err := ioutil.TempFile("", "fake-for-submission.*.zip")
+	tmpZipFile, err := os.CreateTemp("", "fake-for-submission.*.zip")
 	require.NoError(t, err)
 	defer os.Remove(tmpZipFile.Name())
 

--- a/pkg/packagekit/applenotarization/applenotarization_test.go
+++ b/pkg/packagekit/applenotarization/applenotarization_test.go
@@ -38,7 +38,7 @@ func TestCheckSuccess(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fileBytes, err := ioutil.ReadFile(tt.fakeFile)
+		fileBytes, err := os.ReadFile(tt.fakeFile)
 		require.NoError(t, err)
 		n := New("myname@example.com", "123password", "X11111AAAA")
 		n.fakeResponse = string(fileBytes)
@@ -77,7 +77,7 @@ func TestSubmit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fileBytes, err := ioutil.ReadFile(tt.fakeFile)
+		fileBytes, err := os.ReadFile(tt.fakeFile)
 		require.NoError(t, err)
 		n := New("myname@example.com", "123password", "X11111AAAA")
 		n.fakeResponse = string(fileBytes)

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -5,7 +5,6 @@ package authenticode
 
 import (
 	"context"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestSign(t *testing.T) {
 	// copy our test file
 	data, err := os.ReadFile(srcExe)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(testExe, data, 0755)
+	err = os.WriteFile(testExe, data, 0755)
 	require.NoError(t, err)
 
 	// confirm that we _don't_ have a sig on this file

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -40,7 +40,7 @@ func TestSign(t *testing.T) {
 	testExe := filepath.Join(tmpDir, "test.exe")
 
 	// copy our test file
-	data, err := ioutil.ReadFile(srcExe)
+	data, err := os.ReadFile(srcExe)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(testExe, data, 0755)
 	require.NoError(t, err)

--- a/pkg/packagekit/authenticode/authenticode_test.go
+++ b/pkg/packagekit/authenticode/authenticode_test.go
@@ -5,6 +5,7 @@ package authenticode
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"

--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,7 +87,7 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 
 	outputFilename := fmt.Sprintf("%s-%s.%s", po.Name, po.Version, f.outputType)
 
-	outputPathDir, err := ioutil.TempDir("", "packaging-fpm-output")
+	outputPathDir, err := os.MkdirTemp("", "packaging-fpm-output")
 	if err != nil {
 		return fmt.Errorf("making TempDir: %w", err)
 	}

--- a/pkg/packagekit/package_pkg.go
+++ b/pkg/packagekit/package_pkg.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +25,7 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions) error {
 		return err
 	}
 
-	outputPathDir, err := ioutil.TempDir("", "packaging-pkg-output")
+	outputPathDir, err := os.MkdirTemp("", "packaging-pkg-output")
 	if err != nil {
 		return fmt.Errorf("making TempDir: %w", err)
 	}

--- a/pkg/packagekit/package_test.go
+++ b/pkg/packagekit/package_test.go
@@ -2,7 +2,7 @@ package packagekit
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kolide/kit/env"
@@ -27,16 +27,16 @@ func TestPackageTrivial(t *testing.T) {
 		AppleSigningKey: "Developer ID Installer: Kolide Inc (YZ3EM74M78)",
 	}
 
-	err := PackageFPM(context.TODO(), ioutil.Discard, po, AsTar())
+	err := PackageFPM(context.TODO(), io.Discard, po, AsTar())
 	require.NoError(t, err)
 
-	err = PackageFPM(context.TODO(), ioutil.Discard, po, AsDeb())
+	err = PackageFPM(context.TODO(), io.Discard, po, AsDeb())
 	require.NoError(t, err)
 
-	err = PackageFPM(context.TODO(), ioutil.Discard, po, AsRPM())
+	err = PackageFPM(context.TODO(), io.Discard, po, AsRPM())
 	require.NoError(t, err)
 
-	err = PackagePkg(context.TODO(), ioutil.Discard, po)
+	err = PackagePkg(context.TODO(), io.Discard, po)
 	require.NoError(t, err)
 
 }

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -138,7 +137,7 @@ func New(packageRoot string, mainWxsContent []byte, wixOpts ...WixOpt) (*wixTool
 	}
 
 	for _, ef := range wo.extraFiles {
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			filepath.Join(wo.buildDir, ef.Name),
 			ef.Content,
 			0644); err != nil {
@@ -148,7 +147,7 @@ func New(packageRoot string, mainWxsContent []byte, wixOpts ...WixOpt) (*wixTool
 
 	mainWxsPath := filepath.Join(wo.buildDir, "Installer.wxs")
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		mainWxsPath,
 		mainWxsContent,
 		0644); err != nil {

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -119,7 +119,7 @@ func New(packageRoot string, mainWxsContent []byte, wixOpts ...WixOpt) (*wixTool
 
 	var err error
 	if wo.buildDir == "" {
-		wo.buildDir, err = ioutil.TempDir("", "wix-build-dir")
+		wo.buildDir, err = os.MkdirTemp("", "wix-build-dir")
 		if err != nil {
 			return nil, fmt.Errorf("making temp wix-build-dir: %w", err)
 		}

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -208,7 +208,7 @@ func (wo *wixTool) addServices(ctx context.Context) error {
 	}
 
 	heatFile := filepath.Join(wo.buildDir, "AppFiles.wxs")
-	heatContent, err := ioutil.ReadFile(heatFile)
+	heatContent, err := os.ReadFile(heatFile)
 	if err != nil {
 		return fmt.Errorf("reading AppFiles.wxs: %w", err)
 	}

--- a/pkg/packagekit/wix/wix_test.go
+++ b/pkg/packagekit/wix/wix_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -83,7 +82,7 @@ func setupPackageRoot(packageRoot string) error {
 		return fmt.Errorf("mkdir bin: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(binDir, "hello.txt"), []byte("Hello"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(binDir, "hello.txt"), []byte("Hello"), 0755); err != nil {
 		return fmt.Errorf("Unable to write bin/hello.txt: %w", err)
 	}
 
@@ -93,7 +92,7 @@ func setupPackageRoot(packageRoot string) error {
 		return fmt.Errorf("mkdir var: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(varDir, "vroom.txt"), []byte("Vroom Vroom"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(varDir, "vroom.txt"), []byte("Vroom Vroom"), 0755); err != nil {
 		return fmt.Errorf("Unable to write var/vroom.txt: %w", err)
 	}
 	return nil

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -218,7 +217,7 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 	// Unless we're omitting the secret, write it into the package.
 	// Note that we _always_ set KOLIDE_LAUNCHER_ENROLL_SECRET_PATH
 	if !p.OmitSecret {
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			filepath.Join(p.packageRoot, p.confDir, "secret"),
 			[]byte(p.Secret),
 			secretPerms,

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -104,12 +104,12 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 
 	var err error
 
-	if p.packageRoot, err = ioutil.TempDir("", "package.packageRoot"); err != nil {
+	if p.packageRoot, err = os.MkdirTemp("", "package.packageRoot"); err != nil {
 		return fmt.Errorf("unable to create temporary packaging root directory: %w", err)
 	}
 	defer os.RemoveAll(p.packageRoot)
 
-	if p.scriptRoot, err = ioutil.TempDir("", fmt.Sprintf("package.scriptRoot")); err != nil {
+	if p.scriptRoot, err = os.MkdirTemp("", fmt.Sprintf("package.scriptRoot")); err != nil {
 		return fmt.Errorf("unable to create temporary packaging root directory: %w", err)
 	}
 	defer os.RemoveAll(p.scriptRoot)

--- a/pkg/service/client_jsonrpc.go
+++ b/pkg/service/client_jsonrpc.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -33,7 +32,7 @@ func forceNoChunkedEncoding(ctx context.Context, r *http.Request) context.Contex
 	}
 	r.Body.Close()
 	r.ContentLength = bodyReadBytes
-	r.Body = ioutil.NopCloser(bodyBuf)
+	r.Body = io.NopCloser(bodyBuf)
 
 	return ctx
 }

--- a/pkg/service/client_jsonrpc_test.go
+++ b/pkg/service/client_jsonrpc_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestForceNoChunkedEncoding(t *testing.T) {
 
 	req := &http.Request{
 		Method: "POST",
-		Body:   ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+		Body:   io.NopCloser(bytes.NewBufferString("Hello World")),
 	}
 
 	// Check no ContentLength

--- a/pkg/service/dial_test.go
+++ b/pkg/service/dial_test.go
@@ -8,8 +8,8 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -74,7 +74,7 @@ const (
 
 func calcCertFingerprint(t *testing.T, certpath string) string {
 	// openssl rsa -in certchain-old/leaf.key -outform der -pubout | openssl dgst -sha256
-	certcontents, err := ioutil.ReadFile(certpath)
+	certcontents, err := os.ReadFile(certpath)
 	require.NoError(t, err, "reading", certpath)
 
 	block, _ := pem.Decode(certcontents)
@@ -94,9 +94,9 @@ func TestSwappingCert(t *testing.T) { // nolint:paralleltest
 	stop := startServer(t, &tls.Config{Certificates: []tls.Certificate{cert}})
 	time.Sleep(1 * time.Second)
 
-	pem1, err := ioutil.ReadFile(badCert)
+	pem1, err := os.ReadFile(badCert)
 	require.Nil(t, err)
-	pem2, err := ioutil.ReadFile(goodCert)
+	pem2, err := os.ReadFile(goodCert)
 	require.Nil(t, err)
 	pool := x509.NewCertPool()
 	pool.AppendCertsFromPEM(pem1)
@@ -138,9 +138,9 @@ func TestCertRemainsBad(t *testing.T) { // nolint:paralleltest
 	timer := time.NewTimer(time.Second * 2)
 	<-timer.C
 
-	pem1, err := ioutil.ReadFile(badCert)
+	pem1, err := os.ReadFile(badCert)
 	require.NoError(t, err)
-	pem2, err := ioutil.ReadFile(goodCert)
+	pem2, err := os.ReadFile(goodCert)
 	require.NoError(t, err)
 	pool := x509.NewCertPool()
 	pool.AppendCertsFromPEM(pem1)
@@ -178,7 +178,7 @@ func TestCertPinning(t *testing.T) { // nolint:paralleltest
 	defer stop()
 	time.Sleep(1 * time.Second)
 
-	pem1, err := ioutil.ReadFile(rootCert)
+	pem1, err := os.ReadFile(rootCert)
 	require.Nil(t, err)
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(pem1)
@@ -243,9 +243,9 @@ func TestRootCAs(t *testing.T) { // nolint:paralleltest
 	defer stop()
 	time.Sleep(1 * time.Second)
 
-	rootPEM, err := ioutil.ReadFile(rootCert)
+	rootPEM, err := os.ReadFile(rootCert)
 	require.NoError(t, err)
-	otherPEM, err := ioutil.ReadFile(goodCert)
+	otherPEM, err := os.ReadFile(goodCert)
 	require.NoError(t, err)
 
 	emptyPool := x509.NewCertPool()

--- a/pkg/simulator/hosts.go
+++ b/pkg/simulator/hosts.go
@@ -3,7 +3,6 @@ package simulator
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -68,7 +67,7 @@ func LoadHosts(dir string, logger log.Logger) (map[string]*queryRunner, error) {
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), ".yaml") {
 			path := filepath.Join(dir, file.Name())
-			contents, err := ioutil.ReadFile(path)
+			contents, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("reading file %s: %w", path, err)
 			}

--- a/pkg/simulator/hosts.go
+++ b/pkg/simulator/hosts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -56,7 +57,7 @@ type querySpec struct {
 // LoadHosts will load the host specifications and return a map of the
 // queryRunners representing these host types.
 func LoadHosts(dir string, logger log.Logger) (map[string]*queryRunner, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("listing hosts directory: %w", err)
 	}

--- a/tools/download-osquery.go
+++ b/tools/download-osquery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/kolide/kit/env"
@@ -36,7 +35,7 @@ func main() {
 	cacheDir := *flCacheDir
 	var err error
 	if *flCacheDir == "" {
-		cacheDir, err = ioutil.TempDir("", "download_cache")
+		cacheDir, err = os.MkdirTemp("", "download_cache")
 		if err != nil {
 			fmt.Printf("Could not create temp dir for caching files %v", err)
 			os.Exit(1)


### PR DESCRIPTION
Replace `ioutil` functions with equivalents documented here: https://go.dev/doc/go1.16#ioutil

Relates to https://github.com/kolide/launcher/issues/938

________________

Testing: mostly ran through some quick regression tests.
* Ran package builder; confirmed it could build a pkg with appropriate payload files
* On macOS and on Windows, ran launcher interactive and queried against each table modified by these changes