### PR TITLE
Set root directory to temp directory if not provided

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -89,8 +89,9 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 
 	// determine the root directory, create one if it's not provided
 	rootDirectory := opts.RootDirectory
+	var err error
 	if rootDirectory == "" {
-		rootDirectory, err := agent.MkdirTemp(defaultRootDirectory)
+		rootDirectory, err = agent.MkdirTemp(defaultRootDirectory)
 		if err != nil {
 			return fmt.Errorf("creating temporary root directory: %w", err)
 		}


### PR DESCRIPTION
Fixes issue where if root dir is not provided, we correctly make a temporary directory to use as the root directory, but do not save the value and promptly try to make a directory with path `""`:

```
{"caller":"launcher.go:97","msg":"using default system root directory","path":"/var/folders/0d/l0cmv9pd4qd3j0d98q1st9bm0000gn/T/launcher-root3415220570","severity":"info","ts":"2023-05-09T19:09:56.293064Z"}
{"caller":"main.go:112","creating root directory: mkdir : no such file or directory":"run launcher","severity":"debug","stack":"creating root directory: mkdir : no such file or directory","ts":"2023-05-09T19:09:56.293091Z"}
{"caller":"logutil.go:13","creating root directory: mkdir : no such file or directory":"run launcher","severity":"info","ts":"2023-05-09T19:09:56.293138Z"}
```