### PR TITLE
Don't perform unnecessary restarts when not using new autoupdater

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -315,6 +315,12 @@ func (ta *TufAutoupdater) checkForUpdate() error {
 		return fmt.Errorf("could not download updates: %+v", updateErrors)
 	}
 
+	// Only perform restarts if we're configured to use this new autoupdate library,
+	// to prevent performing unnecessary restarts.
+	if !usingNewAutoupdater(ta.channel) {
+		return nil
+	}
+
 	// If launcher was updated, we want to exit and reload
 	if updatedVersion, ok := updatesDownloaded[binaryLauncher]; ok {
 		level.Debug(ta.logger).Log("msg", "launcher updated -- exiting to load new version", "new_binary_version", updatedVersion)

--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -89,7 +89,7 @@ func getAutoupdateConfig() (*autoupdateConfig, error) {
 // as its version.
 func CheckOutLatest(binary autoupdatableBinary, rootDirectory string, updateDirectory string, channel string, logger log.Logger) (*BinaryUpdateInfo, error) {
 	// TODO: Remove this check once we decide to roll out the new autoupdater more broadly
-	if _, ok := channelsUsingLegacyAutoupdate[channel]; ok {
+	if !usingNewAutoupdater(channel) {
 		return nil, fmt.Errorf("not rolling out new TUF to channel %s that should still use legacy autoupdater", channel)
 	}
 
@@ -107,6 +107,11 @@ func CheckOutLatest(binary autoupdatableBinary, rootDirectory string, updateDire
 	// If we can't find the specific release version that we should be on, then just return the executable
 	// with the most recent version in the library
 	return mostRecentVersion(binary, updateDirectory)
+}
+
+func usingNewAutoupdater(channel string) bool {
+	_, ok := channelsUsingLegacyAutoupdate[channel]
+	return !ok
 }
 
 // findExecutableFromRelease looks at our local TUF repository to find the release for our

--- a/pkg/autoupdate/tuf/library_lookup_test.go
+++ b/pkg/autoupdate/tuf/library_lookup_test.go
@@ -180,3 +180,33 @@ func Test_mostRecentVersion_ReturnsErrorOnNoUpdatesDownloaded(t *testing.T) {
 		})
 	}
 }
+
+func Test_usingNewAutoupdater(t *testing.T) {
+	t.Parallel()
+
+	channelsForTest := []struct {
+		channelName        string
+		usesNewAutoupdater bool
+	}{
+		{
+			channelName:        "nightly",
+			usesNewAutoupdater: true,
+		},
+		{
+			channelName:        "alpha",
+			usesNewAutoupdater: true,
+		},
+		{
+			channelName:        "stable",
+			usesNewAutoupdater: false,
+		},
+		{
+			channelName:        "beta",
+			usesNewAutoupdater: false,
+		},
+	}
+
+	for _, channel := range channelsForTest {
+		require.Equal(t, channel.usesNewAutoupdater, usingNewAutoupdater(channel.channelName))
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

If launcher is not on nightly or alpha channel, it should not restart after performing a download to the new autoupdate library.