### PR TITLE
Disable control service until we are ready to point to new K2 control server

### DIFF
--- a/cmd/launcher/control.go
+++ b/cmd/launcher/control.go
@@ -30,6 +30,7 @@ func createHTTPClient(ctx context.Context, logger log.Logger, opts *launcher.Opt
 	return client, nil
 }
 
+// nolint: deadcode
 func createControlService(ctx context.Context, logger log.Logger, db *bbolt.DB, opts *launcher.Options) (*control.ControlService, error) {
 	level.Debug(logger).Log("msg", "creating control service")
 

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -18,12 +18,9 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/kit/logutil"
-	"github.com/kolide/kit/ulid"
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/cmd/launcher/internal"
 	"github.com/kolide/launcher/cmd/launcher/internal/updater"
-	"github.com/kolide/launcher/ee/control"
-	"github.com/kolide/launcher/ee/control/consumers/notificationconsumer"
 	desktopRunner "github.com/kolide/launcher/ee/desktop/runner"
 	"github.com/kolide/launcher/ee/localserver"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
@@ -180,6 +177,9 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		"build", versionInfo.Revision,
 	)
 
+	// Disable the control service until we are ready to point to K2
+	var runner *desktopRunner.DesktopUsersProcessesRunner
+	/**
 	controlService, err := createControlService(ctx, logger, db, opts)
 	if err != nil {
 		return fmt.Errorf("failed to setup control service: %w", err)
@@ -222,6 +222,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	if err := controlService.RegisterConsumer(notificationconsumer.NotificationSubsystem, notificationConsumer); err != nil {
 		return fmt.Errorf("failed to register notify consumer: %w", err)
 	}
+	*/
 
 	if opts.KolideServerURL == "k2device.kolide.com" ||
 		opts.KolideServerURL == "k2device-preprod.kolide.com" ||


### PR DESCRIPTION
Per discussion on https://github.com/kolide/launcher/pull/1020, we shouldn't make outbound requests to localhost:3000 with no way to disable them on `stable`. This PR temporarily disables the control service to avoid making these outbound requests until we are ready to point to the K2 control server.