### PR TITLE
add quarantine check to scan for quarantine files and meddlesome processes

### DIFF
--- a/pkg/debug/checkups/checkups.go
+++ b/pkg/debug/checkups/checkups.go
@@ -108,6 +108,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&powerCheckup{}, flareSupported},
 		{&osqueryCheckup{k: k}, doctorSupported | flareSupported},
 		{&launcherFlags{}, doctorSupported | flareSupported},
+		{&quarantine{}, doctorSupported | flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/pkg/debug/checkups/checkups.go
+++ b/pkg/debug/checkups/checkups.go
@@ -108,8 +108,8 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&powerCheckup{}, flareSupported},
 		{&osqueryCheckup{k: k}, doctorSupported | flareSupported},
 		{&launcherFlags{}, doctorSupported | flareSupported},
-    {&gnomeExtensions{}, doctorSupported | flareSupported},
-    {&quarantine{}, doctorSupported | flareSupported},
+		{&gnomeExtensions{}, doctorSupported | flareSupported},
+		{&quarantine{}, doctorSupported | flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/pkg/debug/checkups/quarantine.go
+++ b/pkg/debug/checkups/quarantine.go
@@ -15,7 +15,7 @@ import (
 // quarantine:
 // Recursively scans common installation directories to to a given depth.
 // Reports and directories that have the word "quarantine" in their path and the number of files and their names they contain.
-// Fails if any files are found in the above directories.
+// Warns if any files are found in the above directories.
 // Reports possible "meddlesome" processes for information purposes (does not fail due to proccesses running)
 
 // It's difficult to keep track of every possible Anti-Virus or EDRs quarantine directory, but they all seem
@@ -73,6 +73,14 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 			`virus`,
 			`quarantine`,
 			`snitch`,
+			// carbon black possible processes
+			`cbagent`,
+			`carbonblack`,
+			`repmgr`,
+			`repwsc`,
+			`cb.exe`,
+			`cbdaemon`,
+			`cbOsxSensorService`,
 		}
 	)
 
@@ -123,7 +131,7 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 		return nil
 	}
 
-	q.status = Failing
+	q.status = Warning
 	q.summary = fmt.Sprintf("found %d quarantined files", totalQuarantinedFiles)
 	return nil
 }

--- a/pkg/debug/checkups/quarantine.go
+++ b/pkg/debug/checkups/quarantine.go
@@ -61,11 +61,7 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 			continue
 		}
 
-		if err := q.walkDirLimited(extraFh, 0, maxDepth, path, "quarantine"); err != nil {
-			q.summary = fmt.Sprintf("failed to walk %s: %s", path, err)
-			q.status = Failing
-			return nil
-		}
+		q.walkDirLimited(extraFh, 0, maxDepth, path, "quarantine")
 	}
 
 	fmt.Fprintf(extraFh, "%d of %d directories may contain quarantined files\n", len(q.quarantineCounts), q.dirsChecked)
@@ -89,9 +85,9 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 	return nil
 }
 
