### PR TITLE
[TUF] Keep staging directory clean

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -52,6 +52,7 @@ type librarian interface {
 	Available(binary autoupdatableBinary, targetFilename string) bool
 	AddToLibrary(binary autoupdatableBinary, currentVersion string, targetFilename string, targetMetadata data.TargetFileMeta) error
 	TidyLibrary(binary autoupdatableBinary, currentVersion string)
+	Close() error
 }
 
 type querier interface {
@@ -184,6 +185,9 @@ func (ta *TufAutoupdater) Execute() (err error) {
 
 func (ta *TufAutoupdater) Interrupt(_ error) {
 	ta.interrupt <- struct{}{}
+	if err := ta.libraryManager.Close(); err != nil {
+		level.Debug(ta.logger).Log("msg", "could not close library on interrupt", "err", err)
+	}
 }
 
 // tidyLibrary gets the current running version for each binary (so that the current version is not removed)

--- a/pkg/autoupdate/tuf/library_manager_test.go
+++ b/pkg/autoupdate/tuf/library_manager_test.go
@@ -43,6 +43,25 @@ func Test_newUpdateLibraryManager(t *testing.T) {
 	require.True(t, launcherDownloadDir.IsDir(), "launcher download dir is not a directory")
 }
 
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	testBaseDir := filepath.Join(t.TempDir(), "updates")
+	testLibraryManager, err := newUpdateLibraryManager("", nil, testBaseDir, log.NewNopLogger())
+	require.NoError(t, err, "unexpected error creating new update library manager")
+
+	stagedDownloadDir, err := os.Stat(testLibraryManager.stagingDir)
+	require.NoError(t, err, "could not stat staged osqueryd download dir")
+	require.True(t, stagedDownloadDir.IsDir(), "staged osqueryd download dir is not a directory")
+
+	// Close the library
+	require.NoError(t, testLibraryManager.Close(), "expected no error on closing library")
+
+	// Confirm staged download directory is gone
+	_, err = os.Stat(testLibraryManager.stagingDir)
+	require.True(t, os.IsNotExist(err), "expected staged download dir to be removed on Close")
+}
+
 func Test_pathToTargetVersionExecutable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/autoupdate/tuf/mock_librarian_test.go
+++ b/pkg/autoupdate/tuf/mock_librarian_test.go
@@ -40,6 +40,20 @@ func (_m *Mocklibrarian) Available(binary autoupdatableBinary, targetFilename st
 	return r0
 }
 
+// Close provides a mock function with given fields:
+func (_m *Mocklibrarian) Close() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // TidyLibrary provides a mock function with given fields: binary, currentVersion
 func (_m *Mocklibrarian) TidyLibrary(binary autoupdatableBinary, currentVersion string) {
 	_m.Called(binary, currentVersion)


### PR DESCRIPTION
Fixes a couple issues I noticed when working on https://github.com/kolide/launcher/pull/1268:

* If we failed to move an update to the update directory, we didn't correctly clean up its temporary location in the staging directory
* We couldn't tidy non-empty directories in the staging directory