### PR TITLE
Use dispatch semaphore to signal completion of async request

### DIFF
--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -33,11 +33,11 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
 
     // Wait for completion handler to complete so that we get a correct value for `success`
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
-    dispatch_semaphore_wait(semaphore, timeout);
-
-    // If we potentially timed out, remove the pending request
-    NSArray *requests_to_remove = [NSArray arrayWithObjects:identifier, nil];
-    [center removePendingNotificationRequestsWithIdentifiers:requests_to_remove];
+    intptr_t err = dispatch_semaphore_wait(semaphore, timeout);
+    if (err  != 0) {
+        // Timed out, remove the pending request
+        [center removePendingNotificationRequestsWithIdentifiers:@[identifier]];
+    }
 
     return success;
 }

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -35,6 +35,10 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
     dispatch_semaphore_wait(semaphore, timeout);
 
+    // If we potentially timed out, remove the pending request
+    NSArray *requests_to_remove = [NSArray arrayWithObjects:identifier, nil];
+    [center removePendingNotificationRequestsWithIdentifiers:requests_to_remove];
+
     return success;
 }
 
@@ -65,7 +69,7 @@ BOOL sendNotification(char *cTitle, char *cBody) {
     });
 
     // Wait for completion handler to complete so that we get a correct value for `success`
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC);
     dispatch_semaphore_wait(semaphore, timeout);
 
     return success;

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -17,21 +17,23 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
     UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier
         content:content trigger:nil];
 
-    __block BOOL success = YES;
+    __block BOOL success = NO;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 NSLog(@"Could not send notification: %@", error);
-                success = NO;
+            } else {
+                success = YES;
             }
             dispatch_semaphore_signal(semaphore);
         }];
     });
 
     // Wait for completion handler to complete so that we get a correct value for `success`
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+    dispatch_semaphore_wait(semaphore, timeout);
 
     return success;
 }
@@ -63,7 +65,8 @@ BOOL sendNotification(char *cTitle, char *cBody) {
     });
 
     // Wait for completion handler to complete so that we get a correct value for `success`
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+    dispatch_semaphore_wait(semaphore, timeout);
 
     return success;
 }

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -34,7 +34,7 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
     // Wait for completion handler to complete so that we get a correct value for `success`
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
     intptr_t err = dispatch_semaphore_wait(semaphore, timeout);
-    if (err  != 0) {
+    if (err != 0) {
         // Timed out, remove the pending request
         [center removePendingNotificationRequestsWithIdentifiers:@[identifier]];
     }


### PR DESCRIPTION
Fixes issue where logs would report errors when sending notifications on macOS even though the notifications were sent successfully -- we need to wait for our `completionHandler` to complete and set the success variable before returning.