### PR TITLE
[TUF] Don't use new autoupdater yet; don't set env var

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -55,7 +55,28 @@ func main() {
 	// fork-bombing itself. This is an ENV, because there's no
 	// good way to pass it through the flags.
 	if !env.Bool("LAUNCHER_SKIP_UPDATES", false) {
-		runNewerLauncherIfAvailable(ctx, logger)
+		if tuf.UsingNewAutoupdater() {
+			runNewerLauncherIfAvailable(ctx, logger)
+		} else {
+			newerBinary, err := autoupdate.FindNewestSelf(ctx)
+			if err != nil {
+				logutil.Fatal(logger, err, "checking for updated version")
+			}
+
+			if newerBinary != "" {
+				level.Debug(logger).Log(
+					"msg", "preparing to exec new binary",
+					"oldVersion", version.Version().Version,
+					"newBinary", newerBinary,
+				)
+				if err := execwrapper.Exec(ctx, newerBinary, os.Args, os.Environ()); err != nil {
+					logutil.Fatal(logger, err, "exec")
+				}
+				panic("how")
+			} else {
+				level.Debug(logger).Log("msg", "Nothing new")
+			}
+		}
 	}
 
 	// if the launcher is being ran with a positional argument,
@@ -147,16 +168,6 @@ func runSubcommands() error {
 // runNewerLauncherIfAvailable checks the autoupdate library for a newer version
 // of launcher than the currently-running one. If found, it will exec that version.
 func runNewerLauncherIfAvailable(ctx context.Context, logger log.Logger) {
-	// If the legacy autoupdate path variable isn't already set, set it to help
-	// the legacy autoupdater find its update directory even when the newer binary
-	// runs out of a different directory.
-	if _, ok := os.LookupEnv(autoupdate.LegacyLauncherAutoupdatePathEnvVar); !ok {
-		currentPath, err := os.Executable()
-		if err == nil {
-			os.Setenv(autoupdate.LegacyLauncherAutoupdatePathEnvVar, currentPath)
-		}
-	}
-
 	newerBinary, err := latestLauncherPath(ctx, logger)
 	if err != nil {
 		logutil.Fatal(logger, "msg", "checking for updated version", "err", err)
@@ -185,18 +196,7 @@ func runNewerLauncherIfAvailable(ctx context.Context, logger log.Logger) {
 func latestLauncherPath(ctx context.Context, logger log.Logger) (string, error) {
 	newerBinary, err := tuf.CheckOutLatestWithoutConfig("launcher", logger)
 	if err != nil {
-		level.Error(logger).Log(
-			"msg", "could not check out latest launcher, will fall back to old autoupdate library",
-			"err", err,
-		)
-
-		// Fall back to legacy autoupdate library
-		newerBinaryPath, err := autoupdate.FindNewestSelf(ctx)
-		if err != nil {
-			return "", fmt.Errorf("finding newest self: %w", err)
-		}
-
-		return newerBinaryPath, nil
+		return "", fmt.Errorf("checking out latest launcher: %w", err)
 	}
 
 	currentPath, _ := os.Executable()

--- a/pkg/autoupdate/findnew.go
+++ b/pkg/autoupdate/findnew.go
@@ -28,10 +28,6 @@ const defaultBuildTimestamp = "0"
 // This suffix is added to the binary path to find the updates
 const updateDirSuffix = "-updates"
 
-const (
-	LegacyLauncherAutoupdatePathEnvVar = "LAUNCHER_LEGACY_AUTOUPDATE_PATH"
-)
-
 type newestSettings struct {
 	deleteOld               bool
 	deleteCorrupt           bool
@@ -251,11 +247,6 @@ func FindNewest(ctx context.Context, fullBinaryPath string, opts ...newestOption
 //
 // It makes some string assumptions about how things are named.
 func getUpdateDir(fullBinaryPath string) string {
-	if installedPath := os.Getenv(LegacyLauncherAutoupdatePathEnvVar); installedPath != "" {
-		binaryName := filepath.Base(fullBinaryPath)
-		fullBinaryPath = filepath.Join(filepath.Dir(installedPath), binaryName)
-	}
-
 	if strings.Contains(fullBinaryPath, ".app") {
 		binary := filepath.Base(fullBinaryPath)
 		return filepath.Join(FindBaseDir(fullBinaryPath), binary+updateDirSuffix)
@@ -330,11 +321,6 @@ func getPossibleUpdates(ctx context.Context, updateDir, binaryName string) ([]st
 func FindBaseDir(path string) string {
 	if path == "" {
 		return ""
-	}
-
-	if installedPath := os.Getenv(LegacyLauncherAutoupdatePathEnvVar); installedPath != "" {
-		binaryName := filepath.Base(path)
-		path = filepath.Join(filepath.Dir(installedPath), binaryName)
 	}
 
 	// If this is an app bundle installation, we need to adjust the directory -- otherwise we end up with a library

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -88,67 +88,6 @@ func TestGetUpdateDir(t *testing.T) {
 	}
 }
 
-func TestGetUpdateDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
-	// Since we're setting an environment variable, we don't want to run this test at the
-	// same time as other tests.
-
-	t.Cleanup(func() {
-		os.Setenv(LegacyLauncherAutoupdatePathEnvVar, "")
-	})
-
-	var tests = []struct {
-		installPath string
-		currentPath string
-		out         string
-	}{
-		{
-			currentPath: "/a/path/var/id/hostname/updates/binary/1.2.3/binary",
-			installPath: filepath.Clean("/a/bin/launcher"),
-			out:         filepath.Clean("/a/bin/binary-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/binary/1.2.3/binary",
-			installPath: filepath.Clean("/a/Test.app/Contents/MacOS/launcher"),
-			out:         filepath.Clean("/a/bin/binary-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/binary/1.2.3/Test.app/Contents/MacOS/binary",
-			installPath: filepath.Clean("/a/bin/launcher"),
-			out:         filepath.Clean("/a/bin/binary-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/binary/1.2.3/Test.app/Contents/MacOS/binary",
-			installPath: filepath.Clean("/a/Test.app/Contents/MacOS/launcher"),
-			out:         filepath.Clean("/a/bin/binary-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/launcher",
-			installPath: filepath.Clean("/a/bin/launcher"),
-			out:         filepath.Clean("/a/bin/launcher-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/launcher",
-			installPath: filepath.Clean("/a/Test.app/Contents/MacOS/launcher"),
-			out:         filepath.Clean("/a/bin/launcher-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/Test.app/Contents/MacOS/launcher",
-			installPath: filepath.Clean("/a/bin/launcher"),
-			out:         filepath.Clean("/a/bin/launcher-updates"),
-		},
-		{
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/Test.app/Contents/MacOS/launcher",
-			installPath: filepath.Clean("/a/Test.app/Contents/MacOS/launcher"),
-			out:         filepath.Clean("/a/bin/launcher-updates"),
-		},
-	}
-
-	for _, tt := range tests {
-		os.Setenv(LegacyLauncherAutoupdatePathEnvVar, tt.installPath)
-		require.Equal(t, tt.out, getUpdateDir(tt.currentPath), "input: install path %s, current path %s", tt.installPath, tt.currentPath)
-	}
-}
-
 func TestFindBaseDir(t *testing.T) {
 	t.Parallel()
 
@@ -168,47 +107,6 @@ func TestFindBaseDir(t *testing.T) {
 
 	for _, tt := range tests {
 		require.Equal(t, tt.out, FindBaseDir(tt.in), "input: %s", tt.in)
-	}
-}
-
-func TestFindBaseDir_WithEnvVar(t *testing.T) { //nolint:paralleltest
-	// Since we're setting an environment variable, we don't want to run this test at the
-	// same time as other tests.
-
-	t.Cleanup(func() {
-		os.Setenv(LegacyLauncherAutoupdatePathEnvVar, "")
-	})
-
-	var tests = []struct {
-		installPath string
-		currentPath string
-		out         string
-	}{
-		{
-			installPath: "/a/path/bin/launcher",
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/launcher",
-			out:         filepath.Clean("/a/path/bin"),
-		},
-		{
-			installPath: "/a/path/bin/launcher",
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/Test.app/Contents/MacOS/launcher",
-			out:         filepath.Clean("/a/path/bin"),
-		},
-		{
-			installPath: "/a/path/Test.app/Contents/MacOS/launcher",
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/launcher",
-			out:         filepath.Clean("/a/path/bin"),
-		},
-		{
-			installPath: "/a/path/Test.app/Contents/MacOS/launcher",
-			currentPath: "/a/path/var/id/hostname/updates/launcher/1.2.3/Test.app/Contents/MacOS/launcher",
-			out:         filepath.Clean("/a/path/bin"),
-		},
-	}
-
-	for _, tt := range tests {
-		os.Setenv(LegacyLauncherAutoupdatePathEnvVar, tt.installPath)
-		require.Equal(t, tt.out, FindBaseDir(tt.currentPath), "input: install path %s, current path %s", tt.installPath, tt.currentPath)
 	}
 }
 

--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -124,15 +124,18 @@ func TestExecute_launcherUpdate(t *testing.T) {
 	// Assert expectation that we added the expected `testReleaseVersion` to the updates library
 	mockLibraryManager.AssertExpectations(t)
 
-	// Check log lines to confirm that we see the log `received interrupt to restart launcher after update, stopping`, indicating that
-	// the autoupdater shut down at the end
-	logLines := strings.Split(strings.TrimSpace(logBytes.String()), "\n")
+	// In the future, we expect that we'd restart launcher. For now, we don't want unnecessary restarts.
+	/*
+		// Check log lines to confirm that we see the log `received interrupt to restart launcher after update, stopping`, indicating that
+		// the autoupdater shut down at the end
+		logLines := strings.Split(strings.TrimSpace(logBytes.String()), "\n")
 
-	// We expect at least 1 log for the shutdown line.
-	require.GreaterOrEqual(t, len(logLines), 1)
+		// We expect at least 1 log for the shutdown line.
+		require.GreaterOrEqual(t, len(logLines), 1)
 
-	// Check that we shut down
-	require.Contains(t, logLines[len(logLines)-1], "received interrupt to restart launcher after update, stopping")
+		// Check that we shut down
+		require.Contains(t, logLines[len(logLines)-1], "received interrupt to restart launcher after update, stopping")
+	*/
 }
 
 func TestExecute_launcherUpdate_noRestartIfUsingLegacyAutoupdater(t *testing.T) {
@@ -277,8 +280,11 @@ func TestExecute_osquerydUpdate(t *testing.T) {
 	// We expect at least 1 log for the restart line.
 	require.GreaterOrEqual(t, len(logLines), 1)
 
-	// Check that we restarted osqueryd
-	require.Contains(t, logLines[len(logLines)-1], "restarted binary after update")
+	// 	// In the future, we expect that we'd restart osquery. For now, we don't want unnecessary restarts.
+	/*
+		// Check that we restarted osqueryd
+		require.Contains(t, logLines[len(logLines)-1], "restarted binary after update")
+	*/
 
 	// The autoupdater won't stop after an osqueryd download, so interrupt it and let it shut down
 	autoupdater.Interrupt(errors.New("test error"))

--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -27,8 +27,10 @@ type autoupdateConfig struct {
 }
 
 var channelsUsingLegacyAutoupdate = map[string]bool{
-	"stable": true,
-	"beta":   true,
+	"stable":  true,
+	"beta":    true,
+	"alpha":   true,
+	"nightly": true,
 }
 
 // CheckOutLatestWithoutConfig returns information about the latest downloaded executable for our binary,
@@ -47,6 +49,15 @@ func CheckOutLatestWithoutConfig(binary autoupdatableBinary, logger log.Logger) 
 	}
 
 	return CheckOutLatest(binary, cfg.rootDirectory, cfg.updateDirectory, cfg.channel, logger)
+}
+
+func UsingNewAutoupdater() bool {
+	cfg, err := getAutoupdateConfig()
+	if err != nil {
+		return false
+	}
+
+	return usingNewAutoupdater(cfg.channel)
 }
 
 // getAutoupdateConfig reads launcher's config file to determine the configuration values

--- a/pkg/autoupdate/tuf/library_lookup_test.go
+++ b/pkg/autoupdate/tuf/library_lookup_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckOutLatest_withTufRepository(t *testing.T) {
-	t.Parallel()
+func TestCheckOutLatest_withTufRepository(t *testing.T) { //nolint: paralleltest
+	delete(channelsUsingLegacyAutoupdate, "nightly")
+	defer func() {
+		channelsUsingLegacyAutoupdate["nightly"] = true
+	}()
 
 	for _, binary := range binaries {
 		binary := binary
-		t.Run(string(binary), func(t *testing.T) {
-			t.Parallel()
-
+		t.Run(string(binary), func(t *testing.T) { //nolint: paralleltest
 			// Set up an update library
 			rootDir := t.TempDir()
 			updateDir := defaultLibraryDirectory(rootDir)
@@ -52,14 +53,15 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) {
 	}
 }
 
-func TestCheckOutLatest_withoutTufRepository(t *testing.T) {
-	t.Parallel()
+func TestCheckOutLatest_withoutTufRepository(t *testing.T) { // nolint:paralleltest
+	delete(channelsUsingLegacyAutoupdate, "nightly")
+	defer func() {
+		channelsUsingLegacyAutoupdate["nightly"] = true
+	}()
 
 	for _, binary := range binaries {
 		binary := binary
-		t.Run(string(binary), func(t *testing.T) {
-			t.Parallel()
-
+		t.Run(string(binary), func(t *testing.T) { // nolint:paralleltest
 			// Set up an update library, but no TUF repo
 			rootDir := t.TempDir()
 			updateDir := defaultLibraryDirectory(rootDir)
@@ -94,6 +96,21 @@ func TestCheckOutLatest_NotAvailableOnNonNightlyChannels(t *testing.T) {
 
 				_, err := CheckOutLatest(binary, rootDir, "", channel, log.NewNopLogger())
 				require.Error(t, err, "expected error when using new TUF lookup on channel that should be using legacy")
+			})
+		}
+	}
+}
+
+func TestUsingNewAutoupdater(t *testing.T) {
+	t.Parallel()
+
+	for _, binary := range binaries {
+		binary := binary
+		for _, channel := range []string{"beta", "stable", "nightly", "alpha"} {
+			channel := channel
+			t.Run(fmt.Sprintf("%s-%s", binary, channel), func(t *testing.T) {
+				t.Parallel()
+				require.False(t, UsingNewAutoupdater())
 			})
 		}
 	}
@@ -190,11 +207,11 @@ func Test_usingNewAutoupdater(t *testing.T) {
 	}{
 		{
 			channelName:        "nightly",
-			usesNewAutoupdater: true,
+			usesNewAutoupdater: false,
 		},
 		{
 			channelName:        "alpha",
-			usesNewAutoupdater: true,
+			usesNewAutoupdater: false,
 		},
 		{
 			channelName:        "stable",

--- a/pkg/autoupdate/tuf/library_lookup_test.go
+++ b/pkg/autoupdate/tuf/library_lookup_test.go
@@ -17,9 +17,9 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) { //nolint: paralleltest
 		channelsUsingLegacyAutoupdate["nightly"] = true
 	}()
 
-	for _, binary := range binaries {
+	for _, binary := range binaries { //nolint: paralleltest
 		binary := binary
-		t.Run(string(binary), func(t *testing.T) { //nolint: paralleltest
+		t.Run(string(binary), func(t *testing.T) {
 			// Set up an update library
 			rootDir := t.TempDir()
 			updateDir := defaultLibraryDirectory(rootDir)
@@ -59,9 +59,9 @@ func TestCheckOutLatest_withoutTufRepository(t *testing.T) { // nolint:parallelt
 		channelsUsingLegacyAutoupdate["nightly"] = true
 	}()
 
-	for _, binary := range binaries {
+	for _, binary := range binaries { //nolint: paralleltest
 		binary := binary
-		t.Run(string(binary), func(t *testing.T) { // nolint:paralleltest
+		t.Run(string(binary), func(t *testing.T) {
 			// Set up an update library, but no TUF repo
 			rootDir := t.TempDir()
 			updateDir := defaultLibraryDirectory(rootDir)


### PR DESCRIPTION
Rolls back a few of the recent TUF changes -- most notably, nightly/alpha should no longer use the new autoupdater, and we should not set or use the installed version env var.