### PR TITLE
[TUF autoupdater] Don't permanently swap prerelease value

### DIFF
--- a/pkg/autoupdate/tuf/library_manager.go
+++ b/pkg/autoupdate/tuf/library_manager.go
@@ -318,9 +318,15 @@ func sortedVersionsInLibrary(binary autoupdatableBinary, baseUpdateDirectory str
 	// Sort the versions (ascending order)
 	sort.Sort(semver.Collection(versionsInLibrary))
 
-	// Transform versions back into strings now that we've finished sorting them
+	// Transform versions back into strings now that we've finished sorting them; swap the prerelease value back.
 	versionsInLibraryStr := make([]string, len(versionsInLibrary))
 	for i, v := range versionsInLibrary {
+		if v.Prerelease() != "" {
+			versionWithUpdatedPrerelease, err := v.SetPrerelease(strings.Replace(v.Prerelease(), ".", "-", -1))
+			if err == nil {
+				v = &versionWithUpdatedPrerelease
+			}
+		}
 		versionsInLibraryStr[i] = v.Original()
 	}
 

--- a/pkg/autoupdate/tuf/library_manager_test.go
+++ b/pkg/autoupdate/tuf/library_manager_test.go
@@ -538,9 +538,7 @@ func Test_sortedVersionsInLibrary(t *testing.T) {
 	// Create a few valid updates in the library
 	olderValidVersion := "0.13.5"
 	middleValidVersion := "1.0.7-11-abcdabcd"
-	middleValidVersionPrereleaseReplaced := "1.0.7-11.abcdabcd"
 	secondMiddleValidVersion := "1.0.7-16-g6e6704e1dc33"
-	secondMiddleValidVersionPrereleaseReplaced := "1.0.7-16.g6e6704e1dc33"
 	newerValidVersion := "1.0.7"
 	for _, v := range []string{olderValidVersion, middleValidVersion, secondMiddleValidVersion, newerValidVersion} {
 		versionDir := filepath.Join(testBaseDir, "launcher", v)
@@ -565,8 +563,8 @@ func Test_sortedVersionsInLibrary(t *testing.T) {
 	// Confirm valid versions are the ones we expect and that they're sorted in ascending order
 	require.Equal(t, 4, len(validVersions))
 	require.Equal(t, olderValidVersion, validVersions[0], "not sorted")
-	require.Equal(t, middleValidVersionPrereleaseReplaced, validVersions[1], "not sorted")
-	require.Equal(t, secondMiddleValidVersionPrereleaseReplaced, validVersions[2], "not sorted")
+	require.Equal(t, middleValidVersion, validVersions[1], "not sorted")
+	require.Equal(t, secondMiddleValidVersion, validVersions[2], "not sorted")
 	require.Equal(t, newerValidVersion, validVersions[3], "not sorted")
 }
 
@@ -580,11 +578,8 @@ func Test_sortedVersionsInLibrary_devBuilds(t *testing.T) {
 
 	// Create a few valid updates in the library
 	olderVersion := "1.0.16-8-g1594781"
-	olderVersionPrereleaseReplaced := "1.0.16-8.g1594781"
 	middleVersion := "1.0.16-9-g613d85c"
-	middleVersionPrereleaseReplaced := "1.0.16-9.g613d85c"
 	newerVersion := "1.0.16-30-ge34c9a0"
-	newerVersionPrereleaseReplaced := "1.0.16-30.ge34c9a0"
 	for _, v := range []string{olderVersion, middleVersion, newerVersion} {
 		versionDir := filepath.Join(testBaseDir, "launcher", v)
 		executablePath := executableLocation(versionDir, binaryLauncher)
@@ -605,9 +600,9 @@ func Test_sortedVersionsInLibrary_devBuilds(t *testing.T) {
 
 	// Confirm valid versions are the ones we expect and that they're sorted in ascending order
 	require.Equal(t, 3, len(validVersions))
-	require.Equal(t, olderVersionPrereleaseReplaced, validVersions[0], "not sorted")
-	require.Equal(t, middleVersionPrereleaseReplaced, validVersions[1], "not sorted")
-	require.Equal(t, newerVersionPrereleaseReplaced, validVersions[2], "not sorted")
+	require.Equal(t, olderVersion, validVersions[0], "not sorted")
+	require.Equal(t, middleVersion, validVersions[1], "not sorted")
+	require.Equal(t, newerVersion, validVersions[2], "not sorted")
 }
 
 func Test_versionFromTarget(t *testing.T) {


### PR DESCRIPTION
This PR updates the changes made in https://github.com/kolide/launcher/pull/1353 to swap back the prerelease value in the semver after we're done with sorting.