### PR TITLE
better err message for new desktop runner

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -153,7 +153,7 @@ func New(k types.Knapsack, opts ...desktopUsersProcessesRunnerOption) (*DesktopU
 
 	rs, err := runnerserver.New(runner.logger, k)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating desktop runner server: %w", err)
 	}
 
 	runner.runnerServer = rs

--- a/ee/desktop/runner/server/server.go
+++ b/ee/desktop/runner/server/server.go
@@ -39,7 +39,7 @@ type controlRequestIntervalOverrider interface {
 func New(logger log.Logger, controlRequestIntervalOverrider controlRequestIntervalOverrider) (*RunnerServer, error) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating net listener: %w", err)
 	}
 
 	rs := &RunnerServer{


### PR DESCRIPTION
Saw an error around starting desktop server runner today and had to go digging in code the figure out where it was failing. This should make it quicker to identify the issue in the future.