### PR TITLE
Fixing a nondeterministic flag controller test

### DIFF
--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -79,6 +80,7 @@ func (fc *FlagController) Update(kvPairs map[string]string) ([]string, error) {
 
 	// Changed keys is the union of updated keys and deleted keys
 	changedKeys := append(updatedKeys, deletedKeys...)
+	sort.Strings(changedKeys)
 
 	// Now observers can be notified these keys have possibly changed
 	fc.notifyObservers(keys.ToFlagKeys(changedKeys)...)

--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -80,7 +79,6 @@ func (fc *FlagController) Update(kvPairs map[string]string) ([]string, error) {
 
 	// Changed keys is the union of updated keys and deleted keys
 	changedKeys := append(updatedKeys, deletedKeys...)
-	sort.Strings(changedKeys)
 
 	// Now observers can be notified these keys have possibly changed
 	fc.notifyObservers(keys.ToFlagKeys(changedKeys)...)

--- a/pkg/agent/flags/flag_controller_test.go
+++ b/pkg/agent/flags/flag_controller_test.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -208,6 +209,7 @@ func TestControllerUpdate(t *testing.T) {
 			fc := NewFlagController(log.NewNopLogger(), store)
 			assert.NotNil(t, fc)
 
+			sort.Strings(tt.changedKeys)
 			mockObserver := mocks.NewFlagsChangeObserver(t)
 			mockObserver.On("FlagsChanged", keys.ToFlagKeys(tt.changedKeys))
 

--- a/pkg/agent/flags/flag_controller_test.go
+++ b/pkg/agent/flags/flag_controller_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"sort"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -209,16 +209,17 @@ func TestControllerUpdate(t *testing.T) {
 			fc := NewFlagController(log.NewNopLogger(), store)
 			assert.NotNil(t, fc)
 
-			sort.Strings(tt.changedKeys)
 			mockObserver := mocks.NewFlagsChangeObserver(t)
-			mockObserver.On("FlagsChanged", keys.ToFlagKeys(tt.changedKeys))
+			mockObserver.On("FlagsChanged", mock.MatchedBy(func(k []keys.FlagKey) bool {
+				return assert.ElementsMatch(t, k, keys.ToFlagKeys(tt.changedKeys))
+			}))
 
 			fc.RegisterChangeObserver(mockObserver, keys.ToFlagKeys(tt.changedKeys)...)
 
 			changedKeys, err := fc.Update(tt.kvPairs)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.changedKeys, changedKeys)
+			assert.ElementsMatch(t, tt.changedKeys, changedKeys)
 		})
 	}
 }


### PR DESCRIPTION
I noticed this test failed in CI: https://github.com/kolide/launcher/actions/runs/4720672135/jobs/8372995737?pr=933

```
mock: Unexpected Method Call
2023-04-17T11:44:36.4119310Z             FlagsChanged([]keys.FlagKey)
2023-04-17T11:44:36.4120510Z             		0: []keys.FlagKey{"control_server_url", "control_request_interval"}
2023-04-17T11:44:36.4136890Z             
2023-04-17T11:44:36.4221620Z             The closest call I have is: 
2023-04-17T11:44:36.4226430Z             
2023-04-17T11:44:36.4239170Z             FlagsChanged([]keys.FlagKey)
2023-04-17T11:44:36.4326010Z             		0: []keys.FlagKey{"control_request_interval", "control_server_url"}
```

This occurs because the FlagKey slice is generated from ranging over a map, which does not guarantee order.
Comparing the test results with `ElementsMatch` effectively makes the comparison ignore order.