-func (q *quarantine) walkDirLimited(extraFh io.Writer, currentDepth, maxDepth int, dirPath, folderKeyword string) error {
+func (q *quarantine) walkDirLimited(extraFh io.Writer, currentDepth, maxDepth int, dirPath, folderKeyword string) {
 	if currentDepth > maxDepth {
-		return nil
+		return
 	}
 
 	q.dirsChecked++
@@ -102,7 +98,7 @@ func (q *quarantine) walkDirLimited(extraFh io.Writer, currentDepth, maxDepth in
 		// have to give terminal FDA?
 		// so just move on instead of failing
 		fmt.Fprintf(extraFh, "failed to read %s: %s\n", dirPath, err)
-		return nil
+		return
 	}
 
 	for _, dirEntry := range dirEntries {
@@ -125,7 +121,7 @@ func (q *quarantine) walkDirLimited(extraFh io.Writer, currentDepth, maxDepth in
 		q.quarantineCounts[dirPath]++
 	}
 
-	return nil
+	return
 }
 
 func (q *quarantine) logMeddlesomeProccesses(ctx context.Context, extraFh io.Writer, containsSubStrings []string) error {

--- a/pkg/debug/checkups/quarantine.go
+++ b/pkg/debug/checkups/quarantine.go
@@ -1,0 +1,216 @@
+package checkups
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+type quarantine struct {
+	status  Status
+	summary string
+}
+
+func (q *quarantine) Name() string {
+	return "Quarantine"
+}
+
+func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
+
+	var (
+		rootsToScanForQuarantineDirs = []string{
+			`C:\Windows\System32\Drivers`,
+			`C:\ProgramData`,
+
+			`/Library/Application Support`,
+		}
+
+		fileNamesToMatch = []string{
+			`osquery`,
+		}
+
+		meddlesomeProcessPatterns = []string{
+			`crowdstrike`,
+			`opswat`,
+			`defend`,
+			`defense`,
+			`threat`,
+			`virus`,
+			`quarantine`,
+			`snitch`,
+		}
+	)
+
+	fmt.Fprint(extraFh, "starting quarantine check\n")
+	q.logMeddlesomeProccesses(ctx, extraFh, meddlesomeProcessPatterns)
+	fmt.Fprintf(extraFh, "\nsearching for quarantined files:\n")
+
+	var quarantineDirs []string
+
+	// find all the folders that contain the word quarantine
+	for _, root := range rootsToScanForQuarantineDirs {
+		fileInfo, err := os.Stat(root)
+		if err != nil {
+			fmt.Fprintf(extraFh, "%s does not exist\n", root)
+			continue
+		}
+
+		if !fileInfo.IsDir() {
+			fmt.Fprintf(extraFh, "expected %s to be a directory, but was not\n", root)
+			continue
+		}
+
+		dirs := q.findDirsThatContain(extraFh, root, "quarantine")
+		quarantineDirs = append(quarantineDirs, dirs...)
+	}
+
+	if len(quarantineDirs) == 0 {
+		q.status = Passing
+		status := "No quarantine directories found"
+		fmt.Fprint(extraFh, status)
+		q.summary = status
+		return nil
+	}
+
+	// scan quarantine dirs for files that might relate to us
+	for _, dir := range quarantineDirs {
+		if pass, result := q.checkDirForQuarantinedFiles(extraFh, dir, fileNamesToMatch); !pass {
+			q.status = Failing
+			q.summary = result
+			return nil
+		}
+	}
+
+	q.status = Passing
+	q.summary = "No notable files found in quarantine directories"
+	return nil
+}
+
+func (q *quarantine) checkDirForQuarantinedFiles(extraFh io.Writer, path string, quarantineFileNamesToSearchFor []string) (bool, string) {
+	dirEntries, err := os.ReadDir(path)
+	if err != nil {
+		// if we can't read the directory, we can't do much else, error
+		result := fmt.Sprintf("failed to read directory %s: %s", path, err)
+		fmt.Fprint(extraFh, result)
+		return false, result
+	}
+
+	fmt.Fprintf(extraFh, "found %d files in %s\n", len(dirEntries), path)
+
+	if len(dirEntries) == 0 {
+		return true, ""
+	}
+
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			if pass, result := q.checkDirForQuarantinedFiles(extraFh, filepath.Join(path, dirEntry.Name()), quarantineFileNamesToSearchFor); !pass {
+				return pass, result
+			}
+
+			continue
+		}
+
+		for _, pattern := range quarantineFileNamesToSearchFor {
+			fileName := strings.ToLower(dirEntry.Name())
+			pattern := strings.ToLower(pattern)
+
+			if strings.Contains(fileName, pattern) {
+				result := fmt.Sprintf("found file %s in folder %s that contained the string %s", dirEntry.Name(), path, pattern)
+				fmt.Fprint(extraFh, result)
+				return false, result
+			}
+		}
+
+		fmt.Fprintf(extraFh, "no notable files found in %s", dirEntry.Name())
+	}
+
+	return true, ""
+}
+
+func (q *quarantine) findDirsThatContain(extraFh io.Writer, rootDir, substr string) []string {
+	var matchingPaths []string
+	dirCount := 0
+
+	if err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+		dirCount++
+
+		if err != nil {
+			fmt.Fprintf(extraFh, "error walking directory: %v\n", err)
+			return nil
+		}
+
+		if !d.IsDir() {
+			return nil
+		}
+
+		if strings.Contains(strings.ToLower(d.Name()), strings.ToLower(substr)) {
+			matchingPaths = append(matchingPaths, path)
+		}
+
+		return nil
+	}); err != nil {
+		return matchingPaths
+	}
+
+	fmt.Fprintf(extraFh, "%d out of %d scanned directories starting at root %s contained %s\n", len(matchingPaths), dirCount, rootDir, substr)
+	return matchingPaths
+}
+
+func (q *quarantine) logMeddlesomeProccesses(ctx context.Context, extraFh io.Writer, containsSubStrings []string) error {
+	fmt.Fprint(extraFh, "\npossilby meddlesome proccesses:\n")
+	foundMeddlesomeProcesses := false
+
+	ps, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting process list: %w", err)
+	}
+
+	for _, p := range ps {
+		exe, _ := p.Exe()
+
+		for _, s := range containsSubStrings {
+			if !strings.Contains(strings.ToLower(exe), strings.ToLower(s)) {
+				continue
+			}
+			foundMeddlesomeProcesses = true
+
+			pMap := map[string]any{
+				"pid":         p.Pid,
+				"exe":         naIfError(p.ExeWithContext(ctx)),
+				"cmdline":     naIfError(p.CmdlineSliceWithContext(ctx)),
+				"create_time": naIfError(p.CreateTimeWithContext(ctx)),
+				"ppid":        naIfError(p.PpidWithContext(ctx)),
+				"status":      naIfError(p.StatusWithContext(ctx)),
+			}
+
+			fmt.Fprintf(extraFh, "%+v\n", pMap)
+		}
+	}
+
+	if !foundMeddlesomeProcesses {
+		fmt.Fprint(extraFh, "no meddlesome processes found\n")
+	}
+
+	return nil
+}
+
+func (q *quarantine) Status() Status {
+	return q.status
+}
+
+func (q *quarantine) Summary() string {
+	return q.summary
+}
+
+func (q *quarantine) ExtraFileName() string {
+	return "quarantine.log"
+}
+
+func (q *quarantine) Data() any {
+	return nil
+}

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -6,61 +6,62 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kolide/kit/ulid"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
 	t.Parallel()
 
