### PR TITLE
Allow runner.Shutdown to be called more than once

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -42,6 +42,7 @@ type Runner struct {
 	instance     *OsqueryInstance
 	instanceLock sync.Mutex
 	shutdown     chan struct{}
+	interrupted  bool
 	opts         []OsqueryInstanceOption
 }
 
@@ -140,6 +141,12 @@ func (r *Runner) Query(query string) ([]map[string]string, error) {
 // Shutdown instructs the runner to permanently stop the running instance (no
 // restart will be attempted).
 func (r *Runner) Shutdown() error {
+	if r.interrupted {
+		// Already shut down, nothing else to do
+		return nil
+	}
+
+	r.interrupted = true
 	close(r.shutdown)
 	r.instanceLock.Lock()
 	defer r.instanceLock.Unlock()


### PR DESCRIPTION
Relates to: https://github.com/kolide/launcher/issues/1205

@zackattack01 noticed that the osquery runner actor cannot handle being interrupted more than once:

```
panic: close of closed channel

goroutine 1873 [running]:
github.com/kolide/launcher/pkg/osquery/runtime.(*Runner).Shutdown(0x1400070b020)
        /Users/runner/work/launcher/launcher/pkg/osquery/runtime/runner.go:143 +0x38
...
```

This PR corrects that issue in a similar way to how I corrected it in https://github.com/kolide/launcher/pull/1344