### PR TITLE
Give rungroup actors enough time to shut down on service shutdown

### DIFF
--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -92,8 +92,8 @@ func runWindowsSvc(args []string) error {
 	defer func() {
 		if r := recover(); r != nil {
 			level.Info(logger).Log(
-				"msg", "panic occurred",
-				"err", err,
+				"msg", "panic occurred in windows service",
+				"err", r,
 			)
 			time.Sleep(time.Second)
 		}
@@ -186,7 +186,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				level.Info(w.logger).Log("msg", "shutdown request received")
 				changes <- svc.Status{State: svc.StopPending}
 				cancel()
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(2 * time.Second) // give rungroups enough time to shut down
 				changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
 				return ssec, errno
 			default:


### PR DESCRIPTION
I was consistently seeing only 8 of 13 actors get a chance to shut down on windows on service stop -- waiting slightly longer before we return and exit the service gives the other actors a chance to shut down gracefully as well.

As a drive-by, fixes the log when recovering from a panic to include info about the panic.