### PR TITLE
Ensure we can open links with xdg-open on x11

### DIFF
--- a/ee/desktop/runner/runner_linux.go
+++ b/ee/desktop/runner/runner_linux.go
@@ -116,22 +116,22 @@ func (r *DesktopUsersProcessesRunner) userEnvVars(ctx context.Context, uid strin
 			envVars["DISPLAY"] = r.displayFromX11(ctx, session)
 			break
 		} else if sessionType == "wayland" {
-			// For opening links with x-www-browser, we only need DISPLAY.
 			envVars["DISPLAY"] = r.displayFromXwayland(ctx, int32(uidInt))
 
-			// For opening links with xdg-open, we need XDG_DATA_DIRS so that xdg-open can find the mimetype configuration
-			// files to figure out what application to launch.
-
-			// We take the default value according to https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html,
-			// but also include the snapd directory due to an issue on Ubuntu 22.04 where the default
-			// /usr/share/applications/mimeinfo.cache does not contain any applications installed via snap.
-			envVars["XDG_DATA_DIRS"] = "/usr/local/share/:/usr/share/:/var/lib/snapd/desktop"
 			break
 		} else {
 			// Not a graphical session
 			continue
 		}
 	}
+
+	// For opening links with xdg-open, we need XDG_DATA_DIRS so that xdg-open can find the mimetype configuration
+	// files to figure out what application to launch.
+
+	// We take the default value according to https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html,
+	// but also include the snapd directory due to an issue on Ubuntu 22.04 where the default
+	// /usr/share/applications/mimeinfo.cache does not contain any applications installed via snap.
+	envVars["XDG_DATA_DIRS"] = "/usr/local/share/:/usr/share/:/var/lib/snapd/desktop"
 
 	return envVars
 }
@@ -147,7 +147,12 @@ func (r *DesktopUsersProcessesRunner) displayFromX11(ctx context.Context, sessio
 		return defaultDisplay
 	}
 
-	return strings.Trim(string(xDisplayOutput), "\n")
+	display := strings.Trim(string(xDisplayOutput), "\n")
+	if display == "" {
+		return defaultDisplay
+	}
+
+	return display
 }
 
 func (r *DesktopUsersProcessesRunner) displayFromXwayland(ctx context.Context, uid int32) string {

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -31,9 +31,9 @@ const (
 	signalActionInvoked          = "org.freedesktop.Notifications.ActionInvoked"
 )
 
-// We default to x-www-browser first because, if available, it appears to be better at picking
+// We default to xdg-open first because, if available, it appears to be better at picking
 // the correct default browser.
-var browserLaunchers = []string{"x-www-browser", "xdg-open"}
+var browserLaunchers = []string{"xdg-open", "x-www-browser"}
 
 func NewDesktopNotifier(logger log.Logger, iconFilepath string) *dbusNotifier {
 	conn, err := dbus.ConnectSessionBus()


### PR DESCRIPTION
Ensures `DISPLAY` is set correctly on x11, and that we always set `XDG_DATA_DIRS` so that xdg-open will choose the correct browser.

In testing (now and previously), determined xdg-open does a better job choosing the default browser, so updated to prefer that over x-www-browser.