### PR TITLE
action/cache configuration improvements

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -117,6 +117,7 @@ jobs:
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
+        fail-on-cache-miss: true
         enableCrossOsArchive: true
 
     - name: Launcher Version
@@ -156,6 +157,7 @@ jobs:
       with:
         path: ./build
         key: ${{ matrix.artifactos }}-${{ github.run_id }}
+        fail-on-cache-miss: true
         enableCrossOsArchive: true
 
     - name: Upload Build


### PR DESCRIPTION
* Set fail-on-cache-miss whenever we expect to be able to restore from cache to make it easier to see why a pipeline is failing