### PR TITLE
Defer close file in checkup

### DIFF
--- a/pkg/debug/checkups/enroll-secret.go
+++ b/pkg/debug/checkups/enroll-secret.go
@@ -105,6 +105,7 @@ func parseSecret(extraFH io.Writer, secretPath string) (Status, string) {
 		fmt.Fprintf(extraFH, "unknown error: %s\n", err)
 		return Erroring, fmt.Sprintf("unknown error: %s", err)
 	}
+	defer secretFH.Close()
 
 	// If we can read the secret, let's try to extract the munemo
 	tokenRaw, err := io.ReadAll(secretFH)


### PR DESCRIPTION
While borrowing the enroll secret checkup for https://github.com/kolide/launcher/issues/1084, I noticed we were missing a `defer close` to the opened secret file, so I added it.