### PR TITLE
Add flag for bypassing the EE license checks on localserver

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -230,8 +230,8 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	if opts.KolideServerURL == "k2device.kolide.com" ||
 		opts.KolideServerURL == "k2device-preprod.kolide.com" ||
 		opts.KolideServerURL == "localhost:3443" ||
-		strings.HasSuffix(opts.KolideServerURL, "herokuapp.com") {
-
+		strings.HasSuffix(opts.KolideServerURL, "herokuapp.com") ||
+		opts.IAmBreakingEELicense == "yes" {
 		ls, err := localserver.New(logger, db, opts.KolideServerURL)
 		if err != nil {
 			// For now, log this and move on. It might be a fatal error

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -81,11 +81,12 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		flAutoupdateInitialDelay = flagset.Duration("autoupdater_initial_delay", 1*time.Hour, "Initial autoupdater subprocess delay")
 
 		// Development & Debugging options
-		flDebug             = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
-		flOsqueryVerbose    = flagset.Bool("osquery_verbose", false, "Enable verbose osqueryd (default: false)")
-		flDeveloperUsage    = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options")
-		flInsecureTransport = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
-		flInsecureTLS       = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
+		flDebug                = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
+		flOsqueryVerbose       = flagset.Bool("osquery_verbose", false, "Enable verbose osqueryd (default: false)")
+		flDeveloperUsage       = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options")
+		flInsecureTransport    = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
+		flInsecureTLS          = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
+		flIAmBreakingEELicense = flagset.String("i-am-breaking-ee-license", "", "Skip license check before running localserver if value is 'yes' (default: '')")
 
 		// deprecated options, kept for any kind of config file compatibility
 		_ = flagset.String("debug_log_file", "", "DEPRECATED")
@@ -195,6 +196,8 @@ func parseOptions(args []string) (*launcher.Options, error) {
 	} else if *flKolideServerURL == "localhost:3000" {
 		controlServerURL = *flKolideServerURL
 		disableControlTLS = true
+	} else if *flIAmBreakingEELicense == "yes" {
+		controlServerURL = *flKolideServerURL
 	}
 
 	opts := &launcher.Options{
@@ -214,6 +217,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		EnrollSecretPath:                   *flEnrollSecretPath,
 		AutoloadedExtensions:               flAutoloadedExtensions,
 		InsecureTLS:                        *flInsecureTLS,
+		IAmBreakingEELicense:               *flIAmBreakingEELicense,
 		InsecureTransport:                  *flInsecureTransport,
 		KolideHosted:                       *flKolideHosted,
 		KolideServerURL:                    *flKolideServerURL,

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -93,6 +93,8 @@ type Options struct {
 	InsecureTLS bool
 	// InsecureTransport disables TLS in the transport layer.
 	InsecureTransport bool
+	// IAmbreakingEELicense disables the EE license check before running the localserver, if set to 'yes'
+	IAmBreakingEELicense string
 	// CompactDbMaxTx sets the max transaction size for bolt db compaction operations
 	CompactDbMaxTx int64
 }


### PR DESCRIPTION
This commit:
 - adds a (fairly obnoxious) flag to skip the 'is launcher connecting to a kolide host' before starting the localserver

Why?
 - Sometimes we legitimately need to connect to, e.g., an ngrok tunnel for development