### PR TITLE
Notification log updates

### DIFF
--- a/ee/control/consumers/notificationconsumer/notify_consumer.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer.go
@@ -116,7 +116,7 @@ func (nc *NotificationConsumer) notify(notificationToSend notify.Notification) {
 	}
 
 	if err := nc.runner.SendNotification(notificationToSend); err != nil {
-		level.Debug(nc.logger).Log("msg", "could not send notification", "title", notificationToSend.Title, "err", err)
+		// Already logged on desktop side, no need to log again
 		return
 	}
 

--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -86,6 +86,11 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
 BOOL sendNotification(char *cTitle, char *cBody, char *cActionUri) {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
+    // To be removed later -- for troubleshooting purposes only
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+        NSLog(@"desktop_notifier: Notification settings: %@", settings);
+    }];
+
     NSString *title = [NSString stringWithUTF8String:cTitle];
     NSString *body = [NSString stringWithUTF8String:cBody];
     NSString *actionUri = [NSString stringWithUTF8String:cActionUri];

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -281,16 +281,9 @@ func (r *DesktopUsersProcessesRunner) SendNotification(n notify.Notification) er
 	}
 
 	errs := make([]error, 0)
-	for uid, proc := range r.uidProcs {
+	for _, proc := range r.uidProcs {
 		client := client.New(r.authToken, proc.socketPath)
 		if err := client.Notify(n); err != nil {
-			level.Error(r.logger).Log(
-				"msg", "error sending notify command to desktop process",
-				"uid", uid,
-				"pid", proc.process.Pid,
-				"path", proc.path,
-				"err", err,
-			)
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Removes error log that's not needed; should produce an info-level log:

```
{
"caller":"runner.go:685",
"component":"desktop_users_processes_runner",
"level":"info",
"msg":"2023-03-13 11:24:33.377 launcher[54606:2452964] desktop_notifier: Notification settings: \u003cUNNotificationSettings: 0x600000330510; authorizationStatus: Authorized, notificationCenterSetting: Enabled, soundSetting: Enabled, badgeSetting: Enabled, lockScreenSetting: Enabled, carPlaySetting: NotSupported, announcementSetting: NotSupported, criticalAlertSetting: NotSupported, timeSensitiveSetting: NotSupported, alertSetting: Enabled, scheduledDeliverySetting: NotSupported, directMessagesSetting: NotSupported, alertStyle: Alert, groupingSetting: Default providesAppNotificationSettings: No\u003e",
"subprocess":"desktop",
"ts":"2023-03-13T15:24:33.377758Z",
"uid":"501"
}
```