### PR TITLE
Expand TUF checkup

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate.go
+++ b/pkg/autoupdate/tuf/autoupdate.go
@@ -118,7 +118,7 @@ func NewTufAutoupdater(k types.Knapsack, metadataHttpClient *http.Client, mirror
 	// If the update directory wasn't set by a flag, use the default location of <launcher root>/updates.
 	updateDirectory := k.UpdateDirectory()
 	if updateDirectory == "" {
-		updateDirectory = defaultLibraryDirectory(k.RootDirectory())
+		updateDirectory = DefaultLibraryDirectory(k.RootDirectory())
 	}
 	ta.libraryManager, err = newUpdateLibraryManager(k.MirrorServerURL(), mirrorHttpClient, updateDirectory, ta.logger)
 	if err != nil {
@@ -170,7 +170,7 @@ func LocalTufDirectory(rootDirectory string) string {
 	return filepath.Join(rootDirectory, tufDirectoryName)
 }
 
-func defaultLibraryDirectory(rootDirectory string) string {
+func DefaultLibraryDirectory(rootDirectory string) string {
 	return filepath.Join(rootDirectory, "updates")
 }
 

--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -19,14 +19,6 @@ type BinaryUpdateInfo struct {
 	Version string
 }
 
-func (b *BinaryUpdateInfo) String() string {
-	if b.Version != "" {
-		return fmt.Sprintf("%s at %s", b.Version, b.Path)
-	}
-
-	return b.Path
-}
-
 type autoupdateConfig struct {
 	rootDirectory        string
 	updateDirectory      string

--- a/pkg/autoupdate/tuf/library_lookup.go
+++ b/pkg/autoupdate/tuf/library_lookup.go
@@ -19,6 +19,14 @@ type BinaryUpdateInfo struct {
 	Version string
 }
 
+func (b *BinaryUpdateInfo) String() string {
+	if b.Version != "" {
+		return fmt.Sprintf("%s at %s", b.Version, b.Path)
+	}
+
+	return b.Path
+}
+
 type autoupdateConfig struct {
 	rootDirectory        string
 	updateDirectory      string
@@ -103,7 +111,7 @@ func CheckOutLatest(binary autoupdatableBinary, rootDirectory string, updateDire
 	}
 
 	if updateDirectory == "" {
-		updateDirectory = defaultLibraryDirectory(rootDirectory)
+		updateDirectory = DefaultLibraryDirectory(rootDirectory)
 	}
 
 	update, err := findExecutableFromRelease(binary, LocalTufDirectory(rootDirectory), channel, updateDirectory)

--- a/pkg/autoupdate/tuf/library_lookup_test.go
+++ b/pkg/autoupdate/tuf/library_lookup_test.go
@@ -21,7 +21,7 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) {
 
 			// Set up an update library
 			rootDir := t.TempDir()
-			updateDir := defaultLibraryDirectory(rootDir)
+			updateDir := DefaultLibraryDirectory(rootDir)
 
 			// Set up a local TUF repo
 			tufDir := LocalTufDirectory(rootDir)
@@ -61,7 +61,7 @@ func TestCheckOutLatest_withoutTufRepository(t *testing.T) {
 
 			// Set up an update library, but no TUF repo
 			rootDir := t.TempDir()
-			updateDir := defaultLibraryDirectory(rootDir)
+			updateDir := DefaultLibraryDirectory(rootDir)
 			target := fmt.Sprintf("%s-1.1.1.tar.gz", binary)
 			executablePath, executableVersion := pathToTargetVersionExecutable(binary, target, updateDir)
 			require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))

--- a/pkg/autoupdate/tuf/library_manager_test.go
+++ b/pkg/autoupdate/tuf/library_manager_test.go
@@ -42,7 +42,7 @@ func Test_newUpdateLibraryManager(t *testing.T) {
 func Test_pathToTargetVersionExecutable(t *testing.T) {
 	t.Parallel()
 
-	testBaseDir := defaultLibraryDirectory(t.TempDir())
+	testBaseDir := DefaultLibraryDirectory(t.TempDir())
 
 	testVersion := "1.0.7-30-abcdabcd"
 	testTargetFilename := fmt.Sprintf("launcher-%s.tar.gz", testVersion)

--- a/pkg/debug/checkups/tuf.go
+++ b/pkg/debug/checkups/tuf.go
@@ -200,15 +200,17 @@ func (tc *tufCheckup) selectedVersions() map[string]map[string]string {
 	}
 
 	if launcherVersion, err := tuf.CheckOutLatestWithoutConfig("launcher", log.NewNopLogger()); err != nil {
-		selectedVersions["launcher"]["version"] = fmt.Sprintf("error checking out latest version: %v", err)
+		selectedVersions["launcher"]["path"] = fmt.Sprintf("error checking out latest version: %v", err)
 	} else {
-		selectedVersions["launcher"]["version"] = launcherVersion.String()
+		selectedVersions["launcher"]["path"] = launcherVersion.Path
+		selectedVersions["launcher"]["version"] = launcherVersion.Version
 	}
 
 	if osquerydVersion, err := tuf.CheckOutLatestWithoutConfig("osqueryd", log.NewNopLogger()); err != nil {
-		selectedVersions["osqueryd"]["version"] = fmt.Sprintf("error checking out latest version: %v", err)
+		selectedVersions["osqueryd"]["path"] = fmt.Sprintf("error checking out latest version: %v", err)
 	} else {
-		selectedVersions["osqueryd"]["version"] = osquerydVersion.String()
+		selectedVersions["osqueryd"]["path"] = osquerydVersion.Path
+		selectedVersions["osqueryd"]["version"] = osquerydVersion.Version
 	}
 
 	return selectedVersions

--- a/pkg/debug/checkups/tuf.go
+++ b/pkg/debug/checkups/tuf.go
@@ -7,8 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 
+	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/pkg/agent/types"
 	"github.com/kolide/launcher/pkg/autoupdate/tuf"
 )
@@ -30,13 +33,14 @@ type (
 	tufRelease struct {
 		Signed struct {
 			Targets map[string]customTufRelease `json:"targets"`
+			Version int                         `json:"version"`
 		} `json:"signed"`
 	}
 )
 
 func (tc *tufCheckup) Data() map[string]any  { return tc.data }
-func (tc *tufCheckup) ExtraFileName() string { return "" }
-func (tc *tufCheckup) Name() string          { return "Tuf Version" }
+func (tc *tufCheckup) ExtraFileName() string { return "tuf.json" }
+func (tc *tufCheckup) Name() string          { return "TUF" }
 func (tc *tufCheckup) Status() Status        { return tc.status }
 func (tc *tufCheckup) Summary() string       { return tc.summary }
 
@@ -54,7 +58,8 @@ func (tc *tufCheckup) Run(ctx context.Context, extraFH io.Writer) error {
 		return err
 	}
 
-	response, err := tc.fetchTufVersion(httpClient, tufUrl)
+	// Primarily, we want to validate that we can talk to the TUF server
+	releaseVersion, remoteMetadataVersion, err := tc.remoteTufMetadata(httpClient, tufUrl)
 	if err != nil {
 		tc.status = Erroring
 		tc.data[tufUrl.String()] = err.Error()
@@ -62,7 +67,7 @@ func (tc *tufCheckup) Run(ctx context.Context, extraFH io.Writer) error {
 		return nil
 	}
 
-	if response == "" {
+	if releaseVersion == "" {
 		tc.status = Failing
 		tc.data[tufUrl.String()] = "missing from tuf response"
 		tc.summary = "missing version from tuf targets response"
@@ -70,35 +75,141 @@ func (tc *tufCheckup) Run(ctx context.Context, extraFH io.Writer) error {
 	}
 
 	tc.status = Passing
-	tc.data[tufUrl.String()] = response
-	tc.summary = fmt.Sprintf("Successfully gathered release version %s from %s", response, tufUrl.String())
+	tc.data[tufUrl.String()] = releaseVersion
+	tc.summary = fmt.Sprintf("Successfully gathered release version %s from %s", releaseVersion, tufUrl.String())
+
+	// Gather additional data only if we're running flare
+	if extraFH == io.Discard {
+		return nil
+	}
+
+	tufData := map[string]any{
+		"remote_metadata_version": remoteMetadataVersion,
+	}
+
+	if localMetadataVersion, err := tc.localTufMetadata(); err != nil {
+		tufData["local_metadata_version"] = fmt.Sprintf("error getting local metadata version: %v", err)
+	} else {
+		tufData["local_metadata_version"] = localMetadataVersion
+	}
+
+	if localLauncherVersions, err := tc.versionsInLauncherLibrary(); err != nil {
+		tufData["launcher_versions_in_library"] = fmt.Sprintf("error getting versions available in local launcher library: %v", err)
+	} else {
+		tufData["launcher_versions_in_library"] = localLauncherVersions
+	}
+
+	if localOsqueryVersions, err := tc.versionsInOsquerydLibrary(); err != nil {
+		tufData["osqueryd_versions_in_library"] = fmt.Sprintf("error getting versions available in local osqueryd library: %v", err)
+	} else {
+		tufData["osqueryd_versions_in_library"] = localOsqueryVersions
+	}
+
+	tufData["selected_versions"] = tc.selectedVersions()
+
+	if b, err := json.Marshal(tufData); err == nil {
+		_, _ = extraFH.Write(b)
+	}
 
 	return nil
 }
 
-// fetchTufVersion retrieves the latest targets.json from the tuf URL provided.
+// remoteTufMetadata retrieves the latest targets.json from the tuf URL provided.
 // We're attempting to key into the current target for the current platform here,
 // which should look like:
 // https://[TUF_HOST]/repository/targets.json -> full targets blob
 // ---> signed -> targets -> launcher/<GOOS>/<GOARCH|universal>/<RELEASE_CHANNEL>/release.json -> custom -> target
-func (tc *tufCheckup) fetchTufVersion(client *http.Client, url *url.URL) (string, error) {
-	response, err := client.Get(url.String())
+func (tc *tufCheckup) remoteTufMetadata(client *http.Client, tufUrl *url.URL) (string, int, error) {
+	response, err := client.Get(tufUrl.String())
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	defer response.Body.Close()
 
 	var releaseTargets tufRelease
 	if err := json.NewDecoder(response.Body).Decode(&releaseTargets); err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	upgradePathKey := fmt.Sprintf("launcher/%s/%s/%s/release.json", runtime.GOOS, tuf.PlatformArch(), tc.k.UpdateChannel())
 	hostTargets, ok := releaseTargets.Signed.Targets[upgradePathKey]
 
 	if !ok {
-		return "", fmt.Errorf("unable to find matching release data for %s", upgradePathKey)
+		return "", releaseTargets.Signed.Version, fmt.Errorf("unable to find matching release data for %s", upgradePathKey)
 	}
 
-	return hostTargets.Custom.Target, nil
+	return hostTargets.Custom.Target, releaseTargets.Signed.Version, nil
+}
+
+// localTufMetadata inspects the local target metadata to extract the metadata version.
+// We can compare this version to the one retrieved by `remoteTufMetadata` to see whether
+// this installation of launcher is successfully updating its TUF repository.
+func (tc *tufCheckup) localTufMetadata() (int, error) {
+	targetsMetadataFile := filepath.Join(tuf.LocalTufDirectory(tc.k.RootDirectory()), "targets.json")
+	b, err := os.ReadFile(targetsMetadataFile)
+	if err != nil {
+		return 0, fmt.Errorf("reading file %s: %w", targetsMetadataFile, err)
+	}
+
+	var releaseTargets tufRelease
+	if err := json.Unmarshal(b, &releaseTargets); err != nil {
+		return 0, fmt.Errorf("unmarshalling file %s: %w", targetsMetadataFile, err)
+	}
+
+	return releaseTargets.Signed.Version, nil
+}
+
+// versionsInLauncherLibrary returns all updates available in the launcher update directory.
+func (tc *tufCheckup) versionsInLauncherLibrary() ([]string, error) {
+	updatesDir := tc.k.UpdateDirectory()
+	if updatesDir == "" {
+		updatesDir = tuf.DefaultLibraryDirectory(tc.k.RootDirectory())
+	}
+
+	launcherVersionMatchPattern := filepath.Join(updatesDir, "launcher", "*")
+	launcherMatches, err := filepath.Glob(launcherVersionMatchPattern)
+	if err != nil {
+		return nil, fmt.Errorf("globbing for launcher matches at %s: %w", launcherVersionMatchPattern, err)
+	}
+
+	return launcherMatches, nil
+}
+
+// versionsInOsquerydLibrary returns all updates available in the osqueryd update directory.
+func (tc *tufCheckup) versionsInOsquerydLibrary() ([]string, error) {
+	updatesDir := tc.k.UpdateDirectory()
+	if updatesDir == "" {
+		updatesDir = tuf.DefaultLibraryDirectory(tc.k.RootDirectory())
+	}
+
+	osquerydVersionMatchPattern := filepath.Join(updatesDir, "osqueryd", "*")
+	osquerydMatches, err := filepath.Glob(osquerydVersionMatchPattern)
+	if err != nil {
+		return nil, fmt.Errorf("globbing for osqueryd matches at %s: %w", osquerydVersionMatchPattern, err)
+	}
+
+	return osquerydMatches, nil
+}
+
+// selectedVersions returns the versions of launcher and osqueryd that the current
+// installation would select as the correct version to run.
+func (tc *tufCheckup) selectedVersions() map[string]map[string]string {
+	selectedVersions := map[string]map[string]string{
+		"launcher": make(map[string]string),
+		"osqueryd": make(map[string]string),
+	}
+
+	if launcherVersion, err := tuf.CheckOutLatestWithoutConfig("launcher", log.NewNopLogger()); err != nil {
+		selectedVersions["launcher"]["version"] = fmt.Sprintf("error checking out latest version: %v", err)
+	} else {
+		selectedVersions["launcher"]["version"] = launcherVersion.String()
+	}
+
+	if osquerydVersion, err := tuf.CheckOutLatestWithoutConfig("osqueryd", log.NewNopLogger()); err != nil {
+		selectedVersions["osqueryd"]["version"] = fmt.Sprintf("error checking out latest version: %v", err)
+	} else {
+		selectedVersions["osqueryd"]["version"] = osquerydVersion.String()
+	}
+
+	return selectedVersions
 }

--- a/pkg/debug/checkups/tuf.go
+++ b/pkg/debug/checkups/tuf.go
@@ -108,8 +108,8 @@ func (tc *tufCheckup) Run(ctx context.Context, extraFH io.Writer) error {
 
 	tufData["selected_versions"] = tc.selectedVersions()
 
-	if b, err := json.Marshal(tufData); err == nil {
-		_, _ = extraFH.Write(b)
+	if err := json.NewEncoder(extraFH).Encode(tufData); err != nil {
+		tc.summary += fmt.Sprintf("; cannot write extra data: %v", err)
 	}
 
 	return nil

--- a/pkg/debug/checkups/tuf.go
+++ b/pkg/debug/checkups/tuf.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/pkg/agent/types"
@@ -160,7 +161,7 @@ func (tc *tufCheckup) localTufMetadata() (int, error) {
 }
 
 // versionsInLauncherLibrary returns all updates available in the launcher update directory.
-func (tc *tufCheckup) versionsInLauncherLibrary() ([]string, error) {
+func (tc *tufCheckup) versionsInLauncherLibrary() (string, error) {
 	updatesDir := tc.k.UpdateDirectory()
 	if updatesDir == "" {
 		updatesDir = tuf.DefaultLibraryDirectory(tc.k.RootDirectory())
@@ -169,14 +170,19 @@ func (tc *tufCheckup) versionsInLauncherLibrary() ([]string, error) {
 	launcherVersionMatchPattern := filepath.Join(updatesDir, "launcher", "*")
 	launcherMatches, err := filepath.Glob(launcherVersionMatchPattern)
 	if err != nil {
-		return nil, fmt.Errorf("globbing for launcher matches at %s: %w", launcherVersionMatchPattern, err)
+		return "", fmt.Errorf("globbing for launcher matches at %s: %w", launcherVersionMatchPattern, err)
 	}
 
-	return launcherMatches, nil
+	launcherVersions := make([]string, len(launcherMatches))
+	for i := 0; i < len(launcherMatches); i += 1 {
+		launcherVersions[i] = filepath.Base(launcherMatches[i])
+	}
+
+	return strings.Join(launcherVersions, ","), nil
 }
 
 // versionsInOsquerydLibrary returns all updates available in the osqueryd update directory.
-func (tc *tufCheckup) versionsInOsquerydLibrary() ([]string, error) {
+func (tc *tufCheckup) versionsInOsquerydLibrary() (string, error) {
 	updatesDir := tc.k.UpdateDirectory()
 	if updatesDir == "" {
 		updatesDir = tuf.DefaultLibraryDirectory(tc.k.RootDirectory())
@@ -185,10 +191,15 @@ func (tc *tufCheckup) versionsInOsquerydLibrary() ([]string, error) {
 	osquerydVersionMatchPattern := filepath.Join(updatesDir, "osqueryd", "*")
 	osquerydMatches, err := filepath.Glob(osquerydVersionMatchPattern)
 	if err != nil {
-		return nil, fmt.Errorf("globbing for osqueryd matches at %s: %w", osquerydVersionMatchPattern, err)
+		return "", fmt.Errorf("globbing for osqueryd matches at %s: %w", osquerydVersionMatchPattern, err)
 	}
 
-	return osquerydMatches, nil
+	osquerydVersions := make([]string, len(osquerydMatches))
+	for i := 0; i < len(osquerydMatches); i += 1 {
+		osquerydVersions[i] = filepath.Base(osquerydMatches[i])
+	}
+
+	return strings.Join(osquerydVersions, ","), nil
 }
 
 // selectedVersions returns the versions of launcher and osqueryd that the current

--- a/pkg/debug/checkups/tuf_test.go
+++ b/pkg/debug/checkups/tuf_test.go
@@ -1,0 +1,60 @@
+package checkups
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	typesmocks "github.com/kolide/launcher/pkg/agent/types/mocks"
+	tufci "github.com/kolide/launcher/pkg/autoupdate/tuf/ci"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_Tuf(t *testing.T) {
+	t.Parallel()
+
+	tempRootDir := t.TempDir()
+	testReleaseVersion := "2.3.4"
+
+	// Set up a test TUF server to serve legitimate metadata
+	tufServerUrl, _ := tufci.InitRemoteTufServer(t, testReleaseVersion)
+
+	// Set up mock knapsack
+	mockKnapsack := typesmocks.NewKnapsack(t)
+	mockKnapsack.On("Autoupdate").Return(true)
+	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
+	mockKnapsack.On("UpdateChannel").Return("nightly")
+	mockKnapsack.On("RootDirectory").Return(tempRootDir)
+	mockKnapsack.On("UpdateDirectory").Return("")
+
+	testTufCheckup := &tufCheckup{k: mockKnapsack}
+
+	output := &bytes.Buffer{}
+
+	require.NoError(t, testTufCheckup.Run(context.TODO(), output), "did not expect error running checkup")
+
+	// Validate status
+	require.Equal(t, Passing, testTufCheckup.status, "expected passing status")
+
+	// Validate summary -- just confirm we set something
+	require.Greater(t, len(testTufCheckup.summary), 0, "expected summary to be set")
+
+	// Validate data
+	expectedDataKey := fmt.Sprintf("%s/repository/targets.json", tufServerUrl)
+	require.Contains(t, testTufCheckup.data, expectedDataKey, "missing data")
+	launcherTarget, ok := testTufCheckup.data[expectedDataKey].(string)
+	require.True(t, ok, "unexpected type for data key")
+	require.True(t, strings.HasSuffix(launcherTarget, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)))
+
+	// Validate tuf.json has expected data
+	var d map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &d))
+	require.Contains(t, d, "remote_metadata_version")
+	require.Contains(t, d, "local_metadata_version")
+	require.Contains(t, d, "launcher_versions_in_library")
+	require.Contains(t, d, "osqueryd_versions_in_library")
+	require.Contains(t, d, "selected_versions")
+}


### PR DESCRIPTION
Expands the current checkup to pull additional data.

Example output:

```
{
    "launcher_versions_in_library":[
        "/var/kolide-k2/k2device-preprod.kolide.com/updates/launcher/1.1.2",
        "/var/kolide-k2/k2device-preprod.kolide.com/updates/launcher/1.1.2-13-g2789a54",
        "/var/kolide-k2/k2device-preprod.kolide.com/updates/launcher/1.1.2-15-gaa6f573"
    ],
    "local_metadata_version":246,
    "osqueryd_versions_in_library":[
        "/var/kolide-k2/k2device-preprod.kolide.com/updates/osqueryd/5.10.1"
    ],
    "remote_metadata_version":246,
    "selected_versions":{
        "launcher":{
            "path":"/Users/rebeccamahany-horton/Repos/launcher/build/darwin.universal/Kolide.app/Contents/MacOS/launcher",
            "version": ""
        },
        "osqueryd":{
            "path":"/var/kolide-k2/k2device-preprod.kolide.com/updates/osqueryd/5.10.1/osquery.app/Contents/MacOS/osqueryd",
            "version": "5.10.1"
        }
    }
}
```