### PR TITLE
Move TUF test setup to new package

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -1,11 +1,8 @@
 package tuf
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,9 +18,9 @@ import (
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
 	"github.com/kolide/launcher/pkg/agent/types"
 	typesmocks "github.com/kolide/launcher/pkg/agent/types/mocks"
+	tufci "github.com/kolide/launcher/pkg/autoupdate/tuf/ci"
 	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func TestNewTufAutoupdater(t *testing.T) {
@@ -66,7 +63,7 @@ func TestExecute(t *testing.T) {
 
 	testRootDir := t.TempDir()
 	testReleaseVersion := "1.2.3"
-	tufServerUrl, rootJson := initLocalTufServer(t, testReleaseVersion)
+	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, testReleaseVersion)
 	s := setupStorage(t)
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("RootDirectory").Return(testRootDir)
@@ -233,182 +230,6 @@ func Test_cleanUpOldErrors(t *testing.T) {
 	require.NoError(t, err, "could not iterate over keys")
 
 	require.Equal(t, 1, keyCount, "cleanup routine did not clean up correct number of old errors")
-}
-
-// Sets up a local TUF repo with some targets to serve metadata about; returns the URL
-// of a test HTTP server to serve that metadata and the root JSON needed to initialize
-// a client.
-func initLocalTufServer(t *testing.T, testReleaseVersion string) (tufServerURL string, rootJson []byte) {
-	tufDir := t.TempDir()
-
-	// Initialize repo with store
-	localStore := tuf.FileSystemStore(tufDir, nil)
-	repo, err := tuf.NewRepo(localStore)
-	require.NoError(t, err, "could not create new tuf repo")
-	require.NoError(t, repo.Init(false), "could not init new tuf repo")
-
-	// Gen keys
-	_, err = repo.GenKey("root")
-	require.NoError(t, err, "could not gen root key")
-	_, err = repo.GenKey("targets")
-	require.NoError(t, err, "could not gen targets key")
-	_, err = repo.GenKey("snapshot")
-	require.NoError(t, err, "could not gen snapshot key")
-	_, err = repo.GenKey("timestamp")
-	require.NoError(t, err, "could not gen timestamp key")
-
-	// Sign the root metadata file
-	require.NoError(t, repo.Sign("root.json"), "could not sign root metadata file")
-
-	// Create test binaries and release files per binary and per release channel
-	for _, b := range binaries {
-		for _, v := range []string{"0.1.1", "0.12.3-deadbeef", testReleaseVersion} {
-			binaryFileName := fmt.Sprintf("%s-%s.tar.gz", b, v)
-
-			// Create a valid test binary -- an archive of an executable with the proper directory structure
-			// that will actually run -- if this is the release version we care about. If this is not the
-			// release version we care about, then just create a small text file since it won't be downloaded
-			// and evaluated.
-			if v == testReleaseVersion {
-				// Create test binary and copy it to the staged targets directory
-				stagedTargetsDir := filepath.Join(tufDir, "staged", "targets", string(b), runtime.GOOS)
-				executablePath := executableLocation(stagedTargetsDir, b)
-				require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0777), "could not make staging directory")
-				copyBinary(t, executablePath)
-				require.NoError(t, os.Chmod(executablePath, 0755))
-
-				// Compress the binary or app bundle
-				compress(t, binaryFileName, stagedTargetsDir, stagedTargetsDir, b)
-			} else {
-				// Create and commit a test binary
-				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", string(b), runtime.GOOS), 0777), "could not make staging directory")
-				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", string(b), runtime.GOOS, binaryFileName), []byte("I am a test target"), 0777)
-				require.NoError(t, err, "could not write test target binary to temp dir")
-			}
-
-			// Add the target
-			require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s", b, runtime.GOOS, binaryFileName), nil), "could not add test target binary to tuf")
-
-			// Commit
-			require.NoError(t, repo.Snapshot(), "could not take snapshot")
-			require.NoError(t, repo.Timestamp(), "could not take timestamp")
-			require.NoError(t, repo.Commit(), "could not commit")
-
-			if v != testReleaseVersion {
-				continue
-			}
-
-			// If this is our release version, also create and commit a test release file
-			for _, c := range []string{"stable", "beta", "nightly"} {
-				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", string(b), runtime.GOOS, c), 0777), "could not make staging directory")
-				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", string(b), runtime.GOOS, c, "release.json"), []byte("{}"), 0777)
-				require.NoError(t, err, "could not write test target release file to temp dir")
-				customMetadata := fmt.Sprintf("{\"target\":\"%s/%s/%s\"}", b, runtime.GOOS, binaryFileName)
-				require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s/release.json", b, runtime.GOOS, c), []byte(customMetadata)), "could not add test target release file to tuf")
-
-				// Commit
-				require.NoError(t, repo.Snapshot(), "could not take snapshot")
-				require.NoError(t, repo.Timestamp(), "could not take timestamp")
-				require.NoError(t, repo.Commit(), "could not commit")
-			}
-		}
-	}
-
-	// Quick validation that we set up the repo properly: key and metadata files should exist; targets should exist
-	require.DirExists(t, filepath.Join(tufDir, "keys"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "root.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "snapshot.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "targets.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "timestamp.json"))
-	require.DirExists(t, filepath.Join(tufDir, "repository"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "root.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "snapshot.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "timestamp.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, "stable", "release.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "osqueryd", runtime.GOOS, "stable", "release.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "osqueryd", runtime.GOOS, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)))
-
-	// Set up a test server to serve these files
-	testMetadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		pathComponents := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")
-
-		fileToServe := tufDir
-
-		// Allow the test server to also stand in for dl.kolide.co
-		if pathComponents[0] == "kolide" {
-			fileToServe = filepath.Join(fileToServe, "repository", "targets")
-		} else {
-			fileToServe = filepath.Join(fileToServe, pathComponents[0])
-		}
-
-		for i := 1; i < len(pathComponents); i += 1 {
-			fileToServe = filepath.Join(fileToServe, pathComponents[i])
-		}
-
-		http.ServeFile(w, r, fileToServe)
-	}))
-
-	// Make sure we close the server at the end of our test
-	t.Cleanup(func() {
-		testMetadataServer.Close()
-	})
-
-	tufServerURL = testMetadataServer.URL
-
-	metadata, err := repo.GetMeta()
-	require.NoError(t, err, "could not get metadata from test TUF repo")
-	require.Contains(t, metadata, "root.json")
-	rootJson = metadata["root.json"]
-
-	return tufServerURL, rootJson
-}
-
-func compress(t *testing.T, outFileName string, outFileDir string, targetDir string, binary autoupdatableBinary) {
-	out, err := os.Create(filepath.Join(outFileDir, outFileName))
-	require.NoError(t, err, "creating archive: %s in %s", outFileName, outFileDir)
-	defer out.Close()
-
-	gw := gzip.NewWriter(out)
-	defer gw.Close()
-
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	srcFilePath := string(binary)
-	if binary == "launcher" && runtime.GOOS == "darwin" {
-		srcFilePath = filepath.Join("Kolide.app", "Contents", "MacOS", string(binary))
-
-		// Create directory structure for app bundle
-		for _, path := range []string{"Kolide.app", "Kolide.app/Contents", "Kolide.app/Contents/MacOS"} {
-			pInfo, err := os.Stat(filepath.Join(targetDir, path))
-			require.NoError(t, err, "stat for app bundle path %s", path)
-
-			hdr, err := tar.FileInfoHeader(pInfo, path)
-			require.NoError(t, err, "creating header for directory %s", path)
-			hdr.Name = path
-
-			require.NoError(t, tw.WriteHeader(hdr), "writing tar header")
-		}
-	} else if runtime.GOOS == "windows" {
-		srcFilePath += ".exe"
-	}
-
-	srcFile, err := os.Open(filepath.Join(targetDir, srcFilePath))
-	require.NoError(t, err, "opening binary")
-	defer srcFile.Close()
-
-	srcStats, err := srcFile.Stat()
-	require.NoError(t, err, "getting stats to compress binary")
-
-	hdr, err := tar.FileInfoHeader(srcStats, srcStats.Name())
-	require.NoError(t, err, "creating header")
-	hdr.Name = srcFilePath
-
-	require.NoError(t, tw.WriteHeader(hdr), "writing tar header")
-	_, err = io.Copy(tw, srcFile)
-	require.NoError(t, err, "copying file to archive")
 }
 
 func setupStorage(t *testing.T) types.KVStore {

--- a/pkg/autoupdate/tuf/ci/tuf_client.go
+++ b/pkg/autoupdate/tuf/ci/tuf_client.go
@@ -1,0 +1,34 @@
+package tufci
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf/client"
+	filejsonstore "github.com/theupdateframework/go-tuf/client/filejsonstore"
+)
+
+// SeedLocalTufRepo creates a local TUF repo with a valid release under the given version `testTargetVersion`
+func SeedLocalTufRepo(t *testing.T, testTargetVersion string, testRootDir string) {
+	serverUrl, testRootJson := InitRemoteTufServer(t, testTargetVersion)
+
+	// Now set up local repo
+	localTufDir := filepath.Join(testRootDir, "tuf")
+	localStore, err := filejsonstore.NewFileJSONStore(localTufDir)
+	require.NoError(t, err, "could not set up local store")
+
+	// Set up our remote store i.e. tuf.kolide.com
+	remoteOpts := client.HTTPRemoteOptions{
+		MetadataPath: "/repository",
+	}
+	remoteStore, err := client.HTTPRemoteStore(serverUrl, &remoteOpts, http.DefaultClient)
+	require.NoError(t, err, "could not set up remote store")
+
+	metadataClient := client.NewClient(localStore, remoteStore)
+	require.NoError(t, err, metadataClient.Init(testRootJson), "failed to initialze TUF client")
+
+	_, err = metadataClient.Update()
+	require.NoError(t, err, "could not update TUF client")
+}

--- a/pkg/autoupdate/tuf/ci/tuf_server.go
+++ b/pkg/autoupdate/tuf/ci/tuf_server.go
@@ -1,0 +1,214 @@
+package tufci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf"
+)
+
+// InitRemoteTufServer sets up a local TUF repo with some targets to serve metadata about; returns the URL
+// of a test HTTP server to serve that metadata and the root JSON needed to initialize a client.
+func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL string, rootJson []byte) {
+	tufDir := t.TempDir()
+
+	// Initialize repo with store
+	localStore := tuf.FileSystemStore(tufDir, nil)
+	repo, err := tuf.NewRepo(localStore)
+	require.NoError(t, err, "could not create new tuf repo")
+	require.NoError(t, repo.Init(false), "could not init new tuf repo")
+
+	// Gen keys
+	_, err = repo.GenKey("root")
+	require.NoError(t, err, "could not gen root key")
+	_, err = repo.GenKey("targets")
+	require.NoError(t, err, "could not gen targets key")
+	_, err = repo.GenKey("snapshot")
+	require.NoError(t, err, "could not gen snapshot key")
+	_, err = repo.GenKey("timestamp")
+	require.NoError(t, err, "could not gen timestamp key")
+
+	// Sign the root metadata file
+	require.NoError(t, repo.Sign("root.json"), "could not sign root metadata file")
+
+	// Create test binaries and release files per binary and per release channel
+	for _, b := range []string{"osqueryd", "launcher"} {
+		for _, v := range []string{"0.1.1", "0.12.3-deadbeef", testReleaseVersion} {
+			binaryFileName := fmt.Sprintf("%s-%s.tar.gz", b, v)
+
+			// Create a valid test binary -- an archive of an executable with the proper directory structure
+			// that will actually run -- if this is the release version we care about. If this is not the
+			// release version we care about, then just create a small text file since it won't be downloaded
+			// and evaluated.
+			if v == testReleaseVersion {
+				// Create test binary and copy it to the staged targets directory
+				stagedTargetsDir := filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS)
+				executablePath := executableLocation(stagedTargetsDir, b)
+				require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0777), "could not make staging directory")
+				CopyBinary(t, executablePath)
+				require.NoError(t, os.Chmod(executablePath, 0755))
+
+				// Compress the binary or app bundle
+				compress(t, binaryFileName, stagedTargetsDir, stagedTargetsDir, b)
+			} else {
+				// Create and commit a test binary
+				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS), 0777), "could not make staging directory")
+				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, binaryFileName), []byte("I am a test target"), 0777)
+				require.NoError(t, err, "could not write test target binary to temp dir")
+			}
+
+			// Add the target
+			require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s", b, runtime.GOOS, binaryFileName), nil), "could not add test target binary to tuf")
+
+			// Commit
+			require.NoError(t, repo.Snapshot(), "could not take snapshot")
+			require.NoError(t, repo.Timestamp(), "could not take timestamp")
+			require.NoError(t, repo.Commit(), "could not commit")
+
+			if v != testReleaseVersion {
+				continue
+			}
+
+			// If this is our release version, also create and commit a test release file
+			for _, c := range []string{"stable", "beta", "nightly"} {
+				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, c), 0777), "could not make staging directory")
+				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, c, "release.json"), []byte("{}"), 0777)
+				require.NoError(t, err, "could not write test target release file to temp dir")
+				customMetadata := fmt.Sprintf("{\"target\":\"%s/%s/%s\"}", b, runtime.GOOS, binaryFileName)
+				require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s/release.json", b, runtime.GOOS, c), []byte(customMetadata)), "could not add test target release file to tuf")
+
+				// Commit
+				require.NoError(t, repo.Snapshot(), "could not take snapshot")
+				require.NoError(t, repo.Timestamp(), "could not take timestamp")
+				require.NoError(t, repo.Commit(), "could not commit")
+			}
+		}
+	}
+
+	// Quick validation that we set up the repo properly: key and metadata files should exist; targets should exist
+	require.DirExists(t, filepath.Join(tufDir, "keys"))
+	require.FileExists(t, filepath.Join(tufDir, "keys", "root.json"))
+	require.FileExists(t, filepath.Join(tufDir, "keys", "snapshot.json"))
+	require.FileExists(t, filepath.Join(tufDir, "keys", "targets.json"))
+	require.FileExists(t, filepath.Join(tufDir, "keys", "timestamp.json"))
+	require.DirExists(t, filepath.Join(tufDir, "repository"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "root.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "snapshot.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "timestamp.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, "stable", "release.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "osqueryd", runtime.GOOS, "stable", "release.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "osqueryd", runtime.GOOS, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)))
+
+	// Set up a test server to serve these files
+	testMetadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pathComponents := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")
+
+		fileToServe := tufDir
+
+		// Allow the test server to also stand in for dl.kolide.co
+		if pathComponents[0] == "kolide" {
+			fileToServe = filepath.Join(fileToServe, "repository", "targets")
+		} else {
+			fileToServe = filepath.Join(fileToServe, pathComponents[0])
+		}
+
+		for i := 1; i < len(pathComponents); i += 1 {
+			fileToServe = filepath.Join(fileToServe, pathComponents[i])
+		}
+
+		http.ServeFile(w, r, fileToServe)
+	}))
+
+	// Make sure we close the server at the end of our test
+	t.Cleanup(func() {
+		testMetadataServer.Close()
+	})
+
+	tufServerURL = testMetadataServer.URL
+
+	metadata, err := repo.GetMeta()
+	require.NoError(t, err, "could not get metadata from test TUF repo")
+	require.Contains(t, metadata, "root.json")
+	rootJson = metadata["root.json"]
+
+	return tufServerURL, rootJson
+}
+
+func compress(t *testing.T, outFileName string, outFileDir string, targetDir string, binary string) {
+	out, err := os.Create(filepath.Join(outFileDir, outFileName))
+	require.NoError(t, err, "creating archive: %s in %s", outFileName, outFileDir)
+	defer out.Close()
+
+	gw := gzip.NewWriter(out)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	srcFilePath := binary
+	if binary == "launcher" && runtime.GOOS == "darwin" {
+		srcFilePath = filepath.Join("Kolide.app", "Contents", "MacOS", binary)
+
+		// Create directory structure for app bundle
+		for _, path := range []string{"Kolide.app", "Kolide.app/Contents", "Kolide.app/Contents/MacOS"} {
+			pInfo, err := os.Stat(filepath.Join(targetDir, path))
+			require.NoError(t, err, "stat for app bundle path %s", path)
+
+			hdr, err := tar.FileInfoHeader(pInfo, path)
+			require.NoError(t, err, "creating header for directory %s", path)
+			hdr.Name = path
+
+			require.NoError(t, tw.WriteHeader(hdr), "writing tar header")
+		}
+	} else if runtime.GOOS == "windows" {
+		srcFilePath += ".exe"
+	}
+
+	srcFile, err := os.Open(filepath.Join(targetDir, srcFilePath))
+	require.NoError(t, err, "opening binary")
+	defer srcFile.Close()
+
+	srcStats, err := srcFile.Stat()
+	require.NoError(t, err, "getting stats to compress binary")
+
+	hdr, err := tar.FileInfoHeader(srcStats, srcStats.Name())
+	require.NoError(t, err, "creating header")
+	hdr.Name = srcFilePath
+
+	require.NoError(t, tw.WriteHeader(hdr), "writing tar header")
+	_, err = io.Copy(tw, srcFile)
+	require.NoError(t, err, "copying file to archive")
+}
+
+// executableLocation returns the path to the executable in `updateDirectory`.
+func executableLocation(updateDirectory string, binary string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		switch binary {
+		case "launcher":
+			return filepath.Join(updateDirectory, "Kolide.app", "Contents", "MacOS", binary)
+		case "osqueryd":
+			return filepath.Join(updateDirectory, binary)
+		default:
+			return ""
+		}
+	case "windows":
+		return filepath.Join(updateDirectory, fmt.Sprintf("%s.exe", binary))
+	case "linux":
+		return filepath.Join(updateDirectory, binary)
+	default:
+		return filepath.Join(updateDirectory, binary)
+	}
+}