+	const folderKeyword = "quarantine_checkup_test"
+
 	tests := []struct {
-		name       string
-		shouldPass bool
-		pathsFunc  func(t *testing.T) string
+		name                string
+		shouldPass          bool
+		pathsFunc           func(t *testing.T) (string, map[string]int)
+		maxDepth            int
+		expectedDirsChecked int
 	}{
 		{
-			name: "empty dir",
-			pathsFunc: func(t *testing.T) string {
-				return t.TempDir()
-			},
-			shouldPass: true,
-		},
-		{
-			name: "dir does not exist",
-			pathsFunc: func(t *testing.T) string {
-				return ulid.New()
-			},
-			shouldPass: false,
-		},
-		{
-			name: "osquery found",
-			pathsFunc: func(t *testing.T) string {
+			name: "found quarantined files",
+			pathsFunc: func(t *testing.T) (string, map[string]int) {
 				dir := t.TempDir()
-				// add some we don't care about
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "dont care"), nil, 0755))
 
-				// add some we do care about
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", "2", "3"), 0755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "osquery"), nil, 0755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "3", "osquery"), nil, 0755))
-				return dir
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", folderKeyword, "2", "3", "4"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", folderKeyword, "someFile"), nil, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", folderKeyword, "anotherFile"), nil, 0755))
+
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", folderKeyword, "2", "3", "yetAnotherFile"), nil, 0755))
+				return dir, map[string]int{
+					filepath.Join(dir, "1", folderKeyword):           2,
+					filepath.Join(dir, "1", folderKeyword, "2", "3"): 1,
+				}
 			},
-			shouldPass: false,
+			maxDepth:            10,
+			expectedDirsChecked: 6,
+		},
+		{
+			name: "doesnt exceed max depth",
+			pathsFunc: func(t *testing.T) (string, map[string]int) {
+				dir := t.TempDir()
+
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", "2", folderKeyword), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "not in special folder"), nil, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", folderKeyword, "somefile"), nil, 0755))
+				return dir, map[string]int{}
+			},
+			maxDepth:            2,
+			expectedDirsChecked: 3,
 		},
 		{
 			name: "no notable files",
-			pathsFunc: func(t *testing.T) string {
+			pathsFunc: func(t *testing.T) (string, map[string]int) {
 				dir := t.TempDir()
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "dont care"), nil, 0755))
-
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", "2", "3"), 0755))
 				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "dont care"), nil, 0755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "3", "dont care at all"), nil, 0755))
-				return dir
+				return dir, map[string]int{}
 			},
-			shouldPass: true,
+			maxDepth:            10,
+			expectedDirsChecked: 4,
 		},
 	}
 
@@ -68,9 +69,13 @@ func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			q := quarantine{}
-			pass, _ := q.checkDirForQuarantinedFiles(io.Discard, tt.pathsFunc(t), []string{"osquery"})
-			require.Equal(t, tt.shouldPass, pass)
+			q := quarantine{
+				quarantineCounts: make(map[string]int),
+			}
+			rootPath, expected := tt.pathsFunc(t)
+			require.NoError(t, q.walkDirLimited(io.Discard, 0, tt.maxDepth, rootPath, folderKeyword))
+			require.EqualValues(t, expected, q.quarantineCounts)
+			require.Equal(t, tt.expectedDirsChecked, q.dirsChecked)
 		})
 	}
 }

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -73,7 +73,7 @@ func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
 				quarantineCounts: make(map[string]int),
 			}
 			rootPath, expected := tt.pathsFunc(t)
