### PR TITLE
add uptime to hostinfo checkup and tests

### DIFF
--- a/pkg/debug/checkups/checkpoint.go
+++ b/pkg/debug/checkups/checkpoint.go
@@ -75,7 +75,7 @@ func (c *checkPointer) summarizeData(data any) any {
 	switch knownValue := data.(type) {
 	case []string:
 		return strings.Join(knownValue, ",")
-	case string, uint, int, int32, int64:
+	case string, uint, uint64, int, int32, int64:
 		return knownValue
 	default:
 		return fmt.Sprintf("%v", data)

--- a/pkg/debug/checkups/host.go
+++ b/pkg/debug/checkups/host.go
@@ -96,7 +96,7 @@ func formatUptime(uptime uint64) string {
 	for _, unit := range []string{"days", "hours", "minutes", "seconds"} {
 		divisor := unitDivisors[unit]
 		if uptime >= divisor {
-			if uptime == divisor { // cut plural ending if the quantity will be singular
+			if uptime/divisor < 2 { // cut plural ending if the quantity will be singular
 				unit = strings.TrimRight(unit, "s")
 			}
 

--- a/pkg/debug/checkups/host_test.go
+++ b/pkg/debug/checkups/host_test.go
@@ -11,6 +11,7 @@ func Test_formatUptime(t *testing.T) {
 		want   string
 	}{
 		{name: "1 day", uptime: 86400, want: "1 day"},
+		{name: "just over 1 day", uptime: 86401, want: "1 day, 1 second"},
 		{name: "less than a day", uptime: 82860, want: "23 hours, 1 minute"},
 		{name: "just booted", uptime: 0, want: "0 seconds"},
 		{name: "you should reboot", uptime: 34559999, want: "399 days, 23 hours, 59 minutes, 59 seconds"},

--- a/pkg/debug/checkups/host_test.go
+++ b/pkg/debug/checkups/host_test.go
@@ -1,0 +1,27 @@
+package checkups
+
+import "testing"
+
+func Test_formatUptime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		uptime uint64
+		want   string
+	}{
+		{name: "1 day", uptime: 86400, want: "1 day"},
+		{name: "less than a day", uptime: 82860, want: "23 hours, 1 minute"},
+		{name: "just booted", uptime: 0, want: "0 seconds"},
+		{name: "you should reboot", uptime: 34559999, want: "399 days, 23 hours, 59 minutes, 59 seconds"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatUptime(tt.uptime); got != tt.want {
+				t.Errorf("formatUptime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds uptime to the Host Info checkup. 

It will appear as informational output for doctor/flare as follows:
```
Host Info: hostname: example-macbook.localdomain, uptime: 7 days, 23 hours, 8 minutes, 38 seconds
```

It will be logged within checkpoints as follows:
```
zack:launcher❱ lastcheck 'Host Info' | jq '{uptime, uptime_friendly}'
{
  "uptime": 687982,
  "uptime_friendly": "7 days, 23 hours, 6 minutes, 22 seconds"
}
```