### PR TITLE
Set timeouts on notary requests during build

### DIFF
--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -455,7 +455,7 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 		notaryConfigDir,
 		data.GUN(gun),
 		remoteServerURL,
-		&http.Transport{Proxy: http.ProxyFromEnvironment},
+		http.DefaultTransport,
 		passwordRetrieverFn,
 		trustpinning.TrustPinConfig{},
 	)

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -409,7 +409,7 @@ func (b *Builder) GenerateTUF(ctx context.Context) error {
 			return fmt.Errorf("make autoupdate dir %s: %w", localRepo, err)
 		}
 
-		if err := bootstrapFromNotary(notaryConfigDir, conf.RemoteServer.URL, localRepo, gun); err != nil {
+		if err := bootstrapFromNotary(notaryConfigDir, conf.RemoteServer.URL, localRepo, gun, 30*time.Second, 5*time.Minute); err != nil {
 			return fmt.Errorf("bootstrap notary GUN %s: %w", gun, err)
 		}
 	}
@@ -442,7 +442,7 @@ func (b *Builder) execBindata(ctx context.Context, dir string) error {
 	return nil
 }
 
-func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string) error {
+func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string, retryTimeout time.Duration, bootstrapTimeout time.Duration) error {
 	passwordRetrieverFn := func(key, alias string, createNew bool, attempts int) (pass string, giveUp bool, err error) {
 		pass = os.Getenv(key)
 		if pass == "" {
@@ -464,7 +464,7 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 			Proxy:                 http.ProxyFromEnvironment,
 			DialContext:           dialCtx,
 			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
+			ResponseHeaderTimeout: retryTimeout,
 		},
 		passwordRetrieverFn,
 		trustpinning.TrustPinConfig{},
@@ -478,7 +478,7 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 			return fmt.Errorf("getting all target metadata: %w", err)
 		}
 		return nil
-	}, 5*time.Minute, 30*time.Second); err != nil {
+	}, bootstrapTimeout, retryTimeout); err != nil {
 		return err
 	}
 

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -453,7 +453,7 @@ func bootstrapFromNotary(notaryConfigDir, remoteServerURL, localRepo, gun string
 
 	// Safely fetch and validate all TUF metadata from remote Notary server.
 	dialCtx := (&net.Dialer{
-		Timeout:   30 * time.Second,
+		Timeout:   retryTimeout,
 		KeepAlive: 30 * time.Second,
 	}).DialContext
 	repo, err := client.NewFileCachedRepository(


### PR DESCRIPTION
We added a retry in https://github.com/kolide/launcher/pull/1278, but I saw in a [recent job](https://github.com/kolide/launcher/actions/runs/5799484889/job/15719583154) that we were only trying 1 request:

```
ts=2023-08-08T16:30:47.947216363Z
caller=logutil.go:13
severity=info
msg="Target Failed"
err="bootstrap notary GUN kolide/launcher: timeout after 5m0s (1 attempts): getting all target metadata: unable to reach trust server at this time: 500."
target=generate-tuf
```

It looks like this is because we don't have a timeout set. This PR updates the transport we use when talking to notary to set some timeouts.