### PR TITLE
adds session_pid to logging for launcher and launcher desktop

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -79,7 +79,7 @@ func runDesktop(args []string) error {
 	logger := logutil.NewServerLogger(*fldebug)
 	logger = log.With(logger,
 		"subprocess", "desktop",
-		"pid", os.Getpid(),
+		"session_pid", os.Getpid(),
 	)
 
 	// Try to get the current user, so we can use the UID for logging. Not a fatal error if we can't, though

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -59,7 +59,7 @@ const (
 func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) error {
 	thrift.ServerConnectivityCheckInterval = 100 * time.Millisecond
 
-	logger := log.With(ctxlog.FromContext(ctx), "caller", log.DefaultCaller)
+	logger := log.With(ctxlog.FromContext(ctx), "caller", log.DefaultCaller, "session_pid", os.Getpid())
 
 	// If delay_start is configured, wait before running launcher.
 	if opts.DelayStart > 0*time.Second {


### PR DESCRIPTION
Adds "session_pid" to logging for launcher and launcher desktop. Used "session_pid" instead of pid because there are existing logs in runners that use "pid" when logging about their child processes.

closes https://github.com/kolide/launcher/issues/1204