### PR TITLE
Don't return an error during TUF errorlog cleanup (fixes raciness in Test_cleanUpOldErrors)

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -224,7 +224,7 @@ func (ta *TufAutoupdater) cleanUpOldErrors() {
 		if err != nil {
 			// Delete the corrupted key
 			keysToDelete = append(keysToDelete, k)
-			return fmt.Errorf("parsing key %s as timestamp: %w", string(k), err)
+			return nil
 		}
 
 		errorTimestamp := time.Unix(ts, 0)

--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -152,8 +152,7 @@ func Test_cleanUpOldErrors(t *testing.T) {
 
 	// Confirm we added them
 	keyCountBeforeCleanup := 0
-	err := autoupdater.store.ForEach(func(k, _ []byte) error {
-		fmt.Printf("SEEDED KEY: %s\n", string(k))
+	err := autoupdater.store.ForEach(func(_, _ []byte) error {
 		keyCountBeforeCleanup += 1
 		return nil
 	})
@@ -164,8 +163,7 @@ func Test_cleanUpOldErrors(t *testing.T) {
 	autoupdater.cleanUpOldErrors()
 
 	keyCount := 0
-	err = autoupdater.store.ForEach(func(k, _ []byte) error {
-		fmt.Printf("EXISTING KEY: %s\n", string(k))
+	err = autoupdater.store.ForEach(func(_, _ []byte) error {
 		keyCount += 1
 		return nil
 	})

--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -152,7 +152,8 @@ func Test_cleanUpOldErrors(t *testing.T) {
 
 	// Confirm we added them
 	keyCountBeforeCleanup := 0
-	err := autoupdater.store.ForEach(func(_, _ []byte) error {
+	err := autoupdater.store.ForEach(func(k, _ []byte) error {
+		fmt.Printf("SEEDED KEY: %s\n", string(k))
 		keyCountBeforeCleanup += 1
 		return nil
 	})
@@ -163,7 +164,8 @@ func Test_cleanUpOldErrors(t *testing.T) {
 	autoupdater.cleanUpOldErrors()
 
 	keyCount := 0
-	err = autoupdater.store.ForEach(func(_, _ []byte) error {
+	err = autoupdater.store.ForEach(func(k, _ []byte) error {
+		fmt.Printf("EXISTING KEY: %s\n", string(k))
 		keyCount += 1
 		return nil
 	})


### PR DESCRIPTION
Returning an error from `GetterSetterDeleterIterator.ForEach` has different behavior in bbolt vs in-memory implementation at the moment -- for now, fix raciness by not returning an error (which we didn't need here anyway!)