### PR TITLE
Log unsupported type as string

### DIFF
--- a/pkg/log/checkpoint/queried.go
+++ b/pkg/log/checkpoint/queried.go
@@ -54,7 +54,7 @@ func (c *checkPointer) logQueriedInfo() {
 	defer c.lock.RUnlock()
 
 	for k, v := range c.queriedInfo {
-		c.logger.Log(k, v)
+		c.logger.Log(k, fmt.Sprintf("%+v", v))
 	}
 }
 


### PR DESCRIPTION
Our Windows event logger uses the `LogfmtLogger`, which does not support logging maps, slices, structs, and more. This results in us logging "unsupported value type" to the event log, which isn't helpful.

This PR updates the only place where we have this issue currently that I've seen (logging os_info, system_info in the checkpointer). If we foresee this happening more frequently, maybe it's worth a fix in pkg/log/eventlog itself -- but I mostly haven't noticed us logging complex types elsewhere, so I didn't do that in this PR.

<details>
<summary>Screenshots of event log</summary>

Before:

![unsupported-value-type](https://github.com/kolide/launcher/assets/8119675/d7867590-dc10-42e7-8ef1-d45f87c6d53f)

After:

![after](https://github.com/kolide/launcher/assets/8119675/cfb96578-cfb3-4fce-9061-b2f3344b7147)

</details>