### PR TITLE
Compile launcher Windows as a GUI binary to avoid cmd window prompts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,24 +79,25 @@ jobs:
     - name: Test
       run: make test
 
-    # Launcher should always print its version info when called with `version` -- this is a quick
+    # Launcher should always successfully run and exit cleanly when called with `version` -- this is a quick
     # check to ensure that launcher can update to this build.
     - name: Test build - macOS and ubuntu
       if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') }}
       run: |
-        if [[ $(./build/launcher --version) != *"launcher - version"* ]]; then
-          echo "launcher version did not print version information"
+        if ! ./build/launcher --version; then
+          echo "launcher.exe --version failed"
           exit 1
         fi
 
-    # Launcher should always print its version info when called with `version` -- this is a quick
+    # Launcher should always successfully run and exit cleanly when called with `version` -- this is a quick
     # check to ensure that launcher can update to this build.
     - name: Test build - Windows
       if: ${{ contains(matrix.os, 'windows') }}
       shell: powershell
       run: |
-        if(-not (.\build\launcher.exe --version | findstr "launcher - version")) {
-          throw "launcher.exe version did not print version information"
+        .\build\launcher.exe --version
+        if( !$? ) {
+          throw "launcher.exe --version failed"
         }
 
     - name: Upload Build - Windows

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -509,6 +509,11 @@ func (b *Builder) BuildCmd(src, appName string) func(context.Context) error {
 			ldFlags = append(ldFlags, "-w -s")
 		}
 
+		if b.os == "windows" {
+			// this prevents a cmd prompt opening up when desktop is launched
+			ldFlags = append(ldFlags, "-H windowsgui")
+		}
+
 		if b.stampVersion {
 			v, err := b.getVersion(ctx)
 			if err != nil {


### PR DESCRIPTION
Fixed #943 

This PR includes the change to enable Windows launcher to be built as a GUI binary instead of a console binary. We originally [reverted this code](https://github.com/kolide/launcher/pull/982/files) but it appears this doesn't break autoupdate like we originally feared.

The second change updates the CI check to ignore any output and just verify that `launcher --version` ran successfully. This better matches the [check that the autoupdate code performs on binaries](https://github.com/kolide/launcher/blob/main/pkg/autoupdate/findnew.go#L377-L383).

### Behavior changes

Windows CMD will wait for console binaries and return their output, whereas GUI binaries are not waited for and no output is returned:
```powershell
launcher_console.exe --version
{"caller":"main.go:30","msg":"Launcher starting up","revision":"7e862bc58116421ecb154a0ef73ec9f329f42a7e","severity":"info","ts":"2023-02-01T20:55:15.3027199Z","version":"0.13.2-18-g7e862bc-dirty"}
launcher - version 0.13.2-18-g7e862bc-dirty
  branch:       main
  revision:     7e862bc58116421ecb154a0ef73ec9f329f42a7e
  build date:   2023-01-31
  build user:   you
  go version:   go1.19.2

launcher_gui.exe --version
```

To get the output of a GUI binary, we can invoke it via `start`, wait for the output, and redirect it.

```powershell
start /B /wait launcher_gui.exe --version >> output.txt
```

PowerShell will automatically apply `Out-String` to a command's output before sending it to the input of another cmdlet, like `findstr`:
```powershell
PS > launcher_gui.exe --version | Out-String
launcher - version 0.13.2-19-g8631e5c-dirty
  branch:       main
  revision:     8631e5c970f33bb0f859fb9819a6873c33481925
  build date:   2023-02-01
  build user:   CJ Barrett (CJHP\cjbar)
  go version:   go1.19.2
PS > launcher_gui.exe --version
PS > launcher_gui.exe --version | findstr "launcher - version"
launcher - version 0.13.2-19-g8631e5c-dirty
  build date:   2023-02-01
  go version:   go1.19.2
```

### Testing Notes

I was unable to reproduce any bad autoupdate behavior when injecting a GUI binary into the tests for the autoupdate `checkExecutable` code which calls `launcher --version`:
- https://github.com/kolide/launcher/blob/main/pkg/autoupdate/handler.go#L98
- https://github.com/kolide/launcher/blob/main/pkg/autoupdate/findnew.go#L199
- https://github.com/kolide/launcher/blob/main/pkg/autoupdate/findnew.go#L235

I verified replacing my existing launcher installation `updates` dir binaries with GUI binaries still launches successfully.

Some helpful references:

https://stackoverflow.com/questions/54536/win32-gui-app-that-writes-usage-text-to-stdout-when-invoked-as-app-exe-help
https://superuser.com/questions/1198821/how-do-i-read-the-console-output-of-a-windows-gui-application
https://www.sapien.com/blog/2014/12/15/display-output-in-a-gui-application-copy/
https://devblogs.microsoft.com/oldnewthing/20090101-00/?p=19643