### PR TITLE
Don't attempt to parse key if it does not exist

### DIFF
--- a/pkg/agent/keys/local.go
+++ b/pkg/agent/keys/local.go
@@ -52,6 +52,9 @@ func SetupLocalDbKey(logger log.Logger, store types.GetterSetter) (*dbKey, error
 
 func fetchKey(store types.Getter) (*ecdsa.PrivateKey, error) {
 	raw, _ := store.Get([]byte(localKey))
+	if raw == nil {
+		return nil, nil
+	}
 	return x509.ParseECPrivateKey(raw)
 }
 


### PR DESCRIPTION
Prevents the following log on first-time startup after install:

```
{
      "caller":"local.go:35",
      "component":"agentkeys",
      "err":"x509: failed to parse EC private key: asn1: syntax error: sequence truncated",
      "level":"info",
      "msg":"Failed to parse key, regenerating",
      "ts":"2023-05-22T21:21:40.752538Z"
}
```