### PR TITLE
Log more information about unknown process locking osquery pidfile

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -198,12 +198,14 @@ func commonRunnerOptions(logger log.Logger, k types.Knapsack) []runtime.OsqueryI
 	// create the logging adapters for osquery
 	osqueryStderrLogger := kolidelog.NewOsqueryLogAdapter(
 		logger,
+		k.RootDirectory(),
 		kolidelog.WithLevelFunc(level.Info),
 		kolidelog.WithKeyValue("component", "osquery"),
 		kolidelog.WithKeyValue("osqlevel", "stderr"),
 	)
 	osqueryStdoutLogger := kolidelog.NewOsqueryLogAdapter(
 		logger,
+		k.RootDirectory(),
 		kolidelog.WithLevelFunc(level.Debug),
 		kolidelog.WithKeyValue("component", "osquery"),
 		kolidelog.WithKeyValue("osqlevel", "stdout"),

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -215,7 +215,7 @@ func (l *OsqueryLogAdapter) runAndLogLsofOnPidfile() {
 		return
 	}
 
-	fullPidfile := filepath.Join("/private", l.rootDirectory, "osquery.pid")
+	fullPidfile := filepath.Join(l.rootDirectory, "osquery.pid")
 	cmd := exec.Command("lsof", "-R", fullPidfile)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -85,7 +85,7 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 	// information here about the process locking the pidfile.
 	// See: https://github.com/osquery/osquery/issues/7796
 	if bytes.Contains(p, []byte("Refusing to kill non-osqueryd process")) {
-		l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
+		go l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
 	}
 
 	msg := strings.TrimSpace(string(p))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -165,7 +167,11 @@ func (l *OsqueryLogAdapter) runAndLogPs(pid int) {
 	}
 
 	pidStr := strconv.Itoa(pid)
-	cmd := exec.Command("ps", "-p", pidStr, "-o", "user,pid,ppid,pgid,stat,time,command")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ps", "-p", pidStr, "-o", "user,pid,ppid,pgid,stat,time,command")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		level.Debug(l.logger).Log(
@@ -190,7 +196,11 @@ func (l *OsqueryLogAdapter) runAndLogLsofByPID(pid int) {
 	}
 
 	pidStr := strconv.Itoa(pid)
-	cmd := exec.Command("lsof", "-R", "-n", "-p", pidStr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "lsof", "-R", "-n", "-p", pidStr)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		level.Debug(l.logger).Log(
@@ -216,7 +226,11 @@ func (l *OsqueryLogAdapter) runAndLogLsofOnPidfile() {
 	}
 
 	fullPidfile := filepath.Join(l.rootDirectory, "osquery.pid")
-	cmd := exec.Command("lsof", "-R", "-n", fullPidfile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "lsof", "-R", "-n", fullPidfile)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		level.Debug(l.logger).Log(

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -190,7 +190,7 @@ func (l *OsqueryLogAdapter) runAndLogLsofByPID(pid int) {
 	}
 
 	pidStr := strconv.Itoa(pid)
-	cmd := exec.Command("lsof", "-R", "-p", pidStr)
+	cmd := exec.Command("lsof", "-R", "-n", "-p", pidStr)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		level.Debug(l.logger).Log(
@@ -216,7 +216,7 @@ func (l *OsqueryLogAdapter) runAndLogLsofOnPidfile() {
 	}
 
 	fullPidfile := filepath.Join(l.rootDirectory, "osquery.pid")
-	cmd := exec.Command("lsof", "-R", fullPidfile)
+	cmd := exec.Command("lsof", "-R", "-n", fullPidfile)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		level.Debug(l.logger).Log(

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -317,6 +317,8 @@ func (r *Runner) launchOsqueryInstance() error {
 		return fmt.Errorf("fatal error starting osqueryd process: %w", err)
 	}
 
+	level.Info(o.logger).Log("msg", "launched osquery process", "osqueryd_pid", o.cmd.Process.Pid)
+
 	// wait for osquery to create the socket before moving on,
 	// this is intended to serve as a kind of health check
 	// for osquery, if it's started successfully it will create


### PR DESCRIPTION
This PR is an update to https://github.com/kolide/launcher/pull/1130, attempting to collect more information about https://github.com/osquery/osquery/issues/7796.

Adds a log any time we start up osqueryd to note the PID, so we can have a historical record in the logs of previous launcher-owned osqueryd processes.

```
{"caller":"runner.go:320","msg":"launched osquery process","osqueryd_pid":76455,"severity":"info","ts":"2023-06-21T19:11:04.744815Z"}
```

Runs `ps` and `lsof` to attempt to discover more information about the process and what's holding the osquery.pid file.

```
{"caller":"log.go:178","msg":"ran ps on non-osqueryd process using pidfile","output":"USER   PID  PPID  PGID STAT      TIME COMMAND\nroot 76761 76758 76758 S+     0:00.00 ./a.out\n","pid":76761,"severity":"debug","ts":"2023-06-21T19:14:14.771631Z"}
```

```
{"caller":"log.go:202","msg":"ran lsof on non-osqueryd process using pidfile","output":"COMMAND   PID  PPID USER   FD   TYPE DEVICE SIZE/OFF     NODE NAME\na.out   76761 76758 root  cwd    DIR   1,18     2176   256095 /Users/rebeccamahany-horton\na.out   76761 76758 root  txt    REG   1,18    52018 11084464 /Users/rebeccamahany-horton/a.out\na.out   76761 76758 root    0u   CHR   16,1   0t2358     1611 /dev/ttys001\na.out   76761 76758 root    1u   CHR   16,1   0t2358     1611 /dev/ttys001\na.out   76761 76758 root    2u   CHR   16,1   0t2358     1611 /dev/ttys001\na.out   76761 76758 root    3u   REG   1,18        5 13099727 /private/var/kolide-k2/k2device-preprod.kolide.com/osquery.pid\n","pid":76761,"severity":"debug","ts":"2023-06-21T19:14:14.816044Z"}
```

```
{"caller":"log.go:226","msg":"ran lsof on osqueryd pidfile","output":"COMMAND   PID  PPID USER   FD   TYPE DEVICE SIZE/OFF     NODE NAME\na.out   76761 76758 root    3u   REG   1,18        5 13099727 /private/var/kolide-k2/k2device-preprod.kolide.com/osquery.pid\n","pidfile":"/private/var/kolide-k2/k2device-preprod.kolide.com/osquery.pid","severity":"debug","ts":"2023-06-21T19:14:15.002012Z"}
```

Test notes are same as in previous PR.