### PR TITLE
Default to x-www-browser over xdg-open for handling menu actions

### DIFF
--- a/ee/desktop/user/menu/action_open_url_linux.go
+++ b/ee/desktop/user/menu/action_open_url_linux.go
@@ -8,9 +8,7 @@ import (
 	"os/exec"
 )
 
-// We default to x-www-browser first because, if available, it appears to be better at picking
-// the correct default browser.
-var browserLaunchers = []string{"x-www-browser", "xdg-open"}
+var browserLaunchers = []string{"xdg-open", "x-www-browser"}
 
 func open(url string) error {
 	errList := make([]error, 0)

--- a/ee/desktop/user/menu/action_open_url_linux.go
+++ b/ee/desktop/user/menu/action_open_url_linux.go
@@ -18,10 +18,11 @@ func open(url string) error {
 		cmd := exec.Command(browserLauncher, url)
 		if err := cmd.Start(); err != nil {
 			errList = append(errList, fmt.Errorf("could not open browser with %s: %w", browserLauncher, err))
-		} else {
-			// Successfully opened URL, nothing else to do here
-			return nil
+			continue
 		}
+
+		// Successfully opened URL, nothing else to do here
+		return nil
 	}
 	return fmt.Errorf("could not successfully open browser with any given launchers: %+v", errList)
 }

--- a/ee/desktop/user/menu/action_open_url_linux.go
+++ b/ee/desktop/user/menu/action_open_url_linux.go
@@ -4,11 +4,24 @@
 package menu
 
 import (
+	"fmt"
 	"os/exec"
 )
 
-// open opens the specified URL in the default browser of the user
-// See https://stackoverflow.com/a/39324149/1705598
+// We default to x-www-browser first because, if available, it appears to be better at picking
+// the correct default browser.
+var browserLaunchers = []string{"x-www-browser", "xdg-open"}
+
 func open(url string) error {
-	return exec.Command("xdg-open", url).Start()
+	errList := make([]error, 0)
+	for _, browserLauncher := range browserLaunchers {
+		cmd := exec.Command(browserLauncher, url)
+		if err := cmd.Start(); err != nil {
+			errList = append(errList, fmt.Errorf("could not open browser with %s: %w", browserLauncher, err))
+		} else {
+			// Successfully opened URL, nothing else to do here
+			return nil
+		}
+	}
+	return fmt.Errorf("could not successfully open browser with any given launchers: %+v", errList)
 }


### PR DESCRIPTION
Updates `action_open_url_linux` to use same logic as notifications do for opening URLs: https://github.com/kolide/launcher/blob/main/ee/desktop/user/notify/notify_linux.go

See https://github.com/kolide/launcher/pull/1065 PR description for more details.

For whatever reason, I'm seeing different behavior in test than with notifications -- xdg-open does a better job here than x-www-browser does.