### PR TITLE
Remove launcher tables when running in interactive mode.

### DIFF
--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -118,7 +118,6 @@ func loadExtensions(socketPath string, osquerydPath string) (*osquery.ExtensionM
 	}
 
 	extensionManagerServer.RegisterPlugin(table.PlatformTables(client, log.NewNopLogger(), osquerydPath)...)
-	extensionManagerServer.RegisterPlugin(table.LauncherTables(nil, nil)...)
 
 	if err := extensionManagerServer.Start(); err != nil {
 		return nil, fmt.Errorf("error starting extension manager server: %w", err)


### PR DESCRIPTION
One-liner change -- there doesn't seem to be any value to having these tables exist in interactive mode. Most of them will crash when queried anyways.

Closes #959