### PR TITLE
Get `make containers` running with recent version of Golang and launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Note that multistage builds can leverage the tag applied (at build
 # time) to this container
 
-FROM golang:1.15 AS golauncherbuild
+FROM golang:1.20 AS golauncherbuild
 LABEL maintainer="engineering@kolide.co"
 
 # fake data or not?

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Note that multistage builds can leverage the tag applied (at build
 # time) to this container
 
-FROM golang:1.20 AS golauncherbuild
+FROM --platform=linux/amd64 golang:1.20 AS golauncherbuild
 LABEL maintainer="engineering@kolide.co"
 
 # fake data or not?
@@ -31,7 +31,7 @@ RUN cd launcher && git checkout "${gitver}"
 # Build!
 RUN cd launcher && make deps
 RUN cd launcher && make all
-RUN cd launcher && GO111MODULE=on go run cmd/make/make.go -targets=launcher -linkstamp $FAKE
+RUN cd launcher && GO111MODULE=on go run cmd/make/make.go -targets=launcher -linkstamp $FAKE -arch amd64
 
 # Install
 RUN mkdir -p /usr/local/kolide/bin/

--- a/Makefile
+++ b/Makefile
@@ -259,8 +259,9 @@ build-docker: sha = $(shell git describe --always --abbrev=12)
 build-docker:
 	docker build -t launcher-build --build-arg gitver=$(sha) .
 
+build-dockerfake: version = $(shell git describe --always --tags --abbrev=12)
 build-dockerfake:
-	docker build -t launcher-fakedata-build --build-arg gitver=v0.11.21 --build-arg FAKE=-fakedata .
+	docker build -t launcher-fakedata-build --build-arg gitver=$(version) --build-arg FAKE=-fakedata .
 
 dockerfake-%:  build-dockerfake
 	@echo '#### Starting to build target: $@'

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM centos:centos6
+FROM --platform=linux/amd64 centos:centos6
 LABEL maintainer="engineering@kolide.co"
 
 COPY --from=stage1 /usr/local/kolide/bin/* /usr/local/kolide/bin/

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM centos:centos7
+FROM --platform=linux/amd64 centos:centos7
 LABEL maintainer="engineering@kolide.co"
 
 COPY --from=stage1 /usr/local/kolide/bin/* /usr/local/kolide/bin/

--- a/docker/distroless/Dockerfile
+++ b/docker/distroless/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM gcr.io/distroless/base
+FROM --platform=linux/amd64 gcr.io/distroless/base
 LABEL maintainer="engineering@kolide.co"
 
 # RUN mkdir -p /usr/local/kolide/bin/

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM ubuntu:16.04
+FROM --platform=linux/amd64 ubuntu:16.04
 LABEL maintainer="engineering@kolide.co"
 
 COPY --from=stage1 /usr/local/kolide/bin/* /usr/local/kolide/bin/

--- a/docker/ubuntu18/Dockerfile
+++ b/docker/ubuntu18/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM ubuntu:18.04
+FROM --platform=linux/amd64 ubuntu:18.04
 LABEL maintainer="engineering@kolide.co"
 
 COPY --from=stage1 /usr/local/kolide/bin/* /usr/local/kolide/bin/

--- a/docker/ubuntu20/Dockerfile
+++ b/docker/ubuntu20/Dockerfile
@@ -1,7 +1,7 @@
 ARG FAKE
 FROM launcher${FAKE}-build as stage1
 
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 LABEL maintainer="engineering@kolide.co"
 
 COPY --from=stage1 /usr/local/kolide/bin/* /usr/local/kolide/bin/


### PR DESCRIPTION
* Upgrades to golang 1.20, since that's what we build with now
* Updates to use most recent launcher tag instead of hardcoded tag
* Specify platform/arch everywhere for M1 compatibility

Testing steps:

Ran `make containers`, then ran with a few of the resulting images and confirmed it stayed up: `docker run --platform linux/amd64 -i -t gcr.io/kolide-public-containers/launcher-fakedata-ubuntu18:latest -debug -hostname test.ngrok.io -i-am-breaking-ee-license -enroll_secret "secret" -transport jsonrpc` (also tested with ubuntu20, centos7).