### PR TITLE
Consolidating agent temp path/dir creation to a single function

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"os/user"
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/desktop/menu"
 	"github.com/kolide/launcher/ee/desktop/server"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/oklog/run"
 	"github.com/peterbourgon/ff/v3"
 	"github.com/shirou/gopsutil/process"
@@ -193,5 +193,5 @@ func defaultSocketPath() string {
 		return fmt.Sprintf(`\\.\pipe\%s_%d_%s`, socketBaseName, os.Getpid(), ulid.New())
 	}
 
-	return filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", socketBaseName, os.Getpid()))
+	return agent.TempPath(fmt.Sprintf("%s_%d", socketBaseName, os.Getpid()))
 }

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/osquery/runtime"
 	"github.com/kolide/launcher/pkg/service"
@@ -37,7 +38,7 @@ func runFlare(args []string) error {
 		serverURL         = env.String("KOLIDE_LAUNCHER_HOSTNAME", *flHostname)
 		insecureTLS       = env.Bool("KOLIDE_LAUNCHER_INSECURE", false)
 		insecureTransport = env.Bool("KOLIDE_LAUNCHER_INSECURE_TRANSPORT", false)
-		flareSocketPath   = env.String("FLARE_SOCKET_PATH", filepath.Join(os.TempDir(), "flare.sock"))
+		flareSocketPath   = env.String("FLARE_SOCKET_PATH", agent.TempPath("flare.sock"))
 
 		certPins [][]byte
 		rootPool *x509.CertPool

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/osquery/interactive"
 )
@@ -40,7 +41,7 @@ func runInteractive(args []string) error {
 	}
 
 	// have to keep tempdir name short so we don't exceed socket length
-	rootDir, err := os.MkdirTemp("", "launcher-interactive")
+	rootDir, err := os.MkdirTemp(agent.TempPath(""), "launcher-interactive")
 	if err != nil {
 		return fmt.Errorf("creating temp dir for interactive mode: %w", err)
 	}

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -41,7 +41,7 @@ func runInteractive(args []string) error {
 	}
 
 	// have to keep tempdir name short so we don't exceed socket length
-	rootDir, err := os.MkdirTemp(agent.TempPath(""), "launcher-interactive")
+	rootDir, err := agent.MkdirTemp("launcher-interactive")
 	if err != nil {
 		return fmt.Errorf("creating temp dir for interactive mode: %w", err)
 	}

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kolide/launcher/ee/control/consumers/notificationconsumer"
 	desktopRunner "github.com/kolide/launcher/ee/desktop/runner"
 	"github.com/kolide/launcher/ee/localserver"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/debug"
 	"github.com/kolide/launcher/pkg/launcher"
