### PR TITLE
Don't attempt to use secure enclave

### DIFF
--- a/pkg/agent/keys.go
+++ b/pkg/agent/keys.go
@@ -59,10 +59,11 @@ func SetupKeys(logger log.Logger, store types.GetterSetterDeleter) error {
 // This duplicates some of pkg/osquery/extension.go but that feels like the wrong place.
 // Really, we should have a simpler interface over a storage layer.
 const (
-	privateEccData = "privateEccData"
-	publicEccData  = "publicEccData"
+	privateEccData = "privateEccData" // nolint:unused
+	publicEccData  = "publicEccData"  // nolint:unused
 )
 
+// nolint:unused
 func fetchKeyData(store types.Getter) ([]byte, []byte, error) {
 	pri, err := store.Get([]byte(privateEccData))
 	if err != nil {
@@ -77,6 +78,7 @@ func fetchKeyData(store types.Getter) ([]byte, []byte, error) {
 	return pri, pub, nil
 }
 
+// nolint:unused
 func storeKeyData(store types.Setter, pri, pub []byte) error {
 	if pri != nil {
 		if err := store.Set([]byte(privateEccData), pri); err != nil {
@@ -95,6 +97,7 @@ func storeKeyData(store types.Setter, pri, pub []byte) error {
 
 // clearKeyData is used to clear the keys as part of error handling around new keys. It is not intended to be called
 // regularly, and since the path that calls it is around DB errors, it has no error handling.
+// nolint:unused
 func clearKeyData(logger log.Logger, deleter types.Deleter) {
 	level.Info(logger).Log("msg", "Clearing keys")
 	_ = deleter.Delete([]byte(privateEccData), []byte(publicEccData))

--- a/pkg/agent/keys_darwin.go
+++ b/pkg/agent/keys_darwin.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-kit/kit/log"
@@ -20,6 +21,12 @@ func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyI
 	}
 
 	if pubData == nil {
+		// We're seeing issues where launcher hangs (and does not complete startup) on the
+		// Sonoma Beta 2 release when trying to interact with the secure enclave below, on
+		// CreateKey. Since we don't expect this to work at the moment anyway, we are
+		// short-circuiting and returning early for now.
+		return nil, errors.New("secure enclave is not currently supported")
+
 		level.Info(logger).Log("msg", "Generating new keys")
 
 		var err error

--- a/pkg/agent/keys_darwin.go
+++ b/pkg/agent/keys_darwin.go
@@ -5,28 +5,26 @@ package agent
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/go-kit/kit/log"
-	"github.com/kolide/krypto/pkg/secureenclave"
 	"github.com/kolide/launcher/pkg/agent/types"
 )
 
 // nolint:unused
 func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyInt, error) {
-	_, pubData, err := fetchKeyData(store)
-	if err != nil {
-		return nil, err
-	}
+	// We're seeing issues where launcher hangs (and does not complete startup) on the
+	// Sonoma Beta 2 release when trying to interact with the secure enclave below, on
+	// CreateKey. Since we don't expect this to work at the moment anyway, we are
+	// short-circuiting and returning early for now.
+	return nil, errors.New("secure enclave is not currently supported")
 
-	if pubData == nil {
-		// We're seeing issues where launcher hangs (and does not complete startup) on the
-		// Sonoma Beta 2 release when trying to interact with the secure enclave below, on
-		// CreateKey. Since we don't expect this to work at the moment anyway, we are
-		// short-circuiting and returning early for now.
-		return nil, errors.New("secure enclave is not currently supported")
+	/*
+		_, pubData, err := fetchKeyData(store)
+		if err != nil {
+			return nil, err
+		}
 
-		/*
+		if pubData == nil {
 			level.Info(logger).Log("msg", "Generating new keys")
 
 			var err error
@@ -39,13 +37,13 @@ func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyI
 				clearKeyData(logger, store)
 				return nil, fmt.Errorf("storing key: %w", err)
 			}
-		*/
-	}
+		}
 
-	k, err := secureenclave.New(pubData)
-	if err != nil {
-		return nil, fmt.Errorf("creating secureenclave signer: %w", err)
-	}
+		k, err := secureenclave.New(pubData)
+		if err != nil {
+			return nil, fmt.Errorf("creating secureenclave signer: %w", err)
+		}
 
-	return k, nil
+		return k, nil
+	*/
 }

--- a/pkg/agent/keys_darwin.go
+++ b/pkg/agent/keys_darwin.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/krypto/pkg/secureenclave"
 	"github.com/kolide/launcher/pkg/agent/types"
 )
@@ -27,18 +26,20 @@ func setupHardwareKeys(logger log.Logger, store types.GetterSetterDeleter) (keyI
 		// short-circuiting and returning early for now.
 		return nil, errors.New("secure enclave is not currently supported")
 
-		level.Info(logger).Log("msg", "Generating new keys")
+		/*
+			level.Info(logger).Log("msg", "Generating new keys")
 
-		var err error
-		pubData, err = secureenclave.CreateKey()
-		if err != nil {
-			return nil, fmt.Errorf("creating key: %w", err)
-		}
+			var err error
+			pubData, err = secureenclave.CreateKey()
+			if err != nil {
+				return nil, fmt.Errorf("creating key: %w", err)
+			}
 
-		if err := storeKeyData(store, nil, pubData); err != nil {
-			clearKeyData(logger, store)
-			return nil, fmt.Errorf("storing key: %w", err)
-		}
+			if err := storeKeyData(store, nil, pubData); err != nil {
+				clearKeyData(logger, store)
+				return nil, fmt.Errorf("storing key: %w", err)
+			}
+		*/
 	}
 
 	k, err := secureenclave.New(pubData)

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -527,7 +528,7 @@ func TestHelperProcess(t *testing.T) {
 
 	switch args[0] {
 	case "sleep":
-		select {}
+		time.Sleep(10 * time.Second)
 	case "exit0":
 		os.Exit(0)
 	case "exit1":


### PR DESCRIPTION
We can reliably reproduce an issue on macOS Sonoma beta where an attempt to call secureenclave.CreateKey will cause launcher to hang indefinitely, halting startup.

We don't expect this call to work at the moment anyway because we still need to sort out running it in the correct user context, so for now we will disable this call.