### PR TITLE
Allow desktop runner Interrupt to be called multiple times

### DIFF
--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -145,7 +145,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 				assert.NoError(t, r.Execute())
 			}()
 
-			// let is run a few interval
+			// let it run a few intervals
 			time.Sleep(r.updateInterval * 3)
 			r.Interrupt(nil)
 
@@ -185,6 +185,34 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 					p.Process.Wait()
 				}
 			})
+
+			// Confirm we can call Interrupt multiple times without blocking
+			interruptComplete := make(chan struct{})
+			expectedInterrupts := 3
+			for i := 0; i < expectedInterrupts; i += 1 {
+				go func() {
+					r.Interrupt(nil)
+					interruptComplete <- struct{}{}
+				}()
+			}
+
+			receivedInterrupts := 0
+			for {
+				if receivedInterrupts >= expectedInterrupts {
+					break
+				}
+
+				select {
+				case <-interruptComplete:
+					receivedInterrupts += 1
+					continue
+				case <-time.After(5 * time.Second):
+					t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+					t.FailNow()
+				}
+			}
+
+			require.Equal(t, expectedInterrupts, receivedInterrupts)
 		})
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1205

While investigating an autoupdate shutdown issue, noticed that shutdown could block on runner.Interrupt being called multiple times. I experimented with a couple different solutions, but found this was ultimately the simplest solution that didn't result in data races in tests.