### PR TITLE
Rungroup improvements: logging

### DIFF
--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -1,5 +1,10 @@
 package rungroup
 
+// rungroup expands on oklog/run, adding logs to indicate which actor caused
+// the interrupt and which actor, if any, is preventing shutdown. In the
+// future, we would like to add the ability to force shutdown before a given
+// timeout. See: https://github.com/kolide/launcher/issues/1205
+
 import (
 	"fmt"
 

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -61,13 +61,13 @@ func (g *Group) Run() error {
 	}
 
 	// Wait for the first actor to stop.
-	err := <-errors
-	level.Debug(g.logger).Log("msg", "received interrupt error from first actor -- shutting down other actors", "err", err)
+	initialActorErr := <-errors
+	level.Debug(g.logger).Log("msg", "received interrupt error from first actor -- shutting down other actors", "err", initialActorErr)
 
 	// Signal all actors to stop.
 	for _, a := range g.actors {
 		level.Debug(g.logger).Log("msg", "interrupting actor", "actor", a.name)
-		a.interrupt(err.err)
+		a.interrupt(initialActorErr.err)
 	}
 
 	// Wait for all actors to stop.
@@ -77,7 +77,7 @@ func (g *Group) Run() error {
 	}
 
 	// Return the original error.
-	return err.err
+	return initialActorErr.err
 }
 
 func (a actorError) String() string {

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -1,0 +1,80 @@
+package rungroup
+
+import (
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+type (
+	Group struct {
+		logger log.Logger
+		actors []rungroupActor
+	}
+
+	rungroupActor struct {
+		name      string // human-readable identifier for the actor
+		execute   func() error
+		interrupt func(error)
+	}
+
+	actorError struct {
+		errorSourceName string
+		err             error
+	}
+)
+
+func NewRunGroup(logger log.Logger) *Group {
+	return &Group{
+		logger: log.With(logger, "component", "run_group"),
+		actors: make([]rungroupActor, 0),
+	}
+}
+
+func (g *Group) Add(name string, execute func() error, interrupt func(error)) {
+	g.actors = append(g.actors, rungroupActor{name, execute, interrupt})
+}
+
+func (g *Group) Run() error {
+	if len(g.actors) == 0 {
+		return nil
+	}
+
+	// Run each actor.
+	level.Debug(g.logger).Log("msg", "starting all actors", "actor_count", len(g.actors))
+	errors := make(chan actorError, len(g.actors))
+	for _, a := range g.actors {
+		go func(a rungroupActor) {
+			level.Debug(g.logger).Log("msg", "starting actor", "actor", a.name)
+			err := a.execute()
+			errors <- actorError{
+				errorSourceName: a.name,
+				err:             err,
+			}
+		}(a)
+	}
+
+	// Wait for the first actor to stop.
+	err := <-errors
+	level.Debug(g.logger).Log("msg", "received interrupt error from first actor -- shutting down other actors", "err", err)
+
+	// Signal all actors to stop.
+	for _, a := range g.actors {
+		level.Debug(g.logger).Log("msg", "interrupting actor", "actor", a.name)
+		a.interrupt(err.err)
+	}
+
+	// Wait for all actors to stop.
+	for i := 1; i < cap(errors); i++ {
+		e := <-errors
+		level.Debug(g.logger).Log("msg", "successfully interrupted actor", "actor", e.errorSourceName)
+	}
+
+	// Return the original error.
+	return err.err
+}
+
+func (a actorError) String() string {
+	return fmt.Sprintf("%s returned error: %+v", a.errorSourceName, a.err)
+}

--- a/pkg/rungroup/rungroup_test.go
+++ b/pkg/rungroup/rungroup_test.go
@@ -1,0 +1,74 @@
+package rungroup
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_NoActors(t *testing.T) {
+	t.Parallel()
+
+	testRunGroup := NewRunGroup(log.NewNopLogger())
+	require.NoError(t, testRunGroup.Run())
+}
+
+func TestRun_MultipleActors(t *testing.T) {
+	t.Parallel()
+
+	testRunGroup := NewRunGroup(log.NewNopLogger())
+
+	groupReceivedInterrupts := make(chan struct{})
+
+	// First actor waits for interrupt and alerts groupReceivedInterrupts when it's interrupted
+	firstActorInterrupt := make(chan struct{})
+	testRunGroup.Add("firstActor", func() error {
+		<-firstActorInterrupt
+		return nil
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+		firstActorInterrupt <- struct{}{}
+	})
+
+	// Second actor returns error on `execute`, and then alerts groupReceivedInterrupts when it's interrupted
+	expectedError := errors.New("test error from interruptingActor")
+	testRunGroup.Add("interruptingActor", func() error {
+		time.Sleep(1 * time.Second)
+		return expectedError
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+	})
+
+	// Third actor waits for interrupt and alerts groupReceivedInterrupts when it's interrupted
+	anotherActorInterrupt := make(chan struct{})
+	testRunGroup.Add("anotherActor", func() error {
+		<-anotherActorInterrupt
+		return nil
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+		anotherActorInterrupt <- struct{}{}
+	})
+
+	go func() {
+		err := testRunGroup.Run()
+		require.Error(t, err)
+	}()
+
+	receivedInterrupts := 0
+	for {
+		if receivedInterrupts >= 3 {
+			break
+		}
+		select {
+		case <-groupReceivedInterrupts:
+			receivedInterrupts += 1
+		case <-time.After(3 * time.Second):
+			t.Error("did not receive expected interrupts within reasonable time")
+		}
+	}
+
+	require.Equal(t, 3, receivedInterrupts)
+}


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205

Builds on oklog/rungroup to add logging, making it possible to identify which actors are not shutting down in a timely manner.