### PR TITLE
Log process info on osqueryd init error

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -119,14 +119,20 @@ func (l *OsqueryLogAdapter) logInfoAboutUnrecognizedProcessLockingPidfile(p []by
 	}
 
 	// Gather as much info as we can about the process
-	processInfo := make([]interface{}, 0)
-	processInfo = append(processInfo, "pid", pid)
+	processInfo := []interface{}{"pid", pid}
 	processInfo = append(processInfo, "name", getStringStat(unknownProcess.Name))
 	processInfo = append(processInfo, "cmdline", getStringStat(unknownProcess.Cmdline))
 	processInfo = append(processInfo, "status", getStringStat(unknownProcess.Status))
 	processInfo = append(processInfo, "create_time", getIntStat(unknownProcess.CreateTime))
 	processInfo = append(processInfo, "username", getStringStat(unknownProcess.Username))
 	processInfo = append(processInfo, "uids", getSliceStat(unknownProcess.Uids))
+
+	unknownProcessParent, _ := unknownProcess.Parent()
+	if unknownProcessParent != nil {
+		processInfo = append(processInfo, "parent_pid", unknownProcessParent.Pid)
+		processInfo = append(processInfo, "parent_cmdline", getStringStat(unknownProcessParent.Cmdline))
+		processInfo = append(processInfo, "parent_status", getStringStat(unknownProcessParent.Status))
+	}
 
 	level.Debug(l.logger).Log(append(processInfo, "msg", "detected non-osqueryd process using pidfile")...)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -70,14 +70,13 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 
