### PR TITLE
Enable non-prod menu items in pre-prod environments

### DIFF
--- a/ee/desktop/menu/menu_systray.go
+++ b/ee/desktop/menu/menu_systray.go
@@ -109,7 +109,7 @@ func (m *menu) cleanup() {
 
 // Returns true if launcher is running in production
 func (m *menu) isProd() bool {
-	return m.hostname == "k2device-preprod.kolide.com" || m.hostname == "k2device.kolide.com"
+	return m.hostname == "k2device.kolide.com"
 }
 
 // makeActionHandler creates a handler to execute the desired action when a menu item is clicked


### PR DESCRIPTION
This will enable menu items marked as non-prod-only to show up in launchers running against pre-prod.