### PR TITLE
Quick follow up fixes for desktop

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -203,7 +203,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	)
 	runGroup.Add(runner.Execute, runner.Interrupt)
 	controlService.RegisterConsumer("kolide_desktop_menu", runner)
-	controlService.RegisterSubscriber("kolide_desktop_flags", runner)
+	controlService.RegisterSubscriber("agent_flags", runner)
 
 	if opts.KolideServerURL == "k2device.kolide.com" ||
 		opts.KolideServerURL == "k2device-preprod.kolide.com" ||

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -274,7 +274,7 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 
 func (r *DesktopUsersProcessesRunner) Ping() {
 	// kolide_desktop_flags bucket has been updated, query the flags to react to changes
-	enabledRaw, err := r.storedData.GetByKey([]byte("enabled"))
+	enabledRaw, err := r.storedData.GetByKey([]byte("desktop_enabled"))
 	if err != nil {
 		level.Debug(r.logger).Log("msg", "failed to query desktop flags", "err", err)
 		return


### PR DESCRIPTION
I forgot one spot to change the name of the now `agent_flags` bucket. And renamed `enabled` flag to`desktop_enabled` flag to avoid ambiguity.