### PR TITLE
Change flag handling to flag.ContinueOnError

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	opts, err := parseOptions(os.Args[1:])
+	opts, err := parseOptions(logger, os.Args[1:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -40,7 +40,7 @@ func (i *arrayFlags) Set(value string) error {
 // and/or environment variables, determines order of precedence and returns a
 // typed struct of options for further application use
 func parseOptions(args []string) (*launcher.Options, error) {
-	flagset := flag.NewFlagSet("launcher", flag.ExitOnError)
+	flagset := flag.NewFlagSet("launcher", flag.ContinueOnError)
 	flagset.Usage = func() { usage(flagset) }
 
 	var (

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/kolide/kit/stringutil"
 	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestOptionsFromFlags(t *testing.T) { //nolint:paralleltest
 		}
 	}
 
-	opts, err := parseOptions(testFlags)
+	opts, err := parseOptions(log.NewNopLogger(), testFlags)
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -50,7 +51,7 @@ func TestOptionsFromEnv(t *testing.T) { //nolint:paralleltest
 		name := fmt.Sprintf("KOLIDE_LAUNCHER_%s", strings.ToUpper(strings.TrimLeft(k, "-")))
 		require.NoError(t, os.Setenv(name, val))
 	}
-	opts, err := parseOptions([]string{})
+	opts, err := parseOptions(log.NewNopLogger(), []string{})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -81,7 +82,7 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 
 	require.NoError(t, flagFile.Close())
 
-	opts, err := parseOptions([]string{"-config", flagFile.Name()})
+	opts, err := parseOptions(log.NewNopLogger(), []string{"-config", flagFile.Name()})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }

--- a/cmd/launcher/run_compactdb.go
+++ b/cmd/launcher/run_compactdb.go
@@ -10,7 +10,9 @@ import (
 )
 
 func runCompactDb(args []string) error {
-	opts, err := parseOptions(args)
+	logger := logutil.NewServerLogger(false)
+
+	opts, err := parseOptions(logger, args)
 	if err != nil {
 		return err
 	}
@@ -20,7 +22,7 @@ func runCompactDb(args []string) error {
 	}
 
 	// relevel
-	logger := logutil.NewServerLogger(opts.Debug)
+	logger = logutil.NewServerLogger(opts.Debug)
 
 	boltPath := filepath.Join(opts.RootDirectory, "launcher.db")
 

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -45,7 +45,7 @@ func runWindowsSvc(args []string) error {
 		"version", version.Version().Version,
 	)
 
-	opts, err := parseOptions(os.Args[2:])
+	opts, err := parseOptions(logger, os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("msg", "Error parsing options", "err", err)
 		os.Exit(1)
@@ -119,7 +119,7 @@ func runWindowsSvcForeground(args []string) error {
 	logger := logutil.NewCLILogger(true)
 	level.Debug(logger).Log("msg", "foreground service start requested (debug mode)")
 
-	opts, err := parseOptions(os.Args[2:])
+	opts, err := parseOptions(logger, os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		os.Exit(1)


### PR DESCRIPTION
If we remove a config option, we cause launcher to not startup. This is a bit scary. One approach would be to change the flag handling to `flag.ContinueOnError`.

This has the advantage of letting things just work.

But the downside, is that `launcher --garbage-flag` won't prouce an error.

I'm honestly on the fence about it. Another route would be to update the check in https://github.com/kolide/launcher/blob/main/pkg/autoupdate/findnew.go#L235 to pass the config file along, and ensure that it fails there. 

Curious what folks think