### PR TITLE
If we can't start command in test, return err immediately

### DIFF
--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -437,6 +437,9 @@ func TestOsquerySlowStart(t *testing.T) {
 		WithLogger(log.NewLogfmtLogger(&logBytes)),
 		WithStartFunc(func(cmd *exec.Cmd) error {
 			err := cmd.Start()
+			if err != nil {
+				return fmt.Errorf("unexpected error starting command: %w", err)
+			}
 			// suspend the process right away
 			cmd.Process.Signal(syscall.SIGTSTP)
 			go func() {
@@ -444,7 +447,7 @@ func TestOsquerySlowStart(t *testing.T) {
 				time.Sleep(3 * time.Second)
 				cmd.Process.Signal(syscall.SIGCONT)
 			}()
-			return err
+			return nil
 		}),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Addresses occasional error: https://github.com/kolide/launcher/actions/runs/6025570560/job/16346567334?pr=1309

If we can't start osquery, return the error right away instead of trying to access the maybe-nil process.