### PR TITLE
Fix desktop not running when it should be

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -195,11 +195,6 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		checkpointer.SetQuerier(extension)
 	}()
 
-	// For now, while we're in transition from K2 to device trust, we want to default to _not_ running
-	// the desktop process. This can be overridden via control server interaction -- see agent_flags
-	// subsystem.
-	desktopProcessSpawningEnabled := false
-
 	// Create the control service and services that depend on it
 	var runner *desktopRunner.DesktopUsersProcessesRunner
 	if opts.ControlServerURL == "" {
@@ -228,6 +223,16 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			return fmt.Errorf("failed to create KVStore: %w", err)
 		}
 		controlService.RegisterConsumer(agentFlagsSubsystemName, desktopFlagsBucketConsumer)
+
+		desktopEnabledRaw, err := controlStore.Get([]byte("desktop_enabled_v1"))
+		if err != nil {
+			level.Debug(logger).Log("msg", "failed to query desktop_enabled_v1 flag", "err", err)
+		}
+
+		// For now, while we're in transition from K2 to device trust, we want to default to _not_ running
+		// the desktop process. This can be overridden via control server interaction -- if the desktop_enabled_v1
+		// flag is present (regardless of it's value), this indicates control server has told launcher to enable desktop.
+		desktopProcessSpawningEnabled := desktopEnabledRaw != nil
 
 		runner = desktopRunner.New(
 			desktopRunner.WithLogger(logger),

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -224,7 +224,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		}
 		controlService.RegisterConsumer(agentFlagsSubsystemName, desktopFlagsBucketConsumer)
 
-		desktopEnabledRaw, err := controlStore.Get([]byte("desktop_enabled_v1"))
+		desktopEnabledRaw, err := desktopFlagsBucketConsumer.Get([]byte("desktop_enabled_v1"))
 		if err != nil {
 			level.Debug(logger).Log("msg", "failed to query desktop_enabled_v1 flag", "err", err)
 		}


### PR DESCRIPTION
This PR addresses something we overlooked until desktop enablement became defaulted to false.

Control server will tell launcher to enable desktop by sending the `desktop_enabled_v1` flag to it. Launcher will store this in the database, however launcher was not actually querying this value in order to override the default value of `desktopProcessSpawningEnabled`. This PR simply adds a database query to check for this flag and set `desktopProcessSpawningEnabled` to `true` if the flag is present.

In practice, this meant killing the launcher proper process would prevent desktop processes from being spawned in the future. This change should enable desktop again seamlessly - launcher instances which should have desktop enabled should already have the `desktop_enabled_v1` in their databases. Upon upgrade, launcher should observe this now and launch desktop.