### PR TITLE
[TUF autoupdater] Fix prerelease sorting

### DIFF
--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -303,6 +303,15 @@ func sortedVersionsInLibrary(binary autoupdatableBinary, baseUpdateDirectory str
 			continue
 		}
 
+		// We have to swap the hyphen in the prerelease for a period (30-abcdabcd to 30.abcdabcd) so that the
+		// semver library can correctly compare prerelease values.
+		if v.Prerelease() != "" {
+			versionWithUpdatedPrerelease, err := v.SetPrerelease(strings.Replace(v.Prerelease(), "-", ".", -1))
+			if err == nil {
+				v = &versionWithUpdatedPrerelease
+			}
+		}
+
 		versionsInLibrary = append(versionsInLibrary, v)
 	}
 

--- a/pkg/autoupdate/tuf/library_manager_test.go
+++ b/pkg/autoupdate/tuf/library_manager_test.go
@@ -538,7 +538,9 @@ func Test_sortedVersionsInLibrary(t *testing.T) {
 	// Create a few valid updates in the library
 	olderValidVersion := "0.13.5"
 	middleValidVersion := "1.0.7-11-abcdabcd"
+	middleValidVersionPrereleaseReplaced := "1.0.7-11.abcdabcd"
 	secondMiddleValidVersion := "1.0.7-16-g6e6704e1dc33"
+	secondMiddleValidVersionPrereleaseReplaced := "1.0.7-16.g6e6704e1dc33"
 	newerValidVersion := "1.0.7"
 	for _, v := range []string{olderValidVersion, middleValidVersion, secondMiddleValidVersion, newerValidVersion} {
 		versionDir := filepath.Join(testBaseDir, "launcher", v)
@@ -563,9 +565,49 @@ func Test_sortedVersionsInLibrary(t *testing.T) {
 	// Confirm valid versions are the ones we expect and that they're sorted in ascending order
 	require.Equal(t, 4, len(validVersions))
 	require.Equal(t, olderValidVersion, validVersions[0], "not sorted")
-	require.Equal(t, middleValidVersion, validVersions[1], "not sorted")
-	require.Equal(t, secondMiddleValidVersion, validVersions[2], "not sorted")
+	require.Equal(t, middleValidVersionPrereleaseReplaced, validVersions[1], "not sorted")
+	require.Equal(t, secondMiddleValidVersionPrereleaseReplaced, validVersions[2], "not sorted")
 	require.Equal(t, newerValidVersion, validVersions[3], "not sorted")
+}
+
+func Test_sortedVersionsInLibrary_devBuilds(t *testing.T) {
+	t.Parallel()
+
+	// Create update directories
+	testBaseDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(testBaseDir, "launcher"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(testBaseDir, "osqueryd"), 0755))
+
+	// Create a few valid updates in the library
+	olderVersion := "1.0.16-8-g1594781"
+	olderVersionPrereleaseReplaced := "1.0.16-8.g1594781"
+	middleVersion := "1.0.16-9-g613d85c"
+	middleVersionPrereleaseReplaced := "1.0.16-9.g613d85c"
+	newerVersion := "1.0.16-30-ge34c9a0"
+	newerVersionPrereleaseReplaced := "1.0.16-30.ge34c9a0"
+	for _, v := range []string{olderVersion, middleVersion, newerVersion} {
+		versionDir := filepath.Join(testBaseDir, "launcher", v)
+		executablePath := executableLocation(versionDir, binaryLauncher)
+		require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
+		tufci.CopyBinary(t, executablePath)
+		require.NoError(t, os.Chmod(executablePath, 0755))
+		_, err := os.Stat(executablePath)
+		require.NoError(t, err, "did not create binary for test")
+		require.NoError(t, autoupdate.CheckExecutable(context.TODO(), executablePath, "--version"), "binary created for test is corrupt")
+	}
+
+	// Get sorted versions
+	validVersions, invalidVersions, err := sortedVersionsInLibrary(binaryLauncher, testBaseDir)
+	require.NoError(t, err, "expected no error on sorting versions in library")
+
+	// Confirm we don't have any invalid versions
+	require.Equal(t, 0, len(invalidVersions))
+
+	// Confirm valid versions are the ones we expect and that they're sorted in ascending order
+	require.Equal(t, 3, len(validVersions))
+	require.Equal(t, olderVersionPrereleaseReplaced, validVersions[0], "not sorted")
+	require.Equal(t, middleVersionPrereleaseReplaced, validVersions[1], "not sorted")
+	require.Equal(t, newerVersionPrereleaseReplaced, validVersions[2], "not sorted")
 }
 
 func Test_versionFromTarget(t *testing.T) {


### PR DESCRIPTION
The semver package expects that the semver parts will be separated by a period, and ours are separated by a hyphen. This means it won't correctly recognize that versions like "1.0.16-30-ge34c9a0" should be larger than "1.0.16-9-g613d85c", because it's using string comparison instead of splitting out 30 and 9 and comparing those as ints instead.

I'd previously decided this wasn't a big deal because we don't publish tags with pre-releases, but it's been enough of a pain that I think we should just correct the behavior so that it's what we expect.