### PR TITLE
Run osquery version check immediately on launcher startup

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -480,7 +480,7 @@ func runOsqueryVersionCheck(ctx context.Context, logger log.Logger, osquerydPath
 		return
 	}
 
-	versionCtx, versionCancel := context.WithTimeout(ctx, 10*time.Second)
+	versionCtx, versionCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer versionCancel()
 
 	versionCmd := exec.CommandContext(versionCtx, osquerydPath, "--version")


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1211

Operating on the theory that osquery startup may be slow due to the notarization check, this PR adds an earlier execution of the osqueryd binary to kick off the notarization check earlier.