### PR TITLE
Don't log turning off verbose logging more than once

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -523,7 +523,10 @@ func (e *Extension) generateConfigsWithReenroll(ctx context.Context, reenroll bo
 	// If osquery has been running successfully for 10 minutes, then turn off verbose logs.
 	osqueryVerbose := true
 	if uptimeMins, err := history.LatestInstanceUptimeMinutes(); err == nil && uptimeMins >= 10 {
-		level.Debug(e.logger).Log("msg", "osquery has been up for more than 10 minutes, turning off verbose logging", "uptime_mins", uptimeMins)
+		// Only log the state change once -- RequestConfig happens every 5 mins
+		if uptimeMins <= 15 {
+			level.Debug(e.logger).Log("msg", "osquery has been up for more than 10 minutes, turning off verbose logging", "uptime_mins", uptimeMins)
+		}
 		osqueryVerbose = false
 	}
 	config = e.setVerbose(config, osqueryVerbose)


### PR DESCRIPTION
Currently we log `osquery has been up for more than 10 minutes, turning off verbose logging` every 10 minutes, which is not useful. This PR adjusts that behavior.