### PR TITLE
Get enrollment details via exec, not the thrift socket

### DIFF
--- a/docs/architecture/2018-06-15_request_enrollment_details.md
+++ b/docs/architecture/2018-06-15_request_enrollment_details.md
@@ -6,7 +6,8 @@
 
 ## Status
 
-Accepted (June 15, 2018)
+Accepted, June 15, 2018
+Updated, 2023-09, [Revisiting enrollment details](2023-09-29_request_enrollment_details_updates.md)
 
 ## Context
 

--- a/docs/architecture/2023-09-29_request_enrollment_details_updates.md
+++ b/docs/architecture/2023-09-29_request_enrollment_details_updates.md
@@ -1,0 +1,46 @@
+# Revisiting enrollment details
+
+## Authors
+
+- seph ([@directionless](https://github.com/directionless))
+
+## Status
+
+Accepted (2023-09)
+
+## Context
+
+Over the last several years, roughly since late 2021, we've seen
+occasional problems starting up. Internally, we've called this _The
+Monterey Bug_, and there is some information and links in [GitHub
+Issue #1211(https://github.com/kolide/launcher/issues/1211).
+
+We have never managed to diagnose this. We have reproduced small parts
+of it, but nothing that holds up over all.
+
+Our leading theories are that it is somehow related to runtime
+complexity, osquery startup time, and thrift socket contention. There
+may be multiple related and unrelated issues at play.
+
+There is additional complexity that stems from the original
+implementation of
+[`getEnrollmentDetails`](https://github.com/kolide/launcher/blob/ab411f07d1d147b963809df2e1fdb04cb574d1a3/pkg/osquery/extension.go#L934). Because
+it use the osquery socket, it cannot run until osquery is started. But
+simultaneously launcher is trying to register extensions, and osquery
+is trying to enroll. 
+
+## Decision
+
+To both simplify startup ordering _and_ reduce socket contention, we
+can gather enrollment details via execing osquery. Semantically, this
+is a fairly simple change -- we can use the same query, and the same
+osquery.
+
+## Consequences
+
+We incur an exec call during startup. But in return, we can gain
+several benefits: 
+- Decouple enrollment details from the main osquery startup.
+- Reduce contention on the socket during early startup
+- Enrollment no longer has a circular dependency
+- Enables future work to completely pull enrollment into launcher 

--- a/docs/architecture/2023-09-29_request_enrollment_details_updates.md
+++ b/docs/architecture/2023-09-29_request_enrollment_details_updates.md
@@ -1,5 +1,7 @@
 # Revisiting enrollment details
 
+This continues the work started in [Initial Host Details](2018-06-15_request_enrollment_details.md)
+
 ## Authors
 
 - seph ([@directionless](https://github.com/directionless))

--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -65,13 +65,13 @@ func getEnrollDetails(osquerydPath string) (service.EnrollmentDetails, error) {
 		return details, fmt.Errorf("create osquery for enrollment details: %w", err)
 	}
 
-	osqCtx, _ := context.WithTimeout(context.TODO(), 5*time.Second)
+	osqCtx, osqCancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer osqCancel()
 
 	if err := osq.Execute(osqCtx); osqCtx.Err() != nil {
 		return details, fmt.Errorf("query enrollment details context error: %w", osqCtx.Err())
 	} else if err != nil {
 		return details, fmt.Errorf("query enrollment details: %w", err)
-
 	}
 
 	var resp []map[string]string

--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -69,10 +69,10 @@ func getEnrollDetails(ctx context.Context, osquerydPath string) (service.Enrollm
 	osqCtx, osqCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer osqCancel()
 
-	if err := osq.RunSql(osqCtx, []byte(query)); osqCtx.Err() != nil {
+	if sqlErr := osq.RunSql(osqCtx, []byte(query)); osqCtx.Err() != nil {
 		return details, fmt.Errorf("query enrollment details context error: %w", osqCtx.Err())
-	} else if err != nil {
-		return details, fmt.Errorf("query enrollment details: %w", err)
+	} else if sqlErr != nil {
+		return details, fmt.Errorf("query enrollment details: %w", sqlErr)
 	}
 
 	var resp []map[string]string

--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -60,7 +60,6 @@ func getEnrollDetails(ctx context.Context, osquerydPath string) (service.Enrollm
 
 	osq, err := runsimple.NewOsqueryProcess(
 		osquerydPath,
-		runsimple.RunSql([]byte(query)),
 		runsimple.WithStdout(&respBytes),
 	)
 	if err != nil {
@@ -70,7 +69,7 @@ func getEnrollDetails(ctx context.Context, osquerydPath string) (service.Enrollm
 	osqCtx, osqCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer osqCancel()
 
-	if err := osq.Execute(osqCtx); osqCtx.Err() != nil {
+	if err := osq.RunSql(osqCtx, []byte(query)); osqCtx.Err() != nil {
 		return details, fmt.Errorf("query enrollment details context error: %w", osqCtx.Err())
 	} else if err != nil {
 		return details, fmt.Errorf("query enrollment details: %w", err)

--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -1,0 +1,113 @@
+package osquery
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/agent"
+	"github.com/kolide/launcher/pkg/service"
+	"github.com/pkg/errors"
+)
+
+func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
+	var details service.EnrollmentDetails
+
+	// To facilitate manual testing around missing enrollment details,
+	// there is a environmental variable to trigger the failure condition
+	if os.Getenv("LAUNCHER_DEBUG_ENROLL_DETAILS_ERROR") == "true" {
+		return details, errors.New("Skipping enrollment details")
+	}
+
+	// This condition is indicative of a misordering (or race) in
+	// startup. Enrollment has started before `SetQuerier` has
+	// been called.
+	if client == nil {
+		return details, errors.New("no querier")
+	}
+
+	query := `
+	SELECT
+		osquery_info.version as osquery_version,
+		os_version.build as os_build,
+		os_version.name as os_name,
+		os_version.platform as os_platform,
+		os_version.platform_like as os_platform_like,
+		os_version.version as os_version,
+		system_info.hardware_model,
+		system_info.hardware_serial,
+		system_info.hardware_vendor,
+		system_info.hostname,
+		system_info.uuid as hardware_uuid
+	FROM
+		os_version,
+		system_info,
+		osquery_info;
+`
+	resp, err := client.Query(query)
+	if err != nil {
+		return details, fmt.Errorf("query enrollment details: %w", err)
+	}
+
+	if len(resp) < 1 {
+		return details, errors.New("expected at least one row from the enrollment details query")
+	}
+
+	if val, ok := resp[0]["os_version"]; ok {
+		details.OSVersion = val
+	}
+	if val, ok := resp[0]["os_build"]; ok {
+		details.OSBuildID = val
+	}
+	if val, ok := resp[0]["os_name"]; ok {
+		details.OSName = val
+	}
+	if val, ok := resp[0]["os_platform"]; ok {
+		details.OSPlatform = val
+	}
+	if val, ok := resp[0]["os_platform_like"]; ok {
+		details.OSPlatformLike = val
+	}
+	if val, ok := resp[0]["osquery_version"]; ok {
+		details.OsqueryVersion = val
+	}
+	if val, ok := resp[0]["hardware_model"]; ok {
+		details.HardwareModel = val
+	}
+	details.HardwareSerial = serialForRow(resp[0])
+	if val, ok := resp[0]["hardware_vendor"]; ok {
+		details.HardwareVendor = val
+	}
+	if val, ok := resp[0]["hostname"]; ok {
+		details.Hostname = val
+	}
+	if val, ok := resp[0]["hardware_uuid"]; ok {
+		details.HardwareUUID = val
+	}
+
+	// This runs before the extensions are registered. These mirror the
+	// underlying tables.
+	details.LauncherVersion = version.Version().Version
+	details.GOOS = runtime.GOOS
+	details.GOARCH = runtime.GOARCH
+
+	// Pull in some launcher key info. These depend on the agent package, and we'll need to check for nils
+	if agent.LocalDbKeys().Public() != nil {
+		if key, err := x509.MarshalPKIXPublicKey(agent.LocalDbKeys().Public()); err == nil {
+			// der is a binary format, so convert to b64
+			details.LauncherLocalKey = base64.StdEncoding.EncodeToString(key)
+		}
+	}
+	if agent.HardwareKeys().Public() != nil {
+		if key, err := x509.MarshalPKIXPublicKey(agent.HardwareKeys().Public()); err == nil {
+			// der is a binary format, so convert to b64
+			details.LauncherHardwareKey = base64.StdEncoding.EncodeToString(key)
+			details.LauncherHardwareKeySource = agent.HardwareKeys().Type()
+		}
+	}
+
+	return details, nil
+}

--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getEnrollDetails(osquerydPath string) (service.EnrollmentDetails, error) {
+func getEnrollDetails(ctx context.Context, osquerydPath string) (service.EnrollmentDetails, error) {
 	var details service.EnrollmentDetails
 
 	// To facilitate manual testing around missing enrollment details,
@@ -32,6 +32,8 @@ func getEnrollDetails(osquerydPath string) (service.EnrollmentDetails, error) {
 		return details, fmt.Errorf("no binary at %s", osquerydPath)
 	} else if info.IsDir() {
 		return details, fmt.Errorf("%s is a directory", osquerydPath)
+	} else if err != nil {
+		return details, fmt.Errorf("statting %s: %w", osquerydPath, err)
 	}
 
 	query := `
@@ -65,7 +67,7 @@ func getEnrollDetails(osquerydPath string) (service.EnrollmentDetails, error) {
 		return details, fmt.Errorf("create osquery for enrollment details: %w", err)
 	}
 
-	osqCtx, osqCancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	osqCtx, osqCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer osqCancel()
 
 	if err := osq.Execute(osqCtx); osqCtx.Err() != nil {

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -404,11 +404,11 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	// We used to see the enrollment details fail, but now that we're running as an exec,
 	// it seems less likely. Try a couple times, but backoff fast.
 	var enrollDetails service.EnrollmentDetails
-	if e.knapsack.OsquerydPath() == "" {
+	if osqPath := e.knapsack.LatestOsquerydPath(ctx); osqPath == "" {
 		level.Info(logger).Log("msg", "Cannot get additional enrollment details without an osqueryd path. This is probably CI")
 	} else {
 		if err := backoff.WaitFor(func() error {
-			enrollDetails, err = getEnrollDetails(ctx, e.knapsack.OsquerydPath())
+			enrollDetails, err = getEnrollDetails(ctx, osqPath)
 			if err != nil {
 				level.Debug(logger).Log("msg", "getEnrollDetails failed in backoff", "err", err)
 			}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -404,7 +404,7 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	// We've seen this fail, so add some retry logic.
 	var enrollDetails service.EnrollmentDetails
 	if err := backoff.WaitFor(func() error {
-		enrollDetails, err = getEnrollDetails(e.osqueryClient)
+		enrollDetails, err = getEnrollDetails(e.knapsack.OsquerydPath())
 		return err
 	}, 2*time.Minute, 10*time.Second); err != nil {
 		if os.Getenv("LAUNCHER_DEBUG_ENROLL_DETAILS_REQUIRED") == "true" {

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -408,12 +408,12 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 		level.Info(logger).Log("msg", "Cannot get additional enrollment details without an osqueryd path. This is probably CI")
 	} else {
 		if err := backoff.WaitFor(func() error {
-			enrollDetails, err = getEnrollDetails(e.knapsack.OsquerydPath())
+			enrollDetails, err = getEnrollDetails(ctx, e.knapsack.OsquerydPath())
 			if err != nil {
 				level.Debug(logger).Log("msg", "getEnrollDetails failed in backoff", "err", err)
 			}
 			return err
-		}, 5*time.Second, 5*time.Second); err != nil {
+		}, 30*time.Second, 5*time.Second); err != nil {
 			if os.Getenv("LAUNCHER_DEBUG_ENROLL_DETAILS_REQUIRED") == "true" {
 				return "", true, fmt.Errorf("query enrollment details: %w", err)
 			}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -19,7 +17,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
-	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/agent/storage"
 	"github.com/kolide/launcher/pkg/agent/types"
@@ -929,105 +926,6 @@ func (e *Extension) writeResultsWithReenroll(ctx context.Context, results []dist
 	}
 
 	return nil
-}
-
-func getEnrollDetails(client Querier) (service.EnrollmentDetails, error) {
-	var details service.EnrollmentDetails
-
-	// To facilitate manual testing around missing enrollment details,
-	// there is a environmental variable to trigger the failure condition
-	if os.Getenv("LAUNCHER_DEBUG_ENROLL_DETAILS_ERROR") == "true" {
-		return details, errors.New("Skipping enrollment details")
-	}
-
-	// This condition is indicative of a misordering (or race) in
-	// startup. Enrollment has started before `SetQuerier` has
-	// been called.
-	if client == nil {
-		return details, errors.New("no querier")
-	}
-
-	query := `
-	SELECT
-		osquery_info.version as osquery_version,
-		os_version.build as os_build,
-		os_version.name as os_name,
-		os_version.platform as os_platform,
-		os_version.platform_like as os_platform_like,
-		os_version.version as os_version,
-		system_info.hardware_model,
-		system_info.hardware_serial,
-		system_info.hardware_vendor,
-		system_info.hostname,
-		system_info.uuid as hardware_uuid
-	FROM
-		os_version,
-		system_info,
-		osquery_info;
-`
-	resp, err := client.Query(query)
-	if err != nil {
-		return details, fmt.Errorf("query enrollment details: %w", err)
-	}
-
-	if len(resp) < 1 {
-		return details, errors.New("expected at least one row from the enrollment details query")
-	}
-
-	if val, ok := resp[0]["os_version"]; ok {
-		details.OSVersion = val
-	}
-	if val, ok := resp[0]["os_build"]; ok {
-		details.OSBuildID = val
-	}
-	if val, ok := resp[0]["os_name"]; ok {
-		details.OSName = val
-	}
-	if val, ok := resp[0]["os_platform"]; ok {
-		details.OSPlatform = val
-	}
-	if val, ok := resp[0]["os_platform_like"]; ok {
-		details.OSPlatformLike = val
-	}
-	if val, ok := resp[0]["osquery_version"]; ok {
-		details.OsqueryVersion = val
-	}
-	if val, ok := resp[0]["hardware_model"]; ok {
-		details.HardwareModel = val
-	}
-	details.HardwareSerial = serialForRow(resp[0])
-	if val, ok := resp[0]["hardware_vendor"]; ok {
-		details.HardwareVendor = val
-	}
-	if val, ok := resp[0]["hostname"]; ok {
-		details.Hostname = val
-	}
-	if val, ok := resp[0]["hardware_uuid"]; ok {
-		details.HardwareUUID = val
-	}
-
-	// This runs before the extensions are registered. These mirror the
-	// underlying tables.
-	details.LauncherVersion = version.Version().Version
-	details.GOOS = runtime.GOOS
-	details.GOARCH = runtime.GOARCH
-
-	// Pull in some launcher key info. These depend on the agent package, and we'll need to check for nils
-	if agent.LocalDbKeys().Public() != nil {
-		if key, err := x509.MarshalPKIXPublicKey(agent.LocalDbKeys().Public()); err == nil {
-			// der is a binary format, so convert to b64
-			details.LauncherLocalKey = base64.StdEncoding.EncodeToString(key)
-		}
-	}
-	if agent.HardwareKeys().Public() != nil {
-		if key, err := x509.MarshalPKIXPublicKey(agent.HardwareKeys().Public()); err == nil {
-			// der is a binary format, so convert to b64
-			details.LauncherHardwareKey = base64.StdEncoding.EncodeToString(key)
-			details.LauncherHardwareKeySource = agent.HardwareKeys().Type()
-		}
-	}
-
-	return details, nil
 }
 
 type initialRunner struct {

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -52,6 +52,7 @@ func makeTempDB(t *testing.T) (db *bbolt.DB, cleanup func()) {
 
 func makeKnapsack(t *testing.T, db *bbolt.DB) types.Knapsack {
 	m := mocks.NewKnapsack(t)
+	m.On("OsquerydPath").Maybe().Return("")
 	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
 	return m
@@ -94,9 +95,9 @@ func TestNewExtensionDatabaseError(t *testing.T) {
 }
 
 func TestGetHostIdentifier(t *testing.T) {
-
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
+
 	k := makeKnapsack(t, db)
 	e, err := NewExtension(&mock.KolideService{}, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -153,9 +153,11 @@ func TestExtensionEnrollTransportError(t *testing.T) {
 			return "", false, errors.New("transport")
 		},
 	}
+
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
+
 	e, err := NewExtension(m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)
 	e.SetQuerier(mockClient{})
@@ -607,6 +609,7 @@ func TestExtensionWriteBufferedLogsEnrollmentInvalid(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
 	k.On("BboltDB").Return(db)
+	k.On("OsquerydPath").Maybe().Return("")
 
 	e, err := NewExtension(m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -983,6 +983,7 @@ func TestExtensionGetQueriesEnrollmentInvalid(t *testing.T) {
 	k := mocks.NewKnapsack(t)
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
+	k.On("OsquerydPath").Maybe().Return("")
 
 	e, err := NewExtension(m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/osquery/osquery-go/plugin/distributed"
 	"github.com/osquery/osquery-go/plugin/logger"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
@@ -53,6 +54,7 @@ func makeTempDB(t *testing.T) (db *bbolt.DB, cleanup func()) {
 func makeKnapsack(t *testing.T, db *bbolt.DB) types.Knapsack {
 	m := mocks.NewKnapsack(t)
 	m.On("OsquerydPath").Maybe().Return("")
+	m.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
 	return m
@@ -610,6 +612,7 @@ func TestExtensionWriteBufferedLogsEnrollmentInvalid(t *testing.T) {
 	k.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
 	k.On("BboltDB").Return(db)
 	k.On("OsquerydPath").Maybe().Return("")
+	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 
 	e, err := NewExtension(m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)
@@ -984,6 +987,7 @@ func TestExtensionGetQueriesEnrollmentInvalid(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("InitialResultsStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.InitialResultsStore.String()))
 	k.On("OsquerydPath").Maybe().Return("")
+	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 
 	e, err := NewExtension(m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
 	require.Nil(t, err)

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 )
 
-// osqueryRunner is a very simple osquery runtime manager. It's designed to start and stop osquery. It has
+// osqueryProcess is a very simple osquery runtime manager. It's designed to start and stop osquery. It has
 // no interactions with the osquery socket, it is purely a process manager.
 type osqueryProcess struct {
 	osquerydPath  string

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -1,0 +1,137 @@
+package runsimple
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+)
+
+// osqueryRunner is a very simple osquery runtime manager. It's designed to start and stop osquery. It has
+// no interactions with the osquery socket, it is purely a process manager.
+type osqueryProcess struct {
+	osquerydPath  string
+	rootDirectory string
+	stdout        io.Writer
+	stderr        io.Writer
+	stdin         io.Reader
+	sql           []byte
+
+	cmd *exec.Cmd
+}
+
+type osqueryProcessOpt func(*osqueryProcess)
+
+// WithRootDirectory is a functional option which allows the user to define the
+// path where filesystem artifacts will be stored. This may include pidfiles,
+// RocksDB database files, etc. If this is not defined, a temporary directory
+// will be used.
+func WithRootDirectory(path string) osqueryProcessOpt {
+	return func(p *osqueryProcess) {
+		p.rootDirectory = path
+	}
+}
+
+// WithStdout is a functional option which allows the user to define where the
+// stdout of the osquery process should be directed. By default, the output will
+// be discarded. This should only be configured once.
+func WithStdout(w io.Writer) osqueryProcessOpt {
+	return func(p *osqueryProcess) {
+		p.stdout = w
+	}
+}
+
+// WithStderr is a functional option which allows the user to define where the
+// stderr of the osquery process should be directed. By default, the output will
+// be discarded. This should only be configured once.
+func WithStderr(w io.Writer) osqueryProcessOpt {
+	return func(p *osqueryProcess) {
+		p.stderr = w
+	}
+}
+
+func WithStdin(r io.Reader) osqueryProcessOpt {
+	return func(p *osqueryProcess) {
+		p.stdin = r
+	}
+}
+
+func RunSql(sql []byte) osqueryProcessOpt {
+	return func(p *osqueryProcess) {
+		// TODO: When we're passing in via stdin, we need to ensure we have a trailing semicolon. Such is the
+		// life of shell nonsense.
+		p.sql = append(sql, []byte("\n;")...)
+	}
+}
+
+func newOsqueryProcess(osquerydPath string, opts ...osqueryProcessOpt) (*osqueryProcess, error) {
+	p := &osqueryProcess{
+		osquerydPath: osquerydPath,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.stdin != nil && p.sql != nil {
+		return nil, errors.New("Cannot specify both stdin and sql")
+	}
+
+	return p, nil
+}
+
+func (p *osqueryProcess) Execute(ctx context.Context) error {
+	// TODO: Not totally sure on ctx here. I think that osquery should probably have it's own context, but also
+	// that it's a better method signature.
+
+	// cmd.Start does not block
+	// Need to call cmd.Wait after it
+	// So how do we manage the start, health, wait in the rest of the control flow?
+
+	args := []string{}
+
+	if p.sql != nil {
+		args = append(args, []string{
+			"-S",
+			"--config_path", "/dev/null",
+			"--disable_events",
+			"--disable_database",
+			"--disable_audit",
+			"--ephemeral",
+			"--json",
+		}...)
+
+		p.stdin = bytes.NewReader(p.sql)
+	} else {
+		panic("Not supported wothout specified sql")
+	}
+
+	p.cmd = exec.CommandContext(ctx, p.osquerydPath, args...)
+
+	// It's okay for these to be nil, so we can just set them without checking.
+	p.cmd.Stdin = p.stdin
+	p.cmd.Stdout = p.stdout
+	p.cmd.Stderr = p.stderr
+
+	//fmt.Printf("About to run %s\n", p.cmd.String())
+	return p.cmd.Run()
+}
+
+/*
+
+func (p *osqueryProcess) Stop() error {
+	proc := p.cmd.Process
+	if proc == nil {
+		return errors.New("No process. Missing start?")
+	}
+
+	err := cmd.Process.Signal(interrupt)
+	if err == nil {
+		err = ctx.Err() // Report ctx.Err() as the reason we interrupted.
+	} else if err.Error() == "os: process already finished" {
+		errc <- nil
+	}
+
+}
+*/

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -1,3 +1,6 @@
+// Package runsimple is meant as a simple runner for osquery. It is initial just handling one off executions, but may
+// perhaps, expand to also handling daemonization
+
 package runsimple
 
 import (
@@ -109,29 +112,3 @@ func (p osqueryProcess) RunVersion(ctx context.Context) error {
 
 	return cmd.Run()
 }
-
-/*
-
-func (p *osqueryProcess) Execute(ctx context.Context) error {
-	// if this grows to replacing the larger osquery runtime, there are a lot of questions about how it will work.
-	//  - cmd.Start does not block, Need to call cmd.Wait after it, So how do we manage the start, health, wait in the rest of the control flow?
-	//  - Should osquery get it's own context? It makes some of the process management easier. But maybe not.
-
-}
-
-
-func (p *osqueryProcess) Stop() error {
-	proc := p.cmd.Process
-	if proc == nil {
-		return errors.New("No process. Missing start?")
-	}
-
-	err := cmd.Process.Signal(interrupt)
-	if err == nil {
-		err = ctx.Err() // Report ctx.Err() as the reason we interrupted.
-	} else if err.Error() == "os: process already finished" {
-		errc <- nil
-	}
-
-}
-*/

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -57,11 +57,12 @@ func WithStdin(r io.Reader) osqueryProcessOpt {
 	}
 }
 
+// RunSql will run a given blob by passing it in as stdin. Note that osquery is perticular. It needs the
+// trailing semicolon, but it's real weird about line breaks, an may return as multiline json output. It
+// is the responsibility of the caller to get the details right.
 func RunSql(sql []byte) osqueryProcessOpt {
 	return func(p *osqueryProcess) {
-		// TODO: When we're passing in via stdin, we need to ensure we have a trailing semicolon. Such is the
-		// life of shell nonsense.
-		p.sql = append(sql, []byte("\n;")...)
+		p.sql = sql
 	}
 }
 
@@ -104,7 +105,7 @@ func (p *osqueryProcess) Execute(ctx context.Context) error {
 
 		p.stdin = bytes.NewReader(p.sql)
 	} else {
-		panic("Not supported wothout specified sql")
+		panic("Not supported without specified sql")
 	}
 
 	p.cmd = exec.CommandContext(ctx, p.osquerydPath, args...)

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -65,7 +65,7 @@ func RunSql(sql []byte) osqueryProcessOpt {
 	}
 }
 
-func newOsqueryProcess(osquerydPath string, opts ...osqueryProcessOpt) (*osqueryProcess, error) {
+func NewOsqueryProcess(osquerydPath string, opts ...osqueryProcessOpt) (*osqueryProcess, error) {
 	p := &osqueryProcess{
 		osquerydPath: osquerydPath,
 	}

--- a/pkg/osquery/runsimple/osqueryrunner.go
+++ b/pkg/osquery/runsimple/osqueryrunner.go
@@ -115,7 +115,6 @@ func (p *osqueryProcess) Execute(ctx context.Context) error {
 	p.cmd.Stdout = p.stdout
 	p.cmd.Stderr = p.stderr
 
-	//fmt.Printf("About to run %s\n", p.cmd.String())
 	return p.cmd.Run()
 }
 

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -1,0 +1,108 @@
+package runsimple
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OsquerySingleSqlNoIO(t *testing.T) {
+	osquerydPath := os.Getenv("OSQUERYD_PATH")
+
+	if osquerydPath == "" {
+		t.Skip("No osquery. Not implemented")
+	}
+
+	osq, err := newOsqueryProcess(osquerydPath, RunSql([]byte("select 1")))
+	require.NoError(t, err)
+
+	require.NoError(t, osq.Execute(context.TODO()))
+}
+
+func Test_OsquerySingleSqlErr(t *testing.T) {
+	osquerydPath := os.Getenv("OSQUERYD_PATH")
+
+	if osquerydPath == "" {
+		t.Skip("No osquery. Not implemented")
+	}
+
+	tests := []struct {
+		name      string
+		sql       string
+		expectErr bool
+		jsonMulti bool
+	}{
+		{
+			name:      "Bad SQL",
+			sql:       "this is not sql;",
+			expectErr: true,
+		},
+		{
+			name:      "Bad SQL, no semicolon",
+			sql:       "this is not sql, no semicolon",
+			expectErr: true,
+		},
+		{
+			name: "select 1",
+			sql:  "select 1",
+		},
+		{
+			name: "select 1;",
+			sql:  "select 1",
+		},
+		{
+			name: "multiselect",
+			sql:  "select 1; select 2",
+		},
+		{
+			name:      "comments",
+			sql:       "select 1; select 2; \n--this is a comment\nselect 3",
+			jsonMulti: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// No parallel, to many execs
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			osq, err := newOsqueryProcess(
+				osquerydPath,
+				RunSql([]byte(tt.sql)),
+				WithStdout(&stdout),
+				WithStderr(&stderr),
+			)
+			require.NoError(t, err)
+
+			if tt.expectErr {
+				require.Error(t, osq.Execute(context.TODO()))
+				require.Contains(t, stderr.String(), "Error")
+				return
+			}
+
+			require.NoError(t, osq.Execute(context.TODO()))
+
+			if tt.jsonMulti {
+				// This is discouraged, and hard to test. So let's bail for now
+				return
+			}
+
+			var result []map[string]string
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+
+			fmt.Println(stderr.String())
+			spew.Dump(result)
+
+		})
+	}
+
+}

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -160,8 +160,8 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 		return fmt.Errorf("Error parsing platform: %s: %w", runtime.GOOS, err)
 	}
 
-	outputFile := filepath.Join(binDirectory, "osqueryd") //, target.PlatformBinaryName("osqueryd"))
-	cacheDir := "/tmp"
+	outputFile := filepath.Join(binDirectory, target.PlatformBinaryName("osqueryd"))
+	cacheDir := binDirectory
 
 	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "stable", target)
 	if err != nil {

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -19,7 +19,7 @@ func Test_OsquerySingleSqlNoIO(t *testing.T) {
 		t.Skip("No osquery. Not implemented")
 	}
 
-	osq, err := newOsqueryProcess(osquerydPath, RunSql([]byte("select 1")))
+	osq, err := NewOsqueryProcess(osquerydPath, RunSql([]byte("select 1")))
 	require.NoError(t, err)
 
 	require.NoError(t, osq.Execute(context.TODO()))
@@ -75,7 +75,7 @@ func Test_OsquerySingleSqlErr(t *testing.T) {
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
-			osq, err := newOsqueryProcess(
+			osq, err := NewOsqueryProcess(
 				osquerydPath,
 				RunSql([]byte(tt.sql)),
 				WithStdout(&stdout),

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -20,10 +20,10 @@ func Test_OsquerySingleSqlNoIO(t *testing.T) {
 		t.Skip("No osquery. Not implemented")
 	}
 
-	osq, err := NewOsqueryProcess(osquerydPath, RunSql([]byte("select 1")))
+	osq, err := NewOsqueryProcess(osquerydPath)
 	require.NoError(t, err)
 
-	require.NoError(t, osq.Execute(context.TODO()))
+	require.NoError(t, osq.RunSql(context.TODO(), []byte("select 1")))
 }
 
 func Test_OsquerySingleSqlErr(t *testing.T) {
@@ -78,19 +78,18 @@ func Test_OsquerySingleSqlErr(t *testing.T) {
 
 			osq, err := NewOsqueryProcess(
 				osquerydPath,
-				RunSql([]byte(tt.sql)),
 				WithStdout(&stdout),
 				WithStderr(&stderr),
 			)
 			require.NoError(t, err)
 
 			if tt.expectErr {
-				require.Error(t, osq.Execute(context.TODO()))
+				require.Error(t, osq.RunSql(context.TODO(), []byte(tt.sql)))
 				require.Contains(t, stderr.String(), "Error")
 				return
 			}
 
-			require.NoError(t, osq.Execute(context.TODO()))
+			require.NoError(t, osq.RunSql(context.TODO(), []byte(tt.sql)))
 
 			if tt.jsonMulti {
 				// This is discouraged, and hard to test. So let's bail for now

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -1,3 +1,4 @@
+//nolint:paralleltest
 package runsimple
 
 import (


### PR DESCRIPTION
Part of my theory around #1211 is that some of the initial startup raciness comes from the initial enrollment details. Launcher is using the socket to fetch them, at the time it's registering, and, and and and...

This PR shifts the enrollment details from an thrift API fetch, to an exec of osquery. It's an extra exec, which isn't ideal, but seems like the lessor of the evils here

TODO:
* [x] Fix tests
* [x] Update ADR
* [x] manually test enrollment macos
* [ ] manually test enrollment windows
* [ ] manually test enrollment linux