### PR TITLE
Fix a couple run groups not exiting

### DIFF
--- a/cmd/launcher/internal/updater/updater.go
+++ b/cmd/launcher/internal/updater/updater.go
@@ -62,9 +62,12 @@ func NewUpdater(
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+
 	updateCmd := &updaterCmd{
 		updater:                 updater,
 		ctx:                     ctx,
+		cancel:                  cancel,
 		stopChan:                make(chan bool),
 		config:                  config,
 		runUpdaterRetryInterval: 30 * time.Minute,
@@ -84,6 +87,7 @@ type updater interface {
 type updaterCmd struct {
 	updater                 updater
 	ctx                     context.Context
+	cancel                  context.CancelFunc
 	stopChan                chan bool
 	stopExecution           func()
 	config                  *UpdaterConfig
@@ -155,4 +159,6 @@ func (u *updaterCmd) interrupt(err error) {
 	if u.stopExecution != nil {
 		u.stopExecution()
 	}
+
+	u.cancel()
 }

--- a/cmd/launcher/internal/updater/updater_test.go
+++ b/cmd/launcher/internal/updater/updater_test.go
@@ -114,6 +114,7 @@ func Test_updaterCmd_execute(t *testing.T) {
 			u := &updaterCmd{
 				updater:                 tt.fields.updater,
 				ctx:                     ctx,
+				cancel:                  cancelCtx,
 				stopChan:                tt.fields.stopChan,
 				config:                  tt.fields.config,
 				runUpdaterRetryInterval: tt.fields.runUpdaterRetryInterval,
@@ -194,9 +195,13 @@ func Test_updaterCmd_interrupt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			ctx, cancel := context.WithCancel(context.Background())
+
 			u := &updaterCmd{
 				stopChan: tt.fields.stopChan,
 				config:   tt.fields.config,
+				ctx:      ctx,
+				cancel:   cancel,
 			}
 
 			// using this wait group to ensure that something gets received on u.StopChan

--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -87,7 +87,7 @@ func NewTufAutoupdater(k types.Knapsack, metadataHttpClient *http.Client, mirror
 		checkInterval:          k.AutoupdateInterval(),
 		store:                  k.AutoupdateErrorsStore(),
 		osquerier:              osquerier,
-		osquerierRetryInterval: 1 * time.Minute,
+		osquerierRetryInterval: 30 * time.Second,
 		logger:                 log.NewNopLogger(),
 	}
 
@@ -184,10 +184,10 @@ func (ta *TufAutoupdater) Execute() (err error) {
 }
 
 func (ta *TufAutoupdater) Interrupt(_ error) {
-	ta.interrupt <- struct{}{}
 	if err := ta.libraryManager.Close(); err != nil {
 		level.Debug(ta.logger).Log("msg", "could not close library on interrupt", "err", err)
 	}
+	ta.interrupt <- struct{}{}
 }
 
 // tidyLibrary gets the current running version for each binary (so that the current version is not removed)
@@ -306,16 +306,16 @@ func (ta *TufAutoupdater) downloadUpdate(binary autoupdatableBinary, targets dat
 		return "", fmt.Errorf("could not find release: %w", err)
 	}
 
+	if ta.libraryManager.Available(binary, release) {
+		return "", nil
+	}
+
 	// Get the current running version if available -- don't error out if we can't
 	// get it, since the worst case is that we download an update whose version matches
 	// our install version.
 	var currentVersion string
 	currentVersion, _ = ta.currentRunningVersion(binary)
 	if currentVersion == versionFromTarget(binary, release) {
-		return "", nil
-	}
-
-	if ta.libraryManager.Available(binary, release) {
 		return "", nil
 	}
 

--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -69,6 +69,12 @@ func newUpdateLibraryManager(mirrorUrl string, mirrorClient *http.Client, baseDi
 
 // Close cleans up the temporary staging directory
 func (ulm *updateLibraryManager) Close() error {
+	// Acquire lock to ensure we aren't interrupting an ongoing operation
+	for _, binary := range binaries {
+		ulm.lock.Lock(binary)
+		defer ulm.lock.Unlock(binary)
+	}
+
 	if err := os.RemoveAll(ulm.stagingDir); err != nil {
 		return fmt.Errorf("could not remove staging dir %s: %w", ulm.stagingDir, err)
 	}

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -141,7 +141,7 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 		case <-ticker.C:
 			continue
 		case <-ctx.Done():
-			break
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205

A few of of our 12 rungroup actors would not return from `Execute` on `Interrupt`, locking shutdown:

* TraceExporter was waiting for a cancel that wouldn't happen until after the rungroup exited -- fixed to use the usual interrupt channel instead
* LogShipper (via sendbuffer) would not exit on interrupt because we were breaking out of a select and not the for loop containing it
* Updater (for both launcher and osquery) was, similar to the TraceExporter, waiting for a cancel that wouldn't happen until after the rungroup exited -- to minimize the changeset in this area of the codebase, I just made a new context and ensured we call the cancel on interrupt

I also made some improvements to how quickly the new TUF autoupdater will respond to shutdown requests. If it's in the middle of an update, it can take a few minutes failing and retrying when querying the current running version of osquery (since the osquery extension has already shut down). Now we check availability before checking current running version, since that's a faster short-circuit, and we perform the osquery retries more quickly.