### PR TITLE
Removing old references to target_membership table

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -72,7 +72,7 @@ const (
 	// Bucket name to use for buffered result logs.
 	resultLogsBucket = "result_logs"
 
-	// the bucket which we push values into from server-backed tables, like kolide_target_membership
+	// the bucket which we push values into from server-backed tables
 	ServerProvidedDataBucket = "server_provided_data"
 
 	// DB key for UUID

--- a/pkg/osquery/tables/kolide_server_data/kolide_server_data.go
+++ b/pkg/osquery/tables/kolide_server_data/kolide_server_data.go
@@ -20,10 +20,10 @@ func TablePlugin(db *bbolt.DB) *table.Plugin {
 		table.TextColumn("value"),
 	}
 
-	return table.NewPlugin(tableName, columns, generateTargetMembershipTable(db))
+	return table.NewPlugin(tableName, columns, generateServerDataTable(db))
 }
 
-func generateTargetMembershipTable(db *bbolt.DB) table.GenerateFunc {
+func generateServerDataTable(db *bbolt.DB) table.GenerateFunc {
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 		return dbKeyValueRows(osquery.ServerProvidedDataBucket, db)
 	}

--- a/pkg/osquery/tables/kolide_server_data/kolide_server_data_test.go
+++ b/pkg/osquery/tables/kolide_server_data/kolide_server_data_test.go
@@ -10,7 +10,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func Test_generateTargetMembershipTable(t *testing.T) {
+func Test_generateServerDataTable(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
Noticed some references to the target_membership table that no longer exists got mixed up with the server_data table.