### PR TITLE
Update error message in firmware password table

### DIFF
--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -115,13 +115,13 @@ func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output
 	cmd.Stdout = output
 
 	if err := cmd.Run(); err != nil {
-		level.Info(t.logger).Log(
+		level.Debug(t.logger).Log(
 			"msg", "Error running firmwarepasswd",
 			"stderr", strings.TrimSpace(stderr.String()),
 			"stdout", strings.TrimSpace(output.String()),
 			"err", err,
 		)
-		return fmt.Errorf("running osquery: %w", err)
+		return fmt.Errorf("running firmwarepasswd: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
I happened to notice this said osquery, when it should say firmware password