### PR TITLE
Add post-create-command script for vscode's dev containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pkg/packagekit/wix/internal/assets.go
 
 # VS Code Files
 .vscode/
+.devcontainer/
 
 # scratch pad (notes used during development)
 scratch.*

--- a/tools/vscode-debugging/postCreateCommand.sh
+++ b/tools/vscode-debugging/postCreateCommand.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script installs osquery for Debian-based dev containers if it is not
+# already present.
+#
+# Usage notes:
+# Update your devcontainer.json's "postCreateCommand" to call this script:
+# "postCreateCommand": "sudo ./tools/vscode-debugging/postCreateCommand.sh"
+
+# Install osquery if not present
+if ! command -v osqueryd &> /dev/null
+then
+    echo "installing osquery:"
+
+     # Prepare to install osquery -- we need software-properties-common for add-apt-repository
+    apt-get update
+    apt-get install -y software-properties-common
+    apt-get update
+    export OSQUERY_KEY=1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $OSQUERY_KEY
+    add-apt-repository 'deb [arch=amd64] https://pkg.osquery.io/deb deb main'
+    apt-get update
+
+    # Do the install
+    apt-get install -y osquery
+fi
+
+echo "done"


### PR DESCRIPTION
Add script to install osquery into dev containers -- uses alternative install instructions for Debian Linux from [here](https://osquery.io/downloads/debug/5.5.1).