### PR TITLE
bufferedHttpResponse makes http.Header if nil when accessed

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -207,7 +207,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	if opts.ControlServerURL == "" {
 		level.Debug(logger).Log("msg", "control server URL not set, will not create control service")
 	} else {
-		controlService, err := createControlService(ctx, logger, k.ControlStore(), opts)
+		controlService, err = createControlService(ctx, logger, k.ControlStore(), opts)
 		if err != nil {
 			return fmt.Errorf("failed to setup control service: %w", err)
 		}

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -177,6 +177,10 @@ type bufferedHttpResponse struct {
 }
 
 func (bhr *bufferedHttpResponse) Header() http.Header {
+	if bhr.header == nil {
+		bhr.header = make(http.Header)
+	}
+
 	return bhr.header
 }
 

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -121,7 +121,7 @@ func New(configStore types.Getter, kolideServer string, opts ...LocalServerOptio
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", http.NotFound)
-	mux.Handle("/v0/cmd", ecKryptoMiddleware.Wrap(ecAuthedMux))
+	mux.Handle("/v1/cmd", ecKryptoMiddleware.Wrap(ecAuthedMux))
 
 	// uncomment to test without going through middleware
 	// for example:

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -164,12 +164,16 @@ func (ls *localServer) LoadDefaultKeyIfNotSet() error {
 	serverRsaCertPem := k2RsaServerCert
 	serverEccCertPem := k2EccServerCert
 	switch {
-	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.HasSuffix(ls.kolideServer, ".ngrok.io"):
+	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.Contains(ls.kolideServer, ".ngrok."):
+		level.Debug(ls.logger).Log("msg", "using developer certificates")
 		serverRsaCertPem = localhostRsaServerCert
 		serverEccCertPem = localhostEccServerCert
 	case strings.HasSuffix(ls.kolideServer, ".herokuapp.com"):
+		level.Debug(ls.logger).Log("msg", "using review app certificates")
 		serverRsaCertPem = reviewRsaServerCert
 		serverEccCertPem = reviewEccServerCert
+	default:
+		level.Debug(ls.logger).Log("msg", "using default/production certificates")
 	}
 
 	serverKeyRaw, err := krypto.KeyFromPem([]byte(serverRsaCertPem))


### PR DESCRIPTION
this updates buffered response to initialize its  http.Header if it's nil at the time of access

the built in 404 func calls `ResponseWriter.Header().Set(...)` but this is not initialized by the bufferedHttpResponse, so it was causing launcher panics