### PR TITLE
Ensure osquery config map is always initialized

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -544,6 +544,8 @@ func (e *Extension) setVerbose(config string, osqueryVerbose bool) string {
 			level.Debug(e.logger).Log("msg", "could not unmarshal config, cannot set verbose", "err", err)
 			return config
 		}
+	} else {
+		cfg = make(map[string]any)
 	}
 
 	var opts map[string]any

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -550,7 +550,11 @@ func (e *Extension) setVerbose(config string, osqueryVerbose bool) string {
 
 	var opts map[string]any
 	if cfgOpts, ok := cfg["options"]; ok {
-		opts = cfgOpts.(map[string]any)
+		opts, ok = cfgOpts.(map[string]any)
+		if !ok {
+			level.Debug(e.logger).Log("msg", "config options are malformed, cannot set verbose")
+			return config
+		}
 	} else {
 		opts = make(map[string]any)
 	}

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1302,3 +1302,23 @@ func Test_setVerbose_EmptyConfig(t *testing.T) {
 
 	require.Equal(t, expectedCfg, modifiedCfg)
 }
+
+func Test_setVerbose_MalformedConfig(t *testing.T) {
+	t.Parallel()
+
+	e := &Extension{
+		logger: log.NewNopLogger(),
+	}
+
+	malformedCfg := map[string]any{
+		"options": "options should not be a string, yet it is, oops",
+	}
+	cfgBytes, err := json.Marshal(malformedCfg)
+	require.NoError(t, err)
+	modifiedCfgStr := e.setVerbose(string(cfgBytes), true)
+
+	var modifiedCfg map[string]any
+	require.NoError(t, json.Unmarshal([]byte(modifiedCfgStr), &modifiedCfg))
+
+	require.Equal(t, malformedCfg, modifiedCfg)
+}

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1281,3 +1281,24 @@ func Test_setVerbose(t *testing.T) {
 		})
 	}
 }
+
+func Test_setVerbose_EmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	e := &Extension{
+		logger: log.NewNopLogger(),
+	}
+
+	expectedCfg := map[string]any{
+		"options": map[string]any{
+			"verbose": true,
+		},
+	}
+
+	modifiedCfgStr := e.setVerbose("", true)
+
+	var modifiedCfg map[string]any
+	require.NoError(t, json.Unmarshal([]byte(modifiedCfgStr), &modifiedCfg))
+
+	require.Equal(t, expectedCfg, modifiedCfg)
+}


### PR DESCRIPTION
Fixes panic that can occur if the osquery config is an empty string ("" not "{}"). Fixes panic that can occur if the osquery config options key is malformed.