### PR TITLE
Create a temp staging dir per-download

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -51,7 +51,6 @@ type librarian interface {
 	Available(binary autoupdatableBinary, targetFilename string) bool
 	AddToLibrary(binary autoupdatableBinary, currentVersion string, targetFilename string, targetMetadata data.TargetFileMeta) error
 	TidyLibrary(binary autoupdatableBinary, currentVersion string)
-	Close() error
 }
 
 type querier interface {
@@ -218,9 +217,6 @@ func (ta *TufAutoupdater) Execute() (err error) {
 }
 
 func (ta *TufAutoupdater) Interrupt(_ error) {
-	if err := ta.libraryManager.Close(); err != nil {
-		level.Debug(ta.logger).Log("msg", "could not close library on interrupt", "err", err)
-	}
 	ta.interrupt <- struct{}{}
 }
 

--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -206,10 +206,8 @@ func TestExecute_osquerydUpdate(t *testing.T) {
 	require.Contains(t, logLines[len(logLines)-1], "restarted binary after update")
 
 	// The autoupdater won't stop after an osqueryd download, so interrupt it and let it shut down
-	mockLibraryManager.On("Close").Return(nil)
 	autoupdater.Interrupt(errors.New("test error"))
 	time.Sleep(1 * time.Second)
-	mockLibraryManager.AssertExpectations(t)
 }
 
 func TestExecute_withInitialDelay(t *testing.T) {
@@ -246,7 +244,6 @@ func TestExecute_withInitialDelay(t *testing.T) {
 
 	// Expect that we interrupt
 	mockLibraryManager := NewMocklibrarian(t)
-	mockLibraryManager.On("Close").Return(nil)
 	autoupdater.libraryManager = mockLibraryManager
 
 	// Let the autoupdater run for less than the initial delay
@@ -357,7 +354,6 @@ func Test_storeError(t *testing.T) {
 	// We only expect TidyLibrary to run for osqueryd, since we can't get the current running version
 	// for launcher in tests.
 	mockLibraryManager.On("TidyLibrary", binaryOsqueryd, mock.Anything).Return().Once()
-	mockLibraryManager.On("Close").Return(nil)
 
 	// Set the check interval to something short so we can accumulate some errors
 	autoupdater.checkInterval = 1 * time.Second


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

Reusing the same temp directory for staging TUF downloads is proving more error-prone than it's worth -- I've seen at least a couple instances of `could not download updates: [could not download update for launcher: could not add release launcher-1.0.16.tar.gz for binary launcher to library: could not stage update: could not create file at /tmp/staged-updates612578530/launcher-1.0.16.tar.gz: open /tmp/staged-updates612578530/launcher-1.0.16.tar.gz: no such file or directory]` across two devices, where the temp staging directory no longer exists. I think it makes more sense to create a temp directory on the fly for staging, and clean it up after we finish download.

<details>
<summary>Future work + linked PRs</summary>

Subsequent PRs will tackle the following (order is not set in stone):
1. Devices on beta channel use new autoupdate library
1. Devices on stable channel use new autoupdate library
1. Ship a more up-to-date TUF repo
1. Report new version to K2 after update
1. An "update now" functionality tied to control server
1. Eventually removing the old notary autoupdater

Previous work:
1. https://github.com/kolide/launcher/pull/1081
1. https://github.com/kolide/launcher/pull/1103
1. https://github.com/kolide/launcher/pull/1108
1. https://github.com/kolide/launcher/pull/1110
1. https://github.com/kolide/launcher/pull/1111
1. https://github.com/kolide/launcher/pull/1119
1. https://github.com/kolide/launcher/pull/1168
1. https://github.com/kolide/launcher/pull/1178
1. https://github.com/kolide/launcher/pull/1188
1. https://github.com/kolide/launcher/pull/1185
1. https://github.com/kolide/launcher/pull/1195
1. https://github.com/kolide/launcher/pull/1270
1. https://github.com/kolide/launcher/pull/1268
1. https://github.com/kolide/launcher/pull/1305

</details>