### PR TITLE
Fix for go 1.21

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -11,5 +11,5 @@ For additional documentation on the topic:
 package tools
 
 import (
-	_ "github.com/go-bindata/go-bindata/go-bindata"
+	_ "github.com/go-bindata/go-bindata/go-bindata/"
 )


### PR DESCRIPTION
Something in the 1.21 tooling changed how this works, and broke the janky pipeline we use in `pkg/make/builder.go`. But, this is a simple enough fix. See if CI passes it on 1.20

hat tip to @RebeccaMahany who found this last week