### PR TITLE
Use `text/template` instead of `html/template` in packagekit

### DIFF
--- a/pkg/packagekit/render_systemd.go
+++ b/pkg/packagekit/render_systemd.go
@@ -3,9 +3,9 @@ package packagekit
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"strings"
+	"text/template"
 
 	"go.opencensus.io/trace"
 )

--- a/pkg/packagekit/render_upstart.go
+++ b/pkg/packagekit/render_upstart.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"html/template"
 	"io"
 	"strings"
+	"text/template"
 
 	"go.opencensus.io/trace"
 )


### PR DESCRIPTION
These are init script templates, and they were needlessly rendered with `html/template`. This caused false positives, such as [GO-2023-1751](https://pkg.go.dev/vuln/GO-2023-1751) while it is probably possible to ignore that, we can also quite reasonable use `text/template` here.