### PR TITLE
Add UpToDate key to kolide_softwareupdate tables when there are no recommended updates

### DIFF
--- a/pkg/osquery/tables/execparsers/softwareupdate/parse.go
+++ b/pkg/osquery/tables/execparsers/softwareupdate/parse.go
@@ -17,6 +17,15 @@ func (p *parser) parseSoftwareupdate(reader io.Reader) (any, error) {
 	for p.scanner.Scan() {
 		currentLine := strings.TrimSpace(p.scanner.Text())
 
+		if strings.Contains(currentLine, "No new software available") {
+			// This is our indication that the device is up-to-date: there should be no recommended
+			// updates. Return this data early.
+			results = append(results, map[string]string{
+				"UpToDate": "true",
+			})
+			break
+		}
+
 		// There are some header lines (e.g. `Software Update Tool`) that we can safely discard.
 		// We only care about pairs of lines, where the first line begins in the following way.
 		if !strings.HasPrefix(currentLine, "* Label:") {

--- a/pkg/osquery/tables/execparsers/softwareupdate/parse_test.go
+++ b/pkg/osquery/tables/execparsers/softwareupdate/parse_test.go
@@ -98,14 +98,22 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:     "no update available, --no-scan",
-			input:    no_update_available_noscan,
-			expected: make([]map[string]string, 0),
+			name:  "no update available, --no-scan",
+			input: no_update_available_noscan,
+			expected: []map[string]string{
+				{
+					"UpToDate": "true",
+				},
+			},
 		},
 		{
-			name:     "no update available",
-			input:    no_update_available_scan,
-			expected: make([]map[string]string, 0),
+			name:  "no update available",
+			input: no_update_available_scan,
+			expected: []map[string]string{
+				{
+					"UpToDate": "true",
+				},
+			},
 		},
 		{
 			name:  "update available, --no-scan",


### PR DESCRIPTION
This should allow us to differentiate between no rows due to an error (e.g. a parsing error or a scanning error), and no rows due to the device being up-to-date. Now one row will be returned indicating that the device is up to date.

```
osquery> select * from kolide_softwareupdate_scan;
+------------+--------+----------+-------+-------+
| fullkey    | parent | key      | value | query |
+------------+--------+----------+-------+-------+
| 0/UpToDate | 0      | UpToDate | true  | *     |
+------------+--------+----------+-------+-------+
osquery> select * from kolide_softwareupdate;
+------------+--------+----------+-------+-------+
| fullkey    | parent | key      | value | query |
+------------+--------+----------+-------+-------+
| 0/UpToDate | 0      | UpToDate | true  | *     |
+------------+--------+----------+-------+-------+
```