### PR TITLE
Add kolide_softwareupdate_scan table

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,6 +117,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, []string{`/usr/libexec/remotectl`, `dumpstate`}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`, `--no-scan`}),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,6 +117,6 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, []string{`/usr/libexec/remotectl`, `dumpstate`}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`, `--no-scan`}),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}),
 	}
 }


### PR DESCRIPTION
We are occasionally seeing the new `kolide_softwareupdate` table return 0 rows from devices who should have a software update available. The explanation appears to be that those devices have not scanned for updates recently -- so this PR adds a second table `kolide_softwareupdate_scan` that will perform the scan. With this data, hopefully we should be able to determine whether the lack of scan is why `kolide_softwareupdate` sometimes returns 0 rows when it should return some.