### PR TITLE
Ensure one malformed notification doesn't prevent us from processing the rest of the batch

### DIFF
--- a/docs/multipass/multipass.sh
+++ b/docs/multipass/multipass.sh
@@ -15,7 +15,7 @@ then
     exit 1
 fi
 
-foundvm=$({ multipass info $vmname || true; }) &>/dev/null
+foundvm=$(multipass info $vmname 2>/dev/null)
 if [[ $foundvm == *"State"* ]]
 then
     echo "VM already exists with name $vmname -- choose a new name or run: multipass delete $vmname && multipass purge"

--- a/ee/control/consumers/notificationconsumer/notify_consumer_test.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer_test.go
@@ -309,6 +309,51 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
+func TestUpdate_HandlesMalformedNotifications(t *testing.T) {
+	t.Parallel()
+
+	db := setUpDb(t)
+	mockNotifier := newNotifierMock()
+	testNc := &NotificationConsumer{
+		db:                          db,
+		runner:                      mockNotifier,
+		logger:                      log.NewNopLogger(),
+		notificationRetentionPeriod: defaultRetentionPeriod,
+	}
+
+	// Queue up two notifications -- one malformed, one correctly formed
+	testId := ulid.New()
+	goodNotification := notify.Notification{
+		Title:      fmt.Sprintf("Test title @ %d - %s", time.Now().UnixMicro(), testId),
+		Body:       fmt.Sprintf("Test body @ %d - %s", time.Now().UnixMicro(), testId),
+		ID:         testId,
+		ValidUntil: getValidUntil(),
+	}
+	goodNotificationRaw, err := json.Marshal(goodNotification)
+	require.NoError(t, err)
+	badNotification := struct {
+		AnUnknownField      string `json:"an_unknown_field"`
+		AnotherUnknownField bool   `json:"another_unknown_field"`
+	}{
+		AnUnknownField:      testId,
+		AnotherUnknownField: true,
+	}
+	badNotificationRaw, err := json.Marshal(badNotification)
+	require.NoError(t, err)
+	testNotifications := []json.RawMessage{goodNotificationRaw, badNotificationRaw}
+	testNotificationsRaw, err := json.Marshal(testNotifications)
+	require.NoError(t, err)
+	testNotificationsData := bytes.NewReader(testNotificationsRaw)
+
+	// Expect that the notifier is still called once, to send the good notification
+	mockNotifier.On("SendNotification", mock.Anything).Return(nil)
+
+	// Call update and assert our expectations about sent notifications
+	err = testNc.Update(testNotificationsData)
+	require.NoError(t, err)
+	mockNotifier.AssertNumberOfCalls(t, "SendNotification", 1)
+}
+
 func setUpDb(t *testing.T) *bbolt.DB {
 	// Create a temp directory to hold our bbolt db
 	dbDir := t.TempDir()

--- a/ee/control/consumers/notificationconsumer/notify_consumer_test.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer_test.go
@@ -346,11 +346,12 @@ func TestUpdate_HandlesMalformedNotifications(t *testing.T) {
 	testNotificationsData := bytes.NewReader(testNotificationsRaw)
 
 	// Expect that the notifier is still called once, to send the good notification
-	mockNotifier.On("SendNotification", mock.Anything).Return(nil)
+	mockNotifier.On("SendNotification", goodNotification).Return(nil)
 
 	// Call update and assert our expectations about sent notifications
 	err = testNc.Update(testNotificationsData)
 	require.NoError(t, err)
+	mockNotifier.AssertExpectations(t)
 	mockNotifier.AssertNumberOfCalls(t, "SendNotification", 1)
 }
 


### PR DESCRIPTION
Unmarshal each notification separately so that changes or bugs in notification format do not affect delivering all notifications.

Also fixes an issue that was bugging me where the multipass.sh script would always output 

```
info failed: The following errors occurred:
instance "<vmname>" does not exist
```

even though that's what we want.