### PR TITLE
Move app bundle install location out of bin directory; create launcher symlink in bin directory

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -163,6 +163,8 @@ jobs:
         if [ ! -f /Library/LaunchDaemons/com.launcher.launcher.plist ]; then echo "missing launchd entry" && exit 1; fi
         if [ ! -f /usr/local/launcher/bin/osqueryd ]; then echo "missing osquery binary" && exit 1; fi
         if [ ! -f /usr/local/launcher/Kolide.app/Contents/MacOS/launcher ]; then echo "missing launcher binary" && exit 1; fi
+        if [ ! -L /usr/local/launcher/bin/launcher ]; then echo "missing launcher symlink" && exit 1; fi
+        if [ ! -e /usr/local/launcher/bin/launcher ]; then echo "launcher symlink is present but broken" && exit 1; fi
 
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -162,7 +162,7 @@ jobs:
         # Quick check that at least a couple of the files we expect now exist
         if [ ! -f /Library/LaunchDaemons/com.launcher.launcher.plist ]; then echo "missing launchd entry" && exit 1; fi
         if [ ! -f /usr/local/launcher/bin/osqueryd ]; then echo "missing osquery binary" && exit 1; fi
-        if [ ! -f /usr/local/launcher/bin/Kolide.app/Contents/MacOS/launcher ]; then echo "missing launcher binary" && exit 1; fi
+        if [ ! -f /usr/local/launcher/Kolide.app/Contents/MacOS/launcher ]; then echo "missing launcher binary" && exit 1; fi
 
   # This job is here as a github status check -- it allows us to move
   # the merge dependency from being on all the jobs to this single

--- a/pkg/packagekit/assets/distribution.dist
+++ b/pkg/packagekit/assets/distribution.dist
@@ -3,7 +3,7 @@
 	<title>{{.Title}}</title>
 	<pkg-ref id="com.{{.Identifier}}.launcher">
 		<bundle-version>
-			<bundle CFBundleShortVersionString="{{.Version}}" CFBundleVersion="{{.Version}}" id="com.{{.Identifier}}.launcher" path="usr/local/kolide/bin/Kolide.app"/>
+			<bundle CFBundleShortVersionString="{{.Version}}" CFBundleVersion="{{.Version}}" id="com.{{.Identifier}}.launcher" path="usr/local/kolide/Kolide.app"/>
 		</bundle-version>
 	</pkg-ref>
 	<options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>

--- a/pkg/packaging/detectLauncherVersion.go
+++ b/pkg/packaging/detectLauncherVersion.go
@@ -47,18 +47,19 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 	return nil
 }
 
-// launcherLocation returns the location of the launcher binary within `rootDir`. For darwin,
+// launcherLocation returns the location of the launcher binary within `binDir`. For darwin,
 // it may be in an app bundle -- we check to see if the binary exists there first, and then
 // fall back to the common location if it doesn't.
-func (p *PackageOptions) launcherLocation(rootDir string) string {
+func (p *PackageOptions) launcherLocation(binDir string) string {
 	if p.target.Platform == Darwin {
-		appBundleBinaryPath := filepath.Join(rootDir, "Kolide.app", "Contents", "MacOS", "launcher")
+		// We want /usr/local/Kolide.app, not /usr/local/bin/Kolide.app, so we use Dir to strip out `bin`
+		appBundleBinaryPath := filepath.Join(filepath.Dir(binDir), "Kolide.app", "Contents", "MacOS", "launcher")
 		if info, err := os.Stat(appBundleBinaryPath); err == nil && !info.IsDir() {
 			return appBundleBinaryPath
 		}
 	}
 
-	return filepath.Join(rootDir, p.target.PlatformBinaryName("launcher"))
+	return filepath.Join(binDir, p.target.PlatformBinaryName("launcher"))
 }
 
 // formatVersion formats the version. This is specific to windows. It

--- a/pkg/packaging/detectLauncherVersion_test.go
+++ b/pkg/packaging/detectLauncherVersion_test.go
@@ -66,8 +66,10 @@ func TestLauncherLocation(t *testing.T) {
 
 	// Create a temp directory with an app bundle in it
 	tmpDir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "Kolide.app", "Contents", "MacOS"), 0755))
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
 	baseDir := filepath.Join(tmpDir, "Kolide.app", "Contents", "MacOS")
