### PR TITLE
Perform retry on TUF update

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -150,9 +150,21 @@ func (ta *TufAutoupdater) Interrupt(_ error) {
 }
 
 func (ta *TufAutoupdater) checkForUpdate() error {
-	_, err := ta.metadataClient.Update()
-	if err != nil {
-		return fmt.Errorf("could not update metadata: %w", err)
+	// Attempt an update a couple times before returning an error -- sometimes we just hit caching issues.
+	errs := make([]error, 0)
+	successfulUpdate := false
+	updateTryCount := 3
+	for i := 0; i < updateTryCount; i += 1 {
+		_, err := ta.metadataClient.Update()
+		if err == nil {
+			successfulUpdate = true
+			break
+		}
+
+		errs = append(errs, fmt.Errorf("try %d: %w", i, err))
+	}
+	if !successfulUpdate {
+		return fmt.Errorf("could not update metadata after %d tries: %+v", updateTryCount, errs)
 	}
 
 	// Find the newest release for our channel -- right now for logging purposes only


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

Our TUF metadata files are served by a CDN, so sometimes we receive cached data with a different version than we expect. This is normal, but will cause an update failure. Now we do a couple retries before returning this failure.