### PR TITLE
Use rungroup in desktop; log all desktop logs at debug level

### DIFF
--- a/cmd/launcher/internal/updater/updater.go
+++ b/cmd/launcher/internal/updater/updater.go
@@ -29,7 +29,7 @@ type UpdaterConfig struct {
 	SigChannel         chan os.Signal
 }
 
-// NewUpdater returns an Actor suitable for an oklog/run group. It
+// NewUpdater returns an Actor suitable for a pkg/rungroup group. It
 // is a light wrapper around autoupdate.NewUpdater to simplify having
 // multiple ones in launcher.
 func NewUpdater(

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -720,6 +720,7 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		fmt.Sprintf("PPID=%d", os.Getpid()),
 		fmt.Sprintf("RUNNER_SERVER_URL=%s", r.runnerServer.Url()),
 		fmt.Sprintf("RUNNER_SERVER_AUTH_TOKEN=%s", r.runnerServer.RegisterClient(uid)),
+		fmt.Sprintf("DEBUG=%v", r.knapsack.Debug()),
 	}
 
 	stdErr, err := cmd.StderrPipe()
@@ -737,7 +738,7 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		scanner := bufio.NewScanner(combined)
 
 		for scanner.Scan() {
-			level.Info(r.logger).Log(
+			level.Debug(r.logger).Log(
 				"uid", uid,
 				"subprocess", "desktop",
 				"msg", scanner.Text(),

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -120,7 +120,12 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("KolideServerURL").Return("somewhere-over-the-rainbow.example.com")
 			mockKnapsack.On("DesktopEnabled").Return(true)
-			mockKnapsack.On("Debug").Return(true)
+
+			if os.Getenv("CI") != "true" || runtime.GOOS != "linux" {
+				// Only expect that we call Debug (to set the DEBUG flag on the process) if we actually expect
+				// to be starting a process.
+				mockKnapsack.On("Debug").Return(true)
+			}
 
 			r, err := New(
 				mockKnapsack,

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -120,6 +120,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("KolideServerURL").Return("somewhere-over-the-rainbow.example.com")
 			mockKnapsack.On("DesktopEnabled").Return(true)
+			mockKnapsack.On("Debug").Return(true)
 
 			r, err := New(
 				mockKnapsack,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/mixer/clock v0.0.0-20170901150240-b08e6b4da7ea
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
-	github.com/oklog/run v1.0.0
 	github.com/osquery/osquery-go v0.0.0-20230707154813-2e4891a0f444
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
-github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.3.0/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205