+	require.NoError(t, os.MkdirAll(baseDir, 0755))
 	expectedLauncherBinaryPath := filepath.Join(baseDir, "launcher")
 	f, err := os.Create(expectedLauncherBinaryPath)
 	require.NoError(t, err, "could not create temp file for test")
@@ -75,7 +77,7 @@ func TestLauncherLocation(t *testing.T) {
 	defer os.Remove(expectedLauncherBinaryPath)
 
 	// Now, confirm that we find the binary inside the app bundle
-	require.Equal(t, expectedLauncherBinaryPath, pDarwin.launcherLocation(baseDir))
+	require.Equal(t, expectedLauncherBinaryPath, pDarwin.launcherLocation(binDir))
 
 	// No file check for windows, just expect the binary in the given location
 	pWindows := &PackageOptions{target: Target{Platform: Windows}}

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -350,12 +350,13 @@ func (p *PackageOptions) getBinary(ctx context.Context, symbolicName, binaryName
 	}
 
 	// Check to see if we fetched an app bundle. If so, copy over the app bundle directory.
+	// We want the app bundle to go one level above bin dir (e.g. /usr/local/Kolide.app, not /usr/local/bin/Kolide.app).
 	appBundlePath := filepath.Join(filepath.Dir(localPath), "Kolide.app")
 	appBundleInfo, err := os.Stat(appBundlePath)
 	if err == nil && appBundleInfo.IsDir() {
 		if err := fsutil.CopyDir(
 			appBundlePath,
-			filepath.Join(p.packageRoot, p.binDir, "Kolide.app"),
+			filepath.Join(p.packageRoot, filepath.Dir(p.binDir), "Kolide.app"),
 		); err != nil {
 			return fmt.Errorf("could not copy app bundle: %w", err)
 		}

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -361,6 +361,13 @@ func (p *PackageOptions) getBinary(ctx context.Context, symbolicName, binaryName
 			return fmt.Errorf("could not copy app bundle: %w", err)
 		}
 
+		// Create a symlink from <bin dir>/<binary> to the actual binary location within the app bundle
+		target := filepath.Join("..", "Kolide.app", "Contents", "MacOS", binaryName)
+		symlinkFile := filepath.Join(p.packageRoot, p.binDir, binaryName)
+		if err := os.Symlink(target, symlinkFile); err != nil {
+			return fmt.Errorf("could not create symlink after copying app bundle: %w", err)
+		}
+
 		return nil
 	}
 

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -158,45 +158,74 @@ func Test_getBinary(t *testing.T) {
 
 	// Set up output directory
 	tmpPkgRoot := t.TempDir()
-	binDir := "bin"
-	assert.NoError(t, os.Mkdir(filepath.Join(tmpPkgRoot, binDir), 0755), "could not make temp output directory")
+	binDir := filepath.Join(tmpPkgRoot, "bin")
+	assert.NoError(t, os.Mkdir(binDir, 0755), "could not make temp output directory")
 
 	p := &PackageOptions{
 		packageRoot: tmpPkgRoot,
-		binDir:      binDir,
+		binDir:      "bin",
 	}
 
 	// Verify we found the non-app bundle binary and copied it to the expected location
 	err = p.getBinary(context.TODO(), binaryName, binaryName, cachedBinaryPath)
 	assert.NoError(t, err, "expected to find binary but did not")
 
-	_, err = os.Stat(filepath.Join(tmpPkgRoot, binDir, binaryName))
+	_, err = os.Stat(filepath.Join(binDir, binaryName))
 	assert.NoError(t, err, "did not find binary in output directory")
+}
 
-	// Test looking for app bundle, if we're on macOS
-	if runtime.GOOS == "darwin" {
-		// Set up app bundle directory structure
-		appBundleLocation := filepath.Join(localBinaryDir, "Kolide.app")
-		err := os.MkdirAll(filepath.Join(appBundleLocation, "Contents", "MacOS"), 0755)
-		require.NoError(t, err, "could not make temp app bundle directory")
+func Test_getBinary_AppBundle(t *testing.T) {
+	t.Parallel()
 
-		// Add binary to app bundle
-		f, err := os.Create(filepath.Join(appBundleLocation, "Contents", "MacOS", binaryName))
-		require.NoError(t, err, "could not create app bundle binary")
-		defer f.Close()
-
-		// Verify we found the app bundle and copied over the entire directory to the expected location
-		require.NoError(t, p.getBinary(context.TODO(), binaryName, binaryName, cachedBinaryPath), "expected to find app bundle but did not")
-		require.NoError(t, err, "expected to find app bundle but did not")
-
-		appBundleInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app"))
-		require.NoError(t, err, "did not find app bundle in output directory")
-		require.True(t, appBundleInfo.IsDir(), "app bundle not copied over correctly")
-
-		binaryInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app", "Contents", "MacOS", binaryName))
-		require.NoError(t, err, "did not find app bundle binary in output directory")
-		require.False(t, binaryInfo.IsDir(), "app bundle binary not copied over correctly")
+	if runtime.GOOS != "darwin" {
+		// App bundles are darwin only
+		t.Skip()
 	}
+
+	// Set up cache directory
+	tmpCacheDir := t.TempDir()
+	binaryName := "launcher"
+	version := "nightly"
+	localBinaryDir := filepath.Join(tmpCacheDir, fmt.Sprintf("%s-%s-%s", binaryName, runtime.GOOS, version))
+	assert.NoError(t, os.Mkdir(localBinaryDir, 0755), "could not make temp cache directory")
+
+	// Set up app bundle directory structure in cache
+	appBundleLocation := filepath.Join(localBinaryDir, "Kolide.app")
+	err := os.MkdirAll(filepath.Join(appBundleLocation, "Contents", "MacOS"), 0755)
+	require.NoError(t, err, "could not make temp app bundle directory")
+
+	// Add binary to app bundle in cache
+	f, err := os.Create(filepath.Join(appBundleLocation, "Contents", "MacOS", binaryName))
+	require.NoError(t, err, "could not create app bundle binary")
+	defer f.Close()
+
+	// Set up output directory
+	tmpPkgRoot := t.TempDir()
+	binDir := filepath.Join(tmpPkgRoot, "bin")
+	assert.NoError(t, os.Mkdir(binDir, 0755), "could not make temp output directory")
+
+	p := &PackageOptions{
+		packageRoot: tmpPkgRoot,
+		binDir:      "bin",
+	}
+
+	// Verify we found the app bundle and copied over the entire directory to the expected location
+	require.NoError(t, p.getBinary(context.TODO(), binaryName, binaryName, filepath.Join(localBinaryDir, binaryName)), "expected to find app bundle but did not")
+	require.NoError(t, err, "expected to find app bundle but did not")
+
+	appBundleInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app"))
+	require.NoError(t, err, "did not find app bundle in output directory")
+	require.True(t, appBundleInfo.IsDir(), "app bundle not copied over correctly")
+
+	binaryInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app", "Contents", "MacOS", binaryName))
+	require.NoError(t, err, "did not find app bundle binary in output directory")
+	require.False(t, binaryInfo.IsDir(), "app bundle binary not copied over correctly")
+
+	// Verify that we made the symlink
+	symlinkInfo, err := os.Lstat(filepath.Join(binDir, binaryName))
+	require.NoError(t, err, "did not find symlink in bin directory")
+	// Confirm it's a symlink
+	require.True(t, strings.HasPrefix(symlinkInfo.Mode().String(), "L"))
 }
 
 func testedTargets() []Target {

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -178,24 +178,24 @@ func Test_getBinary(t *testing.T) {
 		// Set up app bundle directory structure
 		appBundleLocation := filepath.Join(localBinaryDir, "Kolide.app")
 		err := os.MkdirAll(filepath.Join(appBundleLocation, "Contents", "MacOS"), 0755)
-		assert.NoError(t, err, "could not make temp app bundle directory")
+		require.NoError(t, err, "could not make temp app bundle directory")
 
 		// Add binary to app bundle
 		f, err := os.Create(filepath.Join(appBundleLocation, "Contents", "MacOS", binaryName))
-		assert.NoError(t, err, "could not create app bundle binary")
+		require.NoError(t, err, "could not create app bundle binary")
 		defer f.Close()
 
 		// Verify we found the app bundle and copied over the entire directory to the expected location
-		assert.NoError(t, p.getBinary(context.TODO(), binaryName, binaryName, cachedBinaryPath), "expected to find app bundle but did not")
-		assert.NoError(t, err, "expected to find app bundle but did not")
+		require.NoError(t, p.getBinary(context.TODO(), binaryName, binaryName, cachedBinaryPath), "expected to find app bundle but did not")
+		require.NoError(t, err, "expected to find app bundle but did not")
 
-		appBundleInfo, err := os.Stat(filepath.Join(tmpPkgRoot, binDir, "Kolide.app"))
-		assert.NoError(t, err, "did not find app bundle in output directory")
-		assert.True(t, appBundleInfo.IsDir(), "app bundle not copied over correctly")
+		appBundleInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app"))
+		require.NoError(t, err, "did not find app bundle in output directory")
+		require.True(t, appBundleInfo.IsDir(), "app bundle not copied over correctly")
 
-		binaryInfo, err := os.Stat(filepath.Join(tmpPkgRoot, binDir, "Kolide.app", "Contents", "MacOS", binaryName))
-		assert.NoError(t, err, "did not find app bundle binary in output directory")
-		assert.False(t, binaryInfo.IsDir(), "app bundle binary not copied over correctly")
+		binaryInfo, err := os.Stat(filepath.Join(tmpPkgRoot, "Kolide.app", "Contents", "MacOS", binaryName))
+		require.NoError(t, err, "did not find app bundle binary in output directory")
+		require.False(t, binaryInfo.IsDir(), "app bundle binary not copied over correctly")
 	}
 }
 

--- a/pkg/packaging/target.go
+++ b/pkg/packaging/target.go
@@ -108,12 +108,13 @@ func (t *Target) PlatformBinaryName(input string) string {
 	return input
 }
 
-func (t *Target) PlatformLauncherPath(rootDir string) string {
+func (t *Target) PlatformLauncherPath(binDir string) string {
 	if t.Platform == Darwin {
-		return filepath.Join(rootDir, "Kolide.app", "Contents", "MacOS", "launcher")
+		// We want /usr/local/Kolide.app, not /usr/local/bin/Kolide.app, so we use Dir to strip out `bin`
+		return filepath.Join(filepath.Dir(binDir), "Kolide.app", "Contents", "MacOS", "launcher")
 	}
 
-	return filepath.Join(rootDir, t.PlatformBinaryName("launcher"))
+	return filepath.Join(binDir, t.PlatformBinaryName("launcher"))
 }
 
 // InitFromString sets a target's init flavor from string representation

--- a/pkg/packaging/target_test.go
+++ b/pkg/packaging/target_test.go
@@ -213,13 +213,13 @@ func TestPlatformLauncherPath(t *testing.T) {
 	t.Parallel()
 
 	targetDarwin := &Target{Platform: Darwin, Init: LaunchD, Package: Pkg}
-	require.Equal(t, filepath.Join("some", "dir", "Kolide.app", "Contents", "MacOS", "launcher"), targetDarwin.PlatformLauncherPath(filepath.Join("some", "dir")))
+	require.Equal(t, filepath.Join("some", "dir", "Kolide.app", "Contents", "MacOS", "launcher"), targetDarwin.PlatformLauncherPath(filepath.Join("some", "dir", "bin")))
 
 	targetWin := &Target{Platform: Windows, Init: NoInit, Package: Msi}
-	require.Equal(t, filepath.Join("some", "dir", "launcher.exe"), targetWin.PlatformLauncherPath(filepath.Join("some", "dir")))
+	require.Equal(t, filepath.Join("some", "dir", "bin", "launcher.exe"), targetWin.PlatformLauncherPath(filepath.Join("some", "dir", "bin")))
 
 	targetLinux := &Target{Platform: Linux, Init: NoInit, Package: Deb}
-	require.Equal(t, filepath.Join("some", "dir", "launcher"), targetLinux.PlatformLauncherPath(filepath.Join("some", "dir")))
+	require.Equal(t, filepath.Join("some", "dir", "bin", "launcher"), targetLinux.PlatformLauncherPath(filepath.Join("some", "dir", "bin")))
 }
 
 func TestTargetPlatformExtensionName(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/955

Followed testing steps as described in [this PR](https://github.com/kolide/launcher/pull/934), confirming the new location of `Kolide.app` and the presence of the launcher symlink, as well as confirming that the symlink actually works.

Renamed a couple variables I'd named `rootDir` that should have been `binDir` to `binDir`.