### PR TITLE
Spawn launcher desktop for human console users only

### DIFF
--- a/ee/consoleuser/consoleuser_darwin.go
+++ b/ee/consoleuser/consoleuser_darwin.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -83,6 +84,11 @@ import (
 //
 // tested on M1 Monterey 12.6
 
+const (
+	// minConsoleUserUid is the minimum UID for human console users
+	minConsoleUserUid = 501
+)
+
 func CurrentUids(ctx context.Context) ([]string, error) {
 	cmd := exec.CommandContext(ctx, "scutil")
 	cmd.Stdin = strings.NewReader("show State:/Users/ConsoleUser")
@@ -131,6 +137,12 @@ func CurrentUids(ctx context.Context) ([]string, error) {
 		}
 
 		if kCGSSessionOnConsole == "" || kCGSSessionUserID == "" {
+			continue
+		}
+
+		// We only care about human console users (UID 501 or greater)
+		uidInt, err := strconv.Atoi(kCGSSessionUserID)
+		if err != nil || uidInt < minConsoleUserUid {
 			continue
 		}
 


### PR DESCRIPTION
Fixed #1034 

I haven't been able to actually test this, and that will take a non-trivial amount of time and effort given that this bug is related to OS upgrades.

However, indications point towards this bug being caused by a console user called `_windowsserver` which normally isn't logged in, but will be logged in after the first boot post-upgrade of macOS. This was causing us to create more than one desktop process, since we interpreted the `_windowsuser` user and the actual human user as two different users.

The change here restricts desktop launcher spawning for console users with UID >= 501, which is the minimum UID for human console users.