### PR TITLE
Ensure there's no schema url mismatch on resource merge

### DIFF
--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -237,7 +237,7 @@ func (t *TraceExporter) setNewGlobalProvider() {
 
 	r, err := resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL, t.attrs...),
+		resource.NewWithAttributes(resource.Default().SchemaURL(), t.attrs...),
 	)
 	if err != nil {
 		level.Debug(t.logger).Log("msg", "could not merge resource", "err", err)

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 )
@@ -240,6 +240,7 @@ func (t *TraceExporter) setNewGlobalProvider() {
 		resource.NewWithAttributes(semconv.SchemaURL, t.attrs...),
 	)
 	if err != nil {
+		level.Debug(t.logger).Log("msg", "could not merge resource", "err", err)
 		r = resource.Default()
 	}
 

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -235,9 +235,10 @@ func (t *TraceExporter) setNewGlobalProvider() {
 	t.attrLock.RLock()
 	defer t.attrLock.RUnlock()
 
+	defaultResource := resource.Default()
 	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(resource.Default().SchemaURL(), t.attrs...),
+		defaultResource,
+		resource.NewWithAttributes(defaultResource.SchemaURL(), t.attrs...),
 	)
 	if err != nil {
 		level.Debug(t.logger).Log("msg", "could not merge resource", "err", err)


### PR DESCRIPTION
```
{"caller":"launcher.go:333","component":"trace_exporter","err":"cannot merge resource due to conflicting Schema URL","level":"debug","msg":"could not merge resource","session_pid":31747,"ts":"2023-10-19T19:23:53.554933Z"}
```