### PR TITLE
makes ec middleware test valid, adds some sanity assertions to test

### DIFF
--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -104,6 +104,7 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 
 		level.Debug(e.logger).Log("msg", "Successful challenge. Proxying")
 
+		// bhr contains the data returned by the request defined above
 		bhr := &bufferedHttpResponse{}
 		next.ServeHTTP(bhr, newReq)
 

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -121,6 +121,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 			require.NoError(t, err)
 
 			responseUnmarshalled, err := challenge.UnmarshalResponse(returnedResponseBytes)
+			require.NoError(t, err)
 			require.Equal(t, challengeId, responseUnmarshalled.ChallengeId)
 
 			opened, err := responseUnmarshalled.Open(*privateEncryptionKey)

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -126,7 +126,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 			opened, err := responseUnmarshalled.Open(*privateEncryptionKey)
 			require.NoError(t, err)
 			require.Equal(t, challengeData, opened.ChallengeData)
-			require.Equal(t, opened.ResponseData, responseData)
+			require.Equal(t, responseData, opened.ResponseData)
 			require.WithinDuration(t, time.Now(), time.Unix(opened.Timestamp, 0), time.Second*5)
 		})
 	}


### PR DESCRIPTION
While combing through launcher code trying to resolve an issue, realized a test was invalid. The krypto-ec-middleware test handler was returning the data we expected the middle ware to return. Fixed test and added a few sanity assertions, but the bug was only in the test. Actual code still good.