### PR TITLE
Start to include arch in packaging targets + packaging commands

### DIFF
--- a/pkg/packagekit/assets/distribution.dist
+++ b/pkg/packagekit/assets/distribution.dist
@@ -6,7 +6,7 @@
 			<bundle CFBundleShortVersionString="{{.Version}}" CFBundleVersion="{{.Version}}" id="com.{{.Identifier}}.launcher" path="usr/local/{{.Identifier}}/Kolide.app"/>
 		</bundle-version>
 	</pkg-ref>
-	<options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
+	<options customize="never" require-scripts="false" hostArchitectures="{{.HostArchitectures}}"/>
 	<choices-outline>
 		<line choice="default">
 			<line choice="com.{{.Identifier}}.launcher"/>

--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -30,6 +30,7 @@ const (
 type fpmOptions struct {
 	outputType outputType
 	replaces   []string
+	arch       string
 }
 
 type FpmOpt func(*fpmOptions)
@@ -67,6 +68,12 @@ func WithReplaces(r []string) FpmOpt {
 	}
 }
 
+func WithArch(arch string) FpmOpt {
+	return func(f *fpmOptions) {
+		f.arch = arch
+	}
+}
+
 func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ...FpmOpt) error {
 	ctx, span := trace.StartSpan(ctx, "packagekit.PackageRPM")
 	defer span.End()
@@ -79,6 +86,10 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 
 	if f.outputType == "" {
 		return errors.New("Missing output type")
+	}
+
+	if f.arch == "" {
+		return errors.New("missing architecture")
 	}
 
 	if err := isDirectory(po.Root); err != nil {
@@ -99,6 +110,7 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 		"-t", string(f.outputType),
 		"-n", fmt.Sprintf("%s-%s", po.Name, po.Identifier),
 		"-v", po.Version,
+		"-a", f.arch,
 		"-p", filepath.Join("/out", outputFilename),
 		"-C", "/pkgsrc",
 	}

--- a/pkg/packagekit/package_test.go
+++ b/pkg/packagekit/package_test.go
@@ -36,7 +36,7 @@ func TestPackageTrivial(t *testing.T) {
 	err = PackageFPM(context.TODO(), io.Discard, po, AsRPM())
 	require.NoError(t, err)
 
-	err = PackagePkg(context.TODO(), io.Discard, po)
+	err = PackagePkg(context.TODO(), io.Discard, po, "universal")
 	require.NoError(t, err)
 
 }

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -78,14 +78,12 @@ func WithBuildDir(path string) WixOpt {
 func WithDocker(image string) WixOpt {
 	return func(wo *wixTool) {
 		wo.dockerImage = image
-
 	}
 }
 
 func WithUI() WixOpt {
 	return func(wo *wixTool) {
 		wo.ui = true
-
 	}
 }
 

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -388,24 +388,24 @@ func (p *PackageOptions) makePackage(ctx context.Context) error {
 
 	switch {
 	case p.target.Package == Deb:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsDeb(), packagekit.WithReplaces(oldPackageNames)); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsDeb(), packagekit.WithReplaces(oldPackageNames), packagekit.WithArch(string(p.target.Arch))); err != nil {
 			return fmt.Errorf("packaging, target %s: %w", p.target.String(), err)
 		}
 	case p.target.Package == Rpm:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsRPM(), packagekit.WithReplaces(oldPackageNames)); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsRPM(), packagekit.WithReplaces(oldPackageNames), packagekit.WithArch(string(p.target.Arch))); err != nil {
 			return fmt.Errorf("packaging, target %s: %w", p.target.String(), err)
 		}
 
 	case p.target.Package == Tar:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsTar(), packagekit.WithReplaces(oldPackageNames)); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsTar(), packagekit.WithReplaces(oldPackageNames), packagekit.WithArch(string(p.target.Arch))); err != nil {
 			return fmt.Errorf("packaging, target %s: %w", p.target.String(), err)
 		}
 	case p.target.Package == Pacman:
-		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsPacman(), packagekit.WithReplaces(oldPackageNames)); err != nil {
+		if err := packagekit.PackageFPM(ctx, p.packageWriter, p.packagekitops, packagekit.AsPacman(), packagekit.WithReplaces(oldPackageNames), packagekit.WithArch(string(p.target.Arch))); err != nil {
 			return fmt.Errorf("packaging, target %s: %w", p.target.String(), err)
 		}
 	case p.target.Package == Pkg:
-		if err := packagekit.PackagePkg(ctx, p.packageWriter, p.packagekitops); err != nil {
+		if err := packagekit.PackagePkg(ctx, p.packageWriter, p.packagekitops, string(p.target.Arch)); err != nil {
 			return fmt.Errorf("packaging, target %s: %w", p.target.String(), err)
 		}
 	case p.target.Package == Msi:

--- a/pkg/packaging/target.go
+++ b/pkg/packaging/target.go
@@ -86,11 +86,11 @@ func (t *Target) Parse(s string) error {
 	}
 
 	// For now, set the default arch according to the given platform
-	if defaultArch, ok := defaultArchMap[t.Platform]; ok {
-		t.Arch = defaultArch
-	} else {
+	defaultArch, ok := defaultArchMap[t.Platform]
+	if !ok {
 		return fmt.Errorf("cannot select default arch for unknown platform %s", t.Platform)
 	}
+	t.Arch = defaultArch
 
 	return nil
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1149

This is a small part of the packaging updates: specifying the architecture we're building for when building packages, to allow us to later specify arm64 when we'd like to build arm64 packages. For macOS, this amounted to moving a hardcoded line out of the dist file, to be set by an option instead. For our FPM packaging, this amounted to passing in the `-a` flag, again set by an option. For our Wix build, this is already set: https://github.com/kolide/launcher/blob/main/pkg/packagekit/wix/wix.go#L274