### PR TITLE
converts kolide_server_data table to be generic launcher_db table, adds table for agent_flags

### DIFF
--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/dev_table_tooling"
 	"github.com/kolide/launcher/pkg/osquery/tables/firefox_preferences"
-	"github.com/kolide/launcher/pkg/osquery/tables/kolide_server_data"
+	"github.com/kolide/launcher/pkg/osquery/tables/launcher_db"
 	"github.com/kolide/launcher/pkg/osquery/tables/osquery_instance_history"
 	"github.com/kolide/launcher/pkg/osquery/tables/tdebug"
 	"github.com/kolide/launcher/pkg/osquery/tables/zfs"
@@ -23,7 +23,8 @@ func LauncherTables(db *bbolt.DB, opts *launcher.Options) []osquery.OsqueryPlugi
 		LauncherConfigTable(db),
 		LauncherDbInfo(db),
 		LauncherInfoTable(db),
-		kolide_server_data.TablePlugin(db),
+		launcher_db.TablePlugin(db, "kolide_server_data", "server_provided_data"),
+		launcher_db.TablePlugin(db, "kolide_control_flags", "agent_flags"),
 		LauncherAutoupdateConfigTable(opts),
 		osquery_instance_history.TablePlugin(),
 	}

--- a/pkg/osquery/tables/launcher_db/launcher_db.go
+++ b/pkg/osquery/tables/launcher_db/launcher_db.go
@@ -1,31 +1,28 @@
-package kolide_server_data
+package launcher_db
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/osquery/osquery-go/plugin/table"
 
 	"go.etcd.io/bbolt"
 )
 
-const tableName = "kolide_server_data"
-
 // TablePlugin provides an osquery table plugin that exposes data found in the server_provided_data launcher.db bucket.
 // This data is intended to be updated by the control server.
-func TablePlugin(db *bbolt.DB) *table.Plugin {
+func TablePlugin(db *bbolt.DB, tableName, bucketName string) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("key"),
 		table.TextColumn("value"),
 	}
 
-	return table.NewPlugin(tableName, columns, generateServerDataTable(db))
+	return table.NewPlugin(tableName, columns, generateLauncherDbTable(db, bucketName))
 }
 
-func generateServerDataTable(db *bbolt.DB) table.GenerateFunc {
+func generateLauncherDbTable(db *bbolt.DB, bucket string) table.GenerateFunc {
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-		return dbKeyValueRows(osquery.ServerProvidedDataBucket, db)
+		return dbKeyValueRows(bucket, db)
 	}
 }
 

--- a/pkg/osquery/tables/launcher_db/launcher_db_test.go
+++ b/pkg/osquery/tables/launcher_db/launcher_db_test.go
@@ -1,4 +1,4 @@
-package kolide_server_data
+package launcher_db
 
 import (
 	"path/filepath"
@@ -10,7 +10,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func Test_generateServerDataTable(t *testing.T) {
+func Test_generateLauncherDbTable(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
closes [1089](https://github.com/kolide/launcher/issues/1089)