-	logContext := l.extraKeyVals
 	if bytes.Contains(p, []byte("Refusing to kill non-osqueryd process")) {
-		logContext = append(logContext, getInfoAboutUnrecognizedProcessLockingPidfile(p)...)
+		l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
 	}
 
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
-	if err := lf(l.logger).Log(append(logContext, "msg", msg, "caller", caller)...); err != nil {
+	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {
 		return 0, err
 	}
 	return len(p), nil
@@ -88,31 +87,48 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 // it does not appear to be another instance of osquery. We attempt to log additional
 // information here about the process locking the pidfile.
 // See: https://github.com/osquery/osquery/issues/7796
-func getInfoAboutUnrecognizedProcessLockingPidfile(p []byte) []interface{} {
+func (l *OsqueryLogAdapter) logInfoAboutUnrecognizedProcessLockingPidfile(p []byte) {
 	matches := pidRegex.FindAllStringSubmatch(string(p), -1)
 	if len(matches) < 1 || len(matches[0]) < 2 {
-		return []interface{}{"process_info_err", fmt.Sprintf("could not extract PID of non-osqueryd process using pidfile: %s", string(p))}
+		level.Debug(l.logger).Log(
+			"msg", "could not extract PID of non-osqueryd process using pidfile from log line",
+			"log_line", string(p),
+		)
+		return
 	}
+
 	pidStr := strings.TrimSpace(matches[0][1]) // We want the group, not the full match
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {
-		return []interface{}{"process_info_err", fmt.Sprintf("could not extract PID of non-osqueryd process %s using pidfile: %v", pidStr, err)}
+		level.Debug(l.logger).Log(
+			"msg", "could not extract PID of non-osqueryd process using pidfile",
+			"pid", pidStr,
+			"err", err,
+		)
+		return
 	}
 
 	unknownProcess, err := process.NewProcess(int32(pid))
 	if err != nil {
-		return []interface{}{"process_info_err", fmt.Sprintf("could not get non-osqueryd process %d using pidfile: %v", pid, err)}
+		level.Debug(l.logger).Log(
+			"msg", "could not get non-osqueryd process using pidfile",
+			"pid", pid,
+			"err", err,
+		)
+		return
 	}
 
 	// Gather as much info as we can about the process
 	processInfo := make([]interface{}, 0)
-	processInfo = append(processInfo, "process_name", getStringStat(unknownProcess.Name))
-	processInfo = append(processInfo, "process_cmdline", getStringStat(unknownProcess.Cmdline))
-	processInfo = append(processInfo, "process_status", getStringStat(unknownProcess.Status))
-	processInfo = append(processInfo, "process_create_time", getIntStat(unknownProcess.CreateTime))
-	processInfo = append(processInfo, "process_username", getStringStat(unknownProcess.Username))
+	processInfo = append(processInfo, "pid", pid)
+	processInfo = append(processInfo, "name", getStringStat(unknownProcess.Name))
+	processInfo = append(processInfo, "cmdline", getStringStat(unknownProcess.Cmdline))
+	processInfo = append(processInfo, "status", getStringStat(unknownProcess.Status))
+	processInfo = append(processInfo, "create_time", getIntStat(unknownProcess.CreateTime))
+	processInfo = append(processInfo, "username", getStringStat(unknownProcess.Username))
+	processInfo = append(processInfo, "uids", getSliceStat(unknownProcess.Uids))
 
-	return processInfo
+	level.Debug(l.logger).Log(append(processInfo, "msg", "detected non-osqueryd process using pidfile")...)
 }
 
 // getStringStat is a small wrapper around gopsutil/process functions
@@ -135,4 +151,15 @@ func getIntStat(getFunc func() (int64, error)) string {
 		return fmt.Sprintf("could not get stat: %v", err)
 	}
 	return fmt.Sprintf("%d", stat)
+}
+
+// getSliceStat is a small wrapper around gopsutil/process functions
+// to return the stat if available, or an error message if not, so
+// that either way the info will be captured in the log.
+func getSliceStat(getFunc func() ([]int32, error)) string {
+	stat, err := getFunc()
+	if err != nil {
+		return fmt.Sprintf("could not get stat: %v", err)
+	}
+	return fmt.Sprintf("%+v", stat)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -120,6 +121,7 @@ func (l *OsqueryLogAdapter) logInfoAboutUnrecognizedProcessLockingPidfile(p []by
 
 	// Gather as much info as we can about the process
 	processInfo := []interface{}{"pid", pid}
+	processInfo = append(processInfo, "launcher_pid", os.Getpid())
 	processInfo = append(processInfo, "name", getStringStat(unknownProcess.Name))
 	processInfo = append(processInfo, "cmdline", getStringStat(unknownProcess.Cmdline))
 	processInfo = append(processInfo, "status", getStringStat(unknownProcess.Status))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -2,11 +2,14 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/shirou/gopsutil/process"
 )
 
 // OsqueryLogAdapater creates an io.Writer implementation useful for attaching
@@ -65,10 +68,63 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 
+	var oneTimeExtraKeyVals []string
+	if bytes.Contains(p, []byte("Refusing to kill non-osqueryd process")) {
+		oneTimeExtraKeyVals = getInfoAboutUnrecognizedProcessUsingPidfile(p)
+	}
+
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
-	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller)...); err != nil {
+	if err := lf(l.logger).Log(append(l.extraKeyVals, "msg", msg, "caller", caller, oneTimeExtraKeyVals)...); err != nil {
 		return 0, err
 	}
 	return len(p), nil
+}
+
+func getInfoAboutUnrecognizedProcessUsingPidfile(p []byte) []string {
+	pidStr := strings.TrimSpace(strings.TrimPrefix(string(p), "Refusing to kill non-osqueryd process"))
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return []string{"process_info_err", fmt.Sprintf("could not extract PID of non-osqueryd process %s using pidfile: %v", pidStr, err)}
+	}
+
+	unknownProcess, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return []string{"process_info_err", fmt.Sprintf("could not get non-osqueryd process %d using pidfile: %v", pid, err)}
+	}
+
+	// Gather as much info as we can about the process
+	processInfo := make([]string, 0)
+	processInfo = append(processInfo, "process_name", getStringStat(unknownProcess.Name))
+	processInfo = append(processInfo, "process_cmdline", getStringStat(unknownProcess.Cmdline))
+	processInfo = append(processInfo, "process_open_files", getStructStat(unknownProcess.OpenFiles))
+	processInfo = append(processInfo, "process_status", getStringStat(unknownProcess.Status))
+	processInfo = append(processInfo, "process_create_time", getIntStat(unknownProcess.CreateTime))
+	processInfo = append(processInfo, "process_username", getStringStat(unknownProcess.Username))
+
+	return processInfo
+}
+
+func getStringStat(getFunc func() (string, error)) string {
+	stat, err := getFunc()
+	if err != nil {
+		return fmt.Sprintf("could not get stat: %v", err)
+	}
+	return stat
+}
+
+func getIntStat(getFunc func() (int64, error)) string {
+	stat, err := getFunc()
+	if err != nil {
+		return fmt.Sprintf("could not get stat: %v", err)
+	}
+	return fmt.Sprintf("%d", stat)
+}
+
+func getStructStat(getFunc func() ([]process.OpenFilesStat, error)) string {
+	stat, err := getFunc()
+	if err != nil {
+		return fmt.Sprintf("could not get stat: %v", err)
+	}
+	return fmt.Sprintf("%+v", stat)
 }


