### PR TITLE
Update mdmclient output parsing

### DIFF
--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -150,7 +150,7 @@ func (t *Table) transformOutput(in []byte) ([]byte, error) {
 	// the one that matches the response structures.
 	out = bytes.Replace(out, []byte("\n}\n"), []byte("\n};\n"), 2)
 
-	// Adjust the PushToken entry, if present
+	// Adjust the PushToken and SignerCertificates entries, if present
 	out = transformLengthByteEntriesInOutput(out)
 
 	var retOut []byte

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -128,6 +128,12 @@ func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflat
 // transformOutput has some hackish rules to transform the output into a "proper" gnustep plist
 func (t *Table) transformOutput(in []byte) ([]byte, error) {
 	out := headerRegex.ReplaceAll(in, []byte{})
+
+	// We can't access the agent response when running launcher normally -- we get the error
+	// "[ERROR] Unable to target 'local user' via XPC when running as daemon". In that case,
+	// remove the null agent response.
+	out = bytes.Replace(out, []byte("Agent response: (null)\n"), []byte{}, 1)
+
 	out = bytes.Replace(out, []byte("Daemon response: {"), []byte("DaemonResponse = {"), 1)
 	out = bytes.Replace(out, []byte("Agent response: {"), []byte("AgentResponse = {"), 1)
 

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -147,6 +147,11 @@ func (t *Table) transformOutput(in []byte) ([]byte, error) {
 	return retOut, nil
 }
 
+// transformPushTokenInOutput adjusts the formatting of the PushToken property to be
+// parseable in a plist.
+//
+// original: `PushToken = {length = 32, bytes = 0x068b4535 172f7bd3 851facee c98e0d88 ... 38625271 61731ac3 };`
+// transformed: `PushToken = {length = 32; bytes = "0x068b4535 172f7bd3 851facee c98e0d88 ... 38625271 61731ac3 "; };`
 func transformPushTokenInOutput(out []byte) []byte {
 	matches := pushTokenRegex.FindAllSubmatchIndex(out, -1)
 
@@ -155,7 +160,7 @@ func transformPushTokenInOutput(out []byte) []byte {
 	}
 
 	// Iterate backwards through matches to avoid messing up indices for earlier
-	// matches when performing replacements.
+	// matches when performing insertions.
 	for i := len(matches) - 1; i >= 0; i -= 1 {
 		match := matches[i]
 		// First two items in `match` are start/end indices for entire line; second two items are

--- a/pkg/osquery/tables/mdmclient/mdmclient_test.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient_test.go
@@ -35,7 +35,7 @@ func TestTransformOutput(t *testing.T) {
 		},
 		{
 			in:           "QueryInstalledProfiles.output",
-			expectedRows: 30,
+			expectedRows: 32,
 		},
 		{
 			in:           "QuerySecurityInfo.output",

--- a/pkg/osquery/tables/mdmclient/mdmclient_test.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient_test.go
@@ -30,6 +30,10 @@ func TestTransformOutput(t *testing.T) {
 			expectedRows: 96,
 		},
 		{
+			in:           "QueryDeviceInformation_NullAgentResponse.output",
+			expectedRows: 60,
+		},
+		{
 			in:           "QueryInstalledProfiles.output",
 			expectedRows: 30,
 		},

--- a/pkg/osquery/tables/mdmclient/mdmclient_test.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient_test.go
@@ -26,6 +26,10 @@ func TestTransformOutput(t *testing.T) {
 			expectedRows: 1659,
 		},
 		{
+			in:           "QueryDeviceInformation_WithHeader.output",
+			expectedRows: 96,
+		},
+		{
 			in:           "QueryInstalledProfiles.output",
 			expectedRows: 30,
 		},

--- a/pkg/osquery/tables/mdmclient/testdata/QueryDeviceInformation_NullAgentResponse.output
+++ b/pkg/osquery/tables/mdmclient/testdata/QueryDeviceInformation_NullAgentResponse.output
@@ -1,0 +1,78 @@
+=== CPF_GetInstalledProfiles === (<Device>)
+Number of <Device> profiles found: 6 (Filtered: 0)
+Daemon response: {
+	QueryResponses =	 {
+		ActiveManagedUsers =		 (
+			"DD1C35B7-F8DD-441F-ABE1-DEADBEEFCAFE"
+		);
+		AutoSetupAdminAccounts =		 (
+		);
+		AvailableDeviceCapacity = 1761;
+		AwaitingConfiguration = 0;
+		BatteryLevel = 1;
+		BluetoothMAC = "5C:E9:1E:81:35:78";
+		BuildVersion = 22E261;
+		CurrentConsoleManagedUser = "DD1C35B7-F8DD-441F-ABE1-DEADBEEFCAFE";
+		DeviceCapacity = 1995;
+		DeviceName = "Some Device";
+		EACSPreflight = success;
+		EthernetMAC = "5c:e9:1e:85:12:98";
+		HasBattery = 1;
+		HostName = "somedevice.lan";
+		IsActivationLockEnabled = 1;
+		IsActivationLockSupported = 1;
+		IsAppleSilicon = 1;
+		IsSupervised = 1;
+		LocalHostName = "Some-Device";
+		MDMOptions =		 {
+			ActivationLockAllowedWhileSupervised = 1;
+			BootstrapTokenAllowed = 1;
+		};
+		Model = "Mac14,6";
+		ModelName = "MacBook Pro";
+		ModelNumber = "Z176000HGLL/A";
+		OSUpdateSettings =		 {
+			AutoCheckEnabled = 1;
+			AutomaticAppInstallationEnabled = 1;
+			AutomaticOSInstallationEnabled = 1;
+			AutomaticSecurityUpdatesEnabled = 1;
+			BackgroundDownloadEnabled = 1;
+			CatalogURL = "https://swscan.apple.com/content/catalogs/others/index-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz";
+			IsDefaultCatalog = 1;
+			PreviousScanDate = "2023-05-03 07:28:42 +0000";
+			PreviousScanResult = 2;
+		};
+		OSVersion = "13.3.1";
+		OSXSoftwareUpdateStatus =		 {
+			AutoCheckEnabled = 1;
+			AutomaticAppInstallationEnabled = 1;
+			AutomaticOSInstallationEnabled = 1;
+			AutomaticSecurityUpdatesEnabled = 1;
+			BackgroundDownloadEnabled = 1;
+			CatalogURL = "https://swscan.apple.com/content/catalogs/others/index-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz";
+			IsDefaultCatalog = 1;
+			PreviousScanDate = "2023-05-03 07:28:42 +0000";
+			PreviousScanResult = 2;
+		};
+		PINRequiredForDeviceLock = 1;
+		PINRequiredForEraseDevice = 0;
+		ProductName = "Mac14,6";
+		ProvisioningUDID = "00006021-001C28663AF00000";
+		PushToken = {length = 32, bytes = 0x068b4535 172f7bd3 851facee abcdabcd ... 38625271 61731ac3};
+		SerialNumber = GV9T7D0000;
+		SoftwareUpdateDeviceID = J416c00;
+		SupplementalBuildVersion = 22E772610a;
+		SupplementalOSVersionExtra = "(a)";
+		SupportsLOMDevice = 0;
+		SupportsiOSAppInstalls = 1;
+		SystemIntegrityProtectionEnabled = 1;
+		UDID = "048D2650-6A62-5A93-87BE-DEADBEEFCAFE";
+		WiFiMAC = "5c:e9:1e:85:12:98";
+		XsanConfiguration =		 {
+			role = unconfigured;
+		};
+		iTunesStoreAccountHash = "NQBfrI+cV1y9dfhj2iA0000=";
+		iTunesStoreAccountIsActive = 1;
+	};
+}
+Agent response: (null)

--- a/pkg/osquery/tables/mdmclient/testdata/QueryDeviceInformation_WithHeader.output
+++ b/pkg/osquery/tables/mdmclient/testdata/QueryDeviceInformation_WithHeader.output
@@ -1,0 +1,118 @@
+=== CPF_GetInstalledProfiles === (<Device>)
+Number of <Device> profiles found: 6 (Filtered: 0)
+Daemon response: {
+	QueryResponses =	 {
+		ActiveManagedUsers =		 (
+			"DD1C35B7-F8DD-441F-ABE1-DEADBEEFCAFE"
+		);
+		AutoSetupAdminAccounts =		 (
+		);
+		AvailableDeviceCapacity = 1761;
+		AwaitingConfiguration = 0;
+		BatteryLevel = 1;
+		BluetoothMAC = "5C:E9:1E:81:35:78";
+		BuildVersion = 22E261;
+		CurrentConsoleManagedUser = "DD1C35B7-F8DD-441F-ABE1-DEADBEEFCAFE";
+		DeviceCapacity = 1995;
+		DeviceName = "Some Device";
+		EACSPreflight = success;
+		EthernetMAC = "5c:e9:1e:85:12:98";
+		HasBattery = 1;
+		HostName = "somedevice.lan";
+		IsActivationLockEnabled = 1;
+		IsActivationLockSupported = 1;
+		IsAppleSilicon = 1;
+		IsSupervised = 1;
+		LocalHostName = "Some-Device";
+		MDMOptions =		 {
+			ActivationLockAllowedWhileSupervised = 1;
+			BootstrapTokenAllowed = 1;
+		};
+		Model = "Mac14,6";
+		ModelName = "MacBook Pro";
+		ModelNumber = "Z176000HGLL/A";
+		OSUpdateSettings =		 {
+			AutoCheckEnabled = 1;
+			AutomaticAppInstallationEnabled = 1;
+			AutomaticOSInstallationEnabled = 1;
+			AutomaticSecurityUpdatesEnabled = 1;
+			BackgroundDownloadEnabled = 1;
+			CatalogURL = "https://swscan.apple.com/content/catalogs/others/index-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz";
+			IsDefaultCatalog = 1;
+			PreviousScanDate = "2023-05-03 07:28:42 +0000";
+			PreviousScanResult = 2;
+		};
+		OSVersion = "13.3.1";
+		OSXSoftwareUpdateStatus =		 {
+			AutoCheckEnabled = 1;
+			AutomaticAppInstallationEnabled = 1;
+			AutomaticOSInstallationEnabled = 1;
+			AutomaticSecurityUpdatesEnabled = 1;
+			BackgroundDownloadEnabled = 1;
+			CatalogURL = "https://swscan.apple.com/content/catalogs/others/index-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz";
+			IsDefaultCatalog = 1;
+			PreviousScanDate = "2023-05-03 07:28:42 +0000";
+			PreviousScanResult = 2;
+		};
+		PINRequiredForDeviceLock = 1;
+		PINRequiredForEraseDevice = 0;
+		ProductName = "Mac14,6";
+		ProvisioningUDID = "00006021-001C28663AF00000";
+		PushToken = {length = 32, bytes = 0x068b4535 172f7bd3 851facee abcdabcd ... 38625271 61731ac3};
+		SerialNumber = GV9T7D0000;
+		SoftwareUpdateDeviceID = J416c00;
+		SupplementalBuildVersion = 22E772610a;
+		SupplementalOSVersionExtra = "(a)";
+		SupportsLOMDevice = 0;
+		SupportsiOSAppInstalls = 1;
+		SystemIntegrityProtectionEnabled = 1;
+		UDID = "048D2650-6A62-5A93-87BE-DEADBEEFCAFE";
+		WiFiMAC = "5c:e9:1e:85:12:98";
+		XsanConfiguration =		 {
+			role = unconfigured;
+		};
+		iTunesStoreAccountHash = "NQBfrI+cV1y9dfhj2iA0000=";
+		iTunesStoreAccountIsActive = 1;
+	};
+}
+Agent response: {
+	QueryResponses =	 {
+		AvailableDeviceCapacity = 1761;
+		AwaitingConfiguration = 0;
+		BatteryLevel = 1;
+		BluetoothMAC = "5C:E9:1E:81:35:78";
+		BuildVersion = 22E261;
+		DeviceCapacity = 1995;
+		DeviceName = "Some Device";
+		EthernetMAC = "5c:e9:1e:85:12:98";
+		HasBattery = 1;
+		HostName = "some-device.lan";
+		IsAppleSilicon = 1;
+		IsSupervised = 1;
+		LocalHostName = "Some-Device";
+		MDMOptions =		 {
+			ActivationLockAllowedWhileSupervised = 1;
+			BootstrapTokenAllowed = 1;
+		};
+		Model = "Mac14,6";
+		ModelName = "MacBook Pro";
+		ModelNumber = "Z176000HGLL/A";
+		NotOnConsole = 0;
+		OSVersion = "13.3.1";
+		ProductName = "Mac14,6";
+		ProvisioningUDID = "00006021-001C28663AF00000";
+		PushToken = {length = 32, bytes = 0x068b4535 172f7bd3 851facee c98e0d88 ... 38625271 61731ac3 };
+		SerialNumber = GV9T7D0000;
+		SoftwareUpdateDeviceID = J416cAP;
+		SupplementalBuildVersion = 22E772610a;
+		SupplementalOSVersionExtra = "(a)";
+		SupportsiOSAppInstalls = 1;
+		UDID = "048D2650-6A62-5A93-87BE-DEADBEEFCAFE";
+		UserID = "DD1C35B7-F8DD-441F-ABE1-DEADBEEFCAFE";
+		UserLongName = "Some User";
+		UserShortName = someuser;
+		WiFiMAC = "5c:e9:1e:85:12:98";
+		iTunesStoreAccountHash = "NQBfrI+cV1y9dfhj2iA0000=";
+		iTunesStoreAccountIsActive = 1;
+	};
+}

--- a/pkg/osquery/tables/mdmclient/testdata/QueryInstalledProfiles.output
+++ b/pkg/osquery/tables/mdmclient/testdata/QueryInstalledProfiles.output
@@ -40,8 +40,8 @@ Daemon response: {
             PayloadUUID = "00000000-1111-1111-1111-222222222222";
             PayloadVersion = 1;
             SignerCertificates =             (
-                <30820576 3082045e 2b97>,
-                <30820418 30820300 9237bb40>
+                {length = 1402, bytes = 0x30820576 3082045e a0030201 02020809 ... afb8b2d1 abcdabcd },
+                {length = 1052, bytes = 0x30820418 30820300 a0030201 02020804 ... 26cffc17 abcdabcd }
             );
         }
     );


### PR DESCRIPTION
Makes a few adjustments to how we parse mdmclient output:

* At some point after we created this table, the output began to include some header lines that we could not fit into our plist; now, we remove them
* QueryDeviceInformation output now sometimes includes a `PushToken` that we could not parse as a plist; now, we update the formatting to parse it
* QueryInstalledProfiles output now formats `SignerCertificates` in a similar way; their formatting is now updated similarly
* Because launcher runs as a daemon, we cannot access the agent response, which gave us an `AgentResponse: (null)` line that we cannot parse; now, we remove it