### PR TITLE
Add NixOS packages upgradeable

### DIFF
--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -68,6 +68,10 @@ func Netstat(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/sbin/netstat", arg...)
 }
 
+func NixEnv(ctx context.Context, arg ...string) (*exec.Cmd, error) {
+	return validatedCommand(ctx, "/nix/var/nix/profiles/default/bin/nix-env", arg...)
+}
+
 func Open(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/open", arg...)
 }

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -83,6 +83,10 @@ func Lsof(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/lsof", arg...)
 }
 
+func NixEnv(ctx context.Context, arg ...string) (*exec.Cmd, error) {
+	return validatedCommand(ctx, "/nix/var/nix/profiles/default/bin/nix-env", arg...)
+}
+
 func Nmcli(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/nmcli", arg...)
 }

--- a/ee/tables/dataflattentable/exec.go
+++ b/ee/tables/dataflattentable/exec.go
@@ -48,6 +48,8 @@ func TablePluginExec(logger log.Logger, tableName string, dataSourceType DataSou
 		t.flattenBytesFunc = dataflatten.Plist
 	case JsonType:
 		t.flattenBytesFunc = dataflatten.Json
+	case XmlType:
+		t.flattenBytesFunc = dataflatten.Xml
 	case KeyValueType:
 		// TODO: allow callers of TablePluginExec to specify the record
 		// splitting strategy

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,6 +117,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		systemprofiler.TablePlugin(logger),
 		munki.ManagedInstalls(logger),
 		munki.MunkiReport(logger),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-s", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,7 +117,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		systemprofiler.TablePlugin(logger),
 		munki.ManagedInstalls(logger),
 		munki.MunkiReport(logger),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-s", "-c", "--xml"}),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -117,7 +117,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		systemprofiler.TablePlugin(logger),
 		munki.ManagedInstalls(logger),
 		munki.MunkiReport(logger),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-c", "--xml"}),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -48,7 +48,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
 			allowedcmd.Lsblk, []string{"-fJp"},
 		),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-c", "--xml"}),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv []string{"--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -48,7 +48,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
 			allowedcmd.Lsblk, []string{"-fJp"},
 		),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv []string{"--query", "--installed", "-c", "--xml"}),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -48,7 +48,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
 			allowedcmd.Lsblk, []string{"-fJp"},
 		),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-s", "-c", "--xml"}),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -48,6 +48,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
 			allowedcmd.Lsblk, []string{"-fJp"},
 		),
+		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, []string{"/nix/var/nix/profiles/default/bin/nix-env", "--query", "--installed", "-s", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),


### PR DESCRIPTION
Adding a xml exec parser for NixOS packages. `nix-env` with `-c` can check package version and output into xml or json format. Json doesn't seem to return `versionDiff`, which is super useful on the check side, so I chose to add the XML parsing to the exec datatypes.

```
osquery> SELECT * FROM kolide_nix_upgradeable;
+----------------------------------+---------------------+---------------------+-----------------+-------+
| fullkey                          | parent              | key                 | value           | query |
+----------------------------------+---------------------+---------------------+-----------------+-------+
| items/item/0/-pname              | items/item/0        | -pname              | nix             | *     |
| items/item/0/-maxComparedVersion | items/item/0        | -maxComparedVersion | 2.17.0          | *     |
| items/item/0/-name               | items/item/0        | -name               | nix-2.18.0      | *     |
| items/item/0/-outputName         | items/item/0        | -outputName         |                 | *     |
| items/item/0/-system             | items/item/0        | -system             | unknown         | *     |
| items/item/0/-version            | items/item/0        | -version            | 2.18.0          | *     |
| items/item/0/-versionDiff        | items/item/0        | -versionDiff        | >               | *     |
| items/item/0/output/-name        | items/item/0/output | -name               | out             | *     |
| items/item/0/-attrPath           | items/item/0        | -attrPath           | 1               | *     |
| items/item/1/-pname              | items/item/1        | -pname              | nss-cacert      | *     |
| items/item/1/-system             | items/item/1        | -system             | unknown         | *     |
| items/item/1/-versionDiff        | items/item/1        | -versionDiff        | =               | *     |
| items/item/1/output/-name        | items/item/1/output | -name               | out             | *     |
| items/item/1/-attrPath           | items/item/1        | -attrPath           | 0               | *     |
| items/item/1/-outputName         | items/item/1        | -outputName         |                 | *     |
| items/item/1/-version            | items/item/1        | -version            | 3.92            | *     |
| items/item/1/-maxComparedVersion | items/item/1        | -maxComparedVersion | 3.92            | *     |
| items/item/1/-name               | items/item/1        | -name               | nss-cacert-3.92 | *     |
+----------------------------------+---------------------+---------------------+-----------------+-------+
```

This is super early in testing on a mac not a full NixOS install, but the general idea should work.