### PR TITLE
[TUF] Don't call Fatal when there are no updates downloaded yet

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -170,7 +170,7 @@ func runSubcommands() error {
 func runNewerLauncherIfAvailable(ctx context.Context, logger log.Logger) {
 	newerBinary, err := latestLauncherPath(ctx, logger)
 	if err != nil {
-		logutil.Fatal(logger, "msg", "checking for updated version", "err", err)
+		level.Info(logger).Log("msg", "could not get updated version", "err", err)
 	}
 
 	if newerBinary == "" {


### PR DESCRIPTION
When fixing the immediate issue for https://github.com/kolide/launcher/issues/1365, I noticed that we should not be failing out regardless -- in the event that there are no updates in the library, we should continue to run the current binary.