### PR TITLE
Update localserver to handle more developer URLs

### DIFF
--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -159,13 +159,15 @@ func (ls *localServer) LoadDefaultKeyIfNotSet() error {
 	serverEccCertPem := k2EccServerCert
 	switch {
 	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.Contains(ls.kolideServer, ".ngrok."):
-		level.Debug(ls.logger).Log("msg", "using developer server certificate")
+		level.Debug(ls.logger).Log("msg", "using developer certificates")
 		serverRsaCertPem = localhostRsaServerCert
 		serverEccCertPem = localhostEccServerCert
 	case strings.HasSuffix(ls.kolideServer, ".herokuapp.com"):
-		level.Debug(ls.logger).Log("msg", "using review app server certificate")
+		level.Debug(ls.logger).Log("msg", "using review app certificates")
 		serverRsaCertPem = reviewRsaServerCert
 		serverEccCertPem = reviewEccServerCert
+	default:
+		level.Debug(ls.logger).Log("msg", "using default/production certificates")
 	}
 
 	serverKeyRaw, err := krypto.KeyFromPem([]byte(serverRsaCertPem))

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -158,10 +158,12 @@ func (ls *localServer) LoadDefaultKeyIfNotSet() error {
 	serverRsaCertPem := k2RsaServerCert
 	serverEccCertPem := k2EccServerCert
 	switch {
-	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.HasSuffix(ls.kolideServer, ".ngrok.io"):
+	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.Contains(ls.kolideServer, ".ngrok."):
+		level.Debug(ls.logger).Log("msg", "using developer server certificate")
 		serverRsaCertPem = localhostRsaServerCert
 		serverEccCertPem = localhostEccServerCert
 	case strings.HasSuffix(ls.kolideServer, ".herokuapp.com"):
+		level.Debug(ls.logger).Log("msg", "using review app server certificate")
 		serverRsaCertPem = reviewRsaServerCert
 		serverEccCertPem = reviewEccServerCert
 	}


### PR DESCRIPTION
Turns out, there are both `ngrok.io` and `ngrok.dev` URLs out there. Update the dev cert check to support that

Also add some debugging