### PR TITLE
Flag day for the new menu format

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -320,7 +320,10 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 
 func (r *DesktopUsersProcessesRunner) Ping() {
 	// agent_flags bucket has been updated, query the flags to react to changes
-	enabledRaw, err := r.flagsGetter.Get([]byte("desktop_enabled"))
+	// This has a `v1` appended, because the menu data format went from v0 to v1 -- we
+	// added `hasCapability`. Doing this cleanly required a flag day. Future work will
+	// need to do something else, probably something where the menu data is versioned.
+	enabledRaw, err := r.flagsGetter.Get([]byte("desktop_enabled_v1"))
 	if err != nil {
 		level.Debug(r.logger).Log("msg", "failed to query desktop flags", "err", err)
 		return


### PR DESCRIPTION
This does a couple things as a prep for customer rollout. 

First, it adjusts the startup behavior. The desktop no longer always starts for the Kolide tenant. This is to better test customer behavior.

Second, it changes the control flag to enable the desktop. This is to head off a race condition around deployment sequencing. We already have code out, in the wild. So if we ship menu data, it will try to parse it. _But_ we've added functionality that won't display right. So we need some kind of versioning around the menu data. I'm not really sure what that will look like. (specifically, what do we display in the menu, if it can't handle the format). So a flag day feels simplest.

__Note:__ This means all the menus will vanish without corresponding changes in the K2 delivered control data. 