### PR TITLE
Ensure panic is logged fully

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -86,7 +86,7 @@ func main() {
 		if r := recover(); r != nil {
 			level.Info(logger).Log(
 				"msg", "panic occurred",
-				"err", err,
+				"err", r,
 			)
 			time.Sleep(time.Second)
 		}


### PR DESCRIPTION
We don't currently capture panics fully in the logs:

```
{"caller":"locallogger.go:43","err":null,"level":"info","msg":"panic occurred","ts":"2023-08-29T21:14:12.416401082Z"}
```

This change updates to log the panic, e.g.:

```
{"caller":"main.go:87","err":"runtime error: index out of range [0] with length 0","msg":"panic occurred","severity":"info","ts":"2023-08-29T21:27:43.650019Z"}
```