### PR TITLE
Replace deadcode linter with unused linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ run:
 linters:
   enable:
     - bodyclose
-    - deadcode
+    - unused
     - gofmt
     - govet
     - misspell
@@ -24,7 +24,6 @@ linters:
     - noctx
     - staticcheck
     - structcheck
-    - unused
     - varcheck
 
 linters-settings:

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -35,7 +35,6 @@ var (
 	// Command line colors
 	cyanText   *color.Color
 	headerText *color.Color
-	yellowText *color.Color
 	whiteText  *color.Color
 	greenText  *color.Color
 	redText    *color.Color
@@ -50,7 +49,6 @@ var (
 
 	// Indented output for checkup results
 	info func(a ...interface{})
-	warn func(a ...interface{})
 	fail func(a ...interface{})
 	pass func(a ...interface{})
 )
@@ -63,7 +61,6 @@ func configureOutput(w io.Writer) {
 	// Command line colors
 	cyanText = color.New(color.FgCyan, color.BgBlack)
 	headerText = color.New(color.Bold, color.FgHiWhite, color.BgBlack)
-	yellowText = color.New(color.FgHiYellow, color.BgBlack)
 	whiteText = color.New(color.FgWhite, color.BgBlack)
 	greenText = color.New(color.FgGreen, color.BgBlack)
 	redText = color.New(color.Bold, color.FgRed, color.BgBlack)
@@ -88,9 +85,6 @@ func configureOutput(w io.Writer) {
 	info = func(a ...interface{}) {
 		whiteText.FprintlnFunc()(doctorWriter, fmt.Sprintf("\t%s", a...))
 	}
-	warn = func(a ...interface{}) {
-		yellowText.FprintlnFunc()(doctorWriter, fmt.Sprintf("\t%s", a...))
-	}
 	fail = func(a ...interface{}) {
 		whiteText.FprintlnFunc()(doctorWriter, fmt.Sprintf("❌\t%s", a...))
 	}
@@ -108,7 +102,6 @@ type checkup struct {
 func runDoctor(args []string) error {
 	// Doctor assumes a launcher installation (at least partially) exists
 	// Overriding some of the default values allows options to be parsed making this assumption
-	defaultKolideHosted = true
 	defaultAutoupdate = true
 	setDefaultPaths()
 

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -33,7 +33,6 @@ import (
 func runFlare(args []string) error {
 	// Flare assumes a launcher installation (at least partially) exists
 	// Overriding some of the default values allows options to be parsed making this assumption
-	defaultKolideHosted = true
 	defaultAutoupdate = true
 	setDefaultPaths()
 

--- a/cmd/launcher/options.go
+++ b/cmd/launcher/options.go
@@ -31,7 +31,6 @@ var (
 	defaultEtcDirectoryPath  string
 	defaultBinDirectoryPath  string
 	defaultConfigFilePath    string
-	defaultKolideHosted      bool
 	defaultAutoupdate        bool
 )
 

--- a/ee/desktop/user/menu/menu_systray.go
+++ b/ee/desktop/user/menu/menu_systray.go
@@ -104,11 +104,6 @@ func (m *menu) cleanup() {
 	doneChans = nil
 }
 
-// Returns true if launcher is running in production
-func (m *menu) isProd() bool {
-	return m.hostname == "k2device-preprod.kolide.com" || m.hostname == "k2device.kolide.com"
-}
-
 // makeActionHandler creates a handler to execute the desired action when a menu item is clicked
 func (m *menu) makeActionHandler(item *systray.MenuItem, ap ActionPerformer) {
 	if ap == nil {

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -336,12 +336,3 @@ func (ls *localServer) rateLimitHandler(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-func (ls *localServer) kryptoBoxOutboundHandler(http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	})
-}
-
-func (ls *localServer) verify(message []byte, sig []byte) error {
-	return krypto.RsaVerify(ls.serverKey, message, sig)
-}

--- a/pkg/agent/keys_darwin.go
+++ b/pkg/agent/keys_darwin.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/types"
 )
 
-// nolint: deadcode
+// nolint:unused
 func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyInt, error) {
 	_, pubData, err := fetchKeyData(store)
 	if err != nil {

--- a/pkg/agent/keys_tpm.go
+++ b/pkg/agent/keys_tpm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/types"
 )
 
-// nolint: deadcode
+// nolint:unused
 func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyInt, error) {
 	priData, pubData, err := fetchKeyData(store)
 	if err != nil {

--- a/pkg/log/checkpoint/checkpoint_test.go
+++ b/pkg/log/checkpoint/checkpoint_test.go
@@ -6,15 +6,11 @@ import (
 	"testing"
 
 	"github.com/kolide/launcher/pkg/agent/types/mocks"
-	"github.com/kolide/launcher/pkg/launcher"
 )
 
 func Test_urlsToTest(t *testing.T) {
 	t.Parallel()
 
-	type args struct {
-		opts launcher.Options
-	}
 	tests := []struct {
 		name string
 		mock func(t *testing.T) *mocks.Flags
@@ -129,7 +125,6 @@ func Test_parseUrl(t *testing.T) {
 
 	type args struct {
 		addr string
-		opts launcher.Options
 	}
 	tests := []struct {
 		name              string

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -223,7 +223,6 @@ type OsqueryInstance struct {
 	extensionManagerServers []*osquery.ExtensionManagerServer
 	extensionManagerClient  *osquery.ExtensionManagerClient
 	clientLock              sync.Mutex
-	paths                   *osqueryFilePaths
 	rmRootDirectory         func()
 	usingTempDir            bool
 	stats                   *history.Instance
@@ -303,7 +302,6 @@ type osqueryOptions struct {
 	enrollSecretPath      string
 	loggerPluginFlag      string
 	osqueryFlags          []string
-	retries               uint
 	rootDirectory         string
 	stderr                io.Writer
 	stdout                io.Writer

--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -33,14 +33,6 @@ func TouchIDSystemConfig(client *osquery.ExtensionManagerClient, logger log.Logg
 type touchIDSystemConfigTable struct {
 	client *osquery.ExtensionManagerClient
 	logger log.Logger
-	config *touchIDSystemConfig
-}
-
-type touchIDSystemConfig struct {
-	touchIDCompatible int
-	secureEnclaveCPU  string
-	touchIDEnabled    int
-	touchIDUnlock     int
 }
 
 // TouchIDSystemConfigGenerate will be called whenever the table is queried.

--- a/pkg/osquery/table/touchid_user_darwin.go
+++ b/pkg/osquery/table/touchid_user_darwin.go
@@ -38,16 +38,6 @@ func TouchIDUserConfig(client *osquery.ExtensionManagerClient, logger log.Logger
 type touchIDUserConfigTable struct {
 	client *osquery.ExtensionManagerClient
 	logger log.Logger
-	config *touchIDUserConfig
-}
-
-type touchIDUserConfig struct {
-	uid                    int
-	fingerprintsRegistered int
-	touchIDUnlock          int
-	touchIDApplePay        int
-	effectiveUnlock        int
-	effectiveApplePay      int
 }
 
 func (t *touchIDUserConfigTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -143,12 +143,3 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	}
 	return results, nil
 }
-
-func (t *Table) flattenOutput(dataQuery string, systemOutput []byte) ([]dataflatten.Row, error) {
-	flattenOpts := []dataflatten.FlattenOpts{
-		dataflatten.WithLogger(t.logger),
-		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
-	}
-
-	return dataflatten.Plist(systemOutput, flattenOpts...)
-}

--- a/pkg/packagekit/applenotarization/types.go
+++ b/pkg/packagekit/applenotarization/types.go
@@ -23,7 +23,7 @@ type notarizationInfo struct {
 
 // this is eventually used by callers in other repos
 //
-//nolint:deadcode
+//nolint:unused
 type notarizationUpload struct {
 	ProductErrors []productError `plist:"product-errors"`
 }

--- a/pkg/packagekit/authenticode/authenticode.go
+++ b/pkg/packagekit/authenticode/authenticode.go
@@ -15,14 +15,16 @@ import (
 // are *not* the tool options, but instead our own representation of
 // the arguments.w
 type signtoolOptions struct {
-	extraArgs       []string
-	subjectName     string // If present, use this as the `/n` argument
+	extraArgs []string
+	// If present, use this as the `/n` argument
+	subjectName     string // nolint:unused
 	skipValidation  bool
 	signtoolPath    string
-	timestampServer string
-	rfc3161Server   string
+	timestampServer string // nolint:unused
+	rfc3161Server   string // nolint:unused
 
-	execCC func(context.Context, string, ...string) *exec.Cmd // Allows test overrides
+	// Allows test overrides
+	execCC func(context.Context, string, ...string) *exec.Cmd // nolint:unused
 
 }
 
@@ -48,6 +50,7 @@ func WithSigntoolPath(path string) SigntoolOpt {
 	}
 }
 
+// nolint:unused
 func (so *signtoolOptions) execOut(ctx context.Context, argv0 string, args ...string) (string, string, error) {
 	logger := ctxlog.FromContext(ctx)
 

--- a/pkg/service/dial_test.go
+++ b/pkg/service/dial_test.go
@@ -52,7 +52,7 @@ func startServer(t *testing.T, conf *tls.Config) func() {
 	return grpcServer.Stop
 }
 
-//nolint:deadcode
+//nolint:unused
 const (
 	badCert = "testdata/bad-cert.pem"
 	badKey  = "testdata/bad-key.pem"

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -32,7 +32,6 @@ type HostSimulation struct {
 	host                   QueryRunner
 	uuid                   string
 	enrollSecret           string
-	grpcURL                string
 	insecure               bool
 	insecureGrpc           bool
 	requestQueriesInterval time.Duration

--- a/pkg/simulator/simulator_test.go
+++ b/pkg/simulator/simulator_test.go
@@ -7,12 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockQueryRunner struct{}
-
-func (h *mockQueryRunner) RunQuery(sql string) (results []map[string]string, err error) {
-	return []map[string]string{}, nil
-}
-
 func TestFunctionalOptions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/windows/windowsupdate/iimageinformation.go
+++ b/pkg/windows/windowsupdate/iimageinformation.go
@@ -7,7 +7,7 @@ import (
 // IImageInformation contains information about a localized image that is associated with an update or a category.
 // https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iimageinformation
 type IImageInformation struct {
-	disp    *ole.IDispatch
+	disp    *ole.IDispatch //nolint:unused
 	AltText string
 	Height  int64
 	Source  string

--- a/pkg/windows/windowsupdate/iinstallationbehavior.go
+++ b/pkg/windows/windowsupdate/iinstallationbehavior.go
@@ -7,7 +7,7 @@ import (
 // IInstallationBehavior represents the installation and uninstallation options of an update.
 // https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iinstallationbehavior
 type IInstallationBehavior struct {
-	disp                        *ole.IDispatch
+	disp                        *ole.IDispatch //nolint:unused
 	CanRequestUserInput         bool
 	Impact                      int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationimpact
 	RebootBehavior              int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationrebootbehavior

--- a/pkg/windows/windowsupdate/iupdate.go
+++ b/pkg/windows/windowsupdate/iupdate.go
@@ -358,7 +358,7 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 	return iUpdate, nil
 }
 
-//nolint:deadcode
+//nolint:unused
 func toIUpdateCollection(updates []*IUpdate) (*ole.IDispatch, error) {
 	unknown, err := oleutil.CreateObject("Microsoft.Update.UpdateColl")
 	if err != nil {

--- a/pkg/windows/windowsupdate/iupdatedownloadcontent.go
+++ b/pkg/windows/windowsupdate/iupdatedownloadcontent.go
@@ -7,7 +7,7 @@ import (
 // IUpdateDownloadContent represents the download content of an update.
 // https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatedownloadcontent
 type IUpdateDownloadContent struct {
-	disp        *ole.IDispatch
+	disp        *ole.IDispatch //nolint:unused
 	DownloadUrl string
 }
 

--- a/pkg/windows/windowsupdate/iupdateexception.go
+++ b/pkg/windows/windowsupdate/iupdateexception.go
@@ -7,8 +7,8 @@ import (
 // IUpdateException represents info about the aspects of search results returned in the ISearchResult object that were incomplete. For more info, see Remarks.
 // https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdateexception
 type IUpdateException struct {
-	disp    *ole.IDispatch
-	Context int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
+	disp    *ole.IDispatch //nolint:unused
+	Context int32          // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
 	HResult int64
 	Message string
 }

--- a/tools/autoupdate-v1-tests/main.go
+++ b/tools/autoupdate-v1-tests/main.go
@@ -3,16 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/kardianos/osext"
 )
-
-type thingy struct {
-	binaryName string
-	stagedFile string
-}
 
 type processNotes struct {
 	Pid     int
@@ -70,30 +64,4 @@ func main() {
 
 	fmt.Printf("Finished Main (pid %d)\n", ProcessNotes.Pid)
 
-}
-
-func (b *thingy) rename() error {
-	tmpCurFile := fmt.Sprintf("%s-old", b.binaryName)
-
-	fmt.Println("os.Rename cur to old")
-	if err := os.Rename(b.binaryName, tmpCurFile); err != nil {
-		return fmt.Errorf("os.Rename cur top old: %w", err)
-	}
-
-	fmt.Println("os.Rename stage to cur")
-	if err := os.Rename(b.stagedFile, b.binaryName); err != nil {
-		return fmt.Errorf("os.Rename staged to cur: %w", err)
-	}
-
-	fmt.Println("os.Chmod")
-	if err := os.Chmod(b.binaryName, 0755); err != nil {
-		return fmt.Errorf("os.Chmod: %w", err)
-	}
-
-	fmt.Println("syscall.Exec")
-	if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
-		return fmt.Errorf("syscall.Exec: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
Replaces deprecated `deadcode` linter with maintained `unused` linter and cleans up or ignores resulting errors. This will prevent us from having to see the following on every single lint job:

```
level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
```