### PR TITLE
Only show the Learn More button if we have an action to show

### DIFF
--- a/ee/desktop/notify/notify_darwin.m
+++ b/ee/desktop/notify/notify_darwin.m
@@ -34,7 +34,7 @@ void runNotificationListenerApp(void) {
         UNNotificationAction *learnMoreAction = [UNNotificationAction actionWithIdentifier:@"LearnMoreAction"
             title:@"Learn More" options:UNNotificationActionOptionNone];
 
-        UNNotificationCategory *category = [UNNotificationCategory categoryWithIdentifier:@"KolideNotificationCategory"
+        UNNotificationCategory *category = [UNNotificationCategory categoryWithIdentifier:@"KolideNotificationWithButtonCategory"
             actions:@[learnMoreAction] intentIdentifiers:@[]
             options:UNNotificationCategoryOptionNone];
         NSSet *categories = [NSSet setWithObject:category];
@@ -50,8 +50,12 @@ BOOL doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
     [content autorelease];
     content.title = title;
     content.body = body;
-    content.categoryIdentifier = @"KolideNotificationCategory";
-    content.userInfo = @{@"action_uri": actionUri};
+
+    if (actionUri != (id)[NSNull null] && actionUri.length > 0) {
+        // Only create "Learn more" button if we have an action URI to go with it
+        content.categoryIdentifier = @"KolideNotificationWithButtonCategory";
+        content.userInfo = @{@"action_uri": actionUri};
+    }
 
     NSString *uuid = [[NSUUID UUID] UUIDString];
     NSString *identifier = [NSString stringWithFormat:@"kolide-notify-%@", uuid];


### PR DESCRIPTION
This is already implemented on Windows and Linux, but I'd neglected to come back and fix it for macOS too. For notifications that don't have action URIs, we now won't show the `Learn More` button since it won't do anything.