### PR TITLE
Update osquery-go package to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mixer/clock v0.0.0-20170901150240-b08e6b4da7ea
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/oklog/run v1.0.0
-	github.com/osquery/osquery-go v0.0.0-20230427204930-ff54f5f08296
+	github.com/osquery/osquery-go v0.0.0-20230501171314-2fc54ff75669
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5/go.mod h1:JKR5QhjsYdnIPY7hakgas5sxf8qlA/9wQnLqaMfWdcg=
 github.com/osquery/osquery-go v0.0.0-20230427204930-ff54f5f08296 h1:Jh/mQI9eHGRam9eWRw59eE9DN1/1IW0g90lGiS5yxGo=
 github.com/osquery/osquery-go v0.0.0-20230427204930-ff54f5f08296/go.mod h1:0KzmMhe0PL19cdYq6nd1cT9/5bMMJBTssAfuEgM2i34=
+github.com/osquery/osquery-go v0.0.0-20230501171314-2fc54ff75669 h1:XkFPghRi7tQ8QF1gl+YIG3dTHvpyv4JGJm3cKdRqHr8=
+github.com/osquery/osquery-go v0.0.0-20230501171314-2fc54ff75669/go.mod h1:0KzmMhe0PL19cdYq6nd1cT9/5bMMJBTssAfuEgM2i34=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=


### PR DESCRIPTION
So we can use this https://github.com/osquery/osquery-go/pull/104