### PR TITLE
Don't make temp staging dir inside OS temp dir

### DIFF
--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -94,17 +94,19 @@ func (ulm *updateLibraryManager) AddToLibrary(binary autoupdatableBinary, curren
 	}
 
 	stagedUpdatePath, err := ulm.stageAndVerifyUpdate(binary, targetFilename, targetMetadata)
-	if err != nil {
-		return fmt.Errorf("could not stage update: %w", err)
-	}
-
 	// Remove downloaded archives after update, regardless of success -- this will run before the unlock
 	defer func() {
+		if stagedUpdatePath == "" {
+			return
+		}
 		dirToRemove := filepath.Dir(stagedUpdatePath)
 		if err := os.RemoveAll(dirToRemove); err != nil {
 			level.Debug(ulm.logger).Log("msg", "could not remove temp staging directory", "err", err, "directory", dirToRemove)
 		}
 	}()
+	if err != nil {
+		return fmt.Errorf("could not stage update: %w", err)
+	}
 
 	if err := ulm.moveVerifiedUpdate(binary, targetFilename, stagedUpdatePath); err != nil {
 		return fmt.Errorf("could not move verified update: %w", err)

--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -12,12 +12,12 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fsutil"
-	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/theupdateframework/go-tuf/data"
 	tufutil "github.com/theupdateframework/go-tuf/util"
@@ -116,7 +116,7 @@ func (ulm *updateLibraryManager) AddToLibrary(binary autoupdatableBinary, curren
 // stageAndVerifyUpdate downloads the update indicated by `targetFilename` and verifies it against
 // the given, validated local metadata.
 func (ulm *updateLibraryManager) stageAndVerifyUpdate(binary autoupdatableBinary, targetFilename string, localTargetMetadata data.TargetFileMeta) (string, error) {
-	stagingDir, err := agent.MkdirTemp(fmt.Sprintf("staged-updates-%s", versionFromTarget(binary, targetFilename)))
+	stagingDir, err := ulm.tempDir(binary, fmt.Sprintf("staged-updates-%s", versionFromTarget(binary, targetFilename)))
 	if err != nil {
 		return "", fmt.Errorf("could not create temporary directory for downloading target: %w", err)
 	}
@@ -161,11 +161,22 @@ func (ulm *updateLibraryManager) stageAndVerifyUpdate(binary autoupdatableBinary
 	return stagedUpdatePath, nil
 }
 
+// tempDir creates a directory inside of the updates directory. It is the caller's responsibility to remove
+// the directory when it is no longer needed.
+func (ulm *updateLibraryManager) tempDir(binary autoupdatableBinary, pattern string) (string, error) {
+	directory := filepath.Join(updatesDirectory(binary, ulm.baseDir), fmt.Sprintf("%s-%d", pattern, time.Now().UnixMicro()))
+	if err := os.MkdirAll(directory, 0755); err != nil {
+		return "", fmt.Errorf("making dir %s: %w", directory, err)
+	}
+
+	return directory, nil
+}
+
 // moveVerifiedUpdate untars the update and performs final checks to make sure that it's a valid, working update.
 // Finally, it moves the update to its correct versioned location in the update library for the given binary.
 func (ulm *updateLibraryManager) moveVerifiedUpdate(binary autoupdatableBinary, targetFilename string, stagedUpdate string) error {
 	targetVersion := versionFromTarget(binary, targetFilename)
-	stagedVersionedDirectory, err := agent.MkdirTemp(targetVersion)
+	stagedVersionedDirectory, err := ulm.tempDir(binary, targetVersion)
 	if err != nil {
 		return fmt.Errorf("could not create temporary directory for untarring and validating new update: %w", err)
 	}

--- a/pkg/autoupdate/tuf/library_manager_windows_test.go
+++ b/pkg/autoupdate/tuf/library_manager_windows_test.go
@@ -1,0 +1,108 @@
+//go:build windows
+// +build windows
+
+package tuf
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	tufci "github.com/kolide/launcher/pkg/autoupdate/tuf/ci"
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf/data"
+	"golang.org/x/sys/windows"
+)
+
+func TestAddToLibrary_WindowsACLs(t *testing.T) {
+	t.Parallel()
+
+	// Set up TUF dependencies -- we do this here to avoid re-initializing the local tuf server for each
+	// binary. It's unnecessary work since the mirror serves the same data both times.
+	testBaseDir := t.TempDir()
+	testReleaseVersion := "1.2.4"
+	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, testReleaseVersion)
+	metadataClient, err := initMetadataClient(testBaseDir, tufServerUrl, http.DefaultClient)
+	require.NoError(t, err, "creating metadata client")
+	// Re-initialize the metadata client with our test root JSON
+	require.NoError(t, metadataClient.Init(rootJson), "could not initialize metadata client with test root JSON")
+	_, err = metadataClient.Update()
+	require.NoError(t, err, "could not update metadata client")
+
+	// Get the target metadata
+	launcherTargetMeta, err := metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryLauncher, runtime.GOOS, PlatformArch(), binaryLauncher, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for launcher target")
+	osquerydTargetMeta, err := metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryOsqueryd, runtime.GOOS, PlatformArch(), binaryOsqueryd, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for launcher target")
+
+	testCases := []struct {
+		binary     autoupdatableBinary
+		targetFile string
+		targetMeta data.TargetFileMeta
+	}{
+		{
+			binary:     binaryLauncher,
+			targetFile: fmt.Sprintf("%s-%s.tar.gz", binaryLauncher, testReleaseVersion),
+			targetMeta: launcherTargetMeta,
+		},
+		{
+			binary:     binaryOsqueryd,
+			targetFile: fmt.Sprintf("%s-%s.tar.gz", binaryOsqueryd, testReleaseVersion),
+			targetMeta: osquerydTargetMeta,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(string(tt.binary), func(t *testing.T) {
+			t.Parallel()
+
+			// Set up test library manager
+			testLibraryManager, err := newUpdateLibraryManager(tufServerUrl, http.DefaultClient, testBaseDir, log.NewNopLogger())
+			require.NoError(t, err, "unexpected error creating new update library manager")
+
+			// Request download -- make a couple concurrent requests to confirm that the lock works.
+			var wg sync.WaitGroup
+			for i := 0; i < 5; i += 1 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					require.NoError(t, testLibraryManager.AddToLibrary(tt.binary, "", tt.targetFile, tt.targetMeta), "expected no error adding to library")
+				}()
+			}
+
+			wg.Wait()
+
+			// Confirm the update was downloaded
+			dirInfo, err := os.Stat(filepath.Join(updatesDirectory(tt.binary, testBaseDir), testReleaseVersion))
+			require.NoError(t, err, "checking that update was downloaded")
+			require.True(t, dirInfo.IsDir())
+			executableInfo, err := os.Stat(executableLocation(filepath.Join(updatesDirectory(tt.binary, testBaseDir), testReleaseVersion), tt.binary))
+			require.NoError(t, err, "checking that downloaded update includes executable")
+			require.False(t, executableInfo.IsDir())
+
+			// Confirm ACL for new directory matches parent directory
+			newDirInfo, err := windows.GetNamedSecurityInfo(filepath.Join(updatesDirectory(tt.binary, testBaseDir), testReleaseVersion),
+				windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+			require.NoError(t, err, "getting named security info")
+			newDirDacl, _, err := newDirInfo.DACL()
+			require.NoError(t, err, "getting DACL")
+			require.NotNil(t, newDirDacl)
+
+			updateDirInfo, err := windows.GetNamedSecurityInfo((updatesDirectory(tt.binary, testBaseDir)),
+				windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+			require.NoError(t, err, "getting named security info")
+			updateDirDacl, _, err := updateDirInfo.DACL()
+			require.NoError(t, err, "getting DACL")
+			require.NotNil(t, updateDirDacl)
+
+			require.Equal(t, &newDirDacl, &updateDirDacl)
+			require.Equal(t, newDirInfo.String(), updateDirInfo.String())
+		})
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954.

On Windows, when we use C:\Windows\Temp as the parent for the staging directory, the update directory ultimately inherits ACLs that won't let the desktop runner find the updates. So we create the temporary staging directory inside our updates directory, where ACLs are reasonable, instead.