### PR TITLE
Adding missing defer ticker.Stop() calls

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -181,6 +181,7 @@ func listenSignals(logger log.Logger) {
 // monitorParentProcess continuously checks to see if parent is a live and sends on provided channel if it is not
 func monitorParentProcess(logger log.Logger, monitorUrl string, interval time.Duration) {
 	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 
 	client := http.Client{
 		Timeout: interval,

--- a/ee/control/consumers/notificationconsumer/notify_consumer.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer.go
@@ -190,6 +190,8 @@ func (nc *NotificationConsumer) Interrupt(err error) {
 func (nc *NotificationConsumer) runCleanup(ctx context.Context) {
 	ctx, nc.cancel = context.WithCancel(ctx)
 	t := time.NewTicker(nc.cleanupInterval)
+	defer t.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -109,6 +109,7 @@ func (cs *ControlService) Interrupt(err error) {
 
 func (cs *ControlService) Stop() {
 	level.Info(cs.logger).Log("msg", "control service stopping")
+	cs.requestTicker.Stop()
 	if cs.cancel != nil {
 		cs.cancel()
 	}

--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -153,7 +153,9 @@ func (ta *TufAutoupdater) Execute() (err error) {
 	ta.libraryManager.TidyLibrary()
 
 	checkTicker := time.NewTicker(ta.checkInterval)
+	defer checkTicker.Stop()
 	cleanupTicker := time.NewTicker(12 * time.Hour)
+	defer cleanupTicker.Stop()
 
 	for {
 		select {

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -384,8 +384,11 @@ func LaunchSimulation(logger log.Logger, host QueryRunner, grpcURL, uuid, enroll
 		}
 
 		requestQueriesTicker := time.NewTicker(h.requestQueriesInterval)
+		defer requestQueriesTicker.Stop()
 		requestConfigTicker := time.NewTicker(h.requestConfigInterval)
+		defer requestConfigTicker.Stop()
 		publishLogsTicker := time.NewTicker(h.publishLogsInterval)
+		defer publishLogsTicker.Stop()
 
 		for {
 			var err error


### PR DESCRIPTION
In my quest to diagnose excessive Idle Wake Ups, I noticed several places we're not calling `Stop()` on tickers. I don't think this actually fixes anything, but seems like an obvious fix to make.