### PR TITLE
Fix log stream error relating to notifications

### DIFF
--- a/ee/desktop/notify/notify_darwin.go
+++ b/ee/desktop/notify/notify_darwin.go
@@ -9,7 +9,6 @@ package notify
 
 bool sendNotification(char *cTitle, char *cBody, char *cActionUri);
 void runNotificationListenerApp(void);
-void stopNotificationListenerApp(void);
 */
 import "C"
 import (
@@ -35,18 +34,11 @@ func NewDesktopNotifier(logger log.Logger, _ string) *macNotifier {
 }
 
 func (m *macNotifier) Listen() error {
-	if !isBundle() {
-		<-m.interrupt
-		return nil
+	if isBundle() {
+		C.runNotificationListenerApp()
 	}
 
-	// isBundle
-	go func() {
-		<-m.interrupt
-		C.stopNotificationListenerApp()
-	}()
-
-	C.runNotificationListenerApp()
+	<-m.interrupt
 	return nil
 }
 

--- a/ee/desktop/notify/notify_darwin.h
+++ b/ee/desktop/notify/notify_darwin.h
@@ -1,7 +1,0 @@
-#import <Foundation/Foundation.h>
-#import <UserNotifications/UserNotifications.h>
-#import <AppKit/AppKit.h>
-
-@interface NotificationDelegate: NSObject <UNUserNotificationCenterDelegate>
-
-@end

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -3,8 +3,12 @@
 
 // sendNotification draws from Fyne's implementation: https://github.com/fyne-io/fyne/blob/master/app/app_darwin.m
 
-#import "notify_darwin.h"
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+#import <AppKit/AppKit.h>
 
+@interface NotificationDelegate: NSObject <UNUserNotificationCenterDelegate>
+@end
 @implementation NotificationDelegate
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
     NSDictionary *userInfo = response.notification.request.content.userInfo;
@@ -17,6 +21,8 @@
     completionHandler();
 }
 @end
+
+NotificationDelegate *notificationDelegate;
 
 void runNotificationListenerApp(void) {
     @autoreleasepool {
@@ -34,18 +40,9 @@ void runNotificationListenerApp(void) {
         NSSet *categories = [NSSet setWithObject:category];
         [center setNotificationCategories:categories];
 
-        if ([UNUserNotificationCenter class]) {
-            NotificationDelegate *notificationDelegate = [NotificationDelegate new];
-            [notificationDelegate autorelease];
-            [center setDelegate:notificationDelegate];
-        }
-
-        [NSApp run];
+        notificationDelegate = [[NotificationDelegate alloc] init];
+        [center setDelegate:notificationDelegate];
     }
-}
-
-void stopNotificationListenerApp(void) {
-    [NSApp terminate:nil];
 }
 
 BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSString *body, NSString *actionUri) {


### PR DESCRIPTION
Fixes incessant and very noisy errors present in log stream, resulting from two calls to `NSApp run` (one here, and one later from systray):

```
2023-03-10 14:32:41.740066-0500 0x50a624   Error       0x0                  92094  0    launcher: (AppKit) [com.apple.AppKit:General] nextEventMatchingMask should only be called from the Main Thread!
2023-03-10 14:32:41.740301-0500 0x50a624   Error       0x0                  92094  0    launcher: (AppKit) [com.apple.AppKit:General] (
	0   CoreFoundation                      0x0000000187c443e8 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x000000018778eea8 objc_exception_throw + 60
	2   AppKit                              0x000000018ae4d23c -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 2872
	3   AppKit                              0x000000018ae40e0c -[NSApplication run] + 464
	4   launcher                            0x000000010091ae18 runNotificationListenerApp + 328
	5   launcher                            0x00000001003036ec runtime.asmcgocall.abi0 + 124
)
```