### PR TITLE
Add additional log checkpoint information

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -179,7 +179,10 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		"build", versionInfo.Revision,
 	)
 
-	checkpointer.SetQuerier(extension)
+	go func() {
+		time.Sleep(30 * time.Second)
+		checkpointer.SetQuerier(extension)
+	}()
 
 	// Create the control service and services that depend on it
 	var runner *desktopRunner.DesktopUsersProcessesRunner

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -179,6 +179,8 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		"build", versionInfo.Revision,
 	)
 
+	checkpointer.SetQuerier(extension)
+
 	// Create the control service and services that depend on it
 	var runner *desktopRunner.DesktopUsersProcessesRunner
 	if opts.ControlServerURL == "" {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -104,7 +104,8 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	internal.RecordLauncherVersion(rootDirectory)
 
 	// Try to ensure useful info in the logs
-	checkpoint.Run(logger, db, *opts)
+	checkpointer := checkpoint.New(logger, db, *opts)
+	checkpointer.Run()
 
 	// create the certificate pool
 	var rootPool *x509.CertPool

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -180,6 +180,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	)
 
 	go func() {
+		// Sleep to give osquery time to startup before the checkpointer starts using it.
 		time.Sleep(30 * time.Second)
 		checkpointer.SetQuerier(extension)
 	}()

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -70,9 +70,9 @@ func New(logger logger, db *bbolt.DB, opts launcher.Options) *checkPointer {
 	}
 }
 
-// AddQuerier adds the querier into the checkpointer. It is done in a function, so it can happen
+// SetQuerier adds the querier into the checkpointer. It is done in a function, so it can happen
 // later in the startup sequencing.
