### PR TITLE
Ensure Windows launcher prints version to console on `launcher.exe version`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,23 +79,23 @@ jobs:
     - name: Test
       run: make test
 
-    # Launcher should always print its version info when called with `version`, which includes the golang version;
-    # we confirm that it contains that info here.
+    # Launcher should always print its version info when called with `version` -- this is a quick
+    # check to ensure that launcher can update to this build.
     - name: Test build - macOS and ubuntu
       if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') }}
       run: |
-        if [[ $(./build/launcher version) != *go${{env.GOVER}}* ]]; then
+        if [[ $(./build/launcher --version) != *"launcher - version"* ]]; then
           echo "launcher version did not print version information"
           exit 1
         fi
 
-    # Launcher should always print its version info when called with `version`, which includes the golang version;
-    # we confirm that it contains that info here.
+    # Launcher should always print its version info when called with `version` -- this is a quick
+    # check to ensure that launcher can update to this build.
     - name: Test build - Windows
       if: ${{ contains(matrix.os, 'windows') }}
       shell: powershell
       run: |
-        if(-not (.\build\launcher.exe version | findstr "go$env:GOVER")) {
+        if(-not (.\build\launcher.exe --version | findstr "launcher - version")) {
           throw "launcher.exe version did not print version information"
         }
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,6 +79,26 @@ jobs:
     - name: Test
       run: make test
 
+    # Launcher should always print its version info when called with `version`, which includes the golang version;
+    # we confirm that it contains that info here.
+    - name: Test build - macOS and ubuntu
+      if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') }}
+      run: |
+        if [[ $(./build/launcher version) != *go${{env.GOVER}}* ]]; then
+          echo "launcher version did not print version information"
+          exit 1
+        fi
+
+    # Launcher should always print its version info when called with `version`, which includes the golang version;
+    # we confirm that it contains that info here.
+    - name: Test build - Windows
+      if: ${{ contains(matrix.os, 'windows') }}
+      shell: powershell
+      run: |
+        if(-not (.\build\launcher.exe version | findstr "go$env:GOVER")) {
+          throw "launcher.exe version did not print version information"
+        }
+
     - name: Upload Build - Windows
       if: ${{ contains(matrix.os, 'windows') }}
       uses: actions/upload-artifact@v2

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -509,11 +509,6 @@ func (b *Builder) BuildCmd(src, appName string) func(context.Context) error {
 			ldFlags = append(ldFlags, "-w -s")
 		}
 
-		if b.os == "windows" {
-			// this prevents a cmd prompt opening up when desktop is launched
-			ldFlags = append(ldFlags, "-H windowsgui")
-		}
-
 		if b.stampVersion {
 			v, err := b.getVersion(ctx)
 			if err != nil {


### PR DESCRIPTION
Reverts change related to https://github.com/kolide/launcher/issues/943

See https://forum.golangbridge.org/t/no-println-output-with-go-build-ldflags-h-windowsgui/7633/7