### PR TITLE
Run desktop process with launchctl asuser so that notifications work; additionally, some notifications cleanup

### DIFF
--- a/ee/desktop/client/client.go
+++ b/ee/desktop/client/client.go
@@ -35,7 +35,7 @@ func New(authToken, socketPath string) client {
 	client := client{
 		base: http.Client{
 			Transport: transport,
-			Timeout:   1 * time.Second,
+			Timeout:   30 * time.Second,
 		},
 	}
 
@@ -69,9 +69,7 @@ func (c *client) Notify(title, body string) error {
 		return fmt.Errorf("could not send notification: %w", err)
 	}
 
-	if resp.Body != nil {
-		resp.Body.Close()
-	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/ee/desktop/notify/notify_darwin.go
+++ b/ee/desktop/notify/notify_darwin.go
@@ -11,6 +11,7 @@ bool sendNotification(char *title, char *content);
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -21,7 +22,7 @@ func (d *DesktopNotifier) SendNotification(title, body string) error {
 	// Check if we're running inside a bundle -- if we aren't, we should not attempt to send
 	// a notification because it will cause a panic.
 	if !isBundle() {
-		return fmt.Errorf("cannot send notification because this application is not bundled")
+		return errors.New("cannot send notification because this application is not bundled")
 	}
 
 	titleCStr := C.CString(title)
@@ -31,7 +32,7 @@ func (d *DesktopNotifier) SendNotification(title, body string) error {
 
 	success := C.sendNotification(titleCStr, bodyCStr)
 	if !success {
-		return fmt.Errorf("could not send notification %s", title)
+		return fmt.Errorf("could not send notification: %s", title)
 	}
 
 	return nil

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -48,7 +48,7 @@ BOOL sendNotification(char *cTitle, char *cBody) {
     NSString *title = [NSString stringWithUTF8String:cTitle];
     NSString *body = [NSString stringWithUTF8String:cBody];
 
-    __block BOOL success = NO;
+    __block BOOL canSendNotification = NO;
     UNAuthorizationOptions options = (UNAuthorizationOptionAlert | UNAuthorizationStatusProvisional);
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
@@ -62,15 +62,19 @@ BOOL sendNotification(char *cTitle, char *cBody) {
                     NSLog(@"Unable to get permission to send notifications");
                 }
             } else {
-                success = doSendNotification(center, title, body);
+                canSendNotification = YES;
             }
             dispatch_semaphore_signal(semaphore);
         }];
     });
 
-    // Wait for completion handler to complete so that we get a correct value for `success`
+    // Wait for completion handler to complete so that we get a correct value for `canSendNotification`
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC);
     dispatch_semaphore_wait(semaphore, timeout);
 
-    return success;
+    if (canSendNotification) {
+        return doSendNotification(center, title, body);
+    }
+
+    return NO;
 }

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -69,7 +69,7 @@ BOOL sendNotification(char *cTitle, char *cBody) {
     });
 
     // Wait for completion handler to complete so that we get a correct value for `canSendNotification`
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC);
     dispatch_semaphore_wait(semaphore, timeout);
 
     if (canSendNotification) {

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -45,11 +45,6 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
 BOOL sendNotification(char *cTitle, char *cBody) {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
-    // To be removed later -- for troubleshooting purposes only
-    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-        NSLog(@"Notification settings: %@", settings);
-    }];
-
     NSString *title = [NSString stringWithUTF8String:cTitle];
     NSString *body = [NSString stringWithUTF8String:cBody];
 

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -32,7 +32,7 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
     });
 
     // Wait for completion handler to complete so that we get a correct value for `success`
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC);
     intptr_t err = dispatch_semaphore_wait(semaphore, timeout);
     if (err != 0) {
         // Timed out, remove the pending request
@@ -69,7 +69,7 @@ BOOL sendNotification(char *cTitle, char *cBody) {
     });
 
     // Wait for completion handler to complete so that we get a correct value for `success`
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC);
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC);
     dispatch_semaphore_wait(semaphore, timeout);
 
     return success;

