### PR TITLE
exposes table desktop process info in checkpoint and in kolide_desktop_procs table

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -84,7 +84,7 @@ func setInstance(r *DesktopUsersProcessesRunner) {
 	})
 }
 
-func InstanceDesktopProcessRecords() map[string]ProcessRecord {
+func InstanceDesktopProcessRecords() map[string]processRecord {
 	if instance == nil {
 		return nil
 	}
@@ -104,7 +104,7 @@ type DesktopUsersProcessesRunner struct {
 	menuRefreshInterval time.Duration
 	interrupt           chan struct{}
 	// uidProcs is a map of uid to desktop process
-	uidProcs map[string]ProcessRecord
+	uidProcs map[string]processRecord
 	// procsWg is a WaitGroup to wait for all desktop processes to finish during an interrupt
 	procsWg *sync.WaitGroup
 	// interruptTimeout how long to wait for desktop proccesses to finish on interrupt
@@ -130,12 +130,12 @@ type DesktopUsersProcessesRunner struct {
 	runnerServer *runnerserver.RunnerServer
 }
 
-// ProcessRecord is used to track spawned desktop processes.
+// processRecord is used to track spawned desktop processes.
 // The path is used to ensure another process has not taken the same pid.
 // The existence of a process record does not mean the process is running.
 // If, for example, a user logs out, the process record will remain until the
 // user logs in again and it is replaced.
-type ProcessRecord struct {
+type processRecord struct {
 	Process                    *os.Process
 	StartTime, LastHealthCheck time.Time
 	path                       string
@@ -147,7 +147,7 @@ func New(k types.Knapsack, opts ...desktopUsersProcessesRunnerOption) (*DesktopU
 	runner := &DesktopUsersProcessesRunner{
 		logger:                 log.NewNopLogger(),
 		interrupt:              make(chan struct{}),
-		uidProcs:               make(map[string]ProcessRecord),
+		uidProcs:               make(map[string]processRecord),
 		updateInterval:         k.DesktopUpdateInterval(),
 		menuRefreshInterval:    k.DesktopMenuRefreshInterval(),
 		procsWg:                &sync.WaitGroup{},
@@ -545,7 +545,7 @@ func (r *DesktopUsersProcessesRunner) addProcessTrackingRecordForUser(uid string
 		return fmt.Errorf("getting process path: %w", err)
 	}
 
-	r.uidProcs[uid] = ProcessRecord{
+	r.uidProcs[uid] = processRecord{
 		Process:    osProcess,
 		StartTime:  time.Now().UTC(),
 		path:       path,
@@ -618,7 +618,7 @@ func (r *DesktopUsersProcessesRunner) userHasDesktopProcess(uid string) bool {
 	return true
 }
 
-func (r *DesktopUsersProcessesRunner) processExists(processRecord ProcessRecord) bool {
+func (r *DesktopUsersProcessesRunner) processExists(processRecord processRecord) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -464,7 +464,7 @@ func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
 		return fmt.Errorf("determining executable path: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	consoleUsers, err := consoleuser.CurrentUids(ctx)

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -82,7 +82,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 				}
 				user, err := user.Current()
 				require.NoError(t, err)
-				r.uidProcs[user.Uid] = ProcessRecord{
+				r.uidProcs[user.Uid] = processRecord{
 					Process: &os.Process{},
 					path:    "test",
 				}

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -82,8 +82,8 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 				}
 				user, err := user.Current()
 				require.NoError(t, err)
-				r.uidProcs[user.Uid] = processRecord{
-					process: &os.Process{},
+				r.uidProcs[user.Uid] = ProcessRecord{
+					Process: &os.Process{},
 					path:    "test",
 				}
 			},
@@ -176,7 +176,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 					// intentionally ignoring the error here
 					// CI will intermittently fail with "wait: no child processes" due runner.go also calling process.Wait()
 					// racing with this code to remove the child process
-					p.process.Wait()
+					p.Process.Wait()
 				}
 			})
 		})

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/ee/desktop/runner"
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/agent/types"
 )
@@ -107,6 +108,11 @@ func (c *checkPointer) logCheckPoint() {
 		c.logger.Log("notary versions", notaryVersions)
 	}
 	c.logServerProvidedData()
+	c.logDesktopProcs()
+}
+
+func (c *checkPointer) logDesktopProcs() {
+	c.logger.Log("user_desktop_processes", runner.InstanceDesktopProcessRecords())
 }
 
 func (c *checkPointer) logDbSize() {

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/types"
 	"github.com/kolide/launcher/pkg/osquery/tables/cryptoinfotable"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
+	"github.com/kolide/launcher/pkg/osquery/tables/desktopprocs"
 	"github.com/kolide/launcher/pkg/osquery/tables/dev_table_tooling"
 	"github.com/kolide/launcher/pkg/osquery/tables/firefox_preferences"
 	"github.com/kolide/launcher/pkg/osquery/tables/launcher_db"
@@ -29,6 +30,7 @@ func LauncherTables(k types.Knapsack) []osquery.OsqueryPlugin {
 		osquery_instance_history.TablePlugin(),
 		tufinfo.TufReleaseVersionTable(k),
 		launcher_db.TablePlugin("kolide_tuf_autoupdater_errors", k.AutoupdateErrorsStore()),
+		desktopprocs.TablePlugin(),
 	}
 }
 

--- a/pkg/osquery/tables/desktopprocs/desktopprocs.go
+++ b/pkg/osquery/tables/desktopprocs/desktopprocs.go
@@ -1,0 +1,36 @@
+package desktopprocs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kolide/launcher/ee/desktop/runner"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func TablePlugin() *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("uid"),
+		table.TextColumn("pid"),
+		table.TextColumn("start_time"),
+		table.TextColumn("last_health_check"),
+	}
+	return table.NewPlugin("kolide_desktop_procs", columns, generate())
+}
+
+func generate() table.GenerateFunc {
+	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		results := []map[string]string{}
+
+		for k, v := range runner.InstanceDesktopProcessRecords() {
+			results = append(results, map[string]string{
+				"uid":               k,
+				"pid":               fmt.Sprint(v.Process.Pid),
+				"start_time":        fmt.Sprint(v.StartTime),
+				"last_health_check": fmt.Sprint(v.LastHealthCheck),
+			})
+		}
+
+		return results, nil
+	}
+}


### PR DESCRIPTION
* bumps timeout on scutil cmd used to determine console users for desktop process from 2 -> 10 seconds
* exposes table with information about desktop processes
* adds desktop processes info to checkpointer