### PR TITLE
Increasing thrift's ServerConnectivityCheckInterval from 5ms to 100ms

### DIFF
--- a/cmd/grpc.ext/grpc.go
+++ b/cmd/grpc.ext/grpc.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/env"
 	"github.com/kolide/kit/logutil"
@@ -105,6 +106,8 @@ func main() {
 	if err != nil {
 		logutil.Fatal(logger, "err", fmt.Errorf("starting grpc extension: %w", err), "stack", fmt.Sprintf("%+v", err))
 	}
+
+	thrift.ServerConnectivityCheckInterval = 100 * time.Millisecond
 
 	// create an extension server
 	server, err := osquery.NewExtensionManagerServer(

--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/logutil"
 	"github.com/kolide/kit/version"
@@ -34,6 +35,8 @@ func main() {
 
 	// allow for osqueryd to create the socket path
 	time.Sleep(2 * time.Second)
+
+	thrift.ServerConnectivityCheckInterval = 100 * time.Millisecond
 
 	// create an extension server
 	server, err := osquery.NewExtensionManagerServer(

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/logutil"
@@ -56,6 +57,8 @@ const (
 // rungroups with the various options, and goes! If autoupdate is
 // enabled, the finalizers will trigger various restarts.
 func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) error {
+	thrift.ServerConnectivityCheckInterval = 100 * time.Millisecond
+
 	logger := log.With(ctxlog.FromContext(ctx), "caller", log.DefaultCaller)
 
 	// If delay_start is configured, wait before running launcher.

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -101,7 +101,6 @@ func buildOsqueryFlags(socketPath, augeasLensesPath string, osqueryFlags []strin
 }
 
 func loadExtensions(socketPath string, osquerydPath string) (*osquery.ExtensionManagerServer, error) {
-
 	extensionManagerServer, err := osquery.NewExtensionManagerServer(
 		extensionName,
 		socketPath,

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/kit/testutil"
@@ -45,6 +46,8 @@ func TestMain(m *testing.M) {
 	}
 
 	testOsqueryBinaryDirectory = filepath.Join(binDirectory, "osqueryd")
+
+	thrift.ServerConnectivityCheckInterval = 100 * time.Millisecond
 
 	if err := downloadOsqueryInBinDir(binDirectory); err != nil {
 		fmt.Printf("Failed to download osquery: %v\n", err)


### PR DESCRIPTION
This changes the Thrift server-side connectivity checks to be 20 times less frequent.

From Thrift documentation:

> ServerConnectivityCheckInterval defines the ticker interval used by
> connectivity check in thrift compiled TProcessorFunc implementations.

So we have two-way connectivity checks occurring where:

- Every 5 seconds, launcher osquery client is pinging the osquery Thrift server to check that the osquery process is still running.
- Every 5 milliseconds, the osquery Thirft server is checking that the socket connected to the client is still open.

Increasing the latency to 100ms seems reasonable.