### PR TITLE
Don't use hardcoded path to signtool.exe if we can help it

### DIFF
--- a/pkg/packagekit/package_wix_test.go
+++ b/pkg/packagekit/package_wix_test.go
@@ -1,6 +1,8 @@
 package packagekit
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,5 +48,21 @@ func TestGenerateMicrosoftProductCode(t *testing.T) {
 		require.Equal(t, len("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"), len(guid))
 		require.Equal(t, tt.out, guid)
 	}
+}
 
+func Test_getSigntoolPath(t *testing.T) {
+	t.Parallel()
+
+	signtoolPath := getSigntoolPath()
+
+	switch runtime.GOOS {
+	case "windows":
+		// We should expect to find signtool somewhere, but not necessarily at
+		// our default path.
+		require.True(t, strings.HasSuffix(signtoolPath, "signtool.exe"))
+	case "darwin", "linux":
+		// Tests the case where signtool.exe won't be found. We don't actually
+		// expect to run wix on darwin or linux.
+		require.Equal(t, defaultSigntoolPath, signtoolPath, "expected fallback to default signtool path when signtool isn't present")
+	}
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1257

Coming back to this suggestion from seph since I have some extra time: https://github.com/kolide/launcher/pull/1253#pullrequestreview-1533472602