### PR TITLE
Add error handler to replace global otel error handler

### DIFF
--- a/pkg/traces/exporter/error_handler.go
+++ b/pkg/traces/exporter/error_handler.go
@@ -1,0 +1,23 @@
+package exporter
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// errorHandler implements the go.opentelemetry.io/otel/internal/global.ErrorHandler interface.
+// We use our own error handler instead of the default global one to avoid errors being printed
+// to our logs without JSON formatting and without appropriate log level consideration.
+type errorHandler struct {
+	logger log.Logger
+}
+
+func newErrorHandler(logger log.Logger) *errorHandler {
+	return &errorHandler{
+		logger: logger,
+	}
+}
+
+func (e *errorHandler) Handle(err error) {
+	level.Debug(e.logger).Log("msg", "tracing error", "err", err)
+}

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -96,6 +96,11 @@ func NewTraceExporter(ctx context.Context, k types.Knapsack, client osquery.Quer
 		return t, nil
 	}
 
+	// Set our own error handler to avoid otel printing errors
+	otel.SetErrorHandler(newErrorHandler(
+		log.With(logger, "component", "trace_exporter"),
+	))
+
 	t.addDeviceIdentifyingAttributes()
 
 	// Set the provider with as many resource attributes as we can get immediately


### PR DESCRIPTION
The default global otel error handler prints all logs to stderr, which a) messes up our log formatting and b) is not desirable since it doesn't account for log level. This PR adds a small error handler to ensure that otel errors are logged with our usual logger, at the appropriate level.

From:

```
2023/06/21 13:29:16 traces export: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:4317: connect: connection refused"
```

To:

```
{"caller":"error_handler.go:22","component":"trace_exporter","err":"traces export: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:4317: connect: connection refused\"","msg":"tracing error","session_pid":67708,"severity":"debug","ts":"2023-06-23T15:15:44.558797Z"}
```