### PR TITLE
Hide command prompt window when launching URLs on Windows

### DIFF
--- a/ee/desktop/menu/action_open_url.go
+++ b/ee/desktop/menu/action_open_url.go
@@ -1,10 +1,6 @@
 package menu
 
 import (
-	"os/exec"
-	"runtime"
-	"syscall"
-
 	"github.com/go-kit/kit/log/level"
 )
 
@@ -20,31 +16,4 @@ func (a actionOpenURL) Perform(m *menu) {
 			"URL", a.URL,
 			"err", err)
 	}
-}
-
-// open opens the specified URL in the default browser of the user
-// See https://stackoverflow.com/a/39324149/1705598
-func open(url string) error {
-	var cmd string
-	var args []string
-
-	switch runtime.GOOS {
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/C", "start"}
-	case "darwin":
-		cmd = "/usr/bin/open"
-	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
-	}
-	args = append(args, url)
-
-	command := exec.Command(cmd, args...)
-	if runtime.GOOS == "windows" {
-		// https://stackoverflow.com/questions/42500570/how-to-hide-command-prompt-window-when-using-exec-in-golang
-		// Otherwise the cmd window will appear briefly
-		command.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	}
-
-	return command.Start()
 }

--- a/ee/desktop/menu/action_open_url.go
+++ b/ee/desktop/menu/action_open_url.go
@@ -3,6 +3,7 @@ package menu
 import (
 	"os/exec"
 	"runtime"
+	"syscall"
 
 	"github.com/go-kit/kit/log/level"
 )
@@ -30,12 +31,20 @@ func open(url string) error {
 	switch runtime.GOOS {
 	case "windows":
 		cmd = "cmd"
-		args = []string{"/c", "start"}
+		args = []string{"/C", "start"}
 	case "darwin":
 		cmd = "/usr/bin/open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
 	}
 	args = append(args, url)
-	return exec.Command(cmd, args...).Start()
+
+	command := exec.Command(cmd, args...)
+	if runtime.GOOS == "windows" {
+		// https://stackoverflow.com/questions/42500570/how-to-hide-command-prompt-window-when-using-exec-in-golang
+		// Otherwise the cmd window will appear briefly
+		command.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	}
+
+	return command.Start()
 }

--- a/ee/desktop/menu/action_open_url_darwin.go
+++ b/ee/desktop/menu/action_open_url_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+// +build darwin
+
+package menu
+
+import (
+	"os/exec"
+)
+
+// open opens the specified URL in the default browser of the user
+// See https://stackoverflow.com/a/39324149/1705598
+func open(url string) error {
+	return exec.Command("/usr/bin/open", url).Start()
+}

--- a/ee/desktop/menu/action_open_url_linux.go
+++ b/ee/desktop/menu/action_open_url_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package menu
+
+import (
+	"os/exec"
+)
+
+// open opens the specified URL in the default browser of the user
+// See https://stackoverflow.com/a/39324149/1705598
+func open(url string) error {
+	return exec.Command("xdg-open", url).Start()
+}

--- a/ee/desktop/menu/action_open_url_windows.go
+++ b/ee/desktop/menu/action_open_url_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+// +build windows
+
+package menu
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// open opens the specified URL in the default browser of the user
+// See https://stackoverflow.com/a/39324149/1705598
+func open(url string) error {
+	cmd := exec.Command("cmd", "/C", "start", url)
+	// https://stackoverflow.com/questions/42500570/how-to-hide-command-prompt-window-when-using-exec-in-golang
+	// Otherwise the cmd window will appear briefly
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd.Start()
+}


### PR DESCRIPTION
This gets rid of the ugly cmd window appearing when users click on menu items with `action: open-url`