### PR TITLE
Log query params and URL when we can't extract the challenge box

### DIFF
--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -136,7 +136,7 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 		challengeBox, err := extractChallenge(r)
 		if err != nil {
 			traces.SetError(span, err)
-			level.Debug(e.logger).Log("msg", "failed to extract box from request", "err", err)
+			level.Debug(e.logger).Log("msg", "failed to extract box from request", "err", err, "path", r.URL.Path, "query_params", r.URL.RawQuery)
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Example updated log, now making it easier to see which request (/v1/cmd and not /v0/cmd) has the associated error and what the invalid box looks like:

```
{"caller":"server.go:2514",
"component":"localserver",
"err":"msgpack: number of fields in array-encoded struct has changed",
"keytype":"ec",
"level":"debug",
"msg":"failed to extract box from request",
"path":"/v1/cmd",
"query_params":"box=null",
"session_pid":40707,
"ts":"2023-10-05T17:47:04.15271Z"}
```