### PR TITLE
Fix double read from an io.Reader inside the menu generation

### DIFF
--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -134,7 +134,7 @@ func (cs *ControlService) Fetch() error {
 			}
 		}
 
-		if hash == lastHash {
+		if hash == lastHash && !agent.Flags.ForceControlSubsystems() {
 			// The last fetched update is still fresh
 			// Nothing to do, skip to the next subsystem
 			continue

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -272,6 +273,10 @@ func (r *DesktopUsersProcessesRunner) SendNotification(title, body string) error
 
 // Update handles control server updates for the desktop-menu subsystem
 func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
+	if data == nil {
+		return errors.New("data is nil")
+	}
+
 	var dataCopy bytes.Buffer
 	dataTee := io.TeeReader(data, &dataCopy)
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -272,26 +272,20 @@ func (r *DesktopUsersProcessesRunner) SendNotification(title, body string) error
 
 // Update handles control server updates for the desktop-menu subsystem
 func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
-	var menu menu.MenuData
-
 	var dataCopy bytes.Buffer
 	dataTee := io.TeeReader(data, &dataCopy)
 
-	if err := json.NewDecoder(dataTee).Decode(&menu); err != nil {
-		if agent.Flags.DebugServerData() {
+	// Regardless, we will write the menu data out to a file that can be grabbed by
+	// any desktop user processes, either when they refresh, or when they are spawned.
+	if err := r.generateMenuFile(dataTee); err != nil {
+		if agent.Flags.DebugServerData() || true {
 			level.Error(r.logger).Log(
-				"msg", "failed to decode menu data",
+				"msg", "failed to generate menu file",
 				"error", err,
 				"data", dataCopy.String(),
 			)
 		}
-		return fmt.Errorf("failed to decode menu data: %w", err)
-	}
-
-	// Regardless, we will write the menu data out to a file that can be grabbed by
-	// any desktop user processes, either when they refresh, or when they are spawned.
-	if err := r.generateMenuFile(data); err != nil {
-		return err
+		return fmt.Errorf("failed to generate menu file: %w", err)
 	}
 
 	// Tell any running desktop user processes that they should refresh the latest menu data
@@ -379,10 +373,10 @@ func (r *DesktopUsersProcessesRunner) generateMenuFile(data io.Reader) error {
 
 	var menu menu.MenuData
 	if err := json.NewDecoder(bytes.NewReader(parsedMenuDataBytes)).Decode(&menu); err != nil {
-		return fmt.Errorf("failed to decode menu data: %w", err)
+		return fmt.Errorf("failed to decode menu data post processing: %w", err)
 	}
 
-	// Regardless, we will write the menu data out to a file that can be grabbed by
+	// Write the menu data out to a file that can be grabbed by
 	// any desktop user processes, either when they refresh, or when they are spawned.
 	if err := r.writeSharedFile(r.menuPath(), menu); err != nil {
 		return err

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -283,7 +283,7 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 	// Regardless, we will write the menu data out to a file that can be grabbed by
 	// any desktop user processes, either when they refresh, or when they are spawned.
 	if err := r.generateMenuFile(dataTee); err != nil {
-		if agent.Flags.DebugServerData() || true {
+		if agent.Flags.DebugServerData() {
 			level.Error(r.logger).Log(
 				"msg", "failed to generate menu file",
 				"error", err,

--- a/pkg/agent/flags.go
+++ b/pkg/agent/flags.go
@@ -2,6 +2,7 @@ package agent
 
 type flagInt interface {
 	DebugServerData() bool
+	ForceControlSubsystems() bool
 }
 
 var Flags flagInt = &initialFlagTest{}
@@ -9,5 +10,10 @@ var Flags flagInt = &initialFlagTest{}
 type initialFlagTest struct{}
 
 func (initialFlagTest) DebugServerData() bool {
+	return false
+}
+
+// ForceControlSubsystems causes the control system to process each system. Regardless of the last hash value
+func (initialFlagTest) ForceControlSubsystems() bool {
 	return false
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -62,12 +62,13 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 
 	if bytes.Contains(p, []byte("Accelerating distributed query checkins")) {
 		lf = level.Debug
+		return len(p), nil
 	}
 
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
 	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {
-		return 0, err
+		return len(p), err
 	}
 	return len(p), nil
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -61,14 +61,14 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 	}
 
 	if bytes.Contains(p, []byte("Accelerating distributed query checkins")) {
-		lf = level.Debug
+		// Skip writing this. But we still return len(p) so the caller thinks it was written
 		return len(p), nil
 	}
 
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
 	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {
-		return len(p), err
+		return 0, err
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
Inside the desktop runner's menu handling code, there was a double read of an io.Reader. This causes the second one to fail. The first one looks like it was from an earlier refactor, I removed it. 

Also adds another debugging flag and squelches a log