### PR DESCRIPTION
This PR logs additional info whenever we detect [this osquery issue](https://github.com/osquery/osquery/issues/7796), in an attempt to understand why we occasionally see another unrecognized process holding the osquery lockfile.

Example log:

```
{
  "caller": "log.go:147",
  "cmdline": "./a.out",
  "create_time": "1681494252000",
  "launcher_pid": 38413,
  "msg": "detected non-osqueryd process using pidfile",
  "name": "a.out",
  "parent_cmdline": "sudo ./a.out",
  "parent_pid": 38409,
  "parent_status": "S",
  "pid": 38410,
  "severity": "debug",
  "status": "S",
  "system_uptime": 84572,
  "ts": "2023-04-14T17:44:18.867178Z",
  "uids": "[0]",
  "username": "root"
}
```

<details>
<summary>Test notes</summary>

In order to reproduce this error, you must stop launcher, then create another process that will use and lock the osqueryd pidfile. The only way I found that didn't result in an invalid PID error from osquery was to create, write, and lock the pidfile more or less exactly the way osquery does it [here](https://github.com/osquery/osquery/blob/master/osquery/utils/pidfile/pidfile_posix.cpp).

I tested on macOS since that's where we've been seeing these init errors, so the test steps are MacOS-specific.

Test steps:

1. Build launcher with changes and move it to a new update directory with a current timestamp
1. Unload launcher: `sudo launchctl unload /Library/LaunchDaemons/com.kolide-k2.launcher.plist`
1. Run the test script (below), which will overwrite the osquery pidfile for launcher and hold a lock on it for 60 seconds
1. Begin tailing launcher logs
1. Load launcher: `sudo launchctl load /Library/LaunchDaemons/com.kolide-k2.launcher.plist`
1. Observe a log `Refusing to kill non-osqueryd process`, which now includes additional context about the process that's holding the lock on the pidfile

```
#include <iostream>
#include <sstream>
#include <sys/file.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <unistd.h>
#include <chrono>
#include <thread>

using namespace std;

int main() {
  stringstream stream;
  stream << to_string(getpid());
  auto buffer = stream.str();

  int file_handle;
  string path ("/var/kolide-k2/k2device-preprod.kolide.com/osquery.pid");
  file_handle = open(path.c_str(), O_CREAT | O_RDWR | O_APPEND, 0600);
  if (file_handle == -1) {
    printf("open err\n");
    return 1;
  }

  if (ftruncate(file_handle, 0) != 0) {
    printf("truncate error\n");
    return 1;
  }

  auto buffer_size = static_cast<ssize_t>(buffer.size());
  auto remaining_bytes = buffer_size;

  buffer_size = remaining_bytes = {static_cast<ssize_t>(buffer.size())};

  for (int retry = 0; retry < 5 && remaining_bytes > 0; ++retry) {
    auto buffer_ptr = buffer.data() + buffer_size - remaining_bytes;

    auto count = write(file_handle, buffer_ptr, remaining_bytes);
    if (count == -1) {
      if (errno == EINTR) {
        continue;
      }

      break;
    }

    remaining_bytes -= count;
  }

  if (remaining_bytes != 0) {
    printf("io error\n");
    return 1;
  }

  if (fchmod(file_handle, 0600) != 0) {
    printf("chmod\n");
    return 1;
  }

  if (fchown(file_handle, getuid(), getgid()) != 0) {
    printf("chown\n");
    return 1;
  }

  int lock_status{};
  lock_status = flock(file_handle, LOCK_NB | LOCK_EX);
  if (lock_status == -1) {
    printf("flock\n");
    return 1;
  }

  printf("locked, sleeping\n");
  this_thread::sleep_for(chrono::milliseconds(60000));

  printf("done sleeping\n");

  flock(file_handle, LOCK_UN);
  close(file_handle);

  return 0;
}
```

</details>