### PR TITLE
Change menu template data to a map type

### DIFF
--- a/ee/desktop/menu/menu_template.go
+++ b/ee/desktop/menu/menu_template.go
@@ -8,17 +8,23 @@ import (
 )
 
 const (
-	funcHasCapability = "hasCapability"
-	funcRelativeTime  = "relativeTime"
+	CurrentMenuVersion string = "0.1.0" // Bump menu version when major changes occur to the TemplateData format
+
+	// Capabilities queriable via hasCapability
+	funcHasCapability     = "hasCapability"
+	funcRelativeTime      = "relativeTime"
+	errorlessTemplateVars = "errorlessTemplateVars" // capability to evaluate undefined template vars without failing
+
+	// TemplateData keys
+	LauncherVersion    string = "LauncherVersion"
+	LauncherRevision   string = "LauncherRevision"
+	GoVersion          string = "GoVersion"
+	ServerHostname     string = "ServerHostname"
+	LastMenuUpdateTime string = "LastMenuUpdateTime"
+	MenuVersion        string = "MenuVersion"
 )
 
-type TemplateData struct {
-	LauncherVersion    string `json:",omitempty"`
-	LauncherRevision   string `json:",omitempty"`
-	GoVersion          string `json:",omitempty"`
-	ServerHostname     string `json:",omitempty"`
-	LastMenuUpdateTime int64  `json:",omitempty"`
-}
+type TemplateData map[string]interface{}
 
 type templateParser struct {
 	td *TemplateData
@@ -42,7 +48,10 @@ func (tp *templateParser) Parse(text string) (string, error) {
 	t, err := template.New("menu_template").Funcs(template.FuncMap{
 		// hasCapability enables interoperability between different versions of launcher
 		funcHasCapability: func(capability string) bool {
-			if capability == funcRelativeTime {
+			switch capability {
+			case funcRelativeTime:
+				return true
+			case errorlessTemplateVars:
 				return true
 			}
 			return false

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -411,11 +411,12 @@ func (r *DesktopUsersProcessesRunner) generateMenuFile() error {
 	}
 
 	td := &menu.TemplateData{
-		LauncherVersion:    v.Version,
-		LauncherRevision:   v.Revision,
-		GoVersion:          v.GoVersion,
-		ServerHostname:     r.hostname,
-		LastMenuUpdateTime: info.ModTime().Unix(),
+		menu.LauncherVersion:    v.Version,
+		menu.LauncherRevision:   v.Revision,
+		menu.GoVersion:          v.GoVersion,
+		menu.ServerHostname:     r.hostname,
+		menu.LastMenuUpdateTime: info.ModTime().Unix(),
+		menu.MenuVersion:        menu.CurrentMenuVersion,
 	}
 
 	menuTemplateFileBytes, err := os.ReadFile(r.menuTemplatePath())


### PR DESCRIPTION
This PR adds a few things to make menu template data and variables easier to define.

Changing the `TemplateData` struct to a map allows template expansion to avoid parsing errors when looking up nonexistent template variables. Avoiding the errors means that one undefined template variable no longer causes the entire input to fail and results in no menu update.

Previous versions of launcher can handle this without failing:

```
{{if hasCapability `errorlessTemplateVars`}}{{.MenuVersion}}{{else}}{{end}}
```


While new versions of launcher can just as easily handle template variables whether or not they are defined:


```
{{if .MenuVersion}}Menu Version is: {{.MenuVersion}}{{else}}{{end}} // evaluates to "Menu Version is: 0.1.0"
{{if .UndefinedVar}}This is never used: {{.UndefinedVar}}{{else}}Fallback{{end}} // evaluates to "Fallback"
Undefined: {{.UndefinedVar}} // evaluates to "Undefined: <no value>"
```