### PR TITLE
Moving to Go 1.20

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20' # Need quotes, see https://github.com/actions/setup-go/issues/326#issuecomment-1415636066
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20' # Need quotes, see https://github.com/actions/setup-go/issues/326#issuecomment-1415636066
+          go-version: '1.20.3'
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
     branches: '**'
 
 env:
-  GOVER: 1.20
+  GOVER: '1.20.3'
 
 jobs:
   build_and_test:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
     branches: '**'
 
 env:
-  GOVER: 1.19.8
+  GOVER: 1.20
 
 jobs:
   build_and_test:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20' # Need quotes, see https://github.com/actions/setup-go/issues/326#issuecomment-1415636066
+          go-version: '1.20.3'
 
       - run: make deps
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - run: make deps
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20' # Need quotes, see https://github.com/actions/setup-go/issues/326#issuecomment-1415636066
 
       - run: make deps
 

--- a/go.mod
+++ b/go.mod
@@ -116,4 +116,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,6 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5/go.mod h1:JKR5QhjsYdnIPY7hakgas5sxf8qlA/9wQnLqaMfWdcg=
-github.com/osquery/osquery-go v0.0.0-20230427204930-ff54f5f08296 h1:Jh/mQI9eHGRam9eWRw59eE9DN1/1IW0g90lGiS5yxGo=
-github.com/osquery/osquery-go v0.0.0-20230427204930-ff54f5f08296/go.mod h1:0KzmMhe0PL19cdYq6nd1cT9/5bMMJBTssAfuEgM2i34=
 github.com/osquery/osquery-go v0.0.0-20230501171314-2fc54ff75669 h1:XkFPghRi7tQ8QF1gl+YIG3dTHvpyv4JGJm3cKdRqHr8=
 github.com/osquery/osquery-go v0.0.0-20230501171314-2fc54ff75669/go.mod h1:0KzmMhe0PL19cdYq6nd1cT9/5bMMJBTssAfuEgM2i34=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
Go 1.20 doesn't have anything significant that we necessarily _need_ right now. However, after spending some time recently profiling launcher performance, I'm eager to see what gains we may get from the [Runtime improvements, as well as potentially take advantage of profile-guided optimization](https://go.dev/doc/go1.20).

> Runtime
> 
> Some of the garbage collector's internal data structures were reorganized to be both more space and CPU efficient. This change reduces memory overheads and improves overall CPU performance by up to 2%.
> 
> The garbage collector behaves less erratically with respect to goroutine assists in some circumstances.
> 
> Go 1.20 adds a new runtime/coverage package containing APIs for writing coverage profile data at runtime from long-running and/or server programs that do not terminate via os.Exit().
> 
> Compiler
> 
> Go 1.20 adds preview support for profile-guided optimization (PGO). PGO enables the toolchain to perform application- and workload-specific optimizations based on run-time profile information. Currently, the compiler supports pprof CPU profiles, which can be collected through usual means, such as the runtime/pprof or net/http/pprof packages. To enable PGO, pass the path of a pprof profile file via the -pgo flag to go build, as mentioned [above](https://go.dev/doc/go1.20#go-command). Go 1.20 uses PGO to more aggressively inline functions at hot call sites. Benchmarks for a representative set of Go programs show enabling profile-guided inlining optimization improves performance about 3–4%. See the [PGO user guide](https://go.dev/doc/pgo) for detailed documentation. We plan to add more profile-guided optimizations in future releases. Note that profile-guided optimization is a preview, so please use it with appropriate caution.
> 
> The Go 1.20 compiler upgraded its front-end to use a new way of handling the compiler's internal data, which fixes several generic-types issues and enables type declarations within generic functions and methods.
> 
> The compiler now [rejects anonymous interface cycles](https://go.dev/issue/56103) with a compiler error by default. These arise from tricky uses of [embedded interfaces](https://go.dev/ref/spec#Embedded_interfaces) and have always had subtle correctness issues, yet we have no evidence that they're actually used in practice. Assuming no reports from users adversely affected by this change, we plan to update the language specification for Go 1.22 to formally disallow them so tools authors can stop supporting them too.
> 
> Go 1.18 and 1.19 saw regressions in build speed, largely due to the addition of support for generics and follow-on work. Go 1.20 improves build speeds by up to 10%, bringing it back in line with Go 1.17. Relative to Go 1.19, generated code performance is also generally slightly improved.