### PR TITLE
Listen for sigterm, so launcher can shut down gracefully on launchd unload

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -222,8 +222,8 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	runGroup.Add("sigChannel", func() error {
 		signal.Notify(sigChannel, os.Interrupt, syscall.SIGTERM)
 		select {
-		case <-sigChannel:
-			level.Info(logger).Log("msg", "beginning shutdown via signal")
+		case sig := <-sigChannel:
+			level.Info(logger).Log("msg", "beginning shutdown via signal", "signal_received", sig)
 			return nil
 		}
 	}, func(_ error) {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -219,7 +220,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 	// Add a rungroup to catch things on the sigChannel
 	// Attach a notifier for os.Interrupt
 	runGroup.Add("sigChannel", func() error {
-		signal.Notify(sigChannel, os.Interrupt)
+		signal.Notify(sigChannel, os.Interrupt, syscall.SIGTERM)
 		select {
 		case <-sigChannel:
 			level.Info(logger).Log("msg", "beginning shutdown via signal")


### PR DESCRIPTION
We don't get shutdown logs in launcher right now because launcher is not listening for SIGTERM, which is what launchd will send launcher when shutting it down. With this update, launcher will a) log its shutdown, making logs easier to understand; and b) attempt a graceful shutdown via the rungroup actors.