### PR TITLE
If autoupdate channel is not set, do not use new autoupdater

### DIFF
--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -26,12 +26,7 @@ type autoupdateConfig struct {
 	localDevelopmentPath string
 }
 
-var channelsUsingLegacyAutoupdate = map[string]bool{
-	"stable":  true,
-	"beta":    true,
-	"alpha":   true,
-	"nightly": true,
-}
+var channelsUsingNewAutoupdater = map[string]bool{}
 
 // CheckOutLatestWithoutConfig returns information about the latest downloaded executable for our binary,
 // searching for launcher configuration values in its config file.
@@ -123,8 +118,8 @@ func CheckOutLatest(binary autoupdatableBinary, rootDirectory string, updateDire
 }
 
 func usingNewAutoupdater(channel string) bool {
-	_, ok := channelsUsingLegacyAutoupdate[channel]
-	return !ok
+	_, ok := channelsUsingNewAutoupdater[channel]
+	return ok
 }
 
 // findExecutableFromRelease looks at our local TUF repository to find the release for our

--- a/pkg/autoupdate/tuf/library_lookup_test.go
+++ b/pkg/autoupdate/tuf/library_lookup_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestCheckOutLatest_withTufRepository(t *testing.T) { //nolint: paralleltest
-	delete(channelsUsingLegacyAutoupdate, "nightly")
+	channelsUsingNewAutoupdater["nightly"] = true
 	defer func() {
-		channelsUsingLegacyAutoupdate["nightly"] = true
+		delete(channelsUsingNewAutoupdater, "nightly")
 	}()
 
 	for _, binary := range binaries { //nolint: paralleltest
@@ -54,9 +54,9 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) { //nolint: paralleltest
 }
 
 func TestCheckOutLatest_withoutTufRepository(t *testing.T) { // nolint:paralleltest
-	delete(channelsUsingLegacyAutoupdate, "nightly")
+	channelsUsingNewAutoupdater["nightly"] = true
 	defer func() {
-		channelsUsingLegacyAutoupdate["nightly"] = true
+		delete(channelsUsingNewAutoupdater, "nightly")
 	}()
 
 	for _, binary := range binaries { //nolint: paralleltest
@@ -219,6 +219,10 @@ func Test_usingNewAutoupdater(t *testing.T) {
 		},
 		{
 			channelName:        "beta",
+			usesNewAutoupdater: false,
+		},
+		{
+			channelName:        "",
 			usesNewAutoupdater: false,
 		},
 	}


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1365

The bug can be reproduced by running launcher against a config file that does not have an `update_channel` set.