### PR TITLE
Fixed an edge case where no menu/icon shows up

### DIFF
--- a/ee/desktop/user/menu/menu.go
+++ b/ee/desktop/user/menu/menu.go
@@ -74,23 +74,24 @@ func New(logger log.Logger, hostname, filePath string) *menu {
 // getMenuData ingests the shared menu.json file created by the desktop runner
 // It unmarshals the data into a MenuData struct representing the menu, which is suitable for parsing and building the menu
 func (m *menu) getMenuData() *MenuData {
+	// Ensure that at a minumum we return a default menu, in case reading/unmarshaling fails
+	var menu MenuData
+	defer menu.SetDefaults()
+
 	if m.filePath == "" {
-		return nil
+		return &menu
 	}
 
 	menuFileBytes, err := os.ReadFile(m.filePath)
 	if err != nil {
 		level.Error(m.logger).Log("msg", "failed to read menu file", "path", m.filePath)
-		return nil
+		return &menu
 	}
 
-	var menu MenuData
 	if err := json.Unmarshal(menuFileBytes, &menu); err != nil {
 		level.Error(m.logger).Log("msg", "failed to unmarshal menu json")
-		return nil
+		return &menu
 	}
-
-	menu.SetDefaults()
 
 	return &menu
 }

--- a/ee/desktop/user/menu/menu.go
+++ b/ee/desktop/user/menu/menu.go
@@ -74,7 +74,7 @@ func New(logger log.Logger, hostname, filePath string) *menu {
 // getMenuData ingests the shared menu.json file created by the desktop runner
 // It unmarshals the data into a MenuData struct representing the menu, which is suitable for parsing and building the menu
 func (m *menu) getMenuData() *MenuData {
-	// Ensure that at a minumum we return a default menu, in case reading/unmarshaling fails
+	// Ensure that at a minimum we return a default menu, in case reading/unmarshaling fails
 	var menu MenuData
 	defer menu.SetDefaults()
 


### PR DESCRIPTION
I found this bug while messing around with my menu JSON.

### The bug

When no `menu.json` file exists, or it is otherwise corrupt, the `getMenuData` method would return `nil` and result in no menu bar, and no systray icon.

This normally would never happen, because the desktop runner will always attempt to parse the `menu_template` and generate a `menu.json` before running desktop. However, you can get into this case if the `menu_template` becomes corrupt or contains invalid JSON/template data. This is unlikely, but even in this scenario, we want to at least show the default menu and icon.

### The fix

The change here ensures that `menu.SetDefaults()` is always called (which will provide default values when not set), and `getMenuData` will never return `nil`.