### PR TITLE
Pick golang version from go.mod

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,9 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.20.6'
+          go-version-file: './go.mod'
+          check-latest: true
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: '**'
 
-env:
-  GOVER: '1.20.6'
-
 jobs:
   build_and_test:
     name: launcher
@@ -32,7 +29,8 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{env.GOVER}}
+        go-version-file: './go.mod'
+        check-latest: true
       id: go
 
     # use bash, because the powershell syntax is different and this is a cross platform workflow
@@ -144,7 +142,8 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{env.GOVER}}
+        go-version-file: './go.mod'
+        check-latest: true
       id: go
 
     - id: go-cache-paths

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.20.6'
+          go-version-file: './go.mod'
+          check-latest: true
 
       - run: make deps
 


### PR DESCRIPTION
Uses https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file -- this should prevent us from having to constantly bump golang patch versions as a response to govulncheck errors.