### PR TITLE
Add to legacy autoupdater initial delay to stagger legacy+new autoupdaters

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -410,7 +410,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			MirrorURL:          k.MirrorServerURL(),
 			NotaryPrefix:       k.NotaryPrefix(),
 			HTTPClient:         httpClient,
-			InitialDelay:       k.AutoupdateInitialDelay() + k.AutoupdateInterval()/2,
+			InitialDelay:       k.AutoupdateInitialDelay() + k.AutoupdateInterval()/2 + 5*time.Minute,
 			SigChannel:         sigChannel,
 		}
 
@@ -430,7 +430,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 			MirrorURL:          k.MirrorServerURL(),
 			NotaryPrefix:       k.NotaryPrefix(),
 			HTTPClient:         httpClient,
-			InitialDelay:       k.AutoupdateInitialDelay(),
+			InitialDelay:       k.AutoupdateInitialDelay() + 5*time.Minute,
 			SigChannel:         sigChannel,
 		}
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

Gives us a little buffer so that the legacy autoupdater is not stuck performing a download while the new autoupdater is trying to perform a restart.