### PR TITLE
Use kolide/toast fork

### DIFF
--- a/ee/desktop/notify/notify_windows.go
+++ b/ee/desktop/notify/notify_windows.go
@@ -5,7 +5,7 @@ package notify
 
 import (
 	"github.com/go-kit/kit/log"
-	"gopkg.in/toast.v1"
+	"github.com/kolide/toast"
 )
 
 type windowsNotifier struct {

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 
 require (
 	github.com/kolide/systray v1.10.3
-	github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185
+	github.com/kolide/toast v1.0.0
 	github.com/shirou/gopsutil/v3 v3.23.3
 )
 

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 
 require (
 	github.com/kolide/systray v1.10.3
-	github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1
+	github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185
 	github.com/shirou/gopsutil/v3 v3.23.3
 )
 

--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,8 @@ require (
 
 require (
 	github.com/kolide/systray v1.10.3
+	github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1
 	github.com/shirou/gopsutil/v3 v3.23.3
-	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899 h1:xxLm19kyV9FUxN7T9
 github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899/go.mod h1:PvKvoNvMWfyPXZN9/yXNrGtAasI2b+sc8RpwkCJGzzc=
 github.com/kolide/systray v1.10.3 h1:PcWYvDepwRn2Sk7mLXM5LlMiIwCTRTUEqDELATVJYx0=
 github.com/kolide/systray v1.10.3/go.mod h1:FwK9yUmU3JO+vA7TOLQSFRgEQ3euLxOqic5qlBtFrik=
+github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1 h1:UfsTlINehzFYr83fXTleQNcaj1vvU1ONf49LsHFR0BI=
+github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1/go.mod h1:84R5sM7VWn6morUpJBGKrBMZB3Cm9OrmtBLWHwSEWL0=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80/go.mod h1:x3dEGYbZovhD1t8OwEgdyu/4ZCvrn9QvkbPtOZnul8k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -903,8 +905,6 @@ gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2 h1:MZF6J7CV6s/h0HBkfqebrYfKCVEo5iN+wzE4QhV3Evo=
-gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2/go.mod h1:s1Sn2yZos05Qfs7NKt867Xe18emOmtsO3eAKbDaon0o=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899 h1:xxLm19kyV9FUxN7T9
 github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899/go.mod h1:PvKvoNvMWfyPXZN9/yXNrGtAasI2b+sc8RpwkCJGzzc=
 github.com/kolide/systray v1.10.3 h1:PcWYvDepwRn2Sk7mLXM5LlMiIwCTRTUEqDELATVJYx0=
 github.com/kolide/systray v1.10.3/go.mod h1:FwK9yUmU3JO+vA7TOLQSFRgEQ3euLxOqic5qlBtFrik=
-github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185 h1:yCX0furyvoiSD9cJtkBHiwhY6VhUMOcQlSal+UygTXQ=
-github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185/go.mod h1:84R5sM7VWn6morUpJBGKrBMZB3Cm9OrmtBLWHwSEWL0=
+github.com/kolide/toast v1.0.0 h1:pQViHayQVSzkdz0v8xnYuC/o4L7LF8mUuLCvpZ21efU=
+github.com/kolide/toast v1.0.0/go.mod h1:84R5sM7VWn6morUpJBGKrBMZB3Cm9OrmtBLWHwSEWL0=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80/go.mod h1:x3dEGYbZovhD1t8OwEgdyu/4ZCvrn9QvkbPtOZnul8k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899 h1:xxLm19kyV9FUxN7T9
 github.com/kolide/krypto v0.0.0-20230209233022-9fce3e429899/go.mod h1:PvKvoNvMWfyPXZN9/yXNrGtAasI2b+sc8RpwkCJGzzc=
 github.com/kolide/systray v1.10.3 h1:PcWYvDepwRn2Sk7mLXM5LlMiIwCTRTUEqDELATVJYx0=
 github.com/kolide/systray v1.10.3/go.mod h1:FwK9yUmU3JO+vA7TOLQSFRgEQ3euLxOqic5qlBtFrik=
-github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1 h1:UfsTlINehzFYr83fXTleQNcaj1vvU1ONf49LsHFR0BI=
-github.com/kolide/toast v0.0.0-20230417172259-c2bbecd7e0a1/go.mod h1:84R5sM7VWn6morUpJBGKrBMZB3Cm9OrmtBLWHwSEWL0=
+github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185 h1:yCX0furyvoiSD9cJtkBHiwhY6VhUMOcQlSal+UygTXQ=
+github.com/kolide/toast v0.0.0-20230417184432-2a74b503c185/go.mod h1:84R5sM7VWn6morUpJBGKrBMZB3Cm9OrmtBLWHwSEWL0=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80 h1:XFzdAHvTlbQoHZdEgOEiFt93eyfXP6VZCwH5p+lPpBg=
 github.com/kolide/updater v0.0.0-20190315001611-15bbc19b5b80/go.mod h1:x3dEGYbZovhD1t8OwEgdyu/4ZCvrn9QvkbPtOZnul8k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Since go-toast/toast is not actively maintained and we needed to make an update in order to be able to send notifications with emojis, we forked the repo. This PR points to our new fork with the updates in place.