-func (c *checkPointer) AddQuerier(querier querierInt) {
+func (c *checkPointer) SetQuerier(querier querierInt) {
 	c.querier = querier
 	c.queryStaticInfo()
 }
@@ -80,11 +80,6 @@ func (c *checkPointer) AddQuerier(querier querierInt) {
 // Run starts a log checkpoint routine. The purpose of this is to
 // ensure we get good debugging information in the logs.
 func (c *checkPointer) Run() {
-
-	// Things to add:
-	//  * invoke osquery for better hardware info
-	//  * runtime stats, like memory allocations
-
 	go func() {
 		c.logCheckPoint()
 
@@ -98,71 +93,72 @@ func (c *checkPointer) logCheckPoint() {
 	// Attempt to populate anything
 	c.queryStaticInfo()
 
-	// Log static info
+	c.logStaticValues()
+	c.logOsqueryInfo()
+	c.logger.Log("hostname", hostName())
+	c.logger.Log("notableFiles", fileNamesInDirs(notableFileDirs...))
+	c.logDbSize()
+	c.logKolideServerVersion()
+	c.logConnections()
+	c.logIpLookups()
+	c.logNotaryVersions()
+}
+
+func (c *checkPointer) logStaticValues() {
 	c.lock.RLock()
 	for k, v := range c.staticInfo {
 		c.logger.Log(k, v)
 	}
 	c.lock.RUnlock()
-
-	// This info is not status, but may changes over time. As such, it is regenerate
-	c.logOsqueryInfo()
-	c.logger.Log("hostname", hostName())
-	c.logger.Log("notableFiles", fileNamesInDirs(notableFileDirs...))
-	logDbSize(c.logger, c.db)
-	logConnections(c.logger, c.opts)
-	logIpLookups(c.logger, c.opts)
-	logKolideServerVersion(c.logger, c.opts)
-	logNotaryVersions(c.logger, c.opts)
 }
 
-func logDbSize(logger log.Logger, db *bbolt.DB) {
-	boltStats, err := agent.GetStats(db)
+func (c *checkPointer) logDbSize() {
+	boltStats, err := agent.GetStats(c.db)
 	if err != nil {
-		logger.Log("bbolt db size", err.Error())
+		c.logger.Log("bbolt db size", err.Error())
 	} else {
-		logger.Log("bbolt db size", boltStats.DB.Size)
+		c.logger.Log("bbolt db size", boltStats.DB.Size)
 	}
 }
 
-func logKolideServerVersion(logger logger, opts launcher.Options) {
-	if !opts.KolideHosted {
+func (c *checkPointer) logKolideServerVersion() {
+	if !c.opts.KolideHosted {
 		return
 	}
 
 	httpClient := &http.Client{Timeout: requestTimeout}
 
-	kolideServerUrl, err := parseUrl(fmt.Sprintf("%s/version", opts.KolideServerURL), opts)
+	kolideServerUrl, err := parseUrl(fmt.Sprintf("%s/version", c.opts.KolideServerURL), c.opts)
 	if err != nil {
-		logger.Log("kolide server version fetch", err)
+		c.logger.Log("kolide server version fetch", err)
 	} else {
-		logger.Log("kolide server version fetch", fetchFromUrls(httpClient, kolideServerUrl))
+		c.logger.Log("kolide server version fetch", fetchFromUrls(httpClient, kolideServerUrl))
 	}
 }
 
-func logNotaryVersions(logger logger, opts launcher.Options) {
-	if !opts.KolideHosted || !opts.Autoupdate {
+func (c *checkPointer) logNotaryVersions() {
+	if !c.opts.KolideHosted || !c.opts.Autoupdate {
 		return
 	}
 
 	httpClient := &http.Client{Timeout: requestTimeout}
 
-	notaryUrl, err := parseUrl(fmt.Sprintf("%s/v2/kolide/launcher/_trust/tuf/targets/releases.json", opts.NotaryServerURL), opts)
+	notaryUrl, err := parseUrl(fmt.Sprintf("%s/v2/kolide/launcher/_trust/tuf/targets/releases.json", c.opts.NotaryServerURL), c.opts)
 	if err != nil {
-		logger.Log("notary versions", err)
+		c.logger.Log("notary versions", err)
 	} else {
-		logger.Log("notary versions", fetchNotaryVersions(httpClient, notaryUrl))
+		c.logger.Log("notary versions", fetchNotaryVersions(httpClient, notaryUrl))
 	}
 }
 
-func logConnections(logger logger, opts launcher.Options) {
+func (c *checkPointer) logConnections() {
 	dialer := &net.Dialer{Timeout: requestTimeout}
-	logger.Log("connections", testConnections(dialer, urlsToTest(opts)...))
+	c.logger.Log("connections", testConnections(dialer, urlsToTest(c.opts)...))
 }
 
-func logIpLookups(logger logger, opts launcher.Options) {
+func (c *checkPointer) logIpLookups() {
 	ipLookuper := &net.Resolver{}
-	logger.Log("ip loook ups", lookupHostsIpv4s(ipLookuper, urlsToTest(opts)...))
+	c.logger.Log("ip loook ups", lookupHostsIpv4s(ipLookuper, urlsToTest(c.opts)...))
 }
 
 func urlsToTest(opts launcher.Options) []*url.URL {

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -88,15 +88,16 @@ func (c *checkPointer) Run() {
 }
 
 func (c *checkPointer) logCheckPoint() {
-	// Attempt to populate anything
+	// populate and log the queried static info
 	c.queryStaticInfo()
+	c.logQueriedInfo()
 
 	c.logger.Log("runtime", runtimeInfo)
 	c.logger.Log("launcher", launcherInfo)
-	c.logQueriedInfo()
-	c.logOsqueryInfo()
 	c.logger.Log("hostname", hostName())
 	c.logger.Log("notableFiles", fileNamesInDirs(notableFileDirs...))
+
+	c.logOsqueryInfo()
 	c.logDbSize()
 	c.logKolideServerVersion()
 	c.logConnections()

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -51,14 +51,13 @@ type checkPointer struct {
 	db      *bbolt.DB
 	opts    launcher.Options
 
-	lock          sync.RWMutex
-	queriedInfo   map[string]any
-	staticQueried bool
+	lock        sync.RWMutex
+	queriedInfo map[string]any
 }
 
 func New(logger logger, db *bbolt.DB, opts launcher.Options) *checkPointer {
 	return &checkPointer{
-		logger: log.With(logger, "msg", "log checkpoint"),
+		logger: log.With(logger, "component", "log checkpoint"),
 		db:     db,
 		opts:   opts,
 
@@ -103,19 +102,6 @@ func (c *checkPointer) logCheckPoint() {
 	c.logConnections()
 	c.logIpLookups()
 	c.logNotaryVersions()
-}
-
-func (c *checkPointer) logQueriedInfo() {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
-	if !c.staticQueried {
-		return
-	}
-
-	for k, v := range c.queriedInfo {
-		c.logger.Log(k, v)
-	}
 }
 
 func (c *checkPointer) logDbSize() {

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -104,6 +104,7 @@ func (c *checkPointer) logCheckPoint() {
 	c.logConnections()
 	c.logIpLookups()
 	c.logNotaryVersions()
+	c.logServerProvidedData()
 }
 
 func (c *checkPointer) logDbSize() {

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -94,7 +94,7 @@ func (c *checkPointer) logCheckPoint() {
 	c.logger.Log("runtime", runtimeInfo)
 	c.logger.Log("launcher", launcherInfo)
 	c.logger.Log("hostname", hostName())
-	c.logger.Log("notableFiles", fileNamesInDirs(notableFileDirs...))
+	c.logger.Log("notableFiles", filesInDirs(notableFileDirs...))
 
 	c.logOsqueryInfo()
 	c.logDbSize()

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -164,7 +164,7 @@ func (c *checkPointer) logConnections() {
 
 func (c *checkPointer) logIpLookups() {
 	ipLookuper := &net.Resolver{}
-	c.logger.Log("ip loook ups", lookupHostsIpv4s(ipLookuper, urlsToTest(c.opts)...))
+	c.logger.Log("ip look ups", lookupHostsIpv4s(ipLookuper, urlsToTest(c.opts)...))
 }
 
 func urlsToTest(opts launcher.Options) []*url.URL {

--- a/pkg/log/checkpoint/files.go
+++ b/pkg/log/checkpoint/files.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func fileNamesInDirs(dirnames ...string) map[string]string {
+func filesInDirs(dirnames ...string) map[string]string {
 	results := make(map[string]string)
 
 	for _, dirname := range dirnames {

--- a/pkg/log/checkpoint/queried.go
+++ b/pkg/log/checkpoint/queried.go
@@ -49,12 +49,21 @@ func (c *checkPointer) logOsqueryInfo() {
 	c.logger.Log("osquery_info", info)
 }
 
+func (c *checkPointer) logQueriedInfo() {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	for k, v := range c.queriedInfo {
+		c.logger.Log(k, v)
+	}
+}
+
 // queryStaticInfo usually the querier to add additional static info.
 func (c *checkPointer) queryStaticInfo() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if c.querier == nil || c.staticQueried {
+	if c.querier == nil {
 		return
 	}
 
@@ -71,8 +80,6 @@ func (c *checkPointer) queryStaticInfo() {
 	} else {
 		c.queriedInfo["system_info"] = info
 	}
-
-	c.staticQueried = true
 }
 
 func (c *checkPointer) query(sql string) (map[string]string, error) {

--- a/pkg/log/checkpoint/queried.go
+++ b/pkg/log/checkpoint/queried.go
@@ -62,14 +62,14 @@ func (c *checkPointer) queryStaticInfo() {
 		c.logger.Log("msg", "failed to query os info", "err", err)
 		return
 	} else {
-		c.staticInfo["os_info"] = info
+		c.queriedInfo["os_info"] = info
 	}
 
 	if info, err := c.query(systemSqlQuery); err != nil {
 		c.logger.Log("msg", "failed to query os info", "err", err)
 		return
 	} else {
-		c.staticInfo["system_info"] = info
+		c.queriedInfo["system_info"] = info
 	}
 
 	c.staticQueried = true

--- a/pkg/log/checkpoint/queried.go
+++ b/pkg/log/checkpoint/queried.go
@@ -1,0 +1,93 @@
+package checkpoint
+
+import (
+	"errors"
+	"fmt"
+)
+
+const osSqlQuery = `
+SELECT
+	os_version.build as os_build,
+	os_version.name as os_name,
+	os_version.platform as os_platform,
+	os_version.platform_like as os_platform_like,
+	os_version.version as os_version
+FROM
+	os_version
+`
+
+const systemSqlQuery = `
+SELECT
+	system_info.hardware_model,
+	system_info.hardware_serial,
+	system_info.hardware_vendor,
+	system_info.hostname,
+	system_info.uuid as hardware_uuid
+FROM
+	system_info
+`
+
+const osquerySqlQuery = `
+SELECT
+	osquery_info.version as osquery_version,
+	osquery_info.instance_id as osquery_instance_id
+FROM
+    osquery_info
+`
+
+func (c *checkPointer) logOsqueryInfo() {
+	if c.querier == nil {
+		return
+	}
+
+	info, err := c.query(osquerySqlQuery)
+	if err != nil {
+		c.logger.Log("msg", "error querying osquery info", "err", err)
+		return
+	}
+
+	c.logger.Log("osquery_info", info)
+}
+
+// queryStaticInfo usually the querier to add additional static info.
+func (c *checkPointer) queryStaticInfo() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.querier == nil || c.staticQueried {
+		return
+	}
+
+	if info, err := c.query(osSqlQuery); err != nil {
+		c.logger.Log("msg", "failed to query os info", "err", err)
+		return
+	} else {
+		c.staticInfo["os_info"] = info
+	}
+
+	if info, err := c.query(systemSqlQuery); err != nil {
+		c.logger.Log("msg", "failed to query os info", "err", err)
+		return
+	} else {
+		c.staticInfo["system_info"] = info
+	}
+
+	c.staticQueried = true
+}
+
+func (c *checkPointer) query(sql string) (map[string]string, error) {
+	if c.querier == nil {
+		return nil, errors.New("no querier")
+	}
+
+	resp, err := c.querier.Query(sql)
+	if err != nil {
+		return nil, fmt.Errorf("error querying for static: %s", err)
+	}
+
+	if len(resp) < 1 {
+		return nil, errors.New("expected at least one row for static details")
+	}
+
+	return resp[0], nil
+}

--- a/pkg/log/checkpoint/server_data.go
+++ b/pkg/log/checkpoint/server_data.go
@@ -10,6 +10,7 @@ var serverProvidedDataKeys = []string{
 	"organization_id",
 	"device_id",
 	"remote_ip",
+	"tombstone_id",
 }
 
 // logServerProvidedData sends a subset of the server data into the checkpoint logs. This iterates over the

--- a/pkg/log/checkpoint/server_data.go
+++ b/pkg/log/checkpoint/server_data.go
@@ -9,6 +9,7 @@ var serverProvidedDataKeys = []string{
 	"munemo",
 	"organization_id",
 	"device_id",
+	"remote_ip",
 }
 
 // logServerProvidedData sends a subset of the server data into the checkpoint logs. This iterates over the

--- a/pkg/log/checkpoint/server_data.go
+++ b/pkg/log/checkpoint/server_data.go
@@ -1,0 +1,40 @@
+package checkpoint
+
+import (
+	"github.com/kolide/launcher/pkg/osquery"
+	"go.etcd.io/bbolt"
+)
+
+var serverProvidedDataKeys = []string{
+	"munemo",
+	"organization_id",
+	"device_id",
+}
+
+// logServerProvidedData sends a subset of the server data into the checkpoint logs. This iterates over the
+// desired keys, as a way to handle missing values.
+func (c *checkPointer) logServerProvidedData() {
+	data := make(map[string]string, len(serverProvidedDataKeys))
+
+	if err := c.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(osquery.ServerProvidedDataBucket))
+		if b == nil {
+			return nil
+		}
+
+		for _, key := range serverProvidedDataKeys {
+			val := b.Get([]byte(key))
+			if val == nil {
+				continue
+			}
+
+			data[key] = string(val)
+		}
+
+		return nil
+	}); err != nil {
+		c.logger.Log("server_data", "error fetching data", "err", err)
+	}
+
+	c.logger.Log("server_data", data)
+}


### PR DESCRIPTION
In thinking about how to add more information to the checkpoint logs it felt like this needed to become a struct -- easier to hold some state, add a querier, and whatnot.

1. Refactor to a checkpointer struct, moved the `Run` around a little
2. Add a `SetQuerier` function
3. When there is a querier, additional things are queried. 


Fixes: #1061