### PR TITLE
Add Network Report to flare and doctor

### DIFF
--- a/pkg/debug/checkups/checkups.go
+++ b/pkg/debug/checkups/checkups.go
@@ -102,6 +102,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&runtimeCheckup{}, flareSupported},
 		{&enrollSecretCheckup{}, doctorSupported | flareSupported},
 		{&bboltdbCheckup{k: k}, flareSupported},
+		{&networkCheckup{}, doctorSupported | flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/pkg/debug/checkups/network.go
+++ b/pkg/debug/checkups/network.go
@@ -1,0 +1,129 @@
+package checkups
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+type networkCheckup struct {
+	status  Status
+	summary string
+}
+
+func (n *networkCheckup) Name() string {
+	return "Network Report"
+}
+
+func (n *networkCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
+	// Confirm that we can listen on the local network -- launcher has to be able to do this
+	// in order to communicate with desktop processes
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		n.status = Failing
+		n.summary = fmt.Sprintf("launcher cannot listen on local network: %v", err)
+	} else {
+		listener.Close()
+		n.status = Passing
+		n.summary = "launcher can listen on local network"
+	}
+
+	extraZip := zip.NewWriter(extraWriter)
+	defer extraZip.Close()
+
+	// Gather results of ipconfig/ifconfig for extra writer
+	if err := gatherNetworkConfiguration(ctx, extraZip); err != nil {
+		return fmt.Errorf("gathering networkconfig: %w", err)
+	}
+
+	// Gather /etc/hosts for posix systems for extra writer
+	if err := gatherEtcHosts(extraZip); err != nil {
+		return fmt.Errorf("gathering /etc/hosts: %w", err)
+	}
+
+	return nil
+}
+
+func (n *networkCheckup) ExtraFileName() string {
+	return "network.zip"
+}
+
+func (n *networkCheckup) Status() Status {
+	return n.status
+}
+
+func (n *networkCheckup) Summary() string {
+	return n.summary
+}
+
+func (n *networkCheckup) Data() any {
+	return nil
+}
+
+// gatherNetworkConfiguration runs ifconfig on linux/macos and ipconfig on windows,
+// writing the ouptut to the given zip writer
+func gatherNetworkConfiguration(ctx context.Context, z *zip.Writer) error {
+	out, err := z.Create("networkconfig")
+	if err != nil {
+		return fmt.Errorf("creating networkconfig: %w", err)
+	}
+
+	var configCommand string
+	var configArgs []string
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		configCommand = "ifconfig"
+		configArgs = []string{"-a"}
+	case "windows":
+		configCommand = "ipconfig"
+		configArgs = []string{"/all"}
+	default:
+		return fmt.Errorf("not supported for %s", runtime.GOOS)
+	}
+
+	cmd := exec.CommandContext(ctx, configCommand, configArgs...)
+	cmdOutput, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running command %s %v: %w", configCommand, configArgs, err)
+	}
+
+	if _, err := out.Write(cmdOutput); err != nil {
+		return fmt.Errorf("writing network config: %w", err)
+	}
+
+	return nil
+}
+
+// gatherEtcHosts returns the contents of the /etc/hosts file on posix systems
+func gatherEtcHosts(z *zip.Writer) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	out, err := z.Create("etchosts")
+	if err != nil {
+		return fmt.Errorf("creating etc hosts: %w", err)
+	}
+
+	etcHostsFile, err := os.Open("/etc/hosts")
+	if err != nil {
+		return fmt.Errorf("opening /etc/hosts: %w", err)
+	}
+	defer etcHostsFile.Close()
+
+	etcHostsRaw, err := io.ReadAll(etcHostsFile)
+	if err != nil {
+		return fmt.Errorf("reading /etc/hosts: %w", err)
+	}
+
+	if _, err := out.Write(etcHostsRaw); err != nil {
+		return fmt.Errorf("writing /etc/hosts contents to zip: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds Network Report to flare and doctor:
* Checks that launcher can listen on local network
* Saves contents of `/etc/hosts` to zip, on applicable systems
* Saves output of ifconfig/ipconfig to zip

<details>
<summary>Sample doctor output</summary>

✅	Process Report: found 3 kolide processes
 	Platform: platform: darwin, architecture: arm64
 	Launcher Version: version 1.0.13-3-g55dd7bf-dirty
✅	Root directory contents: root directory (/var/kolide-k2/k2device-preprod.kolide.com) contains 26 files
✅	Check communication with Kolide: successfully connected to device and control server
✅	Logs: debug.json is 832574 bytes, and was last modified at 2023-08-02 13:55:46.94567559 -0400 EDT
✅	Binary directory contents: binary directory (/usr/local/kolide-k2) contains 2 files
✅	Launchd: state is running
✅	Enrollment Secret: claim for nababe
✅	Network Report: launcher can listen on local network

</details>