### PR TITLE
launcher doctor subcommand

### DIFF
--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -30,12 +30,12 @@ import (
 )
 
 var (
+	// Command line colors and printing functions
 	cRunning = color.New(color.FgCyan)
 	cHeader  = color.New(color.FgHiWhite).Add(color.Bold)
 	cWarn    = color.New(color.FgHiYellow)
-
-	pass = color.New(color.FgGreen).PrintlnFunc()
-	fail = color.New(color.FgRed).Add(color.Bold).PrintlnFunc()
+	pass     = color.New(color.FgGreen).PrintlnFunc()
+	fail     = color.New(color.FgRed).Add(color.Bold).PrintlnFunc()
 
 	// Println functions for checkup details
 	cInfo = color.New(color.FgWhite)
@@ -55,7 +55,7 @@ var (
 	configFile string
 )
 
-// checkup is
+// checkup encapsulates a launcher health checkup
 type checkup struct {
 	name   string
 	check  func() (string, error)
@@ -138,6 +138,7 @@ func runDoctor(args []string) error {
 	return nil
 }
 
+// parseDoctorOptions parses command line options and provides defaults
 func parseDoctorOptions(args []string) (*launcher.Options, error) {
 	flagset := flag.NewFlagSet("launcher doctor", flag.ExitOnError)
 	flagset.Usage = func() { usage(flagset) }
@@ -350,6 +351,7 @@ func parseDoctorOptions(args []string) (*launcher.Options, error) {
 	return opts, nil
 }
 
+// run logs the results of a checkup being run
 func (c *checkup) run() {
 	if c.check == nil {
 	}
@@ -368,6 +370,7 @@ func (c *checkup) run() {
 	}
 }
 
+// checkupPlatform verifies that the current platform is supported by launcher
 func checkupPlatform(os string) (string, error) {
 	if slices.Contains([]string{"windows", "darwin", "linux"}, os) {
 		return fmt.Sprintf("Platform: %s", os), nil
@@ -380,6 +383,7 @@ type launcherFile struct {
 	found bool
 }
 
+// checkupRootDir tests for the presence of important files in the launcher root directory
 func checkupRootDir(filepaths []string) (string, error) {
 	importantFiles := []*launcherFile{
 		{
@@ -420,6 +424,7 @@ func checkupRootDir(filepaths []string) (string, error) {
 	return "", fmt.Errorf("%d root directory files not found", failures)
 }
 
+// checkupConnectivity tests connections to Kolide cloud services
 func checkupConnectivity(logger log.Logger, k types.Knapsack) (string, error) {
 	var failures int
 	checkpointer := checkpoint.New(logger, k)
@@ -451,6 +456,7 @@ func checkupConnectivity(logger log.Logger, k types.Knapsack) (string, error) {
 	}
 
 	for k, v := range notaryVersions {
+		// Check for failure if the notary version isn't a parsable integer
 		if _, err := strconv.ParseInt(v, 10, 32); err == nil {
 			good(fmt.Sprintf("%s - %s", k, v))
 		} else {
@@ -466,6 +472,7 @@ func checkupConnectivity(logger log.Logger, k types.Knapsack) (string, error) {
 	return "", fmt.Errorf("%d failures encountered while attempting communication with Kolide", failures)
 }
 
+// checkupVersion tests to see if the current launcher version is up to date
 func checkupVersion(v version.Info) (string, error) {
 	info(fmt.Sprintf("Current version: %s", v.Version))
 	// TODO: Query TUF for latest available version for this launcher instance
@@ -479,6 +486,7 @@ func checkupVersion(v version.Info) (string, error) {
 	return "", fmt.Errorf("launcher is out of date")
 }
 
+// checkupConfigFile tests that the config file is valid and logs it's contents
 func checkupConfigFile(filepath string) (string, error) {
 	file, err := os.Open(filepath)
 	if err != nil {
@@ -494,6 +502,7 @@ func checkupConfigFile(filepath string) (string, error) {
 	return "Config file found", nil
 }
 
+// checkupLogFiles checks to see if expected log files are present
 func checkupLogFiles(filepaths []string) (string, error) {
 	var foundCurrentLogFile bool
 	for _, f := range filepaths {
@@ -519,6 +528,7 @@ func checkupLogFiles(filepaths []string) (string, error) {
 	return "", fmt.Errorf("No log file found")
 }
 
+// getFilepaths returns a list of file paths matching the pattern
 func getFilepaths(elem ...string) []string {
 	fileGlob := filepath.Join(elem...)
 	filepaths, err := filepath.Glob(fileGlob)

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -325,11 +325,7 @@ func checkupOsquery(updateChannel, tufServerURL, osquerydPath string) (string, e
 	}
 
 	info(fmt.Sprintf("Target version:\t%s", targetVersion))
-
-	if targetVersion != currentVersion {
-		return "", fmt.Errorf("osqueryd is out of date")
-	}
-	return "Up to date!", nil
+	return "Osquery version checks complete", nil
 }
 
 func checkupFilesPresent(filepaths []string, importantFiles []*launcherFile) (string, error) {
@@ -421,11 +417,7 @@ func checkupVersion(updateChannel, tufServerURL string, v version.Info) (string,
 	}
 
 	info(fmt.Sprintf("Target version:\t%s", targetVersion))
-
-	if targetVersion != v.Version {
-		return "", fmt.Errorf("launcher is out of date")
-	}
-	return "Up to date!", nil
+	return "Launcher version checks complete", nil
 }
 
 // checkupConfigFile tests that the config file is valid and logs it's contents

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -82,7 +82,7 @@ func runDoctor(args []string) error {
 
 	checkups := []*checkup{
 		{
-			name: "Check platform",
+			name: "Platform",
 			check: func() (string, error) {
 				return checkupPlatform(runtime.GOOS)
 			},

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -30,12 +30,12 @@ var (
 	doctorWriter io.Writer
 
 	// Command line colors
-	cyanText   = color.New(color.FgCyan)
-	headerText = color.New(color.Bold, color.FgHiWhite)
-	yellowText = color.New(color.FgHiYellow)
-	whiteText  = color.New(color.FgWhite)
-	greenText  = color.New(color.FgGreen)
-	redText    = color.New(color.Bold, color.FgRed)
+	cyanText   = color.New(color.FgCyan, color.BgBlack)
+	headerText = color.New(color.Bold, color.FgHiWhite, color.BgBlack)
+	yellowText = color.New(color.FgHiYellow, color.BgBlack)
+	whiteText  = color.New(color.FgWhite, color.BgBlack)
+	greenText  = color.New(color.FgGreen, color.BgBlack)
+	redText    = color.New(color.Bold, color.FgRed, color.BgBlack)
 
 	// Printf functions
 	cyan = func(format string, a ...interface{}) {

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -288,7 +288,7 @@ func checkupRootDir(filepaths []string) (string, error) {
 func checkupAppBinaries(filepaths []string) (string, error) {
 	importantFiles := []*launcherFile{
 		{
-			name: "launcher",
+			name: windowsAddExe("launcher"),
 		},
 	}
 
@@ -313,7 +313,7 @@ func checkupOsquery(updateChannel, tufServerURL, osquerydPath string) (string, e
 		return "", fmt.Errorf("error occurred while querying osquery version output %s: err: %w", out, err)
 	}
 
-	currentVersion := strings.TrimLeft(string(out), "osqueryd version ")
+	currentVersion := strings.TrimLeft(string(out), fmt.Sprintf("%s version ", windowsAddExe("osqueryd")))
 	currentVersion = strings.TrimRight(currentVersion, "\n")
 
 	info(fmt.Sprintf("Current version:\t%s", currentVersion))
@@ -321,7 +321,7 @@ func checkupOsquery(updateChannel, tufServerURL, osquerydPath string) (string, e
 	// Query the TUF repo for what the target version of osquery is
 	targetVersion, err := tuf.GetChannelVersionFromTufServer("osqueryd", updateChannel, tufServerURL)
 	if err != nil {
-		return "", fmt.Errorf("Failed to query TUF server: %w", err)
+		return "", fmt.Errorf("failed to query TUF server: %w", err)
 	}
 
 	info(fmt.Sprintf("Target version:\t%s", targetVersion))

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/kit/logutil"
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/agent/flags"
 	"github.com/kolide/launcher/pkg/agent/knapsack"
-	"github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/agent/types"
 	"github.com/kolide/launcher/pkg/log/checkpoint"
 
 	"github.com/fatih/color"
@@ -19,51 +21,51 @@ import (
 )
 
 var (
-	cRunning  = color.New(color.FgCyan)
-	cHeader   = color.New(color.FgHiWhite).Add(color.Bold)
-	cProperty = color.New(color.FgWhite)
-	cPass     = color.New(color.FgGreen)
-	cFail     = color.New(color.FgRed).Add(color.Bold)
-	cWarning  = color.New(color.BgHiYellow)
+	cRunning = color.New(color.FgCyan)
+	cHeader  = color.New(color.FgHiWhite).Add(color.Bold)
+	cWarn    = color.New(color.FgHiYellow)
 
-	// Create a custom print function for convenience
 	pass = color.New(color.FgGreen).PrintlnFunc()
-	warn = color.New(color.FgHiYellow).PrintlnFunc()
 	fail = color.New(color.FgRed).Add(color.Bold).PrintlnFunc()
 
+	// Println functions for checkup details
 	cInfo = color.New(color.FgWhite)
 	info  = func(a ...interface{}) {
 		cInfo.Println(fmt.Sprintf("    %s", a...))
 	}
+	warn = func(a ...interface{}) {
+		cWarn.Println(fmt.Sprintf("    %s", a...))
+	}
+	bad = func(a ...interface{}) {
+		cInfo.Println(fmt.Sprintf("❌  %s", a...))
+	}
+	good = func(a ...interface{}) {
+		cInfo.Println(fmt.Sprintf("✅  %s", a...))
+	}
 )
 
+// checkup is
 type checkup struct {
 	name   string
 	check  func() (string, error)
-	checks []func() (string, error)
+	failed bool
 }
 
 func runDoctor(args []string) error {
-	flagset := flag.NewFlagSet("launcher doctor", flag.ExitOnError)
-	var (
-	// configFile = env.String("config", "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags", "")
-
-	// not documented via flags on purpose
-	// configFile = flagset.String("config", "", "config file to parse options from (optional)")
-
-	// configFile = env.String("config", "/etc/kolide-k2/launcher.flags")
-	// etcDir  = env.String("KOLIDE_LAUNCHER_ETC_DIRECTORY", "/etc/kolide-k2/")
-	// rootDir = env.String("KOLIDE_LAUNCHER_ROOT_DIRECTORY", "/var/kolide-k2/k2device-preprod.kolide.com/")
-
-	// flControlRequestInterval = flagset.Duration("control_request_interval", 60*time.Second, "The interval at which the control server requests will be made")
-	// flKolideServerURL        = flagset.String("hostname", "", "The hostname of the gRPC server")
-	)
-	flagset.Usage = commandUsage(flagset, "launcher doctor")
-	if err := flagset.Parse(args); err != nil {
-		return err
+	logger := log.With(logutil.NewCLILogger(true), "caller", log.DefaultCaller)
+	opts, err := parseOptions(os.Args[2:])
+	if err != nil {
+		level.Info(logger).Log("err", err)
+		os.Exit(1)
 	}
 
-	cRunning.Println("Running Kolide launcher checkups...")
+	fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
+	flagController := flags.NewFlagController(logger, nil, fcOpts...)
+	k := knapsack.New(nil, flagController, nil)
+
+	cRunning.Println("Kolide launcher doctor version:")
+	version.PrintFull()
+	cRunning.Println("\nRunning Kolide launcher checkups...")
 
 	checkups := []*checkup{
 		{
@@ -75,52 +77,13 @@ func runDoctor(args []string) error {
 		{
 			name: "Directory contents",
 			check: func() (string, error) {
-				return checkupRootDir(getFilepaths("/var/kolide-k2/k2device-preprod.kolide.com/", "*"))
+				return checkupRootDir(getFilepaths(k.RootDirectory(), "*"))
 			},
-			// checks: []func() (string, error){
-			// 	func() (string, error) {
-			// 		entries, err := os.ReadDir(rootDir)
-			// 		if err != nil {
-			// 			fmt.Println(err)
-			// 		}
-
-			// 		for _, e := range entries {
-			// 			fmt.Println(e.Name())
-			// 		}
-			// 		return "", nil
-			// 	},
-			// 	func() (string, error) {
-			// 		entries, err := os.ReadDir(etcDir)
-			// 		if err != nil {
-			// 			fmt.Println(err)
-			// 		}
-
-			// 		for _, e := range entries {
-			// 			fmt.Println(e.Name())
-			// 		}
-			// 		return "", nil
-			// 	},
-			// },
 		},
 		{
 			name: "Check communication with Kolide",
 			check: func() (string, error) {
-				logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-				// opts := &launcher.Options{}
-
-				// fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
-				// flagController := flags.NewFlagController(logger, nil, fcOpts...)
-
-				mockFlags := mocks.NewFlags(t)
-				if !tt.portDefined {
-					mockFlags.On("InsecureTransportTLS").Return(tt.insecureTransport)
-				}
-
-				k := knapsack.New(nil, flagController, nil)
-				// logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-				checkpointer := checkpoint.New(logger, k)
-
-				return "Successfully communicated with Kolide", nil
+				return checkupConnectivity(logger, k)
 			},
 		},
 		{
@@ -133,79 +96,57 @@ func runDoctor(args []string) error {
 			name: "Check config file",
 			check: func() (string, error) {
 				// "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags"
-				return checkupConfigFile(getFilepaths("/etc/kolide-k2/", "launcher.flags"))
+				filepaths := getFilepaths("/etc/kolide-k2/", "launcher.flags")
+				if filepaths != nil && len(filepaths) > 0 {
+					return checkupConfigFile(filepaths[0])
+				}
+				return "", nil // TODO
 			},
-
-			// checks: []func() (string, error){
-			// 	func() (string, error) {
-			// 		data, err := os.ReadFile(*configFile)
-			// 		if data != nil {
-			// 			fmt.Println(string(data))
-			// 		}
-			// 		if err != nil {
-			// 			return "", fmt.Errorf("No config file found")
-			// 		}
-			// 		return "Config file found", nil
-			// 	},
-			// },
 		},
 		{
 			name: "Check logs",
 			check: func() (string, error) {
-				// "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags"
-				// /var/kolide-k2/k2device-preprod.kolide.com/launcher
-				return checkupLogFiles(getFilepaths("/var/kolide-k2/k2device-preprod.kolide.com/", "debug*"))
-			},
-
-			checks: []func() (string, error){
-				func() (string, error) {
-					// cPass.Println("Kolide")
-					return "", nil
-				},
+				return checkupLogFiles(getFilepaths(k.RootDirectory(), "debug*"))
 			},
 		},
 	}
 
 	failedCheckups := []*checkup{}
 
+	// Sequentially run all of the checkups
 	for _, c := range checkups {
 		c.run()
 	}
 
 	if len(failedCheckups) > 0 {
-		fail("Some checkups failed:")
+		fail("\nSome checkups failed:")
 
 		for _, c := range failedCheckups {
 			fail("%s\n", c.name)
 		}
 	} else {
-		pass("All checkups passed! Your Kolide launcher is healthy.")
+		pass("\nAll checkups passed! Your Kolide launcher is healthy.")
 	}
 
 	return nil
 }
 
 func (c *checkup) run() {
-	cRunning.Printf("Running checkup: ")
+	if c.check == nil {
+	}
+
+	cRunning.Printf("\nRunning checkup: ")
 	cHeader.Printf("%s\n", c.name)
 
-	var err error
-	if c.check != nil {
-		result, err := c.check()
-		if err != nil {
-			cProperty.Println(result)
-			cProperty.Printf("❌  %s\n", err)
-		} else {
-			cProperty.Printf("✅  %s\n", result)
-		}
-	}
-
+	result, err := c.check()
 	if err != nil {
+		info(result)
+		bad(err)
 		fail("𐄂 Checkup failed!")
 	} else {
+		good(result)
 		pass("✔ Checkup passed!")
 	}
-	pass("")
 }
 
 func checkupPlatform(os string) (string, error) {
@@ -215,72 +156,122 @@ func checkupPlatform(os string) (string, error) {
 	return "", fmt.Errorf("Unsupported platform: %s", os)
 }
 
+type launcherFile struct {
+	name  string
+	found bool
+}
+
 func checkupRootDir(filepaths []string) (string, error) {
-	if filepaths != nil && len(filepaths) > 0 {
-		for _, fp := range filepaths {
-			// fmt.Println(filepath.Base(fp))
-			info(filepath.Base(fp))
-		}
-		// data, _ := os.ReadFile(filepaths[0])
-		// if data != nil {
-		// fmt.Println(string(data))
-		return "Root directory files found", nil
-		// }
+	importantFiles := []*launcherFile{
+		{
+			name: "debug.json",
+		},
+		{
+			name: "launcher.db",
+		},
+		{
+			name: "osquery.db",
+		},
 	}
 
-	return "", fmt.Errorf("No root directory files found")
+	if filepaths != nil && len(filepaths) > 0 {
+		for _, fp := range filepaths {
+			for _, f := range importantFiles {
+				if filepath.Base(fp) == f.name {
+					f.found = true
+				}
+			}
+		}
+	}
+
+	var failures int
+	for _, f := range importantFiles {
+		if f.found {
+			good(f.name)
+		} else {
+			bad(f.name)
+			failures = failures + 1
+		}
+	}
+
+	if failures == 0 {
+		return "Root directory files found", nil
+	}
+
+	return "", fmt.Errorf("%d root directory files not found", failures)
+}
+
+func checkupConnectivity(logger log.Logger, k types.Knapsack) (string, error) {
+	checkpointer := checkpoint.New(logger, k)
+
+	connections := checkpointer.Connections()
+	for k, v := range connections {
+		if v == "successful tcp connection" {
+			good(fmt.Sprintf("%s - %s", k, v))
+		} else {
+			bad(fmt.Sprintf("%s - %s", k, v))
+		}
+	}
+
+	ipLookups := checkpointer.IpLookups()
+	for k, v := range ipLookups {
+		valStrSlice, ok := v.([]string)
+		if !ok || len(valStrSlice) == 0 {
+			bad(fmt.Sprintf("%s - %s", k, valStrSlice))
+		} else {
+			good(fmt.Sprintf("%s - %s", k, valStrSlice))
+		}
+	}
+
+	return "Successfully communicated with Kolide", nil
 }
 
 func checkupVersion(v version.Info) (string, error) {
-	warn("Latest available version: Unknown")
-	return fmt.Sprintf("Current version: %s\n", v.Version), nil
-}
+	info(fmt.Sprintf("Current version: %s", v.Version))
+	// TODO: Query TUF for latest available version for this launcher instance
+	warn(fmt.Sprintf("Target version: %s", "Unknown"))
 
-func checkupConfigFile(filepaths []string) (string, error) {
-	if filepaths != nil && len(filepaths) > 0 {
-		// data, _ := os.ReadFile(filepaths[0])
-		// if data != nil {
-		// 	// info(string(data))
-		// 	return "Config file found", nil
-		// }
-
-		file, err := os.Open(filepaths[0])
-		if err != nil {
-			return "", fmt.Errorf("No config file found")
-		}
-		defer file.Close()
-
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			info(scanner.Text())
-		}
-
-		return "Config file found", nil
+	// TODO: Choose failure based on current >= target
+	if true {
+		return "Up to date!", nil
 	}
 
-	return "", fmt.Errorf("No config file found")
+	return "", fmt.Errorf("launcher is out of date")
+}
+
+func checkupConfigFile(filepath string) (string, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return "", fmt.Errorf("No config file found")
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		info(scanner.Text())
+	}
+
+	return "Config file found", nil
 }
 
 func checkupLogFiles(filepaths []string) (string, error) {
 	var foundCurrentLogFile bool
 	for _, f := range filepaths {
 		filename := filepath.Base(f)
-		// fmt.Println(filename)
 		info(filename)
-		// pass("%s found", filename)
+
 		if filename == "debug.json" {
-			// pass("%s found")
 			foundCurrentLogFile = true
+
+			fi, err := os.Stat(f)
+			if err == nil {
+				info("")
+				info(fmt.Sprintf("Most recent log file: %s", filename))
+				info(fmt.Sprintf("Latest modification: %s", fi.ModTime().String()))
+				info(fmt.Sprintf("File size (B): %d", fi.Size()))
+			}
 		}
-		// fmt.Println(filepath.Base(fp))
 	}
-	// if filepaths != nil && len(filepaths) > 0 {
-	// 	// data, _ := os.ReadFile(filepaths[0])
-	// 	// if data != nil {
-	// 	// 	fmt.Println(string(data))
-	// 	// 	return "Log files found", nil
-	// 	// }
-	// }
 
 	if foundCurrentLogFile {
 		return "Log file found", nil
@@ -295,14 +286,6 @@ func getFilepaths(elem ...string) []string {
 	if err == nil && len(filepaths) > 0 {
 		return filepaths
 	}
-	// entries, err := os.ReadDir(dir)
-	// if err != nil {
-	// 	fmt.Println(err)
-	// }
-
-	// for _, e := range entries {
-	// 	fmt.Println(e.Name())
-	// }
 
 	return nil
 }

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"bufio"
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -14,7 +19,11 @@ import (
 	"github.com/kolide/launcher/pkg/agent/flags"
 	"github.com/kolide/launcher/pkg/agent/knapsack"
 	"github.com/kolide/launcher/pkg/agent/types"
+	"github.com/kolide/launcher/pkg/autoupdate"
+	"github.com/kolide/launcher/pkg/autoupdate/tuf"
+	"github.com/kolide/launcher/pkg/launcher"
 	"github.com/kolide/launcher/pkg/log/checkpoint"
+	"github.com/peterbourgon/ff/v3"
 
 	"github.com/fatih/color"
 	"golang.org/x/exp/slices"
@@ -42,6 +51,8 @@ var (
 	good = func(a ...interface{}) {
 		cInfo.Println(fmt.Sprintf("✅  %s", a...))
 	}
+
+	configFile string
 )
 
 // checkup is
@@ -53,7 +64,7 @@ type checkup struct {
 
 func runDoctor(args []string) error {
 	logger := log.With(logutil.NewCLILogger(true), "caller", log.DefaultCaller)
-	opts, err := parseOptions(os.Args[2:])
+	opts, err := parseDoctorOptions(os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		os.Exit(1)
@@ -75,11 +86,12 @@ func runDoctor(args []string) error {
 			},
 		},
 		{
-			name: "Directory contents",
+			name: "Root directory contents",
 			check: func() (string, error) {
 				return checkupRootDir(getFilepaths(k.RootDirectory(), "*"))
 			},
 		},
+		// TODO: Check application directories for launcher & osquery binaries
 		{
 			name: "Check communication with Kolide",
 			check: func() (string, error) {
@@ -95,12 +107,7 @@ func runDoctor(args []string) error {
 		{
 			name: "Check config file",
 			check: func() (string, error) {
-				// "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags"
-				filepaths := getFilepaths("/etc/kolide-k2/", "launcher.flags")
-				if filepaths != nil && len(filepaths) > 0 {
-					return checkupConfigFile(filepaths[0])
-				}
-				return "", nil // TODO
+				return checkupConfigFile(configFile)
 			},
 		},
 		{
@@ -129,6 +136,218 @@ func runDoctor(args []string) error {
 	}
 
 	return nil
+}
+
+func parseDoctorOptions(args []string) (*launcher.Options, error) {
+	flagset := flag.NewFlagSet("launcher doctor", flag.ExitOnError)
+	flagset.Usage = func() { usage(flagset) }
+
+	// TODO: Provide platform-specific defaults for files/dirs in case a config file doesn't exist
+
+	var (
+		// Primary options
+		flAutoloadedExtensions   arrayFlags
+		flCertPins               = flagset.String("cert_pins", "", "Comma separated, hex encoded SHA256 hashes of pinned subject public key info")
+		flControlRequestInterval = flagset.Duration("control_request_interval", 60*time.Second, "The interval at which the control server requests will be made")
+		flEnrollSecret           = flagset.String("enroll_secret", "", "The enroll secret that is used in your environment")
+		flEnrollSecretPath       = flagset.String("enroll_secret_path", "", "Optionally, the path to your enrollment secret")
+		flInitialRunner          = flagset.Bool("with_initial_runner", false, "Run differential queries from config ahead of scheduled interval.")
+		flKolideServerURL        = flagset.String("hostname", "", "The hostname of the gRPC server")
+		flKolideHosted           = flagset.Bool("kolide_hosted", true, "Use Kolide SaaS settings for defaults")
+		flTransport              = flagset.String("transport", "grpc", "The transport protocol that should be used to communicate with remote (default: grpc)")
+		flLoggingInterval        = flagset.Duration("logging_interval", 60*time.Second, "The interval at which logs should be flushed to the server")
+		flOsquerydPath           = flagset.String("osqueryd_path", "", "Path to the osqueryd binary to use (Default: find osqueryd in $PATH)")
+		flRootDirectory          = flagset.String("root_directory", "", "The location of the local database, pidfiles, etc.")
+		flRootPEM                = flagset.String("root_pem", "", "Path to PEM file including root certificates to verify against")
+		flVersion                = flagset.Bool("version", false, "Print Launcher version and exit")
+		flLogMaxBytesPerBatch    = flagset.Int("log_max_bytes_per_batch", 0, "Maximum size of a batch of logs. Recommend leaving unset, and launcher will determine")
+		flOsqueryFlags           arrayFlags // set below with flagset.Var
+		flCompactDbMaxTx         = flagset.Int64("compactdb-max-tx", 65536, "Maximum transaction size used when compacting the internal DB")
+		flConfigFile             = flagset.String("config", "", "config file to parse options from (optional)")
+
+		// osquery TLS endpoints
+		flOsqTlsConfig    = flagset.String("config_tls_endpoint", "", "Config endpoint for the osquery tls transport")
+		flOsqTlsEnroll    = flagset.String("enroll_tls_endpoint", "", "Enroll endpoint for the osquery tls transport")
+		flOsqTlsLogger    = flagset.String("logger_tls_endpoint", "", "Logger endpoint for the osquery tls transport")
+		flOsqTlsDistRead  = flagset.String("distributed_tls_read_endpoint", "", "Distributed read endpoint for the osquery tls transport")
+		flOsqTlsDistWrite = flagset.String("distributed_tls_write_endpoint", "", "Distributed write endpoint for the osquery tls transport")
+
+		// Autoupdate options
+		flAutoupdate             = flagset.Bool("autoupdate", true, "Whether or not the osquery autoupdater is enabled (default: false)")
+		flNotaryServerURL        = flagset.String("notary_url", autoupdate.DefaultNotary, "The Notary update server (default: https://notary.kolide.co)")
+		flTufServerURL           = flagset.String("tuf_url", tuf.DefaultTufServer, "TUF update server (default: https://tuf.kolide.com)")
+		flMirrorURL              = flagset.String("mirror_url", autoupdate.DefaultMirror, "The mirror server for autoupdates (default: https://dl.kolide.co)")
+		flAutoupdateInterval     = flagset.Duration("autoupdate_interval", 1*time.Hour, "The interval to check for updates (default: once every hour)")
+		flUpdateChannel          = flagset.String("update_channel", "stable", "The channel to pull updates from (options: stable, beta, nightly)")
+		flNotaryPrefix           = flagset.String("notary_prefix", autoupdate.DefaultNotaryPrefix, "The prefix for Notary path that contains the collections (default: kolide/)")
+		flAutoupdateInitialDelay = flagset.Duration("autoupdater_initial_delay", 1*time.Hour, "Initial autoupdater subprocess delay")
+		flUpdateDirectory        = flagset.String("update_directory", "", "Local directory to hold updates for osqueryd and launcher")
+
+		// Development & Debugging options
+		flDebug          = flagset.Bool("debug", false, "Whether or not debug logging is enabled (default: false)")
+		flOsqueryVerbose = flagset.Bool("osquery_verbose", false, "Enable verbose osqueryd (default: false)")
+		// flDeveloperUsage       = flagset.Bool("dev_help", false, "Print full Launcher help, including developer options (default: false)")
+		flInsecureTransport    = flagset.Bool("insecure_transport", false, "Do not use TLS for transport layer (default: false)")
+		flInsecureTLS          = flagset.Bool("insecure", false, "Do not verify TLS certs for outgoing connections (default: false)")
+		flIAmBreakingEELicense = flagset.Bool("i-am-breaking-ee-license", false, "Skip license check before running localserver (default: false)")
+		flDelayStart           = flagset.Duration("delay_start", 0*time.Second, "How much time to wait before starting launcher")
+
+		// deprecated options, kept for any kind of config file compatibility
+		_ = flagset.String("debug_log_file", "", "DEPRECATED")
+		_ = flagset.Bool("control", false, "DEPRECATED")
+		_ = flagset.String("control_hostname", "", "DEPRECATED")
+		_ = flagset.Bool("disable_control_tls", false, "Disable TLS encryption for the control features")
+	)
+
+	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
+	flagset.Var(&flAutoloadedExtensions, "autoloaded_extension", "extension paths to autoload, filename without path may be used in same directory as launcher")
+
+	ffOpts := []ff.Option{
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ff.PlainParser),
+	}
+
+	// Windows doesn't really support environmental variables in quite
+	// the same way unix does. This led to Kolide's early Cloud packages
+	// installing with some global environmental variables. Those would
+	// cause an incompatibility with all subsequent launchers. As
+	// they're not part of the normal windows use case, we can skip
+	// using them here.
+	if !skipEnvParse {
+		ffOpts = append(ffOpts, ff.WithEnvVarPrefix("KOLIDE_LAUNCHER"))
+	}
+
+	ff.Parse(flagset, args, ffOpts...)
+
+	// handle --version
+	if *flVersion {
+		version.PrintFull()
+		os.Exit(0)
+	}
+
+	configFile = *flConfigFile
+
+	// If launcher is using a kolide host, we may override many of
+	// the settings. When we're ready, we can _additionally_
+	// conditionalize this on the ServerURL to get all the
+	// existing deployments
+	if *flKolideHosted {
+		*flTransport = "osquery"
+		*flOsqTlsConfig = "/api/osquery/v0/config"
+		*flOsqTlsEnroll = "/api/osquery/v0/enroll"
+		*flOsqTlsLogger = "/api/osquery/v0/log"
+		*flOsqTlsDistRead = "/api/osquery/v0/distributed/read"
+		*flOsqTlsDistWrite = "/api/osquery/v0/distributed/write"
+	}
+
+	// if an osqueryd path was not set, it's likely that we want to use the bundled
+	// osqueryd path, but if it cannot be found, we will fail back to using an
+	// osqueryd found in the path
+	osquerydPath := *flOsquerydPath
+	if osquerydPath == "" {
+		osquerydPath = findOsquery()
+		if osquerydPath == "" {
+			return nil, errors.New("Could not find osqueryd binary")
+		}
+	}
+
+	// On windows, we should make sure osquerydPath ends in .exe
+	if runtime.GOOS == "windows" && !strings.HasSuffix(osquerydPath, ".exe") {
+		osquerydPath = osquerydPath + ".exe"
+	}
+
+	if *flEnrollSecret != "" && *flEnrollSecretPath != "" {
+		return nil, errors.New("Both enroll_secret and enroll_secret_path were defined")
+	}
+
+	updateChannel := autoupdate.Stable
+	switch *flUpdateChannel {
+	case "", "stable":
+		updateChannel = autoupdate.Stable
+	case "beta":
+		updateChannel = autoupdate.Beta
+	case "alpha":
+		updateChannel = autoupdate.Alpha
+	case "nightly":
+		updateChannel = autoupdate.Nightly
+	default:
+		return nil, fmt.Errorf("unknown update channel %s", *flUpdateChannel)
+	}
+
+	certPins, err := parseCertPins(*flCertPins)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set control server URL and control server TLS settings based on Kolide server URL, defaulting to local server
+	controlServerURL := ""
+	insecureControlTLS := false
+	disableControlTLS := false
+
+	switch {
+	case *flKolideServerURL == "k2device.kolide.com":
+		controlServerURL = "k2control.kolide.com"
+
+	case *flKolideServerURL == "k2device-preprod.kolide.com":
+		controlServerURL = "k2control-preprod.kolide.com"
+
+	case strings.HasSuffix(*flKolideServerURL, "herokuapp.com"):
+		controlServerURL = *flKolideServerURL
+
+	case *flKolideServerURL == "localhost:3443":
+		controlServerURL = *flKolideServerURL
+		// We don't plumb flRootPEM through to the control server, just disable TLS for now
+		insecureControlTLS = true
+
+	case *flKolideServerURL == "localhost:3000" || *flIAmBreakingEELicense:
+		controlServerURL = *flKolideServerURL
+		disableControlTLS = true
+	}
+
+	opts := &launcher.Options{
+		Autoupdate:                         *flAutoupdate,
+		AutoupdateInterval:                 *flAutoupdateInterval,
+		AutoupdateInitialDelay:             *flAutoupdateInitialDelay,
+		CertPins:                           certPins,
+		CompactDbMaxTx:                     *flCompactDbMaxTx,
+		Control:                            false,
+		ControlServerURL:                   controlServerURL,
+		ControlRequestInterval:             *flControlRequestInterval,
+		Debug:                              *flDebug,
+		DelayStart:                         *flDelayStart,
+		DisableControlTLS:                  disableControlTLS,
+		InsecureControlTLS:                 insecureControlTLS,
+		EnableInitialRunner:                *flInitialRunner,
+		EnrollSecret:                       *flEnrollSecret,
+		EnrollSecretPath:                   *flEnrollSecretPath,
+		AutoloadedExtensions:               flAutoloadedExtensions,
+		IAmBreakingEELicense:               *flIAmBreakingEELicense,
+		InsecureTLS:                        *flInsecureTLS,
+		InsecureTransport:                  *flInsecureTransport,
+		KolideHosted:                       *flKolideHosted,
+		KolideServerURL:                    *flKolideServerURL,
+		LogMaxBytesPerBatch:                *flLogMaxBytesPerBatch,
+		LoggingInterval:                    *flLoggingInterval,
+		MirrorServerURL:                    *flMirrorURL,
+		NotaryPrefix:                       *flNotaryPrefix,
+		NotaryServerURL:                    *flNotaryServerURL,
+		TufServerURL:                       *flTufServerURL,
+		OsqueryFlags:                       flOsqueryFlags,
+		OsqueryTlsConfigEndpoint:           *flOsqTlsConfig,
+		OsqueryTlsDistributedReadEndpoint:  *flOsqTlsDistRead,
+		OsqueryTlsDistributedWriteEndpoint: *flOsqTlsDistWrite,
+		OsqueryTlsEnrollEndpoint:           *flOsqTlsEnroll,
+		OsqueryTlsLoggerEndpoint:           *flOsqTlsLogger,
+		OsqueryVerbose:                     *flOsqueryVerbose,
+		OsquerydPath:                       osquerydPath,
+		RootDirectory:                      *flRootDirectory,
+		RootPEM:                            *flRootPEM,
+		Transport:                          *flTransport,
+		UpdateChannel:                      updateChannel,
+		UpdateDirectory:                    *flUpdateDirectory,
+	}
+
+	return opts, nil
 }
 
 func (c *checkup) run() {
@@ -202,28 +421,49 @@ func checkupRootDir(filepaths []string) (string, error) {
 }
 
 func checkupConnectivity(logger log.Logger, k types.Knapsack) (string, error) {
+	var failures int
 	checkpointer := checkpoint.New(logger, k)
-
 	connections := checkpointer.Connections()
 	for k, v := range connections {
 		if v == "successful tcp connection" {
 			good(fmt.Sprintf("%s - %s", k, v))
 		} else {
 			bad(fmt.Sprintf("%s - %s", k, v))
+			failures = failures + 1
 		}
 	}
 
 	ipLookups := checkpointer.IpLookups()
 	for k, v := range ipLookups {
 		valStrSlice, ok := v.([]string)
-		if !ok || len(valStrSlice) == 0 {
-			bad(fmt.Sprintf("%s - %s", k, valStrSlice))
-		} else {
+		if ok && len(valStrSlice) > 0 {
 			good(fmt.Sprintf("%s - %s", k, valStrSlice))
+		} else {
+			bad(fmt.Sprintf("%s - %s", k, valStrSlice))
+			failures = failures + 1
 		}
 	}
 
-	return "Successfully communicated with Kolide", nil
+	notaryVersions, err := checkpointer.NotaryVersions()
+	if err != nil {
+		bad(fmt.Errorf("could not fetch notary versions: %w", err))
+		failures = failures + 1
+	}
+
+	for k, v := range notaryVersions {
+		if _, err := strconv.ParseInt(v, 10, 32); err == nil {
+			good(fmt.Sprintf("%s - %s", k, v))
+		} else {
+			bad(fmt.Sprintf("%s - %s", k, v))
+			failures = failures + 1
+		}
+	}
+
+	if failures == 0 {
+		return "Successfully communicated with Kolide", nil
+	}
+
+	return "", fmt.Errorf("%d failures encountered while attempting communication with Kolide", failures)
 }
 
 func checkupVersion(v version.Info) (string, error) {

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -88,6 +88,12 @@ func runDoctor(args []string) error {
 			},
 		},
 		{
+			name: "Check architecture",
+			check: func() (string, error) {
+				return checkupArch(runtime.GOARCH)
+			},
+		},
+		{
 			name: "Root directory contents",
 			check: func() (string, error) {
 				return checkupRootDir(getFilepaths(k.RootDirectory(), "*"))
@@ -377,12 +383,20 @@ func (c *checkup) run() {
 	}
 }
 
-// checkupPlatform verifies that the current platform is supported by launcher
+// checkupPlatform verifies that the current OS is supported by launcher
 func checkupPlatform(os string) (string, error) {
 	if slices.Contains([]string{"windows", "darwin", "linux"}, os) {
 		return fmt.Sprintf("Platform: %s", os), nil
 	}
 	return "", fmt.Errorf("Unsupported platform: %s", os)
+}
+
+// checkupArch verifies that the current architecture is supported by launcher
+func checkupArch(arch string) (string, error) {
+	if slices.Contains([]string{"386", "amd64", "arm64"}, arch) {
+		return fmt.Sprintf("Architecture: %s", arch), nil
+	}
+	return "", fmt.Errorf("Unsupported architecture: %s", arch)
 }
 
 type launcherFile struct {

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -8,7 +8,11 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/agent/knapsack"
+	"github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/checkpoint"
 
 	"github.com/fatih/color"
 	"golang.org/x/exp/slices"
@@ -101,6 +105,21 @@ func runDoctor(args []string) error {
 		{
 			name: "Check communication with Kolide",
 			check: func() (string, error) {
+				logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+				// opts := &launcher.Options{}
+
+				// fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
+				// flagController := flags.NewFlagController(logger, nil, fcOpts...)
+
+				mockFlags := mocks.NewFlags(t)
+				if !tt.portDefined {
+					mockFlags.On("InsecureTransportTLS").Return(tt.insecureTransport)
+				}
+
+				k := knapsack.New(nil, flagController, nil)
+				// logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+				checkpointer := checkpoint.New(logger, k)
+
 				return "Successfully communicated with Kolide", nil
 			},
 		},

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -55,7 +55,6 @@ var (
 	}
 
 	configFile string
-	etcDir     string
 	binDir     string
 )
 

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/kolide/kit/version"
+
+	"github.com/fatih/color"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	cRunning  = color.New(color.FgCyan)
+	cHeader   = color.New(color.FgHiWhite).Add(color.Bold)
+	cProperty = color.New(color.FgWhite)
+	cPass     = color.New(color.FgGreen)
+	cFail     = color.New(color.FgRed).Add(color.Bold)
+	cWarning  = color.New(color.BgHiYellow)
+
+	// Create a custom print function for convenience
+	pass = color.New(color.FgGreen).PrintlnFunc()
+	warn = color.New(color.FgHiYellow).PrintlnFunc()
+	fail = color.New(color.FgRed).Add(color.Bold).PrintlnFunc()
+
+	cInfo = color.New(color.FgWhite)
+	info  = func(a ...interface{}) {
+		cInfo.Println(fmt.Sprintf("    %s", a...))
+	}
+)
+
+type checkup struct {
+	name   string
+	check  func() (string, error)
+	checks []func() (string, error)
+}
+
+func runDoctor(args []string) error {
+	flagset := flag.NewFlagSet("launcher doctor", flag.ExitOnError)
+	var (
+	// configFile = env.String("config", "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags", "")
+
+	// not documented via flags on purpose
+	// configFile = flagset.String("config", "", "config file to parse options from (optional)")
+
+	// configFile = env.String("config", "/etc/kolide-k2/launcher.flags")
+	// etcDir  = env.String("KOLIDE_LAUNCHER_ETC_DIRECTORY", "/etc/kolide-k2/")
+	// rootDir = env.String("KOLIDE_LAUNCHER_ROOT_DIRECTORY", "/var/kolide-k2/k2device-preprod.kolide.com/")
+
+	// flControlRequestInterval = flagset.Duration("control_request_interval", 60*time.Second, "The interval at which the control server requests will be made")
+	// flKolideServerURL        = flagset.String("hostname", "", "The hostname of the gRPC server")
+	)
+	flagset.Usage = commandUsage(flagset, "launcher doctor")
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	cRunning.Println("Running Kolide launcher checkups...")
+
+	checkups := []*checkup{
+		{
+			name: "Check platform",
+			check: func() (string, error) {
+				return checkupPlatform(runtime.GOOS)
+			},
+		},
+		{
+			name: "Directory contents",
+			check: func() (string, error) {
+				return checkupRootDir(getFilepaths("/var/kolide-k2/k2device-preprod.kolide.com/", "*"))
+			},
+			// checks: []func() (string, error){
+			// 	func() (string, error) {
+			// 		entries, err := os.ReadDir(rootDir)
+			// 		if err != nil {
+			// 			fmt.Println(err)
+			// 		}
+
+			// 		for _, e := range entries {
+			// 			fmt.Println(e.Name())
+			// 		}
+			// 		return "", nil
+			// 	},
+			// 	func() (string, error) {
+			// 		entries, err := os.ReadDir(etcDir)
+			// 		if err != nil {
+			// 			fmt.Println(err)
+			// 		}
+
+			// 		for _, e := range entries {
+			// 			fmt.Println(e.Name())
+			// 		}
+			// 		return "", nil
+			// 	},
+			// },
+		},
+		{
+			name: "Check communication with Kolide",
+			check: func() (string, error) {
+				return "Successfully communicated with Kolide", nil
+			},
+		},
+		{
+			name: "Check version",
+			check: func() (string, error) {
+				return checkupVersion(version.Version())
+			},
+		},
+		{
+			name: "Check config file",
+			check: func() (string, error) {
+				// "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags"
+				return checkupConfigFile(getFilepaths("/etc/kolide-k2/", "launcher.flags"))
+			},
+
+			// checks: []func() (string, error){
+			// 	func() (string, error) {
+			// 		data, err := os.ReadFile(*configFile)
+			// 		if data != nil {
+			// 			fmt.Println(string(data))
+			// 		}
+			// 		if err != nil {
+			// 			return "", fmt.Errorf("No config file found")
+			// 		}
+			// 		return "Config file found", nil
+			// 	},
+			// },
+		},
+		{
+			name: "Check logs",
+			check: func() (string, error) {
+				// "/var/kolide-k2/k2device-preprod.kolide.com/launcher.flags"
+				// /var/kolide-k2/k2device-preprod.kolide.com/launcher
+				return checkupLogFiles(getFilepaths("/var/kolide-k2/k2device-preprod.kolide.com/", "debug*"))
+			},
+
+			checks: []func() (string, error){
+				func() (string, error) {
+					// cPass.Println("Kolide")
+					return "", nil
+				},
+			},
+		},
+	}
+
+	failedCheckups := []*checkup{}
+
+	for _, c := range checkups {
+		c.run()
+	}
+
+	if len(failedCheckups) > 0 {
+		fail("Some checkups failed:")
+
+		for _, c := range failedCheckups {
+			fail("%s\n", c.name)
+		}
+	} else {
+		pass("All checkups passed! Your Kolide launcher is healthy.")
+	}
+
+	return nil
+}
+
+func (c *checkup) run() {
+	cRunning.Printf("Running checkup: ")
+	cHeader.Printf("%s\n", c.name)
+
+	var err error
+	if c.check != nil {
+		result, err := c.check()
+		if err != nil {
+			cProperty.Println(result)
+			cProperty.Printf("❌  %s\n", err)
+		} else {
+			cProperty.Printf("✅  %s\n", result)
+		}
+	}
+
+	if err != nil {
+		fail("𐄂 Checkup failed!")
+	} else {
+		pass("✔ Checkup passed!")
+	}
+	pass("")
+}
+
+func checkupPlatform(os string) (string, error) {
+	if slices.Contains([]string{"windows", "darwin", "linux"}, os) {
+		return fmt.Sprintf("Platform: %s", os), nil
+	}
+	return "", fmt.Errorf("Unsupported platform: %s", os)
+}
+
+func checkupRootDir(filepaths []string) (string, error) {
+	if filepaths != nil && len(filepaths) > 0 {
+		for _, fp := range filepaths {
+			// fmt.Println(filepath.Base(fp))
+			info(filepath.Base(fp))
+		}
+		// data, _ := os.ReadFile(filepaths[0])
+		// if data != nil {
+		// fmt.Println(string(data))
+		return "Root directory files found", nil
+		// }
+	}
+
+	return "", fmt.Errorf("No root directory files found")
+}
+
+func checkupVersion(v version.Info) (string, error) {
+	warn("Latest available version: Unknown")
+	return fmt.Sprintf("Current version: %s\n", v.Version), nil
+}
+
+func checkupConfigFile(filepaths []string) (string, error) {
+	if filepaths != nil && len(filepaths) > 0 {
+		// data, _ := os.ReadFile(filepaths[0])
+		// if data != nil {
+		// 	// info(string(data))
+		// 	return "Config file found", nil
+		// }
+
+		file, err := os.Open(filepaths[0])
+		if err != nil {
+			return "", fmt.Errorf("No config file found")
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			info(scanner.Text())
+		}
+
+		return "Config file found", nil
+	}
+
+	return "", fmt.Errorf("No config file found")
+}
+
+func checkupLogFiles(filepaths []string) (string, error) {
+	var foundCurrentLogFile bool
+	for _, f := range filepaths {
+		filename := filepath.Base(f)
+		// fmt.Println(filename)
+		info(filename)
+		// pass("%s found", filename)
+		if filename == "debug.json" {
+			// pass("%s found")
+			foundCurrentLogFile = true
+		}
+		// fmt.Println(filepath.Base(fp))
+	}
+	// if filepaths != nil && len(filepaths) > 0 {
+	// 	// data, _ := os.ReadFile(filepaths[0])
+	// 	// if data != nil {
+	// 	// 	fmt.Println(string(data))
+	// 	// 	return "Log files found", nil
+	// 	// }
+	// }
+
+	if foundCurrentLogFile {
+		return "Log file found", nil
+	}
+	return "", fmt.Errorf("No log file found")
+}
+
+func getFilepaths(elem ...string) []string {
+	fileGlob := filepath.Join(elem...)
+	filepaths, err := filepath.Glob(fileGlob)
+
+	if err == nil && len(filepaths) > 0 {
+		return filepaths
+	}
+	// entries, err := os.ReadDir(dir)
+	// if err != nil {
+	// 	fmt.Println(err)
+	// }
+
+	// for _, e := range entries {
+	// 	fmt.Println(e.Name())
+	// }
+
+	return nil
+}

--- a/cmd/launcher/doctor_test.go
+++ b/cmd/launcher/doctor_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/kolide/kit/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckupPlatform(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		os          string
+		expectedErr bool
+	}{
+		{
+			name:        "supported",
+			os:          runtime.GOOS,
+			expectedErr: false,
+		},
+		{
+			name:        "unsupported",
+			os:          "not-an-os",
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := checkupPlatform(tt.os)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckupVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		version     version.Info
+		expectedErr bool
+	}{
+		{
+			name:        "happy path",
+			version:     version.Version(),
+			expectedErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := checkupVersion(tt.version)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/launcher/doctor_test.go
+++ b/cmd/launcher/doctor_test.go
@@ -42,6 +42,40 @@ func TestCheckupPlatform(t *testing.T) {
 	}
 }
 
+func TestCheckupArch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		os          string
+		expectedErr bool
+	}{
+		{
+			name:        "supported",
+			os:          runtime.GOARCH,
+			expectedErr: false,
+		},
+		{
+			name:        "unsupported",
+			os:          "not-an-arch",
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := checkupArch(tt.os)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCheckupVersion(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/launcher/doctor_test.go
+++ b/cmd/launcher/doctor_test.go
@@ -133,12 +133,12 @@ func TestCheckupRootDir(t *testing.T) {
 	}{
 		{
 			name:        "present",
-			filepaths:   []string{},
+			filepaths:   []string{"debug.json", "launcher.db", "osquery.db"},
 			expectedErr: false,
 		},
 		{
 			name:        "not present",
-			filepaths:   []string{},
+			filepaths:   []string{"not-an-important-file"},
 			expectedErr: true,
 		},
 	}

--- a/cmd/launcher/doctor_test.go
+++ b/cmd/launcher/doctor_test.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"errors"
+	"io"
 	"runtime"
 	"testing"
 
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	// We don't care about the actual CLI output
+	doctorWriter = io.Discard
+}
 
 func TestRunCheckups(t *testing.T) {
 	t.Parallel()
@@ -161,14 +168,18 @@ func TestCheckupVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		version     version.Info
-		expectedErr bool
+		name          string
+		updateChannel string
+		tufServerURL  string
+		version       version.Info
+		expectedErr   bool
 	}{
 		{
-			name:        "happy path",
-			version:     version.Version(),
-			expectedErr: false,
+			name:          "happy path",
+			updateChannel: autoupdate.Stable.String(),
+			tufServerURL:  "https://tuf.kolide.com",
+			version:       version.Version(),
+			expectedErr:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -176,7 +187,7 @@ func TestCheckupVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := checkupVersion(tt.version)
+			_, err := checkupVersion(tt.updateChannel, tt.tufServerURL, tt.version)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {

--- a/cmd/launcher/doctor_test.go
+++ b/cmd/launcher/doctor_test.go
@@ -1,12 +1,59 @@
 package main
 
 import (
+	"errors"
 	"runtime"
 	"testing"
 
 	"github.com/kolide/kit/version"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunCheckups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		checkups []*checkup
+	}{
+		{
+			name: "successful checkups",
+			checkups: []*checkup{
+				{
+					name: "do nothing",
+					check: func() (string, error) {
+						return "", nil
+					},
+				},
+			},
+		},
+		{
+			name: "failed checkup",
+			checkups: []*checkup{
+				{
+					name: "do nothing",
+					check: func() (string, error) {
+						return "", nil
+					},
+				},
+				{
+					name: "return error",
+					check: func() (string, error) {
+						return "", errors.New("checkup error")
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runCheckups(tt.checkups)
+		})
+	}
+}
 
 func TestCheckupPlatform(t *testing.T) {
 	t.Parallel()
@@ -67,6 +114,40 @@ func TestCheckupArch(t *testing.T) {
 			t.Parallel()
 
 			_, err := checkupArch(tt.os)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckupRootDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		filepaths   []string
+		expectedErr bool
+	}{
+		{
+			name:        "present",
+			filepaths:   []string{},
+			expectedErr: false,
+		},
+		{
+			name:        "not present",
+			filepaths:   []string{},
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := checkupRootDir(tt.filepaths)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -27,7 +27,7 @@ func runInteractive(args []string) error {
 
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
 
-	flagset.Usage = commandUsage(flagset, "interactive")
+	flagset.Usage = commandUsage(flagset, "launcher interactive")
 	if err := flagset.Parse(args); err != nil {
 		return err
 	}

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -121,6 +121,8 @@ func runSubcommands() error {
 		run = runSocket
 	case "query":
 		run = runQuery
+	case "doctor":
+		run = runDoctor
 	case "flare":
 		run = runFlare
 	case "svc":

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	opts, err := parseOptions(os.Args[1:])
+	opts, err := parseOptions("", os.Args[1:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -206,11 +206,3 @@ func getArgsAndResponse() (map[string]string, *launcher.Options) {
 
 	return args, opts
 }
-
-func windowsAddExe(in string) string {
-	if runtime.GOOS == "windows" {
-		return in + ".exe"
-	}
-
-	return in
-}

--- a/cmd/launcher/options_test.go
+++ b/cmd/launcher/options_test.go
@@ -28,7 +28,7 @@ func TestOptionsFromFlags(t *testing.T) { //nolint:paralleltest
 		}
 	}
 
-	opts, err := parseOptions(testFlags)
+	opts, err := parseOptions("", testFlags)
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -50,7 +50,7 @@ func TestOptionsFromEnv(t *testing.T) { //nolint:paralleltest
 		name := fmt.Sprintf("KOLIDE_LAUNCHER_%s", strings.ToUpper(strings.TrimLeft(k, "-")))
 		require.NoError(t, os.Setenv(name, val))
 	}
-	opts, err := parseOptions([]string{})
+	opts, err := parseOptions("", []string{})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -63,6 +63,7 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 	flagFile, err := os.CreateTemp("", "flag-file")
 	require.NoError(t, err)
 	defer os.Remove(flagFile.Name())
+	expectedOpts.ConfigFilePath = flagFile.Name()
 
 	for k, val := range testArgs {
 		var err error
@@ -81,7 +82,7 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 
 	require.NoError(t, flagFile.Close())
 
-	opts, err := parseOptions([]string{"-config", flagFile.Name()})
+	opts, err := parseOptions("", []string{"-config", flagFile.Name()})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -160,7 +161,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 		tt := tt
 		os.Clearenv()
 		t.Run(tt.testName, func(t *testing.T) {
-			opts, err := parseOptions(tt.testFlags)
+			opts, err := parseOptions("", tt.testFlags)
 			require.NoError(t, err, "could not parse options")
 			require.Equal(t, tt.expectedControlServer, opts.ControlServerURL, "incorrect control server")
 			require.Equal(t, tt.expectedInsecureControlTLS, opts.InsecureControlTLS, "incorrect insecure TLS")

--- a/cmd/launcher/paths.go
+++ b/cmd/launcher/paths.go
@@ -58,3 +58,12 @@ func getFilepaths(elem ...string) []string {
 
 	return nil
 }
+
+// windowsAddExe appends ".exe" to the input string when running on Windows
+func windowsAddExe(in string) string {
+	if runtime.GOOS == "windows" {
+		return in + ".exe"
+	}
+
+	return in
+}

--- a/cmd/launcher/paths.go
+++ b/cmd/launcher/paths.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+func getDefaults(defaultRootDir, defaultEtcDir, binDir, defaultConfigFile *string) {
+	switch runtime.GOOS {
+	case "darwin":
+		*defaultRootDir = "/var/kolide-k2/k2device.kolide.com/"
+		*defaultEtcDir = "/etc/kolide-k2/"
+		*binDir = "/usr/local/kolide-k2/"
+		*defaultConfigFile = filepath.Join(*defaultEtcDir, "launcher.flags")
+	case "linux":
+		*defaultRootDir = "/var/kolide-k2/k2device.kolide.com/"
+		*defaultEtcDir = "/etc/kolide-k2/"
+		*binDir = "/usr/local/kolide-k2/"
+		*defaultConfigFile = filepath.Join(*defaultEtcDir, "launcher.flags")
+	case "windows":
+		// TODO
+	}
+}
+
+func getAppBinaryPaths() []string {
+	var paths []string
+	switch runtime.GOOS {
+	case "darwin":
+		paths = []string{
+			filepath.Join(binDir, "Kolide.app", "Contents", "MacOS", "launcher"),
+		}
+	case "linux":
+		paths = []string{}
+	case "windows":
+		paths = []string{}
+	}
+	return paths
+}
+
+// getFilepaths returns a list of file paths matching the pattern
+func getFilepaths(elem ...string) []string {
+	fileGlob := filepath.Join(elem...)
+	filepaths, err := filepath.Glob(fileGlob)
+
+	if err == nil && len(filepaths) > 0 {
+		return filepaths
+	}
+
+	return nil
+}

--- a/cmd/launcher/paths.go
+++ b/cmd/launcher/paths.go
@@ -18,7 +18,10 @@ func getDefaults(defaultRootDir, defaultEtcDir, binDir, defaultConfigFile *strin
 		*binDir = "/usr/local/kolide-k2/"
 		*defaultConfigFile = filepath.Join(*defaultEtcDir, "launcher.flags")
 	case "windows":
-		// TODO
+		*defaultRootDir = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data"
+		*defaultEtcDir = ""
+		*binDir = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin"
+		*defaultConfigFile = filepath.Join("C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf", "launcher.flags")
 	}
 }
 
@@ -30,9 +33,13 @@ func getAppBinaryPaths() []string {
 			filepath.Join(binDir, "Kolide.app", "Contents", "MacOS", "launcher"),
 		}
 	case "linux":
-		paths = []string{}
+		paths = []string{
+			filepath.Join(binDir, "launcher.exe"),
+		}
 	case "windows":
-		paths = []string{}
+		paths = []string{
+			filepath.Join(binDir, "launcher.exe"),
+		}
 	}
 	return paths
 }

--- a/cmd/launcher/paths.go
+++ b/cmd/launcher/paths.go
@@ -5,40 +5,43 @@ import (
 	"runtime"
 )
 
-func getDefaults(defaultRootDir, defaultEtcDir, binDir, defaultConfigFile *string) {
+// setDefaultPaths populates the default file/dir paths
+// call this before calling parseOptions if you want to assume these paths exist
+func setDefaultPaths() {
 	switch runtime.GOOS {
 	case "darwin":
-		*defaultRootDir = "/var/kolide-k2/k2device.kolide.com/"
-		*defaultEtcDir = "/etc/kolide-k2/"
-		*binDir = "/usr/local/kolide-k2/"
-		*defaultConfigFile = filepath.Join(*defaultEtcDir, "launcher.flags")
+		defaultRootDirectoryPath = "/var/kolide-k2/k2device.kolide.com/"
+		defaultEtcDirectoryPath = "/etc/kolide-k2/"
+		defaultBinDirectoryPath = "/usr/local/kolide-k2/"
+		defaultConfigFilePath = filepath.Join(defaultEtcDirectoryPath, "launcher.flags")
 	case "linux":
-		*defaultRootDir = "/var/kolide-k2/k2device.kolide.com/"
-		*defaultEtcDir = "/etc/kolide-k2/"
-		*binDir = "/usr/local/kolide-k2/"
-		*defaultConfigFile = filepath.Join(*defaultEtcDir, "launcher.flags")
+		defaultRootDirectoryPath = "/var/kolide-k2/k2device.kolide.com/"
+		defaultEtcDirectoryPath = "/etc/kolide-k2/"
+		defaultBinDirectoryPath = "/usr/local/kolide-k2/"
+		defaultConfigFilePath = filepath.Join(defaultEtcDirectoryPath, "launcher.flags")
 	case "windows":
-		*defaultRootDir = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data"
-		*defaultEtcDir = ""
-		*binDir = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin"
-		*defaultConfigFile = filepath.Join("C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf", "launcher.flags")
+		defaultRootDirectoryPath = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data"
+		defaultEtcDirectoryPath = ""
+		defaultBinDirectoryPath = "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin"
+		defaultConfigFilePath = filepath.Join("C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf", "launcher.flags")
 	}
 }
 
+// getAppBinaryPaths returns the platform specific path where binaries are installed
 func getAppBinaryPaths() []string {
 	var paths []string
 	switch runtime.GOOS {
 	case "darwin":
 		paths = []string{
-			filepath.Join(binDir, "Kolide.app", "Contents", "MacOS", "launcher"),
+			filepath.Join(defaultBinDirectoryPath, "Kolide.app", "Contents", "MacOS", "launcher"),
 		}
 	case "linux":
 		paths = []string{
-			filepath.Join(binDir, "launcher"),
+			filepath.Join(defaultBinDirectoryPath, "launcher"),
 		}
 	case "windows":
 		paths = []string{
-			filepath.Join(binDir, "launcher.exe"),
+			filepath.Join(defaultBinDirectoryPath, "launcher.exe"),
 		}
 	}
 	return paths

--- a/cmd/launcher/paths.go
+++ b/cmd/launcher/paths.go
@@ -34,7 +34,7 @@ func getAppBinaryPaths() []string {
 		}
 	case "linux":
 		paths = []string{
-			filepath.Join(binDir, "launcher.exe"),
+			filepath.Join(binDir, "launcher"),
 		}
 	case "windows":
 		paths = []string{

--- a/cmd/launcher/run_compactdb.go
+++ b/cmd/launcher/run_compactdb.go
@@ -10,7 +10,7 @@ import (
 )
 
 func runCompactDb(args []string) error {
-	opts, err := parseOptions(args)
+	opts, err := parseOptions("compactdb", args)
 	if err != nil {
 		return err
 	}

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -45,7 +45,7 @@ func runWindowsSvc(args []string) error {
 		"version", version.Version().Version,
 	)
 
-	opts, err := parseOptions(os.Args[2:])
+	opts, err := parseOptions("", os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("msg", "Error parsing options", "err", err)
 		os.Exit(1)
@@ -122,7 +122,7 @@ func runWindowsSvcForeground(args []string) error {
 	logger := logutil.NewCLILogger(true)
 	level.Debug(logger).Log("msg", "foreground service start requested (debug mode)")
 
-	opts, err := parseOptions(os.Args[2:])
+	opts, err := parseOptions("", os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/launcher/uninstall.go
+++ b/cmd/launcher/uninstall.go
@@ -32,6 +32,7 @@ func runUninstall(args []string) error {
 		ff.WithEnvVarNoPrefix(),
 	}
 
+	flagset.Usage = commandUsage(flagset, "launcher uninstall")
 	if err := ff.Parse(flagset, args, ffOpts...); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/docker/go v1.5.1-1 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
@@ -87,6 +88,8 @@ require (
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/miekg/pkcs11 v0.0.0-20180208123018-5f6e0d0dad6f // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,8 @@ require (
 )
 
 require (
+	github.com/apache/thrift v0.16.0
+	github.com/fatih/color v1.15.0
 	github.com/kolide/systray v1.10.4
 	github.com/kolide/toast v1.0.0
 	github.com/shirou/gopsutil/v3 v3.23.3
@@ -64,7 +66,6 @@ require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
-	github.com/apache/thrift v0.16.0 // indirect
 	github.com/bugsnag/bugsnag-go v1.3.2 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
@@ -74,7 +75,6 @@ require (
 	github.com/docker/go v1.5.1-1 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -327,7 +329,12 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mat/besticon v3.9.0+incompatible h1:SLaWKCE7ptsjWbQee8Sbx8F/WK4bw8b55tUV4mY0m/c=
 github.com/mat/besticon v3.9.0+incompatible/go.mod h1:mA1auQYHt6CW5e7L9HJLmqVQC8SzNk2gVwouO0AbiEU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -698,6 +705,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210629170331-7dc0b73dc9fb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=

--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -43,6 +44,10 @@ func NewFlagController(logger log.Logger, agentFlagsStore types.KVStore, opts ..
 // getControlServerValue looks for a control-server-provided value for the key and returns it.
 // If a control server value is not found, nil is returned.
 func (fc *FlagController) getControlServerValue(key keys.FlagKey) []byte {
+	if fc == nil || fc.agentFlagsStore == nil {
+		return nil
+	}
+
 	value, err := fc.agentFlagsStore.Get([]byte(key))
 	if err != nil {
 		level.Debug(fc.logger).Log("msg", "failed to get control server key", "key", key, "err", err)
@@ -54,6 +59,10 @@ func (fc *FlagController) getControlServerValue(key keys.FlagKey) []byte {
 
 // setControlServerValue stores a control-server-provided value in the agent flags store.
 func (fc *FlagController) setControlServerValue(key keys.FlagKey, value []byte) error {
+	if fc == nil || fc.agentFlagsStore == nil {
+		return errors.New("agentFlagsStore is nil")
+	}
+
 	err := fc.agentFlagsStore.Set([]byte(key), value)
 	if err != nil {
 		level.Debug(fc.logger).Log("msg", "failed to set control server key", "key", key, "err", err)

--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -130,7 +130,7 @@ func (fc *FlagController) SetKolideHosted(hosted bool) error {
 	return fc.setControlServerValue(keys.KolideHosted, boolToBytes(hosted))
 }
 func (fc *FlagController) KolideHosted() bool {
-	return NewBoolFlagValue(WithDefaultBool(false)).get(fc.getControlServerValue(keys.KolideHosted))
+	return NewBoolFlagValue(WithDefaultBool(fc.cmdLineOpts.KolideHosted)).get(fc.getControlServerValue(keys.KolideHosted))
 }
 
 func (fc *FlagController) EnrollSecret() string {

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -103,4 +103,7 @@ type Options struct {
 	IAmBreakingEELicense bool
 	// DelayStart allows for delaying launcher startup for a configurable amount of time
 	DelayStart time.Duration
+
+	// ConfigFilePath is the config file options were parsed from, if provided
+	ConfigFilePath string
 }

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -98,14 +98,19 @@ func (c *checkPointer) logCheckPoint() {
 	c.logOsqueryInfo()
 	c.logDbSize()
 	c.logKolideServerVersion()
-	c.logConnections()
-	c.logIpLookups()
+	c.logger.Log("connections", c.Connections())
+	c.logger.Log("ip look ups", c.IpLookups())
 	c.logNotaryVersions()
 	c.logServerProvidedData()
 }
 
 func (c *checkPointer) logDbSize() {
-	boltStats, err := agent.GetStats(c.knapsack.BboltDB())
+	db := c.knapsack.BboltDB()
+	if db == nil {
+		return
+	}
+
+	boltStats, err := agent.GetStats(db)
 	if err != nil {
 		c.logger.Log("bbolt db size", err.Error())
 	} else {
@@ -143,14 +148,14 @@ func (c *checkPointer) logNotaryVersions() {
 	}
 }
 
-func (c *checkPointer) logConnections() {
+func (c *checkPointer) Connections() map[string]string {
 	dialer := &net.Dialer{Timeout: requestTimeout}
-	c.logger.Log("connections", testConnections(dialer, urlsToTest(c.knapsack)...))
+	return testConnections(dialer, urlsToTest(c.knapsack)...)
 }
 
-func (c *checkPointer) logIpLookups() {
+func (c *checkPointer) IpLookups() map[string]interface{} {
 	ipLookuper := &net.Resolver{}
-	c.logger.Log("ip look ups", lookupHostsIpv4s(ipLookuper, urlsToTest(c.knapsack)...))
+	return lookupHostsIpv4s(ipLookuper, urlsToTest(c.knapsack)...)
 }
 
 func urlsToTest(flags types.Flags) []*url.URL {

--- a/pkg/log/checkpoint/server_data.go
+++ b/pkg/log/checkpoint/server_data.go
@@ -16,9 +16,14 @@ var serverProvidedDataKeys = []string{
 // logServerProvidedData sends a subset of the server data into the checkpoint logs. This iterates over the
 // desired keys, as a way to handle missing values.
 func (c *checkPointer) logServerProvidedData() {
+	db := c.knapsack.BboltDB()
+	if db == nil {
+		return
+	}
+
 	data := make(map[string]string, len(serverProvidedDataKeys))
 
-	if err := c.knapsack.BboltDB().View(func(tx *bbolt.Tx) error {
+	if err := db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket([]byte(storage.ServerProvidedDataStore))
 		if b == nil {
 			return nil


### PR DESCRIPTION
Fixed https://github.com/kolide/launcher/issues/1145

This PR adds a `launcher doctor` subcommand which runs several checkups to verify launcher installation health.

Notable things in this change:

- Doctor can be used with standard launcher options, since it's using the same underlying `parseOption` function.
- It can also fallback to reasonable defaults, even if a launcher installation, or config file, doesn't exist.
- Checkups are run sequentially and results outputted in a consistent manner via writers; this enables the output to easily be directed to stdout or a file or whatever.
- When run via CLI, the output will be colorized with a black background.
- Adding new checkups and modifying existing ones is straightforward and the underlying reporting/outputting can interact with arbitrary diagnostic functionality.
- Flare will now invoke doctor and pipe the output to the flare log file. Flare needs more work, but this is a start, and makes it more valuable.