### PR TITLE
Small cleanup for initial TUF rollout

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -379,7 +379,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	if k.Autoupdate() {
 		// Create a new TUF autoupdater
 		metadataClient := http.DefaultClient
-		metadataClient.Timeout = 1 * time.Minute
+		metadataClient.Timeout = 30 * time.Second
 		mirrorClient := http.DefaultClient
 		mirrorClient.Timeout = 8 * time.Minute // gives us extra time to avoid a timeout on download
 		tufAutoupdater, err := tuf.NewTufAutoupdater(

--- a/pkg/autoupdate/findnew.go
+++ b/pkg/autoupdate/findnew.go
@@ -251,8 +251,7 @@ func FindNewest(ctx context.Context, fullBinaryPath string, opts ...newestOption
 //
 // It makes some string assumptions about how things are named.
 func getUpdateDir(fullBinaryPath string) string {
-	installedPath := os.Getenv(LegacyAutoupdatePathEnvVar)
-	if installedPath != "" {
+	if installedPath := os.Getenv(LegacyAutoupdatePathEnvVar); installedPath != "" {
 		fullBinaryPath = installedPath
 	}
 

--- a/pkg/autoupdate/findnew.go
+++ b/pkg/autoupdate/findnew.go
@@ -331,8 +331,7 @@ func FindBaseDir(path string) string {
 		return ""
 	}
 
-	installedPath := os.Getenv(LegacyAutoupdatePathEnvVar)
-	if installedPath != "" {
+	if installedPath := os.Getenv(LegacyAutoupdatePathEnvVar); installedPath != "" {
 		path = installedPath
 	}
 

--- a/pkg/autoupdate/findnew.go
+++ b/pkg/autoupdate/findnew.go
@@ -262,9 +262,7 @@ func getUpdateDir(fullBinaryPath string) string {
 
 	// These are cases that shouldn't really happen. But, this is
 	// a bare string function. So return "" when they do.
-	if strings.HasSuffix(fullBinaryPath, "/") {
-		fullBinaryPath = strings.TrimSuffix(fullBinaryPath, "/")
-	}
+	fullBinaryPath = strings.TrimSuffix(fullBinaryPath, "/")
 
 	if fullBinaryPath == "" {
 		return ""

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -92,6 +92,10 @@ func TestGetUpdateDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
 	// Since we're setting an environment variable, we don't want to run this test at the
 	// same time as other tests.
 
+	t.Cleanup(func() {
+		os.Setenv(LegacyAutoupdatePathEnvVar, "")
+	})
+
 	var tests = []struct {
 		installPath string
 		currentPath string
@@ -123,8 +127,6 @@ func TestGetUpdateDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
 		os.Setenv(LegacyAutoupdatePathEnvVar, tt.installPath)
 		require.Equal(t, tt.out, getUpdateDir(tt.currentPath), "input: install path %s, current path %s", tt.installPath, tt.currentPath)
 	}
-
-	os.Setenv(LegacyAutoupdatePathEnvVar, "")
 }
 
 func TestFindBaseDir(t *testing.T) {
@@ -152,6 +154,10 @@ func TestFindBaseDir(t *testing.T) {
 func TestFindBaseDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
 	// Since we're setting an environment variable, we don't want to run this test at the
 	// same time as other tests.
+
+	t.Cleanup(func() {
+		os.Setenv(LegacyAutoupdatePathEnvVar, "")
+	})
 
 	var tests = []struct {
 		installPath string
@@ -184,8 +190,6 @@ func TestFindBaseDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
 		os.Setenv(LegacyAutoupdatePathEnvVar, tt.installPath)
 		require.Equal(t, tt.out, FindBaseDir(tt.currentPath), "input: install path %s, current path %s", tt.installPath, tt.currentPath)
 	}
-
-	os.Setenv(LegacyAutoupdatePathEnvVar, "")
 }
 
 func TestFindNewestEmpty(t *testing.T) {

--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -197,6 +197,10 @@ func (ulm *updateLibraryManager) moveVerifiedUpdate(binary autoupdatableBinary, 
 	if err := os.Rename(stagedVersionedDirectory, newUpdateDirectory); err != nil {
 		return fmt.Errorf("could not move staged target %s from %s to %s: %w", targetFilename, stagedVersionedDirectory, newUpdateDirectory, err)
 	}
+	// Need rwxr-xr-x so that the desktop (running as user) can execute the downloaded binary too
+	if err := os.Chmod(newUpdateDirectory, 0755); err != nil {
+		return fmt.Errorf("could not chmod %s: %w", newUpdateDirectory, err)
+	}
 
 	return nil
 }

--- a/pkg/autoupdate/tuf/library_manager_test.go
+++ b/pkg/autoupdate/tuf/library_manager_test.go
@@ -145,6 +145,9 @@ func TestAddToLibrary(t *testing.T) {
 			dirInfo, err := os.Stat(filepath.Join(updatesDirectory(tt.binary, testBaseDir), testReleaseVersion))
 			require.NoError(t, err, "checking that update was downloaded")
 			require.True(t, dirInfo.IsDir())
+			if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+				require.Equal(t, "drwxr-xr-x", dirInfo.Mode().String())
+			}
 			executableInfo, err := os.Stat(executableLocation(filepath.Join(updatesDirectory(tt.binary, testBaseDir), testReleaseVersion), tt.binary))
 			require.NoError(t, err, "checking that downloaded update includes executable")
 			require.False(t, executableInfo.IsDir())


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

Makes code review changes from https://github.com/kolide/launcher/pull/1268.

<details>
<summary>Future work + linked PRs</summary>

Subsequent PRs will tackle the following (order is not set in stone):
1. Devices on beta channel use new autoupdate library
1. Devices on stable channel use new autoupdate library
1. Ship a more up-to-date TUF repo
1. Report new version to K2 after update
1. An "update now" functionality tied to control server
1. Eventually removing the old notary autoupdater

Previous work:
1. https://github.com/kolide/launcher/pull/1081
1. https://github.com/kolide/launcher/pull/1103
1. https://github.com/kolide/launcher/pull/1108
1. https://github.com/kolide/launcher/pull/1110
1. https://github.com/kolide/launcher/pull/1111
1. https://github.com/kolide/launcher/pull/1119
1. https://github.com/kolide/launcher/pull/1168
1. https://github.com/kolide/launcher/pull/1178
1. https://github.com/kolide/launcher/pull/1188
1. https://github.com/kolide/launcher/pull/1185
1. https://github.com/kolide/launcher/pull/1195
1. https://github.com/kolide/launcher/pull/1270
1. https://github.com/kolide/launcher/pull/1268

</details>