### PR TITLE
Replace delayed auto-start with service dependency in Wix configuration

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -56,6 +56,16 @@ const (
 // enabled, the finalizers will trigger various restarts.
 func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) error {
 	logger := log.With(ctxlog.FromContext(ctx), "caller", log.DefaultCaller)
+
+	// If delay_start is configured, wait before running launcher.
+	if opts.DelayStart > 0*time.Second {
+		level.Debug(logger).Log(
+			"msg", "delay_start configured, waiting before starting launcher",
+			"delay_start", opts.DelayStart.String(),
+		)
+		time.Sleep(opts.DelayStart)
+	}
+
 	level.Debug(logger).Log("msg", "runLauncher starting")
 
 	// We've seen launcher intermittently be unable to recover from

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -30,6 +31,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/storage"
 	agentbbolt "github.com/kolide/launcher/pkg/agent/storage/bbolt"
 	"github.com/kolide/launcher/pkg/autoupdate/tuf"
+	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/debug"
 	"github.com/kolide/launcher/pkg/launcher"
@@ -55,6 +57,21 @@ const (
 func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) error {
 	logger := log.With(ctxlog.FromContext(ctx), "caller", log.DefaultCaller)
 	level.Debug(logger).Log("msg", "runLauncher starting")
+
+	// We've seen launcher intermittently be unable to recover from
+	// DNS failures in the past, so this check gives us a little bit
+	// of room to ensure that we are able to resolve DNS requests
+	// before proceeding with starting launcher.
+	if err := backoff.WaitFor(func() error {
+		_, lookupErr := net.LookupIP(opts.KolideServerURL)
+		return lookupErr
+	}, 10*time.Second, 1*time.Second); err != nil {
+		level.Info(logger).Log(
+			"msg", "could not successfully perform IP lookup before starting launcher, proceeding anyway",
+			"kolide_server_url", opts.KolideServerURL,
+			"err", err,
+		)
+	}
 
 	// determine the root directory, create one if it's not provided
 	rootDirectory := opts.RootDirectory

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -90,6 +90,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		flInsecureTransport    = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
 		flInsecureTLS          = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
 		flIAmBreakingEELicense = flagset.Bool("i-am-breaking-ee-license", false, "Skip license check before running localserver (default: false)")
+		flDelayStart           = flagset.Duration("delay_start", 0*time.Second, "How much time to wait before starting launcher")
 
 		// deprecated options, kept for any kind of config file compatibility
 		_ = flagset.String("debug_log_file", "", "DEPRECATED")
@@ -217,6 +218,7 @@ func parseOptions(args []string) (*launcher.Options, error) {
 		ControlServerURL:                   controlServerURL,
 		ControlRequestInterval:             *flControlRequestInterval,
 		Debug:                              *flDebug,
+		DelayStart:                         *flDelayStart,
 		DisableControlTLS:                  disableControlTLS,
 		InsecureControlTLS:                 insecureControlTLS,
 		EnableInitialRunner:                *flInitialRunner,

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -200,6 +200,7 @@ func getArgsAndResponse() (map[string]string, *launcher.Options) {
 		Transport:              "grpc",
 		UpdateChannel:          "stable",
 		AutoloadedExtensions:   []string{"some-extension.ext"},
+		DelayStart:             0 * time.Second,
 	}
 
 	return args, opts

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -99,6 +99,8 @@ type Options struct {
 	InsecureTransport bool
 	// CompactDbMaxTx sets the max transaction size for bolt db compaction operations
 	CompactDbMaxTx int64
-	// IAmBreakingEELicence disables the EE licence check before runnign the local server
+	// IAmBreakingEELicence disables the EE licence check before running the local server
 	IAmBreakingEELicense bool
+	// DelayStart allows for delaying launcher startup for a configurable amount of time
+	DelayStart time.Duration
 }

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/osquery/table"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/config"
 	"github.com/osquery/osquery-go/plugin/distributed"
 	"github.com/osquery/osquery-go/plugin/logger"
@@ -374,7 +373,7 @@ func (r *Runner) launchOsqueryInstance() error {
 		}
 	}
 
-	o.extensionManagerClient, err = osquery.NewClient(paths.extensionSocketPath, 5*time.Second)
+	o.extensionManagerClient, err = o.StartOsqueryClient(paths)
 	if err != nil {
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -120,7 +120,8 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 
 	if includeService {
 		launcherService := wix.NewService("launcher.exe",
-			wix.WithDelayedStart(),
+			// Ensure that the service does not start until DNS is available, to avoid unrecoverable DNS failures in launcher.
+			wix.WithServiceDependency("Dnscache"),
 			wix.ServiceName(fmt.Sprintf("Launcher%sSvc", strings.Title(po.Identifier))),
 			wix.ServiceArgs([]string{"svc", "-config", po.FlagFile}),
 			wix.ServiceDescription(fmt.Sprintf("The Kolide Launcher (%s)", po.Identifier)),

--- a/pkg/packagekit/wix/doc.go
+++ b/pkg/packagekit/wix/doc.go
@@ -14,7 +14,7 @@ The basic steps of making a package:
  2. Create a packageRoot directory structure
  3. Use `heat` to harvest the file list from the packageRoot
  4. Use `candle` to take the wxs from (1) and (3) and make a wixobj
- 5. Use `light` to compile thje wixobj into an msi
+ 5. Use `light` to compile the wixobj into an msi
 
 While this is a somewhat agnostic wrapper, it does make several
 assumptions about the underlying process. It is not meant as a

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -205,8 +205,9 @@ func NewService(matchString string, opts ...ServiceOpt) *Service {
 	}
 
 	serviceConfig := &ServiceConfig{
-		OnInstall:   Yes,
-		OnReinstall: Yes,
+		OnInstall:        Yes,
+		OnReinstall:      Yes,
+		DelayedAutoStart: No,
 	}
 
 	// If a service name is not specified, replace the .exe with a svc,

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -64,6 +64,14 @@ type ServiceInstall struct {
 	Vital             YesNoType          `xml:",attr,omitempty"` // The overall install should fail if this service fails to install
 	UtilServiceConfig *UtilServiceConfig `xml:",omitempty"`
 	ServiceConfig     *ServiceConfig     `xml:",omitempty"`
+	ServiceDependency *ServiceDependency `xml:",omitempty"`
+}
+
+// ServiceDependency implements
+// https://wixtoolset.org/docs/v3/xsd/wix/servicedependency/
+type ServiceDependency struct {
+	Id    string    `xml:",attr,omitempty"`
+	Group YesNoType `xml:",attr,omitempty"`
 }
 
 // ServiceControl implements
@@ -148,6 +156,15 @@ func WithDisabledService() ServiceOpt {
 		// If this is not explicitly set to none, the installer hangs trying to start the
 		// disabled service.
 		s.serviceControl.Start = StartNone
+	}
+}
+
+func WithServiceDependency(service string) ServiceOpt {
+	return func(s *Service) {
+		s.serviceInstall.ServiceDependency = &ServiceDependency{
+			Id:    service,
+			Group: No, // set to no since `service` is the name of a singular service and not a group of services
+		}
 	}
 }
 

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -28,7 +28,7 @@ func TestService(t *testing.T) {
 
 	expectedXml := `<ServiceInstall Account="[SERVICEACCOUNT]" ErrorControl="normal" Id="DaemonSvc" Name="DaemonSvc" Start="auto" Type="ownProcess" Vital="yes">
                         <ServiceConfig xmlns="http://schemas.microsoft.com/wix/UtilExtension" FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" ResetPeriodInDays="1"></ServiceConfig>
-                        <ServiceConfig xmlns="http://schemas.microsoft.com/wix/2006/wi" OnInstall="yes" OnReinstall="yes"></ServiceConfig>
+                        <ServiceConfig xmlns="http://schemas.microsoft.com/wix/2006/wi" DelayedAutoStart="no" OnInstall="yes" OnReinstall="yes"></ServiceConfig>
                     </ServiceInstall>
                     <ServiceControl Name="DaemonSvc" Id="DaemonSvc" Remove="uninstall" Start="install" Stop="both" Wait="no"></ServiceControl>`
 

--- a/pkg/packagekit/wix/service_test.go
+++ b/pkg/packagekit/wix/service_test.go
@@ -85,6 +85,11 @@ func TestServiceOptions(t *testing.T) {
 			out:  []string{`DelayedAutoStart="yes"`},
 			name: "DelayedStart",
 		},
+		{
+			in:   NewService("daemon.exe", WithServiceDependency("Dnscache")),
+			out:  []string{`ServiceDependency Id="Dnscache"`},
+			name: "ServiceDependency",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1140

Removes delayed auto-start from the Wix configuration, on the assumption that this is what causes launcher to take 2+ minutes to start up after reboot on Windows. In its place, adds service dependency for `Dnscache` to ensure we don't regress on https://github.com/kolide/launcher/issues/232 and https://github.com/kolide/launcher/issues/563.

Reference: https://www.oreilly.com/library/view/wix-36-a/9781782160427/ch11s06.html

This PR also includes a small amount of hardening to hopefully make us more robust to temporary DNS failures:
1. Allow for retries on creating the osquery extension manager client
1. Attempts to lookup the K2 server host before starting launcher, to confirm that DNS works first
1. Adds a flag `delay_start` to allow for delaying launcher -- in case this fix isn't sufficient for some folks, they can configure `delay_start` for long enough that they see the previous behavior again

<details>
<summary>Test notes</summary>

#### Prerequisites 

You will want to have the [Wix Toolset](https://github.com/wixtoolset/wix3/releases/tag/wix3112rtm) installed.

If you get an error `WiX Toolset requires the .NET Framework 3.5.1 Windows feature to be enabled`, you can fix that by running the following:

```
dism.exe /online /enable-feature /featurename:NetFx3
```

#### Building the MSI

Build an MSI using local changes, using the correct enroll secret and adjusting the Wix path as necessary:

```
make -j2 github-build

./build/package-builder.exe make --debug=true --transport=jsonrpc --hostname=k2device-preprod.kolide.com --enroll_secret=<secret goes here> --output_dir=./build/ --wix_path=/c/Program\ Files\ \(x86\)/Wix\ Toolset\ v3.11/bin --identifier=kolide-k2 --launcher_version=./build/launcher.exe
```

#### Test steps

Install the MSI. Validate that launcher is running:

1. Running `get-process | where ProcessName -like "*launcher*"` returns a result that looks reasonable
1. Kolide icon appears in the task bar, with a working menu
1. You can authenticate to k2
1. You can LQ your device from k2
1. Check debug logs (Program Files => Kolide => Launcher-kolide-k2 => data => debug.json) and confirm no very strange errors -- a couple initial DNS failures from the checkpointer seem harmless

Reboot your computer. Validate that launcher begins running very shortly after reboot (within a matter of seconds). Run through the steps above to confirm the same.

<details>