### PR TITLE
reduce early localserver -> osquery contention

### DIFF
--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -213,11 +213,11 @@ func (ls *localServer) runAsyncdWorkers() time.Time {
 }
 
 func (ls *localServer) Start() error {
-	// Spawn background workers. This loop is a bit weird on startup. We want to populate this data as soon as we can,
-	// this is likely to happen before querier is ready. So we wait for <pollInterval> and before starting and then only
-	// rerun if the previous run was unsuccessful, or has been greater than <recalculateInterval>.
-	// Note that this polling is merely a check against time, we don't repopulate this data nearly so often. (But we poll
-	// frequently to account for the difference between wall clock time, and sleep time)
+	// Spawn background workers. The information gathered here is not critical for DT flow- so to reduce early osquery contention
+	// we wait for <pollInterval> and before starting and then only rerun if the previous run was unsuccessful,
+	// or has been greater than <recalculateInterval>. Note that this polling is merely a check against time,
+	// we don't repopulate this data nearly so often. (But we poll frequently to account for the difference between
+	// wall clock time, and sleep time)
 	const (
 		pollInterval        = 15 * time.Minute
 		recalculateInterval = 24 * time.Hour
@@ -231,7 +231,7 @@ func (ls *localServer) Start() error {
 			if time.Since(lastRun) > recalculateInterval {
 				lastRun = ls.runAsyncdWorkers()
 				if lastRun.IsZero() {
-					level.Info(ls.logger).Log("message", "runAsyncdWorkers unsuccessful, will retry in the future.")
+					level.Debug(ls.logger).Log("message", "runAsyncdWorkers unsuccessful, will retry in the future.")
 				}
 			}
 		}


### PR DESCRIPTION
Localserver currently utilizes a backoff routine to repeatedly hit osquery early during startup, and then refreshes information less frequently after the initial load.

The information gathered here is no longer functionally required (is used only for debugging purposes), so we can remove the initial backoff routine and prevent localserver from even attempting to hit osquery for 15 minutes instead.