### PR TITLE
james/json-line-format

### DIFF
--- a/pkg/dataflatten/flatten_test.go
+++ b/pkg/dataflatten/flatten_test.go
@@ -472,7 +472,7 @@ func TestFlatten(t *testing.T) {
 	}
 }
 
-func TestFlattenJsonl(t *testing.T) {
+func TestFlattenJsonlErrors(t *testing.T) {
 	t.Parallel()
 
 	var tests = []flattenTestCase{
@@ -481,11 +481,17 @@ func TestFlattenJsonl(t *testing.T) {
 			err: true,
 		},
 		{
+			// this test case was left over from attempting to parse json that
+			// is contained within a file that is not stricly jsonl
+			// it should error, maybe look at this again in the future?
 			comment: "valid json inline text",
 			in:      `valid json is hidden["a"]in me`,
 			err:     true,
 		},
 		{
+			// this test case was left over from attempting to parse json that
+			// is contained within a file that is not stricly jsonl
+			// it should error, maybe look at this again in the future?
 			comment: "valid json sandwich",
 			in: `
 			there is some json under me

--- a/pkg/dataflatten/jsonl.go
+++ b/pkg/dataflatten/jsonl.go
@@ -1,0 +1,36 @@
+package dataflatten
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func JsonlFile(file string, opts ...FlattenOpts) ([]Row, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	return Jsonl(bufio.NewReader(f), opts...)
+}
+
+func Jsonl(r io.Reader, opts ...FlattenOpts) ([]Row, error) {
+	decoder := json.NewDecoder(r)
+	var objects []interface{}
+
+	for {
+		var object interface{}
+		err := decoder.Decode(&object)
+
+		switch {
+		case err == nil:
+			objects = append(objects, object)
+		case err == io.EOF:
+			return Flatten(objects, opts...)
+		default:
+			return nil, fmt.Errorf("unmarshalling jsonl: %w", err)
+		}
+	}
+}

--- a/pkg/dataflatten/jsonl.go
+++ b/pkg/dataflatten/jsonl.go
@@ -1,7 +1,6 @@
 package dataflatten
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +12,8 @@ func JsonlFile(file string, opts ...FlattenOpts) ([]Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Jsonl(bufio.NewReader(f), opts...)
+	defer f.Close()
+	return Jsonl(f, opts...)
 }
 
 func Jsonl(r io.Reader, opts ...FlattenOpts) ([]Row, error) {

--- a/pkg/dataflatten/testdata/animals.jsonl
+++ b/pkg/dataflatten/testdata/animals.jsonl
@@ -1,0 +1,43 @@
+{
+    "metadata": {
+        "testing": true,
+        "version": "1.0.1"
+    }
+}
+{
+    "system": "users demo"
+}
+{
+    "users": [
+        {
+            "favorites": [
+                "ants"
+            ],
+            "uuid": "abc123",
+            "name": "Alex Aardvark",
+            "id": 1
+        },
+        {
+            "favorites": [
+                "mice",
+                "birds"
+            ],
+            "uuid": "def456",
+            "name": "Bailey Bobcat",
+            "id": 2
+        },
+        {
+            "favorites": [
+                "seeds"
+            ],
+            "uuid": "ghi789",
+            "name": "Cam Chipmunk",
+            "id": 3
+        }
+    ]
+}
+[
+    "array-item-A",
+    "array-item-B",
+    "array-item-C"
+]

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -19,6 +19,7 @@ type DataSourceType int
 const (
 	PlistType DataSourceType = iota + 1
 	JsonType
+	JsonlType
 	ExecType
 	XmlType
 	IniType
@@ -46,6 +47,7 @@ func AllTablePlugins(client *osquery.ExtensionManagerClient, logger log.Logger) 
 		TablePlugin(client, logger, XmlType),
 		TablePlugin(client, logger, IniType),
 		TablePlugin(client, logger, PlistType),
+		TablePlugin(client, logger, JsonlType),
 	}
 }
 
@@ -65,6 +67,9 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, data
 	case JsonType:
 		t.flattenFileFunc = dataflatten.JsonFile
 		t.tableName = "kolide_json"
+	case JsonlType:
+		t.flattenFileFunc = dataflatten.JsonlFile
+		t.tableName = "kolide_jsonl"
 	case XmlType:
 		t.flattenFileFunc = dataflatten.XmlFile
 		t.tableName = "kolide_xml"


### PR DESCRIPTION
adds new table `kolide_jsonl` for parsing json line formatted files

```sql
osquery> select fullkey, parent, key, value from kolide_json where path = '/var/kolide-k2/k2device-preprod.kolide.com/debug.json' limit 5;
+----------+--------+--------+-----------------------------+
| fullkey  | parent | key    | value                       |
+----------+--------+--------+-----------------------------+
| 0/ts     | 0      | ts     | 2023-04-28T16:33:58.362167Z |
| 0/caller | 0      | caller | launcher.go:70              |
| 0/level  | 0      | level  | debug                       |
| 0/msg    | 0      | msg    | runLauncher starting        |
| 1/caller | 1      | caller | checkpoint.go:93            |
+----------+--------+--------+-----------------------------+
```

closes https://github.com/kolide/launcher/issues/1104