### PR TITLE
remove unused osquery client from all table/plugin method signatures

### DIFF
--- a/cmd/launcher.ext/launcher-extension.go
+++ b/cmd/launcher.ext/launcher-extension.go
@@ -57,9 +57,7 @@ func main() {
 	}
 
 	var plugins []osquery.OsqueryPlugin
-	for _, tablePlugin := range table.PlatformTables(client, logger, "osqueryd") {
-		plugins = append(plugins, tablePlugin)
-	}
+	plugins = append(plugins, table.PlatformTables(logger, "osqueryd")...)
 	server.RegisterPlugin(plugins...)
 
 	if err := server.Run(); err != nil {

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -117,7 +117,7 @@ func loadExtensions(socketPath string, osquerydPath string) (*osquery.ExtensionM
 		return extensionManagerServer, fmt.Errorf("error creating extension manager server: %w", err)
 	}
 
-	extensionManagerServer.RegisterPlugin(table.PlatformTables(client, log.NewNopLogger(), osquerydPath)...)
+	extensionManagerServer.RegisterPlugin(table.PlatformTables(log.NewNopLogger(), osquerydPath)...)
 
 	if err := extensionManagerServer.Start(); err != nil {
 		return nil, fmt.Errorf("error starting extension manager server: %w", err)

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -438,7 +438,7 @@ func (r *Runner) launchOsqueryInstance() error {
 	// TODO: Consider chunking, if we find we can only have so
 	// many tables per extension manager
 	o.errgroup.Go(func() error {
-		plugins := table.PlatformTables(o.extensionManagerClient, o.logger, currentOsquerydBinaryPath)
+		plugins := table.PlatformTables(o.logger, currentOsquerydBinaryPath)
 
 		if len(plugins) == 0 {
 			return nil

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -11,12 +11,9 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-
 	"github.com/kolide/kit/fsutil"
-	"github.com/osquery/osquery-go"
-	"github.com/osquery/osquery-go/plugin/table"
-
 	"github.com/kolide/launcher/pkg/agent"
+	"github.com/osquery/osquery-go/plugin/table"
 )
 
 var profileDirs = map[string][]string{
@@ -25,9 +22,8 @@ var profileDirs = map[string][]string{
 }
 var profileDirsDefault = []string{".config/google-chrome", ".config/chromium", "snap/chromium/current/.config/chromium"}
 
-func ChromeLoginDataEmails(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func ChromeLoginDataEmails(logger log.Logger) *table.Plugin {
 	c := &ChromeLoginDataEmailsTable{
-		client: client,
 		logger: logger,
 	}
 	columns := []table.ColumnDefinition{
@@ -39,7 +35,6 @@ func ChromeLoginDataEmails(client *osquery.ExtensionManagerClient, logger log.Lo
 }
 
 type ChromeLoginDataEmailsTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -12,14 +12,12 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/agent"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 // DEPRECATED use kolide_chrome_login_data_emails
-func ChromeLoginKeychainInfo(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func ChromeLoginKeychainInfo(logger log.Logger) *table.Plugin {
 	c := &ChromeLoginKeychain{
-		client: client,
 		logger: logger,
 	}
 	columns := []table.ColumnDefinition{
@@ -31,7 +29,6 @@ func ChromeLoginKeychainInfo(client *osquery.ExtensionManagerClient, logger log.
 }
 
 type ChromeLoginKeychain struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/chrome_user_profiles.go
+++ b/pkg/osquery/table/chrome_user_profiles.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -23,9 +22,8 @@ var chromeLocalStateDirs = map[string][]string{
 // try the list of known linux paths if runtime.GOOS doesn't match 'darwin' or 'windows'
 var chromeLocalStateDirDefault = []string{".config/google-chrome", ".config/chromium", "snap/chromium/current/.config/chromium"}
 
-func ChromeUserProfiles(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func ChromeUserProfiles(logger log.Logger) *table.Plugin {
 	c := &chromeUserProfilesTable{
-		client: client,
 		logger: logger,
 	}
 
@@ -40,7 +38,6 @@ func ChromeUserProfiles(client *osquery.ExtensionManagerClient, logger log.Logge
 }
 
 type chromeUserProfilesTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -11,13 +11,11 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/agent"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func GDriveSyncConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func GDriveSyncConfig(logger log.Logger) *table.Plugin {
 	g := &gdrive{
-		client: client,
 		logger: logger,
 	}
 
@@ -29,7 +27,6 @@ func GDriveSyncConfig(client *osquery.ExtensionManagerClient, logger log.Logger)
 }
 
 type gdrive struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/agent"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func GDriveSyncHistoryInfo(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func GDriveSyncHistoryInfo(logger log.Logger) *table.Plugin {
 	g := &GDriveSyncHistory{
-		client: client,
 		logger: logger,
 	}
 	columns := []table.ColumnDefinition{
@@ -31,7 +29,6 @@ func GDriveSyncHistoryInfo(client *osquery.ExtensionManagerClient, logger log.Lo
 }
 
 type GDriveSyncHistory struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/keyinfo.go
+++ b/pkg/osquery/table/keyinfo.go
@@ -8,17 +8,15 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/keyidentifier"
-	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 type KeyInfoTable struct {
-	client     *osquery.ExtensionManagerClient
 	logger     log.Logger
 	kIdentifer *keyidentifier.KeyIdentifier
 }
 
-func KeyInfo(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func KeyInfo(logger log.Logger) *table.Plugin {
 
 	columns := []table.ColumnDefinition{
 		table.TextColumn("path"),
@@ -40,7 +38,6 @@ func KeyInfo(client *osquery.ExtensionManagerClient, logger log.Logger) *table.P
 	}
 
 	t := &KeyInfoTable{
-		client:     client,
 		logger:     logger,
 		kIdentifer: kIdentifer,
 	}

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -11,10 +11,8 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/agent"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -27,7 +25,7 @@ var onepasswordDataFiles = map[string][]string{
 	},
 }
 
-func OnePasswordAccounts(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func OnePasswordAccounts(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("username"),
 		table.TextColumn("user_email"),
@@ -39,7 +37,6 @@ func OnePasswordAccounts(client *osquery.ExtensionManagerClient, logger log.Logg
 	}
 
 	o := &onePasswordAccountsTable{
-		client: client,
 		logger: logger,
 	}
 
@@ -47,7 +44,6 @@ func OnePasswordAccounts(client *osquery.ExtensionManagerClient, logger log.Logg
 }
 
 type onePasswordAccountsTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -35,14 +35,14 @@ const (
 	screenlockQuery    = "select enabled, grace_period from screenlock"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformTables(logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	munki := munki.New()
 
 	// This table uses undocumented APIs, There is some discussion at the
 	// PR adding the table. See
 	// https://github.com/osquery/osquery/pull/6243
 	screenlockTable := osquery_user_exec_table.TablePlugin(
-		client, logger, "kolide_screenlock",
+		logger, "kolide_screenlock",
 		currentOsquerydBinaryPath, screenlockQuery,
 		[]table.ColumnDefinition{
 			table.IntegerColumn("enabled"),
@@ -50,7 +50,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		})
 
 	keychainAclsTable := osquery_user_exec_table.TablePlugin(
-		client, logger, "kolide_keychain_acls",
+		logger, "kolide_keychain_acls",
 		currentOsquerydBinaryPath, keychainItemsQuery,
 		[]table.ColumnDefinition{
 			table.TextColumn("keychain_path"),
@@ -61,7 +61,7 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		})
 
 	keychainItemsTable := osquery_user_exec_table.TablePlugin(
-		client, logger, "kolide_keychain_items",
+		logger, "kolide_keychain_items",
 		currentOsquerydBinaryPath, keychainAclsQuery,
 		[]table.ColumnDefinition{
 			table.TextColumn("label"),
@@ -77,44 +77,44 @@ func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, c
 		keychainAclsTable,
 		keychainItemsTable,
 		appicons.AppIcons(),
-		ChromeLoginKeychainInfo(client, logger),
-		firmwarepasswd.TablePlugin(client, logger),
-		GDriveSyncConfig(client, logger),
-		GDriveSyncHistoryInfo(client, logger),
+		ChromeLoginKeychainInfo(logger),
+		firmwarepasswd.TablePlugin(logger),
+		GDriveSyncConfig(logger),
+		GDriveSyncHistoryInfo(logger),
 		MDMInfo(logger),
-		macos_software_update.MacOSUpdate(client),
+		macos_software_update.MacOSUpdate(),
 		macos_software_update.RecommendedUpdates(logger),
 		macos_software_update.AvailableProducts(logger),
 		MachoInfo(),
 		Spotlight(),
-		TouchIDUserConfig(client, logger),
-		TouchIDSystemConfig(client, logger),
+		TouchIDUserConfig(logger),
+		TouchIDSystemConfig(logger),
 		UserAvatar(logger),
-		ioreg.TablePlugin(client, logger),
-		profiles.TablePlugin(client, logger),
-		airport.TablePlugin(client, logger),
+		ioreg.TablePlugin(logger),
+		profiles.TablePlugin(logger),
+		airport.TablePlugin(logger),
 		kextpolicy.TablePlugin(),
-		filevault.TablePlugin(client, logger),
-		mdmclient.TablePlugin(client, logger),
+		filevault.TablePlugin(logger),
+		mdmclient.TablePlugin(logger),
 		apple_silicon_security_policy.TablePlugin(logger),
 		legacyexec.TablePlugin(),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_diskutil_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "list", "-plist"}),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_falconctl_stats", dataflattentable.PlistType, []string{"/Applications/Falcon.app/Contents/Resources/falconctl", "stats", "-p"}),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_apfs_list", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "list", "-plist"}),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_apfs_users", dataflattentable.PlistType, []string{"/usr/sbin/diskutil", "apfs", "listUsers", "/", "-plist"}),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_tmutil_destinationinfo", dataflattentable.PlistType, []string{"/usr/bin/tmutil", "destinationinfo", "-X"}),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_powermetrics", dataflattentable.PlistType, []string{"/usr/bin/powermetrics", "-n", "1", "-f", "plist"}),
 		screenlockTable,
-		pwpolicy.TablePlugin(client, logger),
-		systemprofiler.TablePlugin(client, logger),
-		munki.ManagedInstalls(client, logger),
-		munki.MunkiReport(client, logger),
+		pwpolicy.TablePlugin(logger),
+		systemprofiler.TablePlugin(logger),
+		munki.ManagedInstalls(logger),
+		munki.MunkiReport(logger),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, []string{`/usr/libexec/remotectl`, `dumpstate`}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, []string{`/usr/sbin/softwareupdate`, `--list`}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -26,23 +26,23 @@ import (
 	osquery "github.com/osquery/osquery-go"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformTables(logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
-		cryptsetup.TablePlugin(client, logger),
-		gsettings.Settings(client, logger),
-		gsettings.Metadata(client, logger),
-		secureboot.TablePlugin(client, logger),
-		xrdb.TablePlugin(client, logger),
+		cryptsetup.TablePlugin(logger),
+		gsettings.Settings(logger),
+		gsettings.Metadata(logger),
+		secureboot.TablePlugin(logger),
+		xrdb.TablePlugin(logger),
 		fscrypt_info.TablePlugin(logger),
 		falcon_kernel_check.TablePlugin(logger),
 		falconctl.NewFalconctlOptionTable(logger),
 		xfconf.TablePlugin(logger),
 
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_nmcli_wifi", dataflattentable.KeyValueType,
 			[]string{"/usr/bin/nmcli", "--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
-		dataflattentable.TablePluginExec(client, logger, "kolide_lsblk", dataflattentable.JsonType,
+		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
 			[]string{"lsblk", "-J"},
 			dataflattentable.WithBinDirs("/usr/bin", "/bin"),
 		),

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -16,15 +16,15 @@ import (
 	osquery "github.com/osquery/osquery-go"
 )
 
-func platformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformTables(logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		ProgramIcons(),
-		dsim_default_associations.TablePlugin(client, logger),
-		secedit.TablePlugin(client, logger),
-		wifi_networks.TablePlugin(client, logger),
-		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, client, logger),
-		windowsupdatetable.TablePlugin(windowsupdatetable.HistoryTable, client, logger),
-		wmitable.TablePlugin(client, logger),
+		dsim_default_associations.TablePlugin(logger),
+		secedit.TablePlugin(logger),
+		wifi_networks.TablePlugin(logger),
+		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, logger),
+		windowsupdatetable.TablePlugin(windowsupdatetable.HistoryTable, logger),
+		wmitable.TablePlugin(logger),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_dsregcmd", dsregcmd.Parser, []string{`/Windows/System32/dsregcmd.exe`, `/status`}),
 	}
 }

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -30,7 +29,7 @@ var slackConfigDirs = map[string][]string{
 // try the list of known linux paths if runtime.GOOS doesn't match 'darwin' or 'windows'
 var slackConfigDirDefault = []string{".config/Slack"}
 
-func SlackConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func SlackConfig(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("team_id"),
 		table.TextColumn("team_name"),
@@ -41,7 +40,6 @@ func SlackConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	}
 
 	t := &SlackConfigTable{
-		client: client,
 		logger: logger,
 	}
 
@@ -49,7 +47,6 @@ func SlackConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 }
 
 type SlackConfigTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/sshkeys.go
+++ b/pkg/osquery/table/sshkeys.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/kolide/launcher/pkg/keyidentifier"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -24,13 +23,12 @@ var sshDirs = map[string][]string{
 var sshDirsDefault = []string{".ssh/*"}
 
 type SshKeysTable struct {
-	client     *osquery.ExtensionManagerClient
 	logger     log.Logger
 	kIdentifer *keyidentifier.KeyIdentifier
 }
 
 // New returns a new table extension
-func SshKeys(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func SshKeys(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("user"),
 		table.TextColumn("path"),
@@ -52,7 +50,6 @@ func SshKeys(client *osquery.ExtensionManagerClient, logger log.Logger) *table.P
 	}
 
 	t := &SshKeysTable{
-		client:     client,
 		logger:     logger,
 		kIdentifer: kIdentifer,
 	}

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -35,34 +35,34 @@ func LauncherTables(k types.Knapsack) []osquery.OsqueryPlugin {
 }
 
 // PlatformTables returns all tables for the launcher build platform.
-func PlatformTables(client *osquery.ExtensionManagerClient, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func PlatformTables(logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	// Common tables to all platforms
 	tables := []osquery.OsqueryPlugin{
-		ChromeLoginDataEmails(client, logger),
-		ChromeUserProfiles(client, logger),
-		KeyInfo(client, logger),
-		OnePasswordAccounts(client, logger),
-		SlackConfig(client, logger),
-		SshKeys(client, logger),
+		ChromeLoginDataEmails(logger),
+		ChromeUserProfiles(logger),
+		KeyInfo(logger),
+		OnePasswordAccounts(logger),
+		SlackConfig(logger),
+		SshKeys(logger),
 		cryptoinfotable.TablePlugin(logger),
 		dev_table_tooling.TablePlugin(logger),
 		firefox_preferences.TablePlugin(logger),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_zerotier_info", dataflattentable.JsonType, zerotierCli("info")),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_zerotier_networks", dataflattentable.JsonType, zerotierCli("listnetworks")),
-		dataflattentable.TablePluginExec(client, logger,
+		dataflattentable.TablePluginExec(logger,
 			"kolide_zerotier_peers", dataflattentable.JsonType, zerotierCli("listpeers")),
-		tdebug.LauncherGcInfo(client, logger),
-		zfs.ZfsPropertiesPlugin(client, logger),
-		zfs.ZpoolPropertiesPlugin(client, logger),
+		tdebug.LauncherGcInfo(logger),
+		zfs.ZfsPropertiesPlugin(logger),
+		zfs.ZpoolPropertiesPlugin(logger),
 	}
 
 	// The dataflatten tables
-	tables = append(tables, dataflattentable.AllTablePlugins(client, logger)...)
+	tables = append(tables, dataflattentable.AllTablePlugins(logger)...)
 
 	// add in the platform specific ones (as denoted by build tags)
-	tables = append(tables, platformTables(client, logger, currentOsquerydBinaryPath)...)
+	tables = append(tables, platformTables(logger, currentOsquerydBinaryPath)...)
 
 	return tables
 }

--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -10,14 +10,11 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func TouchIDSystemConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TouchIDSystemConfig(logger log.Logger) *table.Plugin {
 	t := &touchIDSystemConfigTable{
-		client: client,
 		logger: logger,
 	}
 	columns := []table.ColumnDefinition{
@@ -31,7 +28,6 @@ func TouchIDSystemConfig(client *osquery.ExtensionManagerClient, logger log.Logg
 }
 
 type touchIDSystemConfigTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/table/touchid_user_darwin.go
+++ b/pkg/osquery/table/touchid_user_darwin.go
@@ -14,13 +14,11 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func TouchIDUserConfig(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TouchIDUserConfig(logger log.Logger) *table.Plugin {
 	t := &touchIDUserConfigTable{
-		client: client,
 		logger: logger,
 	}
 	columns := []table.ColumnDefinition{
@@ -36,7 +34,6 @@ func TouchIDUserConfig(client *osquery.ExtensionManagerClient, logger log.Logger
 }
 
 type touchIDUserConfigTable struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 

--- a/pkg/osquery/tables/airport/table_darwin.go
+++ b/pkg/osquery/tables/airport/table_darwin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -32,7 +31,7 @@ type Table struct {
 
 const tableName = "kolide_airport_util"
 
-func TablePlugin(_ *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("option"),
 	)

--- a/pkg/osquery/tables/cryptsetup/table.go
+++ b/pkg/osquery/tables/cryptsetup/table.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -22,18 +21,16 @@ var cryptsetupPaths = []string{
 const allowedNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/_"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 	name   string
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("name"),
 	)
 
 	t := &Table{
-		client: client,
 		logger: logger,
 		name:   "kolide_cryptsetup_status",
 	}

--- a/pkg/osquery/tables/dataflattentable/exec.go
+++ b/pkg/osquery/tables/dataflattentable/exec.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
@@ -36,11 +35,10 @@ func WithBinDirs(binDirs ...string) ExecTableOpt {
 	}
 }
 
-func TablePluginExec(client *osquery.ExtensionManagerClient, logger log.Logger, tableName string, dataSourceType DataSourceType, execArgs []string, opts ...ExecTableOpt) *table.Plugin {
+func TablePluginExec(logger log.Logger, tableName string, dataSourceType DataSourceType, execArgs []string, opts ...ExecTableOpt) *table.Plugin {
 	columns := Columns()
 
 	t := &Table{
-		client:            client,
 		logger:            level.NewFilter(logger, level.AllowInfo()),
 		tableName:         tableName,
 		execArgs:          execArgs,

--- a/pkg/osquery/tables/dataflattentable/tables.go
+++ b/pkg/osquery/tables/dataflattentable/tables.go
@@ -27,7 +27,6 @@ const (
 )
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 
@@ -41,22 +40,20 @@ type Table struct {
 }
 
 // AllTablePlugins is a helper to return all the expected flattening tables.
-func AllTablePlugins(client *osquery.ExtensionManagerClient, logger log.Logger) []osquery.OsqueryPlugin {
+func AllTablePlugins(logger log.Logger) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
-		TablePlugin(client, logger, JsonType),
-		TablePlugin(client, logger, XmlType),
-		TablePlugin(client, logger, IniType),
-		TablePlugin(client, logger, PlistType),
-		TablePlugin(client, logger, JsonlType),
+		TablePlugin(logger, JsonType),
+		TablePlugin(logger, XmlType),
+		TablePlugin(logger, IniType),
+		TablePlugin(logger, PlistType),
+		TablePlugin(logger, JsonlType),
 	}
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger, dataSourceType DataSourceType) osquery.OsqueryPlugin {
-
+func TablePlugin(logger log.Logger, dataSourceType DataSourceType) osquery.OsqueryPlugin {
 	columns := Columns(table.TextColumn("path"))
 
 	t := &Table{
-		client: client,
 		logger: logger,
 	}
 

--- a/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
+++ b/pkg/osquery/tables/dsim_default_associations/dsim_default_associations.go
@@ -19,23 +19,20 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 const dismCmd = "dism.exe"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns()
 
 	t := &Table{
-		client: client,
 		logger: logger,
 	}
 

--- a/pkg/osquery/tables/filevault/filevault.go
+++ b/pkg/osquery/tables/filevault/filevault.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
@@ -20,17 +19,15 @@ import (
 const fdesetupPath = "/usr/bin/fdesetup"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("status"),
 	}
 
 	t := &Table{
-		client: client,
 		logger: logger,
 	}
 

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd.go
@@ -16,30 +16,28 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/agent"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 	parser *OutputParser
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.IntegerColumn("option_roms_allowed"),
 		table.IntegerColumn("password_enabled"),
 		table.TextColumn("mode"),
 	}
 
-	t := New(client, logger)
+	t := New(logger)
 
 	return table.NewPlugin("kolide_firmwarepasswd", columns, t.generate)
 
 }
 
-func New(client *osquery.ExtensionManagerClient, logger log.Logger) *Table {
+func New(logger log.Logger) *Table {
 	parser := NewParser(logger,
 		[]Matcher{
 			{
@@ -60,7 +58,6 @@ func New(client *osquery.ExtensionManagerClient, logger log.Logger) *Table {
 		})
 
 	return &Table{
-		client: client,
 		logger: level.NewFilter(logger, level.AllowInfo()),
 		parser: parser,
 	}

--- a/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
+++ b/pkg/osquery/tables/firmwarepasswd/firmwarepasswd_test.go
@@ -47,7 +47,7 @@ func TestParser(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		parser := New(nil, log.NewNopLogger()).parser
+		parser := New(log.NewNopLogger()).parser
 
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/osquery/tables/gsettings/gsettings.go
+++ b/pkg/osquery/tables/gsettings/gsettings.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -33,14 +32,13 @@ const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0
 type gsettingsExecer func(ctx context.Context, username string, buf *bytes.Buffer) error
 
 type GsettingsValues struct {
-	client   *osquery.ExtensionManagerClient
 	logger   log.Logger
 	getBytes gsettingsExecer
 }
 
 // Settings returns a table plugin for querying setting values from the
 // gsettings command.
-func Settings(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func Settings(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("schema"),
 		table.TextColumn("key"),
@@ -49,7 +47,6 @@ func Settings(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 	}
 
 	t := &GsettingsValues{
-		client:   client,
 		logger:   logger,
 		getBytes: execGsettings,
 	}

--- a/pkg/osquery/tables/gsettings/metadata.go
+++ b/pkg/osquery/tables/gsettings/metadata.go
@@ -18,20 +18,17 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	osquery "github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 type GsettingsMetadata struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	cmdRunner func(ctx context.Context, args []string, tmpdir string, output *bytes.Buffer) error
 }
 
 // Metadata returns a table plugin for querying metadata about specific keys in
 // specific schemas
-func Metadata(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
-
+func Metadata(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		// TODO: maybe need to add 'path' for relocatable schemas..
 		table.TextColumn("schema"),
@@ -41,7 +38,6 @@ func Metadata(client *osquery.ExtensionManagerClient, logger log.Logger) *table.
 	}
 
 	t := &GsettingsMetadata{
-		client:    client,
 		logger:    logger,
 		cmdRunner: execGsettingsCommand,
 	}

--- a/pkg/osquery/tables/ioreg/ioreg.go
+++ b/pkg/osquery/tables/ioreg/ioreg.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -28,12 +27,11 @@ const ioregPath = "/usr/sbin/ioreg"
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		// ioreg input options. These match the ioreg
@@ -47,7 +45,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	)
 
 	t := &Table{
-		client:    client,
 		logger:    logger,
 		tableName: "kolide_ioreg",
 	}

--- a/pkg/osquery/tables/macos_software_update/software_update_table.go
+++ b/pkg/osquery/tables/macos_software_update/software_update_table.go
@@ -17,12 +17,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 	"golang.org/x/sys/unix"
 )
 
-func MacOSUpdate(client *osquery.ExtensionManagerClient) *table.Plugin {
+func MacOSUpdate() *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.IntegerColumn("autoupdate_managed"),
 		table.IntegerColumn("autoupdate_enabled"),
@@ -32,12 +31,11 @@ func MacOSUpdate(client *osquery.ExtensionManagerClient) *table.Plugin {
 		table.IntegerColumn("critical_updates"),
 		table.IntegerColumn("last_successful_check_timestamp"),
 	}
-	tableGen := &osUpdateTable{client: client}
+	tableGen := &osUpdateTable{}
 	return table.NewPlugin("kolide_macos_software_update", columns, tableGen.generateMacUpdate)
 }
 
 type osUpdateTable struct {
-	client                  *osquery.ExtensionManagerClient
 	macOSBuildVersionPrefix int
 }
 

--- a/pkg/osquery/tables/mdmclient/mdmclient.go
+++ b/pkg/osquery/tables/mdmclient/mdmclient.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -54,18 +53,16 @@ var headerRegex = regexp.MustCompile(`^=== CPF_GetInstalledProfiles === \(<Devic
 var lengthBytesRegex = regexp.MustCompile(`{length = (\d+,) bytes = (0[xX][0-9a-fA-F\.\s]+)}`)
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("command"),
 	)
 
 	t := &Table{
-		client:    client,
 		logger:    logger,
 		tableName: "kolide_mdmclient",
 	}

--- a/pkg/osquery/tables/munki/munki.go
+++ b/pkg/osquery/tables/munki/munki.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/groob/plist"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -28,7 +27,7 @@ func New() *MunkiInfo {
 	}
 }
 
-func (m *MunkiInfo) MunkiReport(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func (m *MunkiInfo) MunkiReport(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("version"),
 		table.TextColumn("start_time"),
@@ -42,7 +41,7 @@ func (m *MunkiInfo) MunkiReport(client *osquery.ExtensionManagerClient, logger l
 	return table.NewPlugin("kolide_munki_report", columns, m.generateMunkiReport)
 }
 
-func (m *MunkiInfo) ManagedInstalls(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func (m *MunkiInfo) ManagedInstalls(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("installed_version"),
 		table.TextColumn("installed"),

--- a/pkg/osquery/tables/osquery_user_exec_table/table.go
+++ b/pkg/osquery/tables/osquery_user_exec_table/table.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -32,7 +31,6 @@ const (
 )
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	osqueryd  string
 	query     string
@@ -40,14 +38,12 @@ type Table struct {
 }
 
 func TablePlugin(
-	client *osquery.ExtensionManagerClient, logger log.Logger,
-	tablename string, osqueryd string, osqueryQuery string, columns []table.ColumnDefinition,
+	logger log.Logger, tablename string, osqueryd string,
+	osqueryQuery string, columns []table.ColumnDefinition,
 ) *table.Plugin {
-
 	columns = append(columns, table.TextColumn("user"))
 
 	t := &Table{
-		client:    client,
 		logger:    logger,
 		osqueryd:  osqueryd,
 		query:     osqueryQuery,
@@ -55,7 +51,6 @@ func TablePlugin(
 	}
 
 	return table.NewPlugin(t.tablename, columns, t.generate)
-
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/tables/profiles/profiles.go
+++ b/pkg/osquery/tables/profiles/profiles.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -39,13 +38,11 @@ var (
 )
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
-
+func TablePlugin(logger log.Logger) *table.Plugin {
 	// profiles options. See `man profiles`. These may not be needed,
 	// we use `show -all` as the default, and it probably covers
 	// everything.
@@ -56,7 +53,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	)
 
 	t := &Table{
-		client:    client,
 		logger:    logger,
 		tableName: "kolide_profiles",
 	}

--- a/pkg/osquery/tables/pwpolicy/pwpolicy.go
+++ b/pkg/osquery/tables/pwpolicy/pwpolicy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -31,20 +30,18 @@ const pwpolicyPath = "/usr/bin/pwpolicy"
 const pwpolicyCmd = "getaccountpolicies"
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 	execCC    func(context.Context, string, ...string) *exec.Cmd
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		table.TextColumn("username"),
 	)
 
 	t := &Table{
-		client:    client,
 		logger:    logger,
 		tableName: "kolide_pwpolicy",
 		execCC:    exec.CommandContext,

--- a/pkg/osquery/tables/secedit/secedit.go
+++ b/pkg/osquery/tables/secedit/secedit.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 
 	"golang.org/x/text/encoding/unicode"
@@ -31,18 +30,15 @@ import (
 const seceditCmd = "secedit"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
-
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("mergedpolicy"),
 	)
 
 	t := &Table{
-		client: client,
 		logger: logger,
 	}
 

--- a/pkg/osquery/tables/secureboot/table.go
+++ b/pkg/osquery/tables/secureboot/table.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/efi"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -15,7 +14,7 @@ type Table struct {
 	logger log.Logger
 }
 
-func TablePlugin(_client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.IntegerColumn("secure_boot"),
 		table.IntegerColumn("setup_mode"),

--- a/pkg/osquery/tables/systemprofiler/systemprofiler.go
+++ b/pkg/osquery/tables/systemprofiler/systemprofiler.go
@@ -50,7 +50,6 @@ import (
 	"github.com/groob/plist"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -81,13 +80,11 @@ type Result struct {
 }
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	tableName string
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
-
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("parentdatatype"),
 		table.TextColumn("datatype"),
@@ -95,7 +92,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	)
 
 	t := &Table{
-		client:    client,
 		logger:    level.NewFilter(logger, level.AllowInfo()),
 		tableName: "kolide_system_profiler",
 	}

--- a/pkg/osquery/tables/tdebug/gc.go
+++ b/pkg/osquery/tables/tdebug/gc.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -26,7 +25,7 @@ type gcTable struct {
 	stats  debug.GCStats
 }
 
-func LauncherGcInfo(_client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func LauncherGcInfo(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns()
 
 	t := &gcTable{

--- a/pkg/osquery/tables/wifi_networks/wifi_networks.go
+++ b/pkg/osquery/tables/wifi_networks/wifi_networks.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/dataflatten"
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -38,16 +37,14 @@ var pwshScript []byte
 type execer func(ctx context.Context, buf *bytes.Buffer) error
 
 type Table struct {
-	client   *osquery.ExtensionManagerClient
 	logger   log.Logger
 	getBytes execer
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := dataflattentable.Columns()
 
 	t := &Table{
-		client:   client,
 		logger:   logger,
 		getBytes: execPwsh(logger),
 	}

--- a/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
+++ b/pkg/osquery/tables/windowsupdatetable/windowsupdate.go
@@ -16,9 +16,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/tables/dataflattentable"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/windows/windowsupdate"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
-
 	"github.com/scjalliance/comshim"
 )
 
@@ -30,13 +28,12 @@ const (
 )
 
 type Table struct {
-	client    *osquery.ExtensionManagerClient
 	logger    log.Logger
 	queryFunc queryFuncType
 	name      string
 }
 
-func TablePlugin(mode tableMode, client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(mode tableMode, logger log.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		table.TextColumn("locale"),
@@ -44,7 +41,6 @@ func TablePlugin(mode tableMode, client *osquery.ExtensionManagerClient, logger 
 	)
 
 	t := &Table{
-		client: client,
 		logger: logger,
 	}
 

--- a/pkg/osquery/tables/wmitable/wmitable.go
+++ b/pkg/osquery/tables/wmitable/wmitable.go
@@ -17,18 +17,16 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		table.TextColumn("namespace"),
@@ -38,7 +36,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	)
 
 	t := &Table{
-		client: client,
 		logger: level.NewFilter(logger),
 	}
 

--- a/pkg/osquery/tables/xrdb/xrdb.go
+++ b/pkg/osquery/tables/xrdb/xrdb.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/agent"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -34,12 +33,11 @@ const allowedDisplayCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 type execer func(ctx context.Context, display, username string, buf *bytes.Buffer) error
 
 type XRDBSettings struct {
-	client   *osquery.ExtensionManagerClient
 	logger   log.Logger
 	getBytes execer
 }
 
-func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func TablePlugin(logger log.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("key"),
 		table.TextColumn("value"),
@@ -48,7 +46,6 @@ func TablePlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *tab
 	}
 
 	t := &XRDBSettings{
-		client:   client,
 		logger:   logger,
 		getBytes: execXRDB,
 	}

--- a/pkg/osquery/tables/zfs/tables.go
+++ b/pkg/osquery/tables/zfs/tables.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/pkg/osquery/tables/tablehelpers"
-	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
 )
@@ -24,7 +23,6 @@ const (
 const allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.@/"
 
 type Table struct {
-	client *osquery.ExtensionManagerClient
 	logger log.Logger
 	cmd    string
 }
@@ -38,9 +36,8 @@ func columns() []table.ColumnDefinition {
 	}
 }
 
-func ZfsPropertiesPlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func ZfsPropertiesPlugin(logger log.Logger) *table.Plugin {
 	t := &Table{
-		client: client,
 		logger: logger,
 		cmd:    zfsPath,
 	}
@@ -48,9 +45,8 @@ func ZfsPropertiesPlugin(client *osquery.ExtensionManagerClient, logger log.Logg
 	return table.NewPlugin("kolide_zfs_properties", columns(), t.generate)
 }
 
-func ZpoolPropertiesPlugin(client *osquery.ExtensionManagerClient, logger log.Logger) *table.Plugin {
+func ZpoolPropertiesPlugin(logger log.Logger) *table.Plugin {
 	t := &Table{
-		client: client,
 		logger: logger,
 		cmd:    zpoolPath,
 	}


### PR DESCRIPTION
This is clean up as part of the effort [here](https://github.com/kolide/launcher/issues/1338) to reduce osquery socket contention.

To simplify the existing table/plugin signatures and discourage additional socket contention going forward, this removes the osquery client parameter from all table plugins. No additional uses beyond those mentioned in the issue were found.

There are no functional changes expected here- please note if you see otherwise