### PR TITLE
Use Healthy function that uses lock

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -419,7 +419,7 @@ func (r *Runner) launchOsqueryInstance() error {
 				// better for a Limiter
 				maxHealthChecks := 5
 				for i := 1; i <= maxHealthChecks; i++ {
-					if err := o.Healthy(); err != nil {
+					if err := r.Healthy(); err != nil {
 						if i == maxHealthChecks {
 							level.Info(o.logger).Log("msg", "Health check failed. Giving up", "attempt", i, "err", err)
 							return fmt.Errorf("health check failed: %w", err)


### PR DESCRIPTION
As I've been attempting to track down the occasional osquery extension communication errors on first-time install, I noticed that we have a runner `Healthy` function with a lock that calls the instance `Healthy` function, but we don't use it, so we don't get the benefit of the lock. It seems safe to switch to using the `Healthy` function with the lock -- I was able to run this just fine, including through the enrollment process.

This may potentially help with the `ping: wrong method name` issue we've been seeing, with the theory being that ping (called by `Healthy`) is interrupting other communication and that this change will prevent the interruption -- but unfortunately I was not able to reproduce this issue locally, so I'm not sure.