### PR TITLE
adjusts to correct log level after setting up log shipper

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -169,6 +169,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	if k.ControlServerURL() != "" {
 		logShipper = logshipper.New(k, logger)
 		logger = teelogger.New(logger, logShipper)
+		logger = log.With(logger, "caller", log.Caller(5))
 	}
 
 	// construct the appropriate http client based on security settings


### PR DESCRIPTION
currently most logs have the following as caller.

```
{"caller":"teelogger.go:25"}
```

the log shipper added 2 more layers (shipper itself and tee logger) so this changes this level from the default 3 to 5