### PR TITLE
Make it safe to call rungroup actor Interrupt multiple times

### DIFF
--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -207,7 +207,8 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 					receivedInterrupts += 1
 					continue
 				case <-time.After(5 * time.Second):
-					t.Error("could not call interrupt multiple times and return within 5 seconds")
+					t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+					t.FailNow()
 				}
 			}
 

--- a/pkg/log/checkpoint/checkpoint.go
+++ b/pkg/log/checkpoint/checkpoint.go
@@ -97,7 +97,12 @@ func (c *checkPointer) Run() error {
 }
 
 func (c *checkPointer) Interrupt(_ error) {
-	c.interrupt <- struct{}{}
+	// Non-blocking channel send
+	select {
+	case c.interrupt <- struct{}{}:
+	default:
+		level.Debug(c.logger).Log("msg", "received additional call to interrupt")
+	}
 }
 
 func (c *checkPointer) Once() {


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205

While investigating an autoupdate shutdown issue, noticed that shutdown could block on runner.Interrupt being called multiple times.