### PR TITLE
Lock build container image for macOS to 11

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-latest
+          - macos-11
           - windows-latest
     steps:
     - name: Check out code
@@ -79,11 +79,18 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Upload Build
-      if: ${{ ! contains(matrix.os, 'ubuntu') }}
+    - name: Upload Build - Windows
+      if: ${{ contains(matrix.os, 'windows') }}
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-build
+        path: build/
+
+    - name: Upload Build - macOS
+      if: ${{ contains(matrix.os, 'macos') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos-latest-build
         path: build/
 
     - name: Upload Build - Ubuntu
@@ -108,7 +115,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-latest
+          - macos-11
           - windows-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
`macos-latest` image is about to be `macos-12` https://github.com/actions/runner-images/issues/6384 -- lock to `macos-11` until we can validate how launcher builds on the new image.

Relates to https://github.com/kolide/launcher/issues/951.