### PR TITLE
Add option to include stderr with stdout for execparser

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,7 +117,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		munki.ManagedInstalls(client, logger),
 		munki.MunkiReport(client, logger),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, []string{`/usr/libexec/remotectl`, `dumpstate`}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`, `--no-scan`}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}, dataflattentable.WithIncludeStderr()),
 	}
 }

--- a/pkg/osquery/tables/airport/table_darwin.go
+++ b/pkg/osquery/tables/airport/table_darwin.go
@@ -52,7 +52,7 @@ type airportExecutor struct {
 }
 
 func (a *airportExecutor) Exec(option string) ([]byte, error) {
-	return tablehelpers.Exec(a.ctx, a.logger, 30, airportPaths, []string{"--" + option})
+	return tablehelpers.Exec(a.ctx, a.logger, 30, airportPaths, []string{"--" + option}, false)
 }
 
 type executor interface {

--- a/pkg/osquery/tables/apple_silicon_security_policy/table.go
+++ b/pkg/osquery/tables/apple_silicon_security_policy/table.go
@@ -38,7 +38,7 @@ func TablePlugin(logger log.Logger) *table.Plugin {
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	var results []map[string]string
 
-	output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{bootPolicyUtilPath}, []string{bootPolicyUtilArgs})
+	output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{bootPolicyUtilPath}, []string{bootPolicyUtilArgs}, false)
 	if err != nil {
 		level.Info(t.logger).Log("msg", "bputil failed", "err", err)
 		return nil, nil

--- a/pkg/osquery/tables/crowdstrike/falcon_kernel_check/table.go
+++ b/pkg/osquery/tables/crowdstrike/falcon_kernel_check/table.go
@@ -34,7 +34,7 @@ func TablePlugin(logger log.Logger) *table.Plugin {
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	output, err := tablehelpers.Exec(ctx, t.logger, 5, []string{kernelCheckUtilPath}, []string{})
+	output, err := tablehelpers.Exec(ctx, t.logger, 5, []string{kernelCheckUtilPath}, []string{}, false)
 	if err != nil {
 		level.Info(t.logger).Log("msg", "exec failed", "err", err)
 		return nil, err

--- a/pkg/osquery/tables/crowdstrike/falconctl/table.go
+++ b/pkg/osquery/tables/crowdstrike/falconctl/table.go
@@ -35,7 +35,7 @@ var (
 	defaultOption = strings.Join(allowedOptions, " ")
 )
 
-type execFunc func(context.Context, log.Logger, int, []string, []string) ([]byte, error)
+type execFunc func(context.Context, log.Logger, int, []string, []string, bool) ([]byte, error)
 
 type falconctlOptionsTable struct {
 	logger    log.Logger
@@ -86,7 +86,7 @@ OUTER:
 		// then the list of options to fetch. Set the command line thusly.
 		args := append([]string{"-g"}, options...)
 
-		output, err := t.execFunc(ctx, t.logger, 30, falconctlPaths, args)
+		output, err := t.execFunc(ctx, t.logger, 30, falconctlPaths, args, false)
 		if err != nil {
 			level.Info(t.logger).Log("msg", "exec failed", "err", err)
 			return nil, err

--- a/pkg/osquery/tables/crowdstrike/falconctl/table_test.go
+++ b/pkg/osquery/tables/crowdstrike/falconctl/table_test.go
@@ -81,7 +81,7 @@ func TestOptionRestrictions(t *testing.T) {
 	}
 }
 
-func noopExec(_ context.Context, log log.Logger, _ int, _ []string, args []string) ([]byte, error) {
+func noopExec(_ context.Context, log log.Logger, _ int, _ []string, args []string, _ bool) ([]byte, error) {
 	log.Log("exec", "exec-in-test", "args", strings.Join(args, " "))
 	return []byte{}, nil
 }

--- a/pkg/osquery/tables/cryptsetup/table.go
+++ b/pkg/osquery/tables/cryptsetup/table.go
@@ -54,7 +54,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	}
 
 	for _, name := range requestedNames {
-		output, err := tablehelpers.Exec(ctx, t.logger, 15, cryptsetupPaths, []string{"--readonly", "status", name})
+		output, err := tablehelpers.Exec(ctx, t.logger, 15, cryptsetupPaths, []string{"--readonly", "status", name}, false)
 		if err != nil {
 			level.Debug(t.logger).Log("msg", "Error execing for status", "name", name, "err", err)
 			continue

--- a/pkg/osquery/tables/dataflattentable/exec_and_parse.go
+++ b/pkg/osquery/tables/dataflattentable/exec_and_parse.go
@@ -24,6 +24,7 @@ type execTableV2 struct {
 	flattener      bytesFlattener
 	timeoutSeconds int
 	tabledebug     bool
+	includeStderr  bool
 	execPaths      []string
 	execArgs       []string
 }
@@ -45,6 +46,12 @@ func WithTableDebug() execTableV2Opt {
 func WithAdditionalExecPaths(paths ...string) execTableV2Opt {
 	return func(t *execTableV2) {
 		t.execPaths = append(t.execPaths, paths...)
+	}
+}
+
+func WithIncludeStderr() execTableV2Opt {
+	return func(t *execTableV2) {
+		t.includeStderr = true
 	}
 }
 
@@ -72,7 +79,7 @@ func NewExecAndParseTable(logger log.Logger, tableName string, p parser, execCmd
 func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	var results []map[string]string
 
-	execOutput, err := tablehelpers.Exec(ctx, t.logger, t.timeoutSeconds, t.execPaths, t.execArgs)
+	execOutput, err := tablehelpers.Exec(ctx, t.logger, t.timeoutSeconds, t.execPaths, t.execArgs, t.includeStderr)
 	if err != nil {
 		// exec will error if there's no binary, so we never want to record that
 		if os.IsNotExist(errors.Cause(err)) {

--- a/pkg/osquery/tables/dev_table_tooling/table.go
+++ b/pkg/osquery/tables/dev_table_tooling/table.go
@@ -54,7 +54,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			continue
 		}
 
-		output, err := tablehelpers.Exec(ctx, t.logger, 30, cmd.binPaths, cmd.args)
+		output, err := tablehelpers.Exec(ctx, t.logger, 30, cmd.binPaths, cmd.args, false)
 		if err != nil {
 			level.Info(t.logger).Log("msg", "execution failed", "name", name, "err", err)
 			continue

--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -38,7 +38,7 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	output, err := tablehelpers.Exec(ctx, t.logger, 10, []string{fdesetupPath}, []string{"status"})
+	output, err := tablehelpers.Exec(ctx, t.logger, 10, []string{fdesetupPath}, []string{"status"}, false)
 	if err != nil {
 		level.Info(t.logger).Log("msg", "fdesetup failed", "err", err)
 

--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -105,7 +105,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 							for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 								// Finally, an inner loop
 
-								ioregOutput, err := tablehelpers.Exec(ctx, t.logger, 30, []string{ioregPath}, ioregArgs)
+								ioregOutput, err := tablehelpers.Exec(ctx, t.logger, 30, []string{ioregPath}, ioregArgs, false)
 								if err != nil {
 									level.Info(t.logger).Log("msg", "ioreg failed", "err", err)
 									continue

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -70,7 +70,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 
-			mdmclientOutput, err := tablehelpers.Exec(ctx, t.logger, 30, []string{mdmclientPath}, []string{mdmclientCommand})
+			mdmclientOutput, err := tablehelpers.Exec(ctx, t.logger, 30, []string{mdmclientPath}, []string{mdmclientCommand}, false)
 			if err != nil {
 				level.Info(t.logger).Log("msg", "mdmclient failed", "err", err)
 				continue

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -107,7 +107,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 						return nil, fmt.Errorf("Unknown user argument: %s", user)
 					}
 
-					output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{profilesPath}, profileArgs)
+					output, err := tablehelpers.Exec(ctx, t.logger, 30, []string{profilesPath}, profileArgs, false)
 					if err != nil {
 						level.Info(t.logger).Log("msg", "ioreg exec failed", "err", err)
 						continue

--- a/pkg/osquery/tables/tablehelpers/exec.go
+++ b/pkg/osquery/tables/tablehelpers/exec.go
@@ -20,7 +20,7 @@ import (
 //  3. It moves the stderr into the return error, if needed.
 //
 // This is not suitable for high performance work -- it allocates new buffers each time.
-func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, possibleBins []string, args []string) ([]byte, error) {
+func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, possibleBins []string, args []string, includeStderr bool) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
@@ -33,7 +33,11 @@ func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, possibleBi
 
 		cmd := exec.CommandContext(ctx, bin, args...)
 		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
+		if includeStderr {
+			cmd.Stderr = &stdout
+		} else {
+			cmd.Stderr = &stderr
+		}
 
 		level.Debug(logger).Log(
 			"msg", "execing",

--- a/pkg/osquery/tables/tablehelpers/exec_test.go
+++ b/pkg/osquery/tables/tablehelpers/exec_test.go
@@ -62,7 +62,7 @@ func TestExec(t *testing.T) {
 			if tt.timeout == 0 {
 				tt.timeout = 30
 			}
-			output, err := Exec(ctx, logger, tt.timeout, tt.bins, tt.args)
+			output, err := Exec(ctx, logger, tt.timeout, tt.bins, tt.args, false)
 			if tt.err {
 				assert.Error(t, err)
 				assert.Empty(t, output)

--- a/pkg/osquery/tables/zfs/tables.go
+++ b/pkg/osquery/tables/zfs/tables.go
@@ -79,7 +79,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	args = append(args, names...)
 
-	output, err := tablehelpers.Exec(ctx, t.logger, 15, []string{t.cmd}, args)
+	output, err := tablehelpers.Exec(ctx, t.logger, 15, []string{t.cmd}, args, false)
 	if err != nil {
 		// exec will error if there's no binary, so we never want to record that
 		if os.IsNotExist(errors.Cause(err)) {


### PR DESCRIPTION
We discovered that `softwareupdate` writes `No new software available` to stderr instead of stdout, meaning we were unable to actually determine whether the device is up-to-date in the kolide_softwareupdate and kolide_softwareupdate_scan tables. This PR adds an option to the execparser to include stderr in stdout; it accomplishes this the same way that exec's `CombinedOutput` function works.