### PR TITLE
bump timeout on mdfind from 30 to 60 seconds

### DIFF
--- a/pkg/osquery/table/mdfind_darwin.go
+++ b/pkg/osquery/table/mdfind_darwin.go
@@ -13,7 +13,7 @@ import (
 )
 
 func mdfind(args ...string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	path := "/usr/bin/mdfind"


### PR DESCRIPTION
We've had some issues with timeouts using the kolide_spotlight table. This bumps the time out from 30 to 60 seconds. This is a bandaid and we should consider updating checks that are looking for files to use osquery mdfind table that uses a C api instead of execing.

I experimented with piping the cmd output to a scanner to start populating the response when each line came in instead of waiting for the command to fully complete, but there was no notable difference in the time it took.