--- a/pkg/autoupdate/tuf/ci/valid_executable.go
+++ b/pkg/autoupdate/tuf/ci/valid_executable.go
@@ -1,0 +1,25 @@
+package tufci
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func CopyBinary(t *testing.T, executablePath string) {
+	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
+
+	destFile, err := os.Create(executablePath)
+	require.NoError(t, err, "create destination file")
+	defer destFile.Close()
+
+	srcFile, err := os.Open(os.Args[0])
+	require.NoError(t, err, "opening binary to copy for test")
+	defer srcFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	require.NoError(t, err, "copying binary")
+}

--- a/pkg/osquery/tables/tufinfo/release_version_test.go
+++ b/pkg/osquery/tables/tufinfo/release_version_test.go
@@ -4,31 +4,17 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"strings"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/kolide/launcher/pkg/agent/types/mocks"
-	"github.com/kolide/launcher/pkg/autoupdate/tuf"
+	tufci "github.com/kolide/launcher/pkg/autoupdate/tuf/ci"
 	"github.com/osquery/osquery-go/gen/osquery"
 
 	"github.com/stretchr/testify/require"
-	gotuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/client"
-	filejsonstore "github.com/theupdateframework/go-tuf/client/filejsonstore"
 )
-
-type tufTarget struct {
-	binary          string
-	operatingSystem string
-	channel         string
-	target          string
-}
 
 func TestTufReleaseVersionTable(t *testing.T) {
 	t.Parallel()
@@ -36,30 +22,13 @@ func TestTufReleaseVersionTable(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 
 	// Set up some expected results
-	testTargets := make([]tufTarget, 0)
-	expectedResults := make(map[string]map[string]map[string]string, 0)
+	expectedResults := make(map[string]string, 0)
 
-	for _, binary := range []string{"launcher", "osqueryd"} {
-		expectedResults[binary] = make(map[string]map[string]string, 0)
-		for _, operatingSystem := range []string{"darwin", "windows", "linux"} {
-			expectedResults[binary][operatingSystem] = make(map[string]string, 0)
-			for _, channel := range []string{"stable", "beta", "nightly"} {
-				testTarget := fmt.Sprintf("%s-%s.tar.gz", binary, randomSemver())
-				testTargets = append(testTargets, tufTarget{
-					binary:          binary,
-					operatingSystem: operatingSystem,
-					channel:         channel,
-					target:          testTarget,
-				})
-				expectedResults[binary][operatingSystem][channel] = fmt.Sprintf("%s/%s/%s", binary, operatingSystem, testTarget)
-			}
-		}
-	}
-
-	// Seed our test repos with expected targets
 	testRootDir := t.TempDir()
-	seedTufRepo(t, testTargets, testRootDir, "launcher")
-	seedTufRepo(t, testTargets, testRootDir, "osqueryd")
+	v := randomSemver()
+	expectedResults["launcher"] = fmt.Sprintf("launcher/%s/launcher-%s.tar.gz", runtime.GOOS, v)
+	expectedResults["osqueryd"] = fmt.Sprintf("osqueryd/%s/osqueryd-%s.tar.gz", runtime.GOOS, v)
+	tufci.SeedLocalTufRepo(t, v, testRootDir)
 
 	mockFlags := mocks.NewFlags(t)
 	mockFlags.On("RootDirectory").Return(testRootDir)
@@ -78,83 +47,10 @@ func TestTufReleaseVersionTable(t *testing.T) {
 	require.Greater(t, len(resp.Response), 0, "expected results but did not receive any")
 
 	for _, row := range resp.Response {
-		expectedTarget, ok := expectedResults[row["binary"]][row["operating_system"]][row["channel"]]
+		expectedTarget, ok := expectedResults[row["binary"]]
 		require.True(t, ok, "found unexpected row: %v", row)
 		require.Equal(t, expectedTarget, row["target"], "target mismatch")
 	}
-}
-
-func seedTufRepo(t *testing.T, testTargets []tufTarget, testRootDir string, binary string) {
-	// Create a "remote" TUF repo and seed it with the expected targets
-	tufDir := t.TempDir()
-
-	// Initialize remote repo with store
-	fsStore := gotuf.FileSystemStore(tufDir, nil)
-	repo, err := gotuf.NewRepo(fsStore)
-	require.NoError(t, err, "could not create new tuf repo")
-
-	// Gen keys
-	_, err = repo.GenKey("root")
-	require.NoError(t, err, "could not gen root key")
-	_, err = repo.GenKey("targets")
-	require.NoError(t, err, "could not gen targets key")
-	_, err = repo.GenKey("snapshot")
-	require.NoError(t, err, "could not gen snapshot key")
-	_, err = repo.GenKey("timestamp")
-	require.NoError(t, err, "could not gen timestamp key")
-
-	// Seed release files
-	for _, testTarget := range testTargets {
-		require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", testTarget.binary, testTarget.operatingSystem, testTarget.channel), 0777), "could not make staging directory")
-		err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", testTarget.binary, testTarget.operatingSystem, testTarget.channel, "release.json"), []byte("{}"), 0777)
-		require.NoError(t, err, "could not write test target release file to temp dir")
-		customMetadata := fmt.Sprintf("{\"target\":\"%s/%s/%s\"}", testTarget.binary, testTarget.operatingSystem, testTarget.target)
-		require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s/release.json", testTarget.binary, testTarget.operatingSystem, testTarget.channel), []byte(customMetadata)), "could not add test target release file to tuf")
-
-		require.NoError(t, repo.Snapshot(), "could not take snapshot")
-		require.NoError(t, repo.Timestamp(), "could not take timestamp")
-		require.NoError(t, repo.Commit(), "could not commit")
-	}
-
-	// Quick validation that we set up the repo properly
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets.json"))
-
-	// Set up a httptest server to serve this data to our local repo
-	testMetadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		pathComponents := strings.Split(r.URL.Path, "/")
-		fileToServe := tufDir
-		for _, c := range pathComponents {
-			fileToServe = filepath.Join(fileToServe, c)
-		}
-		http.ServeFile(w, r, fileToServe)
-	}))
-
-	// Make sure we close the server at the end of our test
-	t.Cleanup(func() {
-		testMetadataServer.Close()
-	})
-
-	// Get metadata to initialize local store
-	metadata, err := repo.GetMeta()
-	require.NoError(t, err, "could not get metadata")
-
-	// Now set up local repo
-	localTufDir := tuf.LocalTufDirectory(testRootDir)
-	localStore, err := filejsonstore.NewFileJSONStore(localTufDir)
-	require.NoError(t, err, "could not set up local store")
-
-	// Set up our remote store i.e. tuf.kolide.com
-	remoteOpts := client.HTTPRemoteOptions{
-		MetadataPath: "/repository",
-	}
-	remoteStore, err := client.HTTPRemoteStore(testMetadataServer.URL, &remoteOpts, http.DefaultClient)
-	require.NoError(t, err, "could not set up remote store")
-
-	metadataClient := client.NewClient(localStore, remoteStore)
-	require.NoError(t, err, metadataClient.Init(metadata["root.json"]), "failed to initialze TUF client")
-
-	_, err = metadataClient.Update()
-	require.NoError(t, err, "could not update TUF client")
 }
 
 func randomSemver() string {


### PR DESCRIPTION
Adds a `tufci` package for reusable/shared test utilities -- this was helpful mostly because pkg/osquery/tables/tufinfo/release_version_test.go and https://github.com/kolide/launcher/pull/1185 both require very similar and lengthy test setup.