--- a/ee/desktop/runner/runner_darwin.go
+++ b/ee/desktop/runner/runner_darwin.go
@@ -4,19 +4,43 @@
 package runner
 
 import (
+	"fmt"
 	"os/exec"
+	"os/user"
 )
 
 // For notifications to work, we must run in the user context with launchctl asuser.
 func runAsUser(uid string, cmd *exec.Cmd) error {
+	// Update command so that we're prepending `launchctl asuser $UID` to the launcher desktop command
+	cmd.Path = "/bin/launchctl"
+	updatedCmdArgs := append([]string{"/bin/launchctl", "asuser", uid}, cmd.Args...)
+	cmd.Args = updatedCmdArgs
+
+	// Ensure that we handle a non-root current user appropriately
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("getting current user: %w", err)
+	}
+
+	runningUser, err := user.LookupId(uid)
+	if err != nil {
+		return fmt.Errorf("looking up user with uid %s: %w", uid, err)
+	}
+
+	// current user not root
+	if currentUser.Uid != "0" {
+		// if the user is running for itself, just run without setting credentials
+		if currentUser.Uid == runningUser.Uid {
+			return cmd.Start()
+		}
+
+		// if the user is running for another user, we have an error because we can't set credentials
+		return fmt.Errorf("current user %s is not root and can't start process for other user %s", currentUser.Uid, uid)
+	}
 
 	// the remaining code in this function is not covered by unit test since it requires root privileges
 	// We may be able to run passwordless sudo in GitHub actions, could possibly exec the tests as sudo.
 	// But we may not have a console user?
-
-	cmd.Path = "/bin/launchctl"
-	updatedCmdArgs := append([]string{"/bin/launchctl", "asuser", uid}, cmd.Args...)
-	cmd.Args = updatedCmdArgs
 
 	return cmd.Start()
 }

--- a/ee/desktop/runner/runner_darwin.go
+++ b/ee/desktop/runner/runner_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+// +build darwin
+
+package runner
+
+import (
+	"os/exec"
+)
+
+// For notifications to work, we must run in the user context with launchctl asuser.
+func runAsUser(uid string, cmd *exec.Cmd) error {
+
+	// the remaining code in this function is not covered by unit test since it requires root privileges
+	// We may be able to run passwordless sudo in GitHub actions, could possibly exec the tests as sudo.
+	// But we may not have a console user?
+
+	cmd.Path = "/bin/launchctl"
+	updatedCmdArgs := append([]string{"/bin/launchctl", "asuser", uid}, cmd.Args...)
+	cmd.Args = updatedCmdArgs
+
+	return cmd.Start()
+}

--- a/ee/desktop/runner/runner_linux.go
+++ b/ee/desktop/runner/runner_linux.go
@@ -1,5 +1,5 @@
-//go:build darwin || linux
-// +build darwin linux
+//go:build linux
+// +build linux
 
 package runner
 

--- a/ee/desktop/server/server.go
+++ b/ee/desktop/server/server.go
@@ -106,6 +106,7 @@ func (s *DesktopServer) pingHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *DesktopServer) notificationHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		level.Error(s.logger).Log("msg", "could not read body of notification request", "err", err)
@@ -122,6 +123,7 @@ func (s *DesktopServer) notificationHandler(w http.ResponseWriter, req *http.Req
 	}
 
 	if err := s.notifier.SendNotification(notificationToSend.Title, notificationToSend.Body); err != nil {
+		level.Error(s.logger).Log("msg", "could not send notification", "err", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
What the title says 🙂 : 
* We run the desktop process with `launchctl asuser` in order to run the desktop process in the user context, where the process will have access to the user bootstrap service and can therefore find the notification service to send notifications. This fixes the issue where notifications would not send when running launcher as a daemon.

As a drive-by:
* Fixes a timeout issue where notifications would send successfully but the runner client would time out before receiving the success
* Also fixes an issue where the notification code was not correctly waiting for the completion handlers to complete, returning failure inappropriately
* Removes troubleshooting code that logged user notification settings; it is no longer needed

____________

Testing notes:

* I tested notifications with a signed app (should send, no error logs) and an unsigned app (should not send, should have error logs)
* I returned data from my mock control server for `kolide_desktop_menu` and confirmed it was reflected in the menu