### PR TITLE
Allow future new menu item actions to be easier to introduce

### DIFF
--- a/ee/desktop/user/menu/action.go
+++ b/ee/desktop/user/menu/action.go
@@ -49,7 +49,9 @@ func (a *Action) UnmarshalJSON(data []byte) error {
 		}
 		a.Performer = openURL
 	default:
-		return fmt.Errorf("unknown action type: %s", action.Type)
+		// Silently ignore unrecognized actions because:
+		// 1. We don't have a logger reference here
+		// 2. As new actions are added, we don't want older versions of launcher to fail to unmarshal menus
 	}
 
 	return nil

--- a/ee/desktop/user/menu/action_test.go
+++ b/ee/desktop/user/menu/action_test.go
@@ -31,9 +31,9 @@ func Test_Unmarshal(t *testing.T) {
 			data: `{"type":""}`,
 		},
 		{
-			name:        "unknown action",
-			data:        `{"type":"unknown_action"}`,
-			expectedErr: true,
+			name:   "unknown action",
+			data:   `{"type":"unknown_action"}`,
+			action: Action{Type: "unknown_action", Action: json.RawMessage(nil), Performer: nil},
 		},
 		{
 			name:   "open url",
@@ -55,7 +55,6 @@ func Test_Unmarshal(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.action, a)
-
 		})
 	}
 }

--- a/ee/desktop/user/menu/menu_template.go
+++ b/ee/desktop/user/menu/menu_template.go
@@ -14,6 +14,7 @@ const (
 	funcHasCapability     = "hasCapability"
 	funcRelativeTime      = "relativeTime"
 	errorlessTemplateVars = "errorlessTemplateVars" // capability to evaluate undefined template vars without failing
+	errorlessActions      = "errorlessActions"      // capability to evaluate undefined menu item actions without failing
 
 	// TemplateData keys
 	LauncherVersion    string = "LauncherVersion"
@@ -52,6 +53,8 @@ func (tp *templateParser) Parse(text string) (string, error) {
 			case funcRelativeTime:
 				return true
 			case errorlessTemplateVars:
+				return true
+			case errorlessActions:
 				return true
 			}
 			return false


### PR DESCRIPTION
Similar in vein to https://github.com/kolide/launcher/pull/1154

While testing out an idea I realized that as it stands, launcher will fail to parse a menu entirely if/when a new menu item action is introduced. It's preferable to gracefully tolerate actions we don't recognize instead of failing. This change eliminates the error, and adds a `errorlessAction` capability which can be used in conjunction with `hasCapability` to introduce new actions while maintaining backwards compatibility.