### PR TITLE
Add auth to control server requests

### DIFF
--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -16,7 +16,7 @@ func createHTTPClient(ctx context.Context, logger log.Logger, opts *launcher.Opt
 	level.Debug(logger).Log("msg", "creating control http client")
 
 	clientOpts := []control.HTTPClientOption{}
-	if opts.InsecureTLS {
+	if opts.InsecureControlTLS {
 		clientOpts = append(clientOpts, control.WithInsecureSkipVerify())
 	}
 	if opts.DisableControlTLS {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -178,47 +178,53 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		"build", versionInfo.Revision,
 	)
 
-	controlService, err := createControlService(ctx, logger, db, opts)
-	if err != nil {
-		return fmt.Errorf("failed to setup control service: %w", err)
-	}
-	runGroup.Add(controlService.Execute, controlService.Interrupt)
+	// Create the control service and services that depend on it
+	var runner *desktopRunner.DesktopUsersProcessesRunner
+	if opts.ControlServerURL == "" {
+		level.Debug(logger).Log("msg", "control server URL not set, will not create control service")
+	} else {
+		controlService, err := createControlService(ctx, logger, db, opts)
+		if err != nil {
+			return fmt.Errorf("failed to setup control service: %w", err)
+		}
+		runGroup.Add(controlService.Execute, controlService.Interrupt)
 
-	// serverDataBucketConsumer handles server data table updates
-	serverDataBucketConsumer := control.NewBucketConsumer(logger, db, osquery.ServerProvidedDataBucket)
-	controlService.RegisterConsumer("kolide_server_data", serverDataBucketConsumer)
+		// serverDataBucketConsumer handles server data table updates
+		serverDataBucketConsumer := control.NewBucketConsumer(logger, db, osquery.ServerProvidedDataBucket)
+		controlService.RegisterConsumer("kolide_server_data", serverDataBucketConsumer)
 
-	desktopFlagsBucketConsumer := control.NewBucketConsumer(logger, db, "agent_flags")
-	controlService.RegisterConsumer("agent_flags", desktopFlagsBucketConsumer)
+		desktopFlagsBucketConsumer := control.NewBucketConsumer(logger, db, "agent_flags")
+		controlService.RegisterConsumer("agent_flags", desktopFlagsBucketConsumer)
 
-	runner := desktopRunner.New(
-		desktopRunner.WithLogger(logger),
-		desktopRunner.WithUpdateInterval(time.Second*5),
-		desktopRunner.WithHostname(opts.KolideServerURL),
-		desktopRunner.WithAuthToken(ulid.New()),
-		desktopRunner.WithUsersFilesRoot(rootDirectory),
-		desktopRunner.WithProcessSpawningEnabled(opts.KolideServerURL == "k2device-preprod.kolide.com" || opts.KolideServerURL == "localhost:3443" || strings.HasSuffix(opts.KolideServerURL, "herokuapp.com")),
-		desktopRunner.WithGetter(desktopFlagsBucketConsumer),
-	)
-	runGroup.Add(runner.Execute, runner.Interrupt)
-	controlService.RegisterConsumer("kolide_desktop_menu", runner)
-	controlService.RegisterSubscriber("agent_flags", runner)
+		runner = desktopRunner.New(
+			desktopRunner.WithLogger(logger),
+			desktopRunner.WithUpdateInterval(time.Second*5),
+			desktopRunner.WithHostname(opts.KolideServerURL),
+			desktopRunner.WithAuthToken(ulid.New()),
+			desktopRunner.WithUsersFilesRoot(rootDirectory),
+			desktopRunner.WithProcessSpawningEnabled(opts.KolideServerURL == "k2device-preprod.kolide.com" || opts.KolideServerURL == "localhost:3443" || strings.HasSuffix(opts.KolideServerURL, "herokuapp.com")),
+			desktopRunner.WithGetter(desktopFlagsBucketConsumer),
+		)
+		runGroup.Add(runner.Execute, runner.Interrupt)
+		controlService.RegisterConsumer("kolide_desktop_menu", runner)
+		controlService.RegisterSubscriber("agent_flags", runner)
 
-	// Run the notification service
-	notificationConsumer, err := notificationconsumer.NewNotifyConsumer(
-		db,
-		runner,
-		ctx,
-		notificationconsumer.WithLogger(logger),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to set up notifier: %w", err)
-	}
-	// Runs the cleanup routine for old notification records
-	runGroup.Add(notificationConsumer.Execute, notificationConsumer.Interrupt)
+		// Run the notification service
+		notificationConsumer, err := notificationconsumer.NewNotifyConsumer(
+			db,
+			runner,
+			ctx,
+			notificationconsumer.WithLogger(logger),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to set up notifier: %w", err)
+		}
+		// Runs the cleanup routine for old notification records
+		runGroup.Add(notificationConsumer.Execute, notificationConsumer.Interrupt)
 
-	if err := controlService.RegisterConsumer(notificationconsumer.NotificationSubsystem, notificationConsumer); err != nil {
-		return fmt.Errorf("failed to register notify consumer: %w", err)
+		if err := controlService.RegisterConsumer(notificationconsumer.NotificationSubsystem, notificationConsumer); err != nil {
+			return fmt.Errorf("failed to register notify consumer: %w", err)
+		}
 	}
 
 	if opts.KolideServerURL == "k2device.kolide.com" ||

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -180,7 +180,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 
 	// Set control server URL and control server TLS settings based on Kolide server URL, defaulting to local server
 	controlServerURL := ""
-	insecureTLS := *flInsecureTLS
+	insecureControlTLS := false
 	disableControlTLS := false
 	if *flKolideServerURL == "k2device.kolide.com" {
 		controlServerURL = "k2control.kolide.com"
@@ -191,7 +191,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	} else if *flKolideServerURL == "localhost:3443" {
 		controlServerURL = *flKolideServerURL
 		// We don't plumb flRootPEM through to the control server, just disable TLS for now
-		insecureTLS = true
+		insecureControlTLS = true
 	} else if *flKolideServerURL == "localhost:3000" {
 		controlServerURL = *flKolideServerURL
 		disableControlTLS = true
@@ -208,11 +208,12 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		ControlRequestInterval:             *flControlRequestInterval,
 		Debug:                              *flDebug,
 		DisableControlTLS:                  disableControlTLS,
+		InsecureControlTLS:                 insecureControlTLS,
 		EnableInitialRunner:                *flInitialRunner,
 		EnrollSecret:                       *flEnrollSecret,
 		EnrollSecretPath:                   *flEnrollSecretPath,
 		AutoloadedExtensions:               flAutoloadedExtensions,
-		InsecureTLS:                        insecureTLS,
+		InsecureTLS:                        *flInsecureTLS,
 		InsecureTransport:                  *flInsecureTransport,
 		KolideHosted:                       *flKolideHosted,
 		KolideServerURL:                    *flKolideServerURL,

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -84,7 +84,6 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		flDebug             = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
 		flOsqueryVerbose    = flagset.Bool("osquery_verbose", false, "Enable verbose osqueryd (default: false)")
 		flDeveloperUsage    = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options")
-		flDisableControlTLS = flagset.Bool("disable_control_tls", false, "Disable TLS encryption for the control features")
 		flInsecureTransport = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
 		flInsecureTLS       = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
 
@@ -92,6 +91,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		_ = flagset.String("debug_log_file", "", "DEPRECATED")
 		_ = flagset.Bool("control", false, "DEPRECATED")
 		_ = flagset.String("control_hostname", "", "DEPRECATED")
+		_ = flagset.Bool("disable_control_tls", false, "Disable TLS encryption for the control features")
 	)
 
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
@@ -181,7 +181,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	// Set control server URL and control server TLS settings based on Kolide server URL, defaulting to local server
 	controlServerURL := "localhost:3000"
 	insecureTLS := *flInsecureTLS
-	disableControlTLS := *flDisableControlTLS
+	disableControlTLS := false
 	if *flKolideServerURL == "k2device.kolide.com" {
 		controlServerURL = "k2control.kolide.com"
 	} else if *flKolideServerURL == "k2device-preprod.kolide.com" {
@@ -323,7 +323,6 @@ func developerUsage(flagset *flag.FlagSet) {
 	printOpt("notary_prefix")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("control_get_shells_interval")
-	printOpt("disable_control_tls")
 	fmt.Fprintf(os.Stderr, "\n")
 	printOpt("osquery_flag")
 	fmt.Fprintf(os.Stderr, "\n")

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -178,6 +178,24 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		return nil, err
 	}
 
+	// Set control server URL and control server TLS settings based on Kolide server URL, defaulting to local server
+	controlServerURL := "localhost:3000"
+	insecureTLS := *flInsecureTLS
+	disableControlTLS := *flDisableControlTLS
+	if *flKolideServerURL == "k2device.kolide.com" {
+		controlServerURL = "k2control.kolide.com"
+	} else if *flKolideServerURL == "k2device-preprod.kolide.com" {
+		controlServerURL = "k2control-preprod.kolide.com"
+	} else if strings.HasSuffix(*flKolideServerURL, "herokuapp.com") {
+		controlServerURL = *flKolideServerURL
+	} else if *flKolideServerURL == "localhost:3443" {
+		controlServerURL = *flKolideServerURL
+		insecureTLS = true
+	} else if *flKolideServerURL == "localhost:3000" {
+		controlServerURL = *flKolideServerURL
+		disableControlTLS = true
+	}
+
 	opts := &launcher.Options{
 		Autoupdate:                         *flAutoupdate,
 		AutoupdateInterval:                 *flAutoupdateInterval,
@@ -185,15 +203,15 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		CertPins:                           certPins,
 		CompactDbMaxTx:                     *flCompactDbMaxTx,
 		Control:                            false,
-		ControlServerURL:                   "localhost:3000",
+		ControlServerURL:                   controlServerURL,
 		ControlRequestInterval:             *flControlRequestInterval,
 		Debug:                              *flDebug,
-		DisableControlTLS:                  *flDisableControlTLS,
+		DisableControlTLS:                  disableControlTLS,
 		EnableInitialRunner:                *flInitialRunner,
 		EnrollSecret:                       *flEnrollSecret,
 		EnrollSecretPath:                   *flEnrollSecretPath,
 		AutoloadedExtensions:               flAutoloadedExtensions,
-		InsecureTLS:                        *flInsecureTLS,
+		InsecureTLS:                        insecureTLS,
 		InsecureTransport:                  *flInsecureTransport,
 		KolideHosted:                       *flKolideHosted,
 		KolideServerURL:                    *flKolideServerURL,

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -179,7 +179,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	}
 
 	// Set control server URL and control server TLS settings based on Kolide server URL, defaulting to local server
-	controlServerURL := "localhost:3000"
+	controlServerURL := ""
 	insecureTLS := *flInsecureTLS
 	disableControlTLS := false
 	if *flKolideServerURL == "k2device.kolide.com" {

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -190,6 +190,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		controlServerURL = *flKolideServerURL
 	} else if *flKolideServerURL == "localhost:3443" {
 		controlServerURL = *flKolideServerURL
+		// We don't plumb flRootPEM through to the control server, just disable TLS for now
 		insecureTLS = true
 	} else if *flKolideServerURL == "localhost:3000" {
 		controlServerURL = *flKolideServerURL

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -88,11 +88,11 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 
 func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 	testCases := []struct {
-		testName                  string
-		testFlags                 []string
-		expectedControlServer     string
-		expectedInsecureTLS       bool
-		expectedDisableControlTLS bool
+		testName                   string
+		testFlags                  []string
+		expectedControlServer      string
+		expectedInsecureControlTLS bool
+		expectedDisableControlTLS  bool
 	}{
 		{
 			testName: "k2-prod",
@@ -100,9 +100,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "k2device.kolide.com",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "k2control.kolide.com",
-			expectedInsecureTLS:       false,
-			expectedDisableControlTLS: false,
+			expectedControlServer:      "k2control.kolide.com",
+			expectedInsecureControlTLS: false,
+			expectedDisableControlTLS:  false,
 		},
 		{
 			testName: "k2-preprod",
@@ -110,9 +110,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "k2device-preprod.kolide.com",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "k2control-preprod.kolide.com",
-			expectedInsecureTLS:       false,
-			expectedDisableControlTLS: false,
+			expectedControlServer:      "k2control-preprod.kolide.com",
+			expectedInsecureControlTLS: false,
+			expectedDisableControlTLS:  false,
 		},
 		{
 			testName: "heroku",
@@ -120,9 +120,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "test.herokuapp.com",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "test.herokuapp.com",
-			expectedInsecureTLS:       false,
-			expectedDisableControlTLS: false,
+			expectedControlServer:      "test.herokuapp.com",
+			expectedInsecureControlTLS: false,
+			expectedDisableControlTLS:  false,
 		},
 		{
 			testName: "localhost with TLS",
@@ -130,9 +130,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "localhost:3443",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "localhost:3443",
-			expectedInsecureTLS:       true,
-			expectedDisableControlTLS: false,
+			expectedControlServer:      "localhost:3443",
+			expectedInsecureControlTLS: true,
+			expectedDisableControlTLS:  false,
 		},
 		{
 			testName: "localhost without TLS",
@@ -140,9 +140,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "localhost:3000",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "localhost:3000",
-			expectedInsecureTLS:       false,
-			expectedDisableControlTLS: true,
+			expectedControlServer:      "localhost:3000",
+			expectedInsecureControlTLS: false,
+			expectedDisableControlTLS:  true,
 		},
 		{
 			testName: "unknown host option",
@@ -150,9 +150,9 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 				"--hostname", "example.com",
 				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
-			expectedControlServer:     "",
-			expectedInsecureTLS:       false,
-			expectedDisableControlTLS: false,
+			expectedControlServer:      "",
+			expectedInsecureControlTLS: false,
+			expectedDisableControlTLS:  false,
 		},
 	}
 
@@ -163,7 +163,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			opts, err := parseOptions(tt.testFlags)
 			require.NoError(t, err, "could not parse options")
 			require.Equal(t, tt.expectedControlServer, opts.ControlServerURL, "incorrect control server")
-			require.Equal(t, tt.expectedInsecureTLS, opts.InsecureTLS, "incorrect insecure TLS")
+			require.Equal(t, tt.expectedInsecureControlTLS, opts.InsecureControlTLS, "incorrect insecure TLS")
 			require.Equal(t, tt.expectedDisableControlTLS, opts.DisableControlTLS, "incorrect disable control TLS")
 		})
 	}

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -98,6 +98,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			testName: "k2-prod",
 			testFlags: []string{
 				"--hostname", "k2device.kolide.com",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
 			expectedControlServer:     "k2control.kolide.com",
 			expectedInsecureTLS:       false,
@@ -107,6 +108,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			testName: "k2-preprod",
 			testFlags: []string{
 				"--hostname", "k2device-preprod.kolide.com",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
 			expectedControlServer:     "k2control-preprod.kolide.com",
 			expectedInsecureTLS:       false,
@@ -116,6 +118,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			testName: "heroku",
 			testFlags: []string{
 				"--hostname", "test.herokuapp.com",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
 			expectedControlServer:     "test.herokuapp.com",
 			expectedInsecureTLS:       false,
@@ -125,6 +128,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			testName: "localhost with TLS",
 			testFlags: []string{
 				"--hostname", "localhost:3443",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
 			expectedControlServer:     "localhost:3443",
 			expectedInsecureTLS:       true,
@@ -134,6 +138,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			testName: "localhost without TLS",
 			testFlags: []string{
 				"--hostname", "localhost:3000",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
 			},
 			expectedControlServer:     "localhost:3000",
 			expectedInsecureTLS:       false,

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -144,6 +144,16 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 			expectedInsecureTLS:       false,
 			expectedDisableControlTLS: true,
 		},
+		{
+			testName: "unknown host option",
+			testFlags: []string{
+				"--hostname", "example.com",
+				"--osqueryd_path", windowsAddExe("/dev/null"),
+			},
+			expectedControlServer:     "",
+			expectedInsecureTLS:       false,
+			expectedDisableControlTLS: false,
+		},
 	}
 
 	for _, tt := range testCases { // nolint:paralleltest
@@ -178,7 +188,7 @@ func getArgsAndResponse() (map[string]string, *launcher.Options) {
 		AutoupdateInterval:     48 * time.Hour,
 		CompactDbMaxTx:         int64(65536),
 		Control:                false,
-		ControlServerURL:       "localhost:3000",
+		ControlServerURL:       "",
 		ControlRequestInterval: 60 * time.Second,
 		KolideServerURL:        randomHostname,
 		LoggingInterval:        time.Duration(randomInt) * time.Second,

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -104,11 +104,6 @@ func runMake(args []string) error {
 			env.String("UPDATE_CHANNEL", ""),
 			"the value that should be used when invoking the launcher's --update_channel flag. Autoupdates will be disabled unless this is specified",
 		)
-		flDisableControlTLS = flagset.Bool(
-			"disable_control_tls",
-			env.Bool("DISABLE_CONTROL_TLS", false),
-			"whether or not the launcher packages should invoke the launcher's --disable_control_tls flag",
-		)
 		flIdentifier = flagset.String(
 			"identifier",
 			env.String("IDENTIFIER", "launcher"),
@@ -237,7 +232,6 @@ func runMake(args []string) error {
 		InsecureTransport: *flInsecureTransport,
 		UpdateChannel:     *flUpdateChannel,
 		InitialRunner:     *flInitialRunner,
-		DisableControlTLS: *flDisableControlTLS,
 		Identifier:        *flIdentifier,
 		OmitSecret:        *flOmitSecret,
 		CertPins:          *flCertPins,

--- a/ee/control/client_http.go
+++ b/ee/control/client_http.go
@@ -85,18 +85,19 @@ func (c *HTTPClient) GetConfig() (io.Reader, error) {
 
 	// Calculate first signature
 	localDbKeys := agent.LocalDbKeys()
-	if localDbKeys.Type() != "noop" {
-		key1, err := keyHeaderValue(localDbKeys)
-		if err != nil {
-			return nil, fmt.Errorf("could not get key header from local db keys: %w", err)
-		}
-		sig1, err := signatureHeaderValue(localDbKeys, challenge)
-		if err != nil {
-			return nil, fmt.Errorf("could not get signature header from local db keys: %w", err)
-		}
-		configReq.Header.Set(HeaderKey, key1)
-		configReq.Header.Set(HeaderSignature, sig1)
+	if localDbKeys.Type() == "noop" {
+		return nil, errors.New("cannot request control data without local keys")
 	}
+	key1, err := keyHeaderValue(localDbKeys)
+	if err != nil {
+		return nil, fmt.Errorf("could not get key header from local db keys: %w", err)
+	}
+	sig1, err := signatureHeaderValue(localDbKeys, challenge)
+	if err != nil {
+		return nil, fmt.Errorf("could not get signature header from local db keys: %w", err)
+	}
+	configReq.Header.Set(HeaderKey, key1)
+	configReq.Header.Set(HeaderSignature, sig1)
 
 	// Calculate second signature if available
 	hardwareKeys := agent.HardwareKeys()

--- a/ee/control/client_http.go
+++ b/ee/control/client_http.go
@@ -84,7 +84,7 @@ func (c *HTTPClient) GetConfig() (io.Reader, error) {
 
 	// Calculate first signature
 	localDbKeys := agent.LocalDbKeys()
-	if localDbKeys.Type() == "noop" {
+	if localDbKeys.Public() == nil {
 		return nil, errors.New("cannot request control data without local keys")
 	}
 	key1, err := echelper.PublicEcdsaToB64Der(localDbKeys.Public().(*ecdsa.PublicKey))
@@ -100,7 +100,7 @@ func (c *HTTPClient) GetConfig() (io.Reader, error) {
 
 	// Calculate second signature if available
 	hardwareKeys := agent.HardwareKeys()
-	if hardwareKeys.Type() != "noop" {
+	if hardwareKeys.Public() != nil {
 		key2, err := echelper.PublicEcdsaToB64Der(hardwareKeys.Public().(*ecdsa.PublicKey))
 		if err != nil {
 			return nil, fmt.Errorf("could not get key header from hardware keys: %w", err)

--- a/ee/control/client_http.go
+++ b/ee/control/client_http.go
@@ -2,13 +2,18 @@ package control
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/krypto/pkg/echelper"
+	"github.com/kolide/launcher/pkg/agent"
 )
 
 // HTTPClient handles retrieving control data via HTTP
@@ -19,6 +24,22 @@ type HTTPClient struct {
 	client     *http.Client
 	insecure   bool
 	disableTLS bool
+	token      string
+}
+
+const (
+	HeaderApiVersion = "X-Kolide-Api-Version"
+	ApiVersion       = "2023-01-01"
+	HeaderChallenge  = "X-Kolide-Challenge"
+	HeaderSignature  = "X-Kolide-Signature"
+	HeaderKey        = "X-Kolide-Key"
+	HeaderSignature2 = "X-Kolide-Signature2"
+	HeaderKey2       = "X-Kolide-Key2"
+)
+
+type configResponse struct {
+	Token  string          `json:"token"`
+	Config json.RawMessage `json:"config"`
 }
 
 func NewControlHTTPClient(logger log.Logger, addr string, client *http.Client, opts ...HTTPClientOption) (*HTTPClient, error) {
@@ -40,77 +61,140 @@ func NewControlHTTPClient(logger log.Logger, addr string, client *http.Client, o
 	return c, nil
 }
 
-func (c *HTTPClient) Get(hash string) (data io.Reader, err error) {
-	verb, path := "GET", fmt.Sprintf("/api/v1/control/%s", hash)
-
-	response, err := c.do(verb, path)
+func (c *HTTPClient) GetConfig() (io.Reader, error) {
+	challengeReq, err := http.NewRequest(http.MethodGet, c.url("/api/agent/config").String(), nil)
 	if err != nil {
-		level.Debug(c.logger).Log(
-			"msg", "error making request to control server endpoint",
-			"err", err,
-		)
-		return nil, err
-	}
-	defer response.Body.Close()
-
-	switch response.StatusCode {
-	case http.StatusNotFound:
-		// This could indicate an inconsistency in server data, or a client logic error
-		level.Error(c.logger).Log(
-			"msg", "got HTTP 404 making control server request",
-		)
-		return nil, err
-
-	case http.StatusNotModified:
-		// The control server sends back a 304 Not Modified status, without a body, which tells
-		// the client that the cached version of the response is still good to use
-		level.Debug(c.logger).Log(
-			"msg", "got HTTP 304 making control server request",
-		)
-		return nil, err
+		return nil, fmt.Errorf("could not create challenge request: %w", err)
 	}
 
-	if response.StatusCode != http.StatusOK {
-		level.Error(c.logger).Log(
-			"msg", "got not-ok status code from control server",
-			"response_code", response.StatusCode,
-			"response_body", response.Body,
-		)
-		return nil, err
-	}
-
-	// response.Body will be closed before this function exits, get all the data now
-	body, err := io.ReadAll(response.Body)
+	challenge, err := c.do(challengeReq)
 	if err != nil {
-		level.Debug(c.logger).Log(
-			"msg", "error reading response body from control server",
-			"err", err,
-		)
-		return nil, err
+		return nil, fmt.Errorf("could not make challenge request: %w", err)
 	}
 
-	reader := bytes.NewReader(body)
+	configReq, err := http.NewRequest(http.MethodPost, c.url("/api/agent/config").String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create config request: %w", err)
+	}
+	configReq.Header.Set(HeaderChallenge, string(challenge))
+	configReq.Header.Set("Content-Type", "application/json")
+	configReq.Header.Set("Accept", "application/json")
+
+	// Calculate first signature
+	localDbKeys := agent.LocalDbKeys()
+	if localDbKeys.Type() != "noop" {
+		key1, err := keyHeaderValue(localDbKeys)
+		if err != nil {
+			return nil, fmt.Errorf("could not get key header from local db keys: %w", err)
+		}
+		sig1, err := signatureHeaderValue(localDbKeys, challenge)
+		if err != nil {
+			return nil, fmt.Errorf("could not get signature header from local db keys: %w", err)
+		}
+		configReq.Header.Set(HeaderKey, key1)
+		configReq.Header.Set(HeaderSignature, sig1)
+	}
+
+	// Calculate second signature if available
+	hardwareKeys := agent.HardwareKeys()
+	if hardwareKeys.Type() != "noop" {
+		key2, err := keyHeaderValue(hardwareKeys)
+		if err != nil {
+			return nil, fmt.Errorf("could not get key header from hardware keys: %w", err)
+		}
+		sig2, err := signatureHeaderValue(hardwareKeys, challenge)
+		if err != nil {
+			return nil, fmt.Errorf("could not get signature header from hardware keys: %w", err)
+		}
+		configReq.Header.Set(HeaderKey2, key2)
+		configReq.Header.Set(HeaderSignature2, sig2)
+	}
+
+	configAndAuthKeyRaw, err := c.do(configReq)
+	if err != nil {
+		return nil, fmt.Errorf("could not make config request: %w", err)
+	}
+
+	var cfgResp configResponse
+	if err := json.Unmarshal(configAndAuthKeyRaw, &cfgResp); err != nil {
+		return nil, fmt.Errorf("could not unmarshal challenge response: %w", err)
+	}
+
+	// Set the auth token for use when fetching objects by their hashes later
+	c.token = cfgResp.Token
+
+	reader := bytes.NewReader(cfgResp.Config)
 	return reader, nil
 }
 
-func (c *HTTPClient) do(verb, path string) (*http.Response, error) {
-	request, err := http.NewRequest(
-		verb,
-		c.url(path).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating request object: %w", err)
+func (c *HTTPClient) GetSubsystemData(hash string) (io.Reader, error) {
+	if c.token == "" {
+		_, err := c.GetConfig()
+		if err != nil {
+			return nil, fmt.Errorf("no token set; could not make request to get one: %w", err)
+		}
 	}
 
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "application/json")
+	dataReq, err := http.NewRequest(http.MethodGet, c.url(fmt.Sprintf("/api/agent/object/%s", hash)).String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create subsystem data request: %w", err)
+	}
 
-	return c.client.Do(request)
+	dataReq.Header.Set("Authorization", "Bearer "+c.token)
+	dataReq.Header.Set("Content-Type", "application/json")
+	dataReq.Header.Set("Accept", "application/json")
+
+	dataRaw, err := c.do(dataReq)
+	if err != nil {
+		return nil, fmt.Errorf("could not make subsystem data request: %w", err)
+	}
+
+	reader := bytes.NewReader(dataRaw)
+	return reader, nil
+}
+
+func (c *HTTPClient) do(req *http.Request) ([]byte, error) {
+	// We always need to include the API version in the headers
+	req.Header.Set(HeaderApiVersion, ApiVersion)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got non-200 status code %d from control server at %s", resp.StatusCode, resp.Request.URL)
+	}
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body from control server at %s: %w", resp.Request.URL, err)
+	}
+
+	return respBytes, nil
 }
 
 func (c *HTTPClient) url(path string) *url.URL {
 	u := *c.baseURL
 	u.Path = path
 	return &u
+}
+
+func keyHeaderValue(k crypto.Signer) (string, error) {
+	keyDer, err := x509.MarshalPKIXPublicKey(k.Public())
+	if err != nil {
+		return "", fmt.Errorf("could not marshal public key: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(keyDer), nil
+}
+
+func signatureHeaderValue(k crypto.Signer, challenge []byte) (string, error) {
+	sig, err := echelper.Sign(k, challenge)
+	if err != nil {
+		return "", fmt.Errorf("could not sign challenge: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(sig), nil
 }

--- a/ee/control/client_http.go
+++ b/ee/control/client_http.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -131,10 +132,7 @@ func (c *HTTPClient) GetConfig() (io.Reader, error) {
 
 func (c *HTTPClient) GetSubsystemData(hash string) (io.Reader, error) {
 	if c.token == "" {
-		_, err := c.GetConfig()
-		if err != nil {
-			return nil, fmt.Errorf("no token set; could not make request to get one: %w", err)
-		}
+		return nil, errors.New("token is nil, cannot request subsystem data")
 	}
 
 	dataReq, err := http.NewRequest(http.MethodGet, c.url(fmt.Sprintf("/api/agent/object/%s", hash)).String(), nil)
@@ -142,7 +140,7 @@ func (c *HTTPClient) GetSubsystemData(hash string) (io.Reader, error) {
 		return nil, fmt.Errorf("could not create subsystem data request: %w", err)
 	}
 
-	dataReq.Header.Set("Authorization", "Bearer "+c.token)
+	dataReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	dataReq.Header.Set("Content-Type", "application/json")
 	dataReq.Header.Set("Accept", "application/json")
 

--- a/ee/control/client_test.go
+++ b/ee/control/client_test.go
@@ -21,16 +21,16 @@ func NewControlTestClient(subsystemMap map[string]string, hashData map[string]an
 	return c, nil
 }
 
-func (c *TestClient) Get(hash string) (data io.Reader, err error) {
-	if hash == "" {
-		bodyBytes, err := json.Marshal(c.subsystemMap)
-		if err != nil {
-			return nil, fmt.Errorf("marshaling json: %w", err)
-		}
-
-		return bytes.NewReader(bodyBytes), nil
+func (c *TestClient) GetConfig() (data io.Reader, err error) {
+	bodyBytes, err := json.Marshal(c.subsystemMap)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling json: %w", err)
 	}
 
+	return bytes.NewReader(bodyBytes), nil
+}
+
+func (c *TestClient) GetSubsystemData(hash string) (data io.Reader, err error) {
 	bodyBytes, err := json.Marshal(c.hashData[hash])
 	if err != nil {
 		return nil, fmt.Errorf("marshaling json: %w", err)

--- a/ee/control/consumers/notificationconsumer/notify_consumer.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer.go
@@ -37,16 +37,13 @@ type notification struct {
 	Title      string    `json:"title"`
 	Body       string    `json:"body"`
 	ID         string    `json:"id"`
-	ValidUntil string    `json:"valid_until"` // ISO8601 format
+	ValidUntil int64     `json:"valid_until"` // timestamp
 	SentAt     time.Time `json:"sent_at,omitempty"`
 }
 
 const (
 	// Identifier for this consumer.
 	NotificationSubsystem = "desktop_notifier"
-
-	// ISO 8601 -- used for valid_until field
-	iso8601Format = "2006-01-02T15:04:05-0700"
 
 	// Approximately 6 months
 	defaultRetentionPeriod = time.Hour * 24 * 30 * 6
@@ -142,14 +139,7 @@ func (nc *NotificationConsumer) notify(notificationToSend notification) {
 
 func (nc *NotificationConsumer) notificationIsValid(notificationToCheck notification) bool {
 	// Check that the notification is not expired --
-	// Parse timestamp string as ISO 8601
-	validUntil, err := time.Parse(iso8601Format, notificationToCheck.ValidUntil)
-	if err != nil {
-		level.Error(nc.logger).Log("msg", "received invalid valid_until timestamp in notification", "valid_until", notificationToCheck.ValidUntil, "err", err)
-
-		// Assume that we should not send a notification containing a malformed field
-		return false
-	}
+	validUntil := time.Unix(notificationToCheck.ValidUntil, 0)
 
 	// Notification has expired
 	if validUntil.Before(time.Now()) {

--- a/ee/control/consumers/notificationconsumer/notify_consumer_test.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer_test.go
@@ -89,30 +89,12 @@ func TestUpdate_ValidatesNotifications(t *testing.T) {
 			},
 		},
 		{
-			name: "Invalid because ValidUntil isn't a timestamp",
-			testNotification: notification{
-				Title:      "Not a timestamp notification",
-				Body:       "Not a timestamp notification body",
-				ID:         ulid.New(),
-				ValidUntil: "not a timestamp",
-			},
-		},
-		{
-			name: "Invalid because ValidUntil has an unexpected format",
-			testNotification: notification{
-				Title:      "Unexpected format notification",
-				Body:       "Unexpected format notification body",
-				ID:         ulid.New(),
-				ValidUntil: time.Now().Add(1 * time.Hour).Format(time.RFC1123),
-			},
-		},
-		{
 			name: "Invalid because the notification is expired",
 			testNotification: notification{
 				Title:      "Expired notification",
 				Body:       "Expired notification body",
 				ID:         ulid.New(),
-				ValidUntil: time.Now().Add(-1 * time.Hour).Format(iso8601Format),
+				ValidUntil: time.Now().Add(-1 * time.Hour).Unix(),
 			},
 		},
 	}
@@ -299,6 +281,6 @@ func setUpDb(t *testing.T) *bbolt.DB {
 	return db
 }
 
-func getValidUntil() string {
-	return time.Now().Add(1 * time.Hour).Format(iso8601Format)
+func getValidUntil() int64 {
+	return time.Now().Add(1 * time.Hour).Unix()
 }

--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -42,7 +42,8 @@ type subscriber interface {
 // dataProvider is an interface for something that can retrieve control data. Authentication, HTTP,
 // file system access, etc. lives below this abstraction layer.
 type dataProvider interface {
-	Get(hash string) (data io.Reader, err error)
+	GetConfig() (io.Reader, error)
+	GetSubsystemData(hash string) (io.Reader, error)
 }
 
 func New(logger log.Logger, ctx context.Context, fetcher dataProvider, opts ...Option) *ControlService {
@@ -102,7 +103,7 @@ func (cs *ControlService) Stop() {
 // Performs a retrieval of the latest control server data, and notifies observers of updates.
 func (cs *ControlService) Fetch() error {
 	// Empty hash means get the map of subsystems & hashes
-	data, err := cs.fetcher.Get("")
+	data, err := cs.fetcher.GetConfig()
 	if err != nil {
 		return fmt.Errorf("getting subsystems map: %w", err)
 	}
@@ -149,7 +150,7 @@ func (cs *ControlService) Fetch() error {
 
 // Fetches latest subsystem data, and notifies observers of updates.
 func (cs *ControlService) fetchAndUpdate(subsystem, hash string) error {
-	data, err := cs.fetcher.Get(hash)
+	data, err := cs.fetcher.GetSubsystemData(hash)
 	if err != nil {
 		return fmt.Errorf("failed to get control data: %w", err)
 	}

--- a/ee/control/control_test.go
+++ b/ee/control/control_test.go
@@ -42,7 +42,11 @@ func (ms *mockGetSet) Set(key, value []byte) error {
 
 type nopDataProvider struct{}
 
-func (dp nopDataProvider) Get(hash string) (data io.Reader, err error) {
+func (dp nopDataProvider) GetConfig() (io.Reader, error) {
+	return nil, nil
+}
+
+func (dp nopDataProvider) GetSubsystemData(hash string) (io.Reader, error) {
 	return nil, nil
 }
 

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -108,7 +108,7 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 		bhr := &bufferedHttpResponse{}
 		next.ServeHTTP(bhr, newReq)
 
-		response, err := challengeBox.Respond(e.signer, bhr.Bytes())
+		response, err := challengeBox.Respond(e.signer, nil, bhr.Bytes())
 		if err != nil {
 			level.Debug(e.logger).Log("msg", "failed to respond", "err", err)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc
 	github.com/kolide/kit v0.0.0-20221107170827-fb85e3d59eab
-	github.com/kolide/krypto v0.0.0-20230128164551-c54b78be5480
+	github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899
 	github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80
 	github.com/kr/pty v1.1.2
 	github.com/mat/besticon v3.9.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc h1:g2S0GQ
 github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc/go.mod h1:5e34JEkxWsOeAd9jvcxkz01tAY/JAGFuabGnNBJ6TT4=
 github.com/kolide/kit v0.0.0-20221107170827-fb85e3d59eab h1:KVR7cs+oPyy85i+8t1ZaNSy1bymCy5FuWyt51pdrXu4=
 github.com/kolide/kit v0.0.0-20221107170827-fb85e3d59eab/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=
-github.com/kolide/krypto v0.0.0-20230128164551-c54b78be5480 h1:nJuFdRvxn+Tjncdk8XqI3TH8kAi/DNOgNnHLp+E2CFk=
-github.com/kolide/krypto v0.0.0-20230128164551-c54b78be5480/go.mod h1:PvKvoNvMWfyPXZN9/yXNrGtAasI2b+sc8RpwkCJGzzc=
+github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899 h1:xxLm19kyV9FUxN7T9B+5IXcMU3kHOyPF/ULHcbz4cD0=
+github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899/go.mod h1:PvKvoNvMWfyPXZN9/yXNrGtAasI2b+sc8RpwkCJGzzc=
 github.com/kolide/systray v1.10.2 h1:98mJhoVE1XHDTMdqag8BGh1Qt9IaA9/wKZCFs0z5VyU=
 github.com/kolide/systray v1.10.2/go.mod h1:FwK9yUmU3JO+vA7TOLQSFRgEQ3euLxOqic5qlBtFrik=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -45,7 +45,7 @@ type Options struct {
 	// appropriate for the transport.
 	LogMaxBytesPerBatch int
 
-	// Control enables the remote control functionality.
+	// Control enables the remote control functionality. It is not in use.
 	Control bool
 	// ControlServerURL URL for control server.
 	ControlServerURL string
@@ -87,6 +87,8 @@ type Options struct {
 	OsqueryFlags []string
 	// DisableControlTLS disables TLS transport with the control server.
 	DisableControlTLS bool
+	// InsecureControlTLS disables TLS certificate validation for the control server.
+	InsecureControlTLS bool
 	// InsecureTLS disables TLS certificate verification.
 	InsecureTLS bool
 	// InsecureTransport disables TLS in the transport layer.

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -44,7 +44,6 @@ type PackageOptions struct {
 	InsecureTransport bool
 	UpdateChannel     string
 	InitialRunner     bool
-	DisableControlTLS bool
 	Identifier        string
 	Title             string
 	OmitSecret        bool
@@ -144,10 +143,6 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 
 	if p.CertPins != "" {
 		launcherMapFlags["cert_pins"] = p.CertPins
-	}
-
-	if p.DisableControlTLS {
-		launcherBoolFlags = append(launcherBoolFlags, "disable_control_tls")
 	}
 
 	if p.Transport != "" {


### PR DESCRIPTION
Description:
* Implement control server auth as defined in this PR: https://github.com/kolide/k2/pull/7083
* Switch `valid_until` for notifications to a timestamp
* Set control server hostname + associated settings based on k2 hostname