### PR TITLE
[TUF autoupdater] Don't perform library lookup for desktop process

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -729,6 +729,7 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		fmt.Sprintf("RUNNER_SERVER_URL=%s", r.runnerServer.Url()),
 		fmt.Sprintf("RUNNER_SERVER_AUTH_TOKEN=%s", r.runnerServer.RegisterClient(uid)),
 		fmt.Sprintf("DEBUG=%v", r.knapsack.Debug()),
+		"LAUNCHER_SKIP_UPDATES=true", // We already know that we want to run the version of launcher in `executablePath`, so there's no need to perform lookups
 	}
 
 	stdErr, err := cmd.StderrPipe()


### PR DESCRIPTION
Prevents this issue:

```
{"caller":":0",
"component":"desktop_users_processes_runner",
"level":"debug",
"msg":
    "{\"caller\":\"library_lookup.go:107\",
    \"component\":\"tuf_library_lookup\",
    \"err\":\"could not get target: error reading directory /var/kolide-k2/k2device-preprod.kolide.com/tuf: open /var/kolide-k2/k2device-preprod.kolide.com/tuf: permission denied\",
    \"msg\":\"could not find executable matching current release\",
    \"severity\":\"info\",
    \"ts\":\"2023-09-14T17:51:02.161682Z\"}",
"session_pid":55849,
"subprocess":"desktop"
,"ts":"2023-09-14T17:51:02.161867Z",
"uid":"501"}
```

(The TUF directory cannot exist with permissions more broad than the ones it's currently granted, so the desktop process will never be able to access it in order to find the release.)

We're already passing in the current executable path when running the desktop process, so there's no need for it to perform lookup.