### PR TITLE
Add an interrupt routine to log checkpoint

### DIFF
--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -60,8 +60,9 @@ type checkPointer struct {
 
 func New(logger logger, k types.Knapsack) *checkPointer {
 	return &checkPointer{
-		logger:   log.With(logger, "component", "log checkpoint"),
-		knapsack: k,
+		logger:    log.With(logger, "component", "log checkpoint"),
+		knapsack:  k,
+		interrupt: make(chan struct{}, 1),
 
 		lock:        sync.RWMutex{},
 		queriedInfo: make(map[string]any),


### PR DESCRIPTION
My launcher keeps not totally dying. Since the logs keep showing checkpoints, I suspect it's the checkpoint actor lingering. And it turns out, there's no real exit routine. So, let's add one...

I'm not actually sure this is the issue, but it feels wrong anyhow