### PR TITLE
ee/localserver: fix dropped error

### DIFF
--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -72,6 +72,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 				malloryKey, err := echelper.GenerateEcdsaKey()
 				require.NoError(t, err)
 				challenge, _, err := challenge.Generate(malloryKey, challengeId, challengeData, cmdReq)
+				require.NoError(t, err)
 				return challenge, nil
 			},
 			loggedErr: "unable to verify signature",


### PR DESCRIPTION
This fixes a dropped test error variable in `ee/localserver`.