@@ -48,7 +49,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	// determine the root directory, create one if it's not provided
 	rootDirectory := opts.RootDirectory
 	if rootDirectory == "" {
-		rootDirectory = filepath.Join(os.TempDir(), defaultRootDirectory)
+		rootDirectory = agent.TempPath(defaultRootDirectory)
 		if _, err := os.Stat(rootDirectory); os.IsNotExist(err) {
 			if err := os.Mkdir(rootDirectory, fsutil.DirMode); err != nil {
 				return fmt.Errorf("creating temporary root directory: %w", err)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/kit/logutil"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/kit/version"
@@ -49,11 +48,9 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	// determine the root directory, create one if it's not provided
 	rootDirectory := opts.RootDirectory
 	if rootDirectory == "" {
-		rootDirectory = agent.TempPath(defaultRootDirectory)
-		if _, err := os.Stat(rootDirectory); os.IsNotExist(err) {
-			if err := os.Mkdir(rootDirectory, fsutil.DirMode); err != nil {
-				return fmt.Errorf("creating temporary root directory: %w", err)
-			}
+		rootDirectory, err := agent.MkdirTemp(defaultRootDirectory)
+		if err != nil {
+			return fmt.Errorf("creating temporary root directory: %w", err)
 		}
 		level.Info(logger).Log(
 			"msg", "using default system root directory",

--- a/cmd/launcher/run_socket.go
+++ b/cmd/launcher/run_socket.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kolide/kit/env"
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/runtime"
 	"github.com/kolide/launcher/pkg/osquery/table"
 )
@@ -19,7 +20,7 @@ func runSocket(args []string) error {
 	var (
 		flPath = flagset.String(
 			"path",
-			env.String("SOCKET_PATH", filepath.Join(os.TempDir(), "osquery.sock")),
+			env.String("SOCKET_PATH", agent.TempPath("osquery.sock")),
 			"The path to the socket",
 		)
 		flLauncherTables = flagset.Bool(

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -150,7 +150,7 @@ func New(opts ...desktopUsersProcessesRunnerOption) *DesktopUsersProcessesRunner
 		updateInterval:         time.Second * 5,
 		procsWg:                &sync.WaitGroup{},
 		interruptTimeout:       time.Second * 10,
-		usersFilesRoot:         filepath.Join(os.TempDir(), "kolide-desktop"),
+		usersFilesRoot:         agent.TempPath("kolide-desktop"),
 		processSpawningEnabled: false,
 	}
 
@@ -553,6 +553,9 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 	cmd := exec.Command(executablePath, "desktop")
 
 	cmd.Env = []string{
+		// without passing the temp var, the desktop icon will not appear on windows and emit the error:
+		// unable to write icon data to temp file: open C:\\windows\\systray_temp_icon_...: Access is denied
+		fmt.Sprintf("TEMP=%s", os.Getenv("TEMP")),
 		fmt.Sprintf("HOSTNAME=%s", r.hostname),
 		fmt.Sprintf("AUTHTOKEN=%s", r.authToken),
 		fmt.Sprintf("SOCKET_PATH=%s", socketPath),

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -77,9 +77,9 @@ func WithAuthToken(token string) desktopUsersProcessesRunnerOption {
 
 // WithUsersFilesRoot sets the launcher root dir with will be the parent dir
 // for kolide desktop files on a per user basis
-func WithUsersFilesRoot(token string) desktopUsersProcessesRunnerOption {
+func WithUsersFilesRoot(usersFilesRoot string) desktopUsersProcessesRunnerOption {
 	return func(r *DesktopUsersProcessesRunner) {
-		r.usersFilesRoot = token
+		r.usersFilesRoot = usersFilesRoot
 	}
 }
 

--- a/pkg/agent/paths.go
+++ b/pkg/agent/paths.go
@@ -1,0 +1,12 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TempPath returns a path within the agent's temp directory tree, by joining the path elements into a single path.
+func TempPath(elem ...string) string {
+	elements := append([]string{os.TempDir(), "kolide-k2"}, elem...)
+	return filepath.Join(elements...)
+}

--- a/pkg/agent/paths.go
+++ b/pkg/agent/paths.go
@@ -7,6 +7,11 @@ import (
 
 // TempPath returns a path within the agent's temp directory tree, by joining the path elements into a single path.
 func TempPath(elem ...string) string {
-	elements := append([]string{os.TempDir(), "kolide-k2"}, elem...)
+	elements := append([]string{os.TempDir()}, elem...)
 	return filepath.Join(elements...)
+}
+
+// MkdirTemp creates a new temporary directory in the TempPath directory.
+func MkdirTemp(pattern string) (string, error) {
+	return os.MkdirTemp(TempPath(), pattern)
 }

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
@@ -592,7 +593,7 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 }
 
 func osqueryTempDir() (string, func(), error) {
-	tempPath, err := os.MkdirTemp("", "")
+	tempPath, err := os.MkdirTemp(agent.TempPath(), "")
 	if err != nil {
 		return "", func() {}, fmt.Errorf("could not make temp path: %w", err)
 	}

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -593,7 +593,7 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 }
 
 func osqueryTempDir() (string, func(), error) {
-	tempPath, err := os.MkdirTemp(agent.TempPath(), "")
+	tempPath, err := agent.MkdirTemp("")
 	if err != nil {
 		return "", func() {}, fmt.Errorf("could not make temp path: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -44,7 +44,7 @@ type ChromeLoginDataEmailsTable struct {
 }
 
 func (c *ChromeLoginDataEmailsTable) generateForPath(ctx context.Context, file userFileInfo) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_chrome_login_data_emails")
+	dir, err := agent.MkdirTemp("kolide_chrome_login_data_emails")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_data_emails tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kolide/kit/fsutil"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
+
+	"github.com/kolide/launcher/pkg/agent"
 )
 
 var profileDirs = map[string][]string{
@@ -42,7 +44,7 @@ type ChromeLoginDataEmailsTable struct {
 }
 
 func (c *ChromeLoginDataEmailsTable) generateForPath(ctx context.Context, file userFileInfo) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp("", "kolide_chrome_login_data_emails")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_chrome_login_data_emails")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_data_emails tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -36,7 +36,7 @@ type ChromeLoginKeychain struct {
 }
 
 func (c *ChromeLoginKeychain) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_chrome_login_keychain")
+	dir, err := agent.MkdirTemp("kolide_chrome_login_keychain")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_keychain tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -35,7 +36,7 @@ type ChromeLoginKeychain struct {
 }
 
 func (c *ChromeLoginKeychain) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp("", "kolide_chrome_login_keychain")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_chrome_login_keychain")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_chrome_login_keychain tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -34,7 +34,7 @@ type gdrive struct {
 }
 
 func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_gdrive_sync_config")
+	dir, err := agent.MkdirTemp("kolide_gdrive_sync_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -33,7 +34,7 @@ type gdrive struct {
 }
 
 func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp("", "kolide_gdrive_sync_config")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_gdrive_sync_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -38,7 +38,7 @@ type GDriveSyncHistory struct {
 // GDriveSyncHistoryGenerate will be called whenever the table is queried. It should return
 // a full table scan.
 func (g *GDriveSyncHistory) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_gdrive_sync_history")
+	dir, err := agent.MkdirTemp("kolide_gdrive_sync_history")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_history tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -37,7 +38,7 @@ type GDriveSyncHistory struct {
 // GDriveSyncHistoryGenerate will be called whenever the table is queried. It should return
 // a full table scan.
 func (g *GDriveSyncHistory) generateForPath(ctx context.Context, path string) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp("", "kolide_gdrive_sync_history")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_gdrive_sync_history")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_gdrive_sync_history tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -53,7 +54,7 @@ type onePasswordAccountsTable struct {
 // generate the onepassword account info results given the path to a
 // onepassword sqlite DB
 func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo userFileInfo) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp("", "kolide_onepassword_accounts")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_onepassword_accounts")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_onepassword_accounts tmp dir: %w", err)
 	}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -54,7 +54,7 @@ type onePasswordAccountsTable struct {
 // generate the onepassword account info results given the path to a
 // onepassword sqlite DB
 func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo userFileInfo) ([]map[string]string, error) {
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_onepassword_accounts")
+	dir, err := agent.MkdirTemp("kolide_onepassword_accounts")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_onepassword_accounts tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
@@ -71,7 +72,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 func (t *Table) execDism(ctx context.Context) ([]byte, error) {
 	// dism.exe outputs xml, but with weird intermingled status. So
 	// instead, we dump it to a temp file.
-	dir, err := os.MkdirTemp("", "kolide_dism")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_dism")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_dism tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -72,7 +72,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 func (t *Table) execDism(ctx context.Context) ([]byte, error) {
 	// dism.exe outputs xml, but with weird intermingled status. So
 	// instead, we dump it to a temp file.
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_dism")
+	dir, err := agent.MkdirTemp("kolide_dism")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_dism tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -97,7 +97,7 @@ func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output
 
 	cmd := exec.CommandContext(ctx, "/usr/sbin/firmwarepasswd", subcommand)
 
-	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-firmwarepasswd")
+	dir, err := agent.MkdirTemp("osq-firmwarepasswd")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -96,7 +97,7 @@ func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output
 
 	cmd := exec.CommandContext(ctx, "/usr/sbin/firmwarepasswd", subcommand)
 
-	dir, err := os.MkdirTemp("", "osq-firmwarepasswd")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-firmwarepasswd")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -122,7 +123,7 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 		}
 	}
 
-	dir, err := os.MkdirTemp("", "osq-gsettings")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-gsettings")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -123,7 +123,7 @@ func execGsettings(ctx context.Context, username string, buf *bytes.Buffer) erro
 		}
 	}
 
-	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-gsettings")
+	dir, err := agent.MkdirTemp("osq-gsettings")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -90,7 +91,7 @@ type keyDescription struct {
 func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema string) ([]keyDescription, error) {
 	var descriptions []keyDescription
 
-	dir, err := os.MkdirTemp("", fmt.Sprintf("osq-gsettings-metadata-%s", schema))
+	dir, err := os.MkdirTemp(agent.TempPath(""), fmt.Sprintf("osq-gsettings-metadata-%s", schema))
 	if err != nil {
 		return descriptions, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -91,7 +91,7 @@ type keyDescription struct {
 func (t *GsettingsMetadata) gsettingsDescribeForSchema(ctx context.Context, schema string) ([]keyDescription, error) {
 	var descriptions []keyDescription
 
-	dir, err := os.MkdirTemp(agent.TempPath(""), fmt.Sprintf("osq-gsettings-metadata-%s", schema))
+	dir, err := agent.MkdirTemp(fmt.Sprintf("osq-gsettings-metadata-%s", schema))
 	if err != nil {
 		return descriptions, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -77,7 +77,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 					// for some subset of the profiles command. I've reported it
 					// to apple (feedback FB8962811), and while it may someday
 					// be fixed, we need to support it where it is.
-					dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_profiles")
+					dir, err := agent.MkdirTemp("kolide_profiles")
 					if err != nil {
 						return nil, fmt.Errorf("creating kolide_profiles tmp dir: %w", err)
 					}

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
@@ -76,7 +77,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 					// for some subset of the profiles command. I've reported it
 					// to apple (feedback FB8962811), and while it may someday
 					// be fixed, we need to support it where it is.
-					dir, err := os.MkdirTemp("", "kolide_profiles")
+					dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_profiles")
 					if err != nil {
 						return nil, fmt.Errorf("creating kolide_profiles tmp dir: %w", err)
 					}

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -95,7 +95,7 @@ func (t *Table) execSecedit(ctx context.Context, mergedPolicy bool) ([]byte, err
 	// The secedit.exe binary does not support outputting the data we need to stdout
 	// Instead we create a tmp directory and pass it to secedit to write the data we need
 	// in INI format.
-	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_secedit_config")
+	dir, err := agent.MkdirTemp("kolide_secedit_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_secedit_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
@@ -94,7 +95,7 @@ func (t *Table) execSecedit(ctx context.Context, mergedPolicy bool) ([]byte, err
 	// The secedit.exe binary does not support outputting the data we need to stdout
 	// Instead we create a tmp directory and pass it to secedit to write the data we need
 	// in INI format.
-	dir, err := os.MkdirTemp("", "kolide_secedit_config")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "kolide_secedit_config")
 	if err != nil {
 		return nil, fmt.Errorf("creating kolide_secedit_config tmp dir: %w", err)
 	}

--- a/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
+++ b/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 )
 
 // ExecOsqueryLaunchctl runs osquery under launchctl, in a user context.
@@ -41,7 +42,7 @@ func ExecOsqueryLaunchctl(ctx context.Context, logger log.Logger, timeoutSeconds
 		query,
 	)
 
-	dir, err := os.MkdirTemp("", "osq-launchctl")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-launchctl")
 	if err != nil {
 		return nil, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
+++ b/pkg/osquery/tables/tablehelpers/exec_osquery_launchctl.go
@@ -42,7 +42,7 @@ func ExecOsqueryLaunchctl(ctx context.Context, logger log.Logger, timeoutSeconds
 		query,
 	)
 
-	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-launchctl")
+	dir, err := agent.MkdirTemp("osq-launchctl")
 	if err != nil {
 		return nil, fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/osquery/osquery-go"
@@ -81,7 +82,7 @@ func execPwsh(logger log.Logger) execer {
 		// write the c# code to a file, so the powershell script can load it
 		// from there. This works around a size limit on args passed to
 		// powershell.exe
-		dir, err := os.MkdirTemp("", "nativewifi")
+		dir, err := os.MkdirTemp(agent.TempPath(""), "nativewifi")
 		if err != nil {
 			return fmt.Errorf("creating nativewifi tmp dir: %w", err)
 		}

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -82,7 +82,7 @@ func execPwsh(logger log.Logger) execer {
 		// write the c# code to a file, so the powershell script can load it
 		// from there. This works around a size limit on args passed to
 		// powershell.exe
-		dir, err := os.MkdirTemp(agent.TempPath(""), "nativewifi")
+		dir, err := agent.MkdirTemp("nativewifi")
 		if err != nil {
 			return fmt.Errorf("creating nativewifi tmp dir: %w", err)
 		}

--- a/pkg/osquery/tables/xrdb/xrdb.go
+++ b/pkg/osquery/tables/xrdb/xrdb.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -126,7 +127,7 @@ func execXRDB(ctx context.Context, displayNum, username string, buf *bytes.Buffe
 		}
 	}
 
-	dir, err := os.MkdirTemp("", "osq-xrdb")
+	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-xrdb")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}

--- a/pkg/osquery/tables/xrdb/xrdb.go
+++ b/pkg/osquery/tables/xrdb/xrdb.go
@@ -127,7 +127,7 @@ func execXRDB(ctx context.Context, displayNum, username string, buf *bytes.Buffe
 		}
 	}
 
-	dir, err := os.MkdirTemp(agent.TempPath(""), "osq-xrdb")
+	dir, err := agent.MkdirTemp("osq-xrdb")
 	if err != nil {
 		return fmt.Errorf("mktemp: %w", err)
 	}


### PR DESCRIPTION
This is a tangent off of https://github.com/kolide/launcher/pull/920 intended to streamline temp file/dir paths so that:

- The locations where we use temp paths can be found easily
- We can treat temp path creation uniformly, and avoid one-off path construction
- Temp dir creation is wrapped and ensured to always use the preferred temp location, and secure directory permissions

This PR does not address potential vulnerabilities regarding privilege escalation where:

- Sometimes we use paths that can be predicted by attackers
- There are directories that are expected to exist before launcher starts, but we do not ensure their permissions are correct