### PR TITLE
Let launcher choose debug icon when running in non-prod

### DIFF
--- a/ee/desktop/menu/menu.go
+++ b/ee/desktop/menu/menu.go
@@ -14,8 +14,7 @@ import (
 type menuIcon string
 
 const (
-	KolideDesktopIcon      = "kolide-desktop"
-	KolideDebugDesktopIcon = "kolide-debug-desktop"
+	KolideDesktopIcon = "kolide-desktop"
 )
 
 // MenuData encapsulates a menu bar icon and accessible menu items

--- a/ee/desktop/menu/menu_parse_test.go
+++ b/ee/desktop/menu/menu_parse_test.go
@@ -63,7 +63,7 @@ func Test_ParseMenuData(t *testing.T) {
 		{
 			name: "happy path",
 			data: &MenuData{
-				Icon:    KolideDebugDesktopIcon,
+				Icon:    KolideDesktopIcon,
 				Tooltip: "Kolide",
 			},
 		},

--- a/ee/desktop/menu/menu_systray.go
+++ b/ee/desktop/menu/menu_systray.go
@@ -46,9 +46,12 @@ func (m *menu) Build() {
 func (m *menu) SetIcon(icon menuIcon) {
 	switch icon {
 	case KolideDesktopIcon:
-		systray.SetTemplateIcon(assets.KolideDesktopIcon, assets.KolideDesktopIcon)
-	case KolideDebugDesktopIcon:
-		systray.SetTemplateIcon(assets.KolideDebugDesktopIcon, assets.KolideDebugDesktopIcon)
+		// Allow launcher to conditionally choose the launcher icon based on whether we're running in production or not
+		if m.isProd() {
+			systray.SetTemplateIcon(assets.KolideDesktopIcon, assets.KolideDesktopIcon)
+		} else {
+			systray.SetTemplateIcon(assets.KolideDebugDesktopIcon, assets.KolideDebugDesktopIcon)
+		}
 	default:
 		level.Debug(m.logger).Log(
 			"msg", "invalid icon",


### PR DESCRIPTION
This enables k2 to not have to worry about if launcher is running in prod or not. Launcher chooses which icon to use, so the default menu will now go back to the debug icon.