### PR TITLE
Remove superfluous logs in actor.Interrupt

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -174,9 +174,7 @@ func createExtensionRuntime(ctx context.Context, k types.Knapsack, launcherClien
 					<-ctx.Done()
 					return nil
 				},
-				Interrupt: func(err error) {
-					level.Info(logger).Log("msg", "extension interrupted", "err", err)
-					level.Debug(logger).Log("msg", "extension interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
+				Interrupt: func(_ error) {
 					ext.Shutdown()
 					if runner != nil {
 						if err := runner.Shutdown(); err != nil {

--- a/cmd/launcher/internal/updater/updater.go
+++ b/cmd/launcher/internal/updater/updater.go
@@ -140,9 +140,9 @@ func (u *updaterCmd) execute() error {
 	return nil
 }
 
-func (u *updaterCmd) interrupt(err error) {
+func (u *updaterCmd) interrupt(_ error) {
 
-	level.Info(u.config.Logger).Log("msg", "updater interrupted", "err", err)
+	level.Info(u.config.Logger).Log("msg", "updater interrupted")
 
 	// non-blocking channel send
 	select {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -217,9 +217,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			level.Info(logger).Log("msg", "beginnning shutdown via signal")
 			return nil
 		}
-	}, func(err error) {
-		level.Info(logger).Log("msg", "interrupted", "err", err)
-		level.Debug(logger).Log("msg", "interrupted", "err", err, "stack", fmt.Sprintf("%+v", err))
+	}, func(_ error) {
 		cancel()
 		close(sigChannel)
 	})

--- a/ee/control/consumers/notificationconsumer/notify_consumer.go
+++ b/ee/control/consumers/notificationconsumer/notify_consumer.go
@@ -183,7 +183,7 @@ func (nc *NotificationConsumer) Execute() error {
 }
 
 // Stops cleanup job
-func (nc *NotificationConsumer) Interrupt(err error) {
+func (nc *NotificationConsumer) Interrupt(_ error) {
 	nc.cancel()
 }
 

--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -105,8 +105,7 @@ func (cs *ControlService) Start(ctx context.Context) {
 	}
 }
 
-func (cs *ControlService) Interrupt(err error) {
-	level.Info(cs.logger).Log("msg", "control service interrupted", "err", err)
+func (cs *ControlService) Interrupt(_ error) {
 	cs.Stop()
 }
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -221,12 +221,7 @@ func (r *DesktopUsersProcessesRunner) Execute() error {
 
 // Interrupt stops creating launcher desktop processes and kills any existing ones.
 // It also signals the execute loop to exit, so new desktop processes cease to spawn.
-func (r *DesktopUsersProcessesRunner) Interrupt(interruptError error) {
-	level.Debug(r.logger).Log(
-		"msg", "sending interrupt to desktop users processes runner",
-		"err", interruptError,
-	)
-
+func (r *DesktopUsersProcessesRunner) Interrupt(_ error) {
 	// Tell the execute loop to stop checking, and exit
 	r.interrupt <- struct{}{}
 

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -280,8 +280,8 @@ func (ls *localServer) Stop() error {
 	return nil
 }
 
-func (ls *localServer) Interrupt(err error) {
-	level.Debug(ls.logger).Log("message", "Stopping due to interrupt", "reason", err)
+func (ls *localServer) Interrupt(_ error) {
+	level.Debug(ls.logger).Log("message", "Stopping due to interrupt")
 	if err := ls.Stop(); err != nil {
 		level.Info(ls.logger).Log("message", "got error interrupting", "error", err)
 	}


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205

A bunch of our rungroup actors log errors in their `Interrupt` functions that did not originate from them. This creates a lot of noise in the logs. Launcher already logs the originating error on exit:

```
{"caller":"locallogger.go:43","level":"debug","run service: fake error from signal notify":"run launcher","stack":"run service: fake error from signal notify","ts":"2023-08-01T16:44:11.189798Z"}
{"caller":"locallogger.go:43","level":"info","run service: fake error from signal notify":"run launcher","ts":"2023-08-01T16:44:11.189913Z"}
```

This PR removes all other extra instances of this log to make shutdown a little less noisy and a little easier to understand.