-			require.NoError(t, q.walkDirLimited(io.Discard, 0, tt.maxDepth, rootPath, folderKeyword))
+			q.walkDirLimited(io.Discard, 0, tt.maxDepth, rootPath, folderKeyword)
 			require.EqualValues(t, expected, q.quarantineCounts)
 			require.Equal(t, tt.expectedDirsChecked, q.dirsChecked)
 		})

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -73,7 +73,7 @@ func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
 				quarantineCounts: make(map[string]int),
 			}
 			rootPath, expected := tt.pathsFunc(t)
-			q.walkDirLimited(io.Discard, 0, tt.maxDepth, rootPath, folderKeyword)
+			q.checkDirs(io.Discard, 0, tt.maxDepth, rootPath, folderKeyword)
 			require.EqualValues(t, expected, q.quarantineCounts)
 			require.Equal(t, tt.expectedDirsChecked, q.dirsChecked)
 		})

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
+func Test_quarantine_checkDirs(t *testing.T) {
 	t.Parallel()
 
 	const folderKeyword = "quarantine_checkup_test"

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -1,0 +1,76 @@
+package checkups
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kolide/kit/ulid"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		shouldPass bool
+		pathsFunc  func(t *testing.T) string
+	}{
+		{
+			name: "empty dir",
+			pathsFunc: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			shouldPass: true,
+		},
+		{
+			name: "dir does not exist",
+			pathsFunc: func(t *testing.T) string {
+				return ulid.New()
+			},
+			shouldPass: false,
+		},
+		{
+			name: "osquery found",
+			pathsFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				// add some we don't care about
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "dont care"), nil, 0755))
+
+				// add some we do care about
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", "2", "3"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "osquery"), nil, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "3", "osquery"), nil, 0755))
+				return dir
+			},
+			shouldPass: false,
+		},
+		{
+			name: "no notable files",
+			pathsFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "dont care"), nil, 0755))
+
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "1", "2", "3"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "dont care"), nil, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", "2", "3", "dont care at all"), nil, 0755))
+				return dir
+			},
+			shouldPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			q := quarantine{}
+			pass, _ := q.checkDirForQuarantinedFiles(io.Discard, tt.pathsFunc(t), []string{"osquery"})
+			require.Equal(t, tt.shouldPass, pass)
+		})
+	}
+}

--- a/pkg/debug/checkups/quarantine_test.go
+++ b/pkg/debug/checkups/quarantine_test.go
@@ -32,8 +32,10 @@ func Test_quarantine_checkDirForQuarantinedFiles(t *testing.T) {
 
 				require.NoError(t, os.WriteFile(filepath.Join(dir, "1", folderKeyword, "2", "3", "yetAnotherFile"), nil, 0755))
 				return dir, map[string]int{
-					filepath.Join(dir, "1", folderKeyword):           2,
-					filepath.Join(dir, "1", folderKeyword, "2", "3"): 1,
+					filepath.Join(dir, "1", folderKeyword):                2,
+					filepath.Join(dir, "1", folderKeyword, "2"):           0,
+					filepath.Join(dir, "1", folderKeyword, "2", "3"):      1,
+					filepath.Join(dir, "1", folderKeyword, "2", "3", "4"): 0,
 				}
 			},
 			maxDepth:            10,


### PR DESCRIPTION
This check reports and files that have "quarantine" in their path. It recursively checks each of the provided root dirs to the specified depth.

example summary:
❌	Quarantine: found 1 quarantined files

example log:
```
starting quarantine check

possilby meddlesome proccesses:
map[cmdline:[] create_time:1693926941054 exe:C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.23080.2006-0\NisSrv.exe pid:9268 ppid:1236 status:error: not implemented yet]
map[cmdline:[] create_time:1693926936001 exe:C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.23080.2006-0\MsMpEng.exe pid:15636 ppid:1236 status:error: not implemented yet]

searching for quarantined files:
failed to read C:\ProgramData\Microsoft\Windows\CapabilityAccessManager: open C:\ProgramData\Microsoft\Windows\CapabilityAccessManager: Access is denied.
/Library/Application Support does not exist
total dirs checked: 1159
quarantine directory paths and files:
C:\ProgramData\Microsoft\Windows Defender\Quarantine: 0 files
C:\ProgramData\quarantine: 1 files
  test.txt

```
