### PR TITLE
Allocate less memory when gathering stack

### DIFF
--- a/pkg/debug/checkups/runtime.go
+++ b/pkg/debug/checkups/runtime.go
@@ -80,7 +80,7 @@ func gatherStack(z *zip.Writer) error {
 		return fmt.Errorf("creating stack: %w", err)
 	}
 
-	buf := make([]byte, 1<<32)
+	buf := make([]byte, 1<<16)
 	stacklen := runtime.Stack(buf, true)
 	if _, err := out.Write(buf[0:stacklen]); err != nil {
 		return fmt.Errorf("writing file: %w", err)


### PR DESCRIPTION
Noticed this issue in flare when running end-to-end tests for launcher on a smallish Windows VM:

```
runtime: VirtualAlloc of 4294967296 bytes failed with errno=1455
fatal error: out of memory
```

The runtime stack points to

```
github.com/kolide/launcher/pkg/debug/checkups.gatherStack(0x13f2e40?)
        D:/a/launcher/launcher/pkg/debug/checkups/runtime.go:83 +0x92 fp=0xc0001716c0 sp=0xc000171660 pc=0xf291f2
```

I don't think we need to allocate as much as we are right now -- moved us down to an amount that's still 10x larger than the actual stack when I test.