### PR TITLE
[TUF autoupdater] Bump lookup logs up to Info level

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -163,11 +163,11 @@ func runNewerLauncherIfAvailable(ctx context.Context, logger log.Logger) {
 	}
 
 	if newerBinary == "" {
-		level.Debug(logger).Log("msg", "nothing newer")
+		level.Info(logger).Log("msg", "nothing newer")
 		return
 	}
 
-	level.Debug(logger).Log(
+	level.Info(logger).Log(
 		"msg", "preparing to exec new binary",
 		"old_version", version.Version().Version,
 		"new_binary", newerBinary,
@@ -201,7 +201,7 @@ func latestLauncherPath(ctx context.Context, logger log.Logger) (string, error) 
 
 	currentPath, _ := os.Executable()
 	if newerBinary.Version != version.Version().Version && newerBinary.Path != currentPath {
-		level.Debug(logger).Log(
+		level.Info(logger).Log(
 			"msg", "got new version of launcher to run",
 			"old_version", version.Version().Version,
 			"new_binary_version", newerBinary.Version,

--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -35,6 +35,7 @@ var channelsUsingLegacyAutoupdate = map[string]bool{
 // searching for launcher configuration values in its config file.
 // For now, it is only available when launcher is on the nightly update channel.
 func CheckOutLatestWithoutConfig(binary autoupdatableBinary, logger log.Logger) (*BinaryUpdateInfo, error) {
+	logger = log.With(logger, "component", "tuf_library_lookup")
 	cfg, err := getAutoupdateConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not get autoupdate config: %w", err)
@@ -99,10 +100,11 @@ func CheckOutLatest(binary autoupdatableBinary, rootDirectory string, updateDire
 
 	update, err := findExecutableFromRelease(binary, LocalTufDirectory(rootDirectory), channel, updateDirectory)
 	if err == nil {
+		level.Info(logger).Log("msg", "found executable matching current release", "path", update.Path, "version", update.Version)
 		return update, nil
 	}
 
-	level.Debug(logger).Log("msg", "could not find executable from release", "err", err)
+	level.Info(logger).Log("msg", "could not find executable matching current release", "err", err)
 
 	// If we can't find the specific release version that we should be on, then just return the executable
 	// with the most recent version in the library


### PR DESCRIPTION
At this point in main.go, we haven't set the `Debug` flag yet on our logger, so we lose all logs at the debug level. This PR bumps up the log level to `Info` for the logs we might care about when debugging autoupdater version selection.