### PR TITLE
add retry logic to getting all target metadata form notary

### DIFF
--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -462,12 +462,14 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 		return fmt.Errorf("create an instance of the TUF repository: %w", err)
 	}
 
-	backoff.WaitFor(func() error {
+	if err := backoff.WaitFor(func() error {
 		if _, err := repo.GetAllTargetMetadataByName(""); err != nil {
 			return fmt.Errorf("getting all target metadata: %w", err)
 		}
 		return nil
-	}, 5*time.Minute, 30*time.Second)
+	}, 5*time.Minute, 30*time.Second); err != nil {
+		return err
+	}
 
 	// Stage TUF metadata and create bindata from it so it can be distributed as part of the Launcher executable
 	source := filepath.Join(notaryConfigDir, "tuf", gun, "metadata")

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 
 	"github.com/theupdateframework/notary/client"
@@ -461,9 +462,12 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 		return fmt.Errorf("create an instance of the TUF repository: %w", err)
 	}
 
-	if _, err := repo.GetAllTargetMetadataByName(""); err != nil {
-		return fmt.Errorf("getting all target metadata: %w", err)
-	}
+	backoff.WaitFor(func() error {
+		if _, err := repo.GetAllTargetMetadataByName(""); err != nil {
+			return fmt.Errorf("getting all target metadata: %w", err)
+		}
+		return nil
+	}, 5*time.Minute, 30*time.Second)
 
 	// Stage TUF metadata and create bindata from it so it can be distributed as part of the Launcher executable
 	source := filepath.Join(notaryConfigDir, "tuf", gun, "metadata")


### PR DESCRIPTION
adds retry logic to handle cases where notary doesn't return metadata such as
https://github.com/kolide/launcher/actions/runs/5731222088/job/15531675282