### PR TITLE
Lock version for ubuntu build container to 20.04

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false # Consider changing this sometime
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
     steps:
@@ -99,7 +99,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,9 +80,17 @@ jobs:
       run: make test
 
     - name: Upload Build
+      if: ${{ ! contains(matrix.os, 'ubuntu') }}
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-build
+        path: build/
+
+    - name: Upload Build - Ubuntu
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ubuntu-latest-build
         path: build/
 
     - name: Upload coverage


### PR DESCRIPTION
Ubuntu launcher binaries built starting today are broken:

```
$ sudo ./launcher interactive
./launcher: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./launcher)
./launcher: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./launcher)
```

Builds yesterday were passing. This appears to be because we use [ubuntu-latest](https://github.com/actions/runner-images) as our build image, and we moved from 20.04 to 22.04 overnight -- compare [yesterday's set up job](https://github.com/kolide/launcher/actions/runs/3524371142/jobs/5909684048) with [today's](https://github.com/kolide/launcher/actions/runs/3533727377/jobs/5929728941).

This change locks our version to 20.04.