### PR TITLE
Fix relativeTime for 'Just Now'

### DIFF
--- a/ee/desktop/user/menu/menu_template.go
+++ b/ee/desktop/user/menu/menu_template.go
@@ -75,7 +75,7 @@ func (tp *templateParser) Parse(text string) (string, error) {
 				return "One Minute Ago"
 			case diff < -5: // more than 5 seconds ago
 				return fmt.Sprintf("%d Seconds Ago", -diff)
-			case diff < 0: // in the last 5 seconds
+			case diff <= 0: // in the last 5 seconds
 				return "Just Now"
 			case diff < 60*10: // less than 10 minutes
 				return "Very Soon"

--- a/ee/desktop/user/menu/menu_template_test.go
+++ b/ee/desktop/user/menu/menu_template_test.go
@@ -74,8 +74,14 @@ func Test_Parse(t *testing.T) {
 			output: "This Menu Was Last Updated 7 Seconds Ago.",
 		},
 		{
-			name:   "relativeTime just now",
+			name:   "relativeTime one second",
 			td:     &TemplateData{LastMenuUpdateTime: time.Now().Add(-1 * time.Second).Unix()},
+			text:   "This Menu Was Last Updated {{if hasCapability `relativeTime`}}{{relativeTime .LastMenuUpdateTime}}{{else}}never{{end}}.",
+			output: "This Menu Was Last Updated Just Now.",
+		},
+		{
+			name:   "relativeTime just now",
+			td:     &TemplateData{LastMenuUpdateTime: time.Now().Unix()},
 			text:   "This Menu Was Last Updated {{if hasCapability `relativeTime`}}{{relativeTime .LastMenuUpdateTime}}{{else}}never{{end}}.",
 			output: "This Menu Was Last Updated Just Now.",
 		},


### PR DESCRIPTION
Sometimes the template function `relativeTime` can be invoked where the `timestamp arg == time.Now()`. This change expands the 'Just Now' interval from:

`(5 seconds ago, now)`
to
`(5 seconds ago, now]`

and 'Very Soon' from:

`[now, in 10 minutes)`
to
`(now, in 10 minutes)`

Fixes an issue with the menu item 'Last Menu Update: Very Soon`
![](https://user-images.githubusercontent.com/1643747/236548229-897d9226-c90c-4333-a215-63fc430c5040.png)
