### PR TITLE
Bump build environment to macos-12 and see how it goes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -136,7 +136,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-11
+          - macos-12
           - windows-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-11
+          - macos-12
           - windows-latest
     steps:
     - name: Check out code


### PR DESCRIPTION
We locked to macos-11 here: https://github.com/kolide/launcher/pull/950

Let's see how we do with macos-12.