### PR TITLE
[Flare] Update a couple things in how flares are shipped

### DIFF
--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -33,7 +33,7 @@ func runFlare(args []string) error {
 		flagset            = flag.NewFlagSet("flare", flag.ExitOnError)
 		flSave             = flagset.String("save", "upload", "local | upload")
 		flOutputDir        = flagset.String("output_dir", ".", "path to directory to save flare output")
-		flUploadRequestURL = flagset.String("upload_request_url", "", "URL to request a signed upload URL")
+		flUploadRequestURL = flagset.String("upload_request_url", "https://api.kolide.com/api/agent/flare", "URL to request a signed upload URL")
 	)
 
 	if err := ff.Parse(flagset, args); err != nil {

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -30,22 +30,10 @@ func runFlare(args []string) error {
 	launcher.SetDefaultPaths()
 
 	var (
-		flagset = flag.NewFlagSet("flare", flag.ExitOnError)
-		flSave  = flagset.String(
-			"save",
-			"local",
-			"local | upload",
-		)
-		flOutputDir = flagset.String(
-			"output_dir",
-			".",
-			"path to directory to save flare output",
-		)
-		flUploadRequestURL = flagset.String(
-			"upload_request_url",
-			"",
-			"URL to request a signed upload URL",
-		)
+		flagset            = flag.NewFlagSet("flare", flag.ExitOnError)
+		flSave             = flagset.String("save", "upload", "local | upload")
+		flOutputDir        = flagset.String("output_dir", ".", "path to directory to save flare output")
+		flUploadRequestURL = flagset.String("upload_request_url", "", "URL to request a signed upload URL")
 	)
 
 	if err := ff.Parse(flagset, args); err != nil {

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -70,6 +70,7 @@ func runFlare(args []string) error {
 		Name() string
 	}
 	var flareDest flareDestinationTyp
+	var successMessage string
 
 	switch *flSave {
 	case "upload":
@@ -78,6 +79,7 @@ func runFlare(args []string) error {
 			return err
 		}
 		flareDest = shipper
+		successMessage = "Flare uploaded successfully"
 	case "local":
 		reportName := fmt.Sprintf("kolide_agent_flare_report_%s.zip", ulid.New())
 		reportPath := filepath.Join(*flOutputDir, reportName)
@@ -88,6 +90,7 @@ func runFlare(args []string) error {
 		}
 		defer flareFile.Close()
 		flareDest = flareFile
+		successMessage = "Flare saved locally"
 	default:
 		return fmt.Errorf(`invalid save option: %s, expected "local" or "upload"`, *flSave)
 
@@ -97,9 +100,6 @@ func runFlare(args []string) error {
 		return err
 	}
 
-	if flareDest.Name() == "" {
-		level.Info(logger).Log("msg", "Flare completed")
-	}
-	level.Info(logger).Log("msg", "Flare completed", "file", flareDest.Name())
+	level.Info(logger).Log("msg", successMessage, "file", flareDest.Name())
 	return nil
 }

--- a/pkg/debug/shipper/shipper.go
+++ b/pkg/debug/shipper/shipper.go
@@ -153,6 +153,7 @@ func (s *shipper) signedUrl() (string, error) {
 	}
 
 	signedUrlRequest.Header.Set(control.HeaderApiVersion, control.ApiVersion)
+	signedUrlRequest.Header.Set("Content-Type", "application/json")
 
 	signHttpRequest(signedUrlRequest, body)
 

--- a/pkg/debug/shipper/shipper.go
+++ b/pkg/debug/shipper/shipper.go
@@ -45,6 +45,7 @@ type shipper struct {
 	writer   io.WriteCloser
 	knapsack types.Knapsack
 
+	uploadName           string
 	uploadRequestURL     string
 	uploadRequest        *http.Request
 	uploadRequestStarted bool
@@ -89,6 +90,10 @@ func New(knapsack types.Knapsack, opts ...shipperOption) (*shipper, error) {
 	s.uploadRequest = req
 
 	return s, nil
+}
+
+func (s *shipper) Name() string {
+	return s.uploadName
 }
 
 func (s *shipper) Write(p []byte) (n int, err error) {
@@ -164,7 +169,8 @@ func (s *shipper) signedUrl() (string, error) {
 	defer signedUrlResponse.Body.Close()
 
 	responseData := struct {
-		URL string `json:"URL"`
+		URL  string `json:"URL"`
+		Name string `json:"name"`
 	}{}
 
 	if err := json.NewDecoder(signedUrlResponse.Body).Decode(&responseData); err != nil {
@@ -175,6 +181,7 @@ func (s *shipper) signedUrl() (string, error) {
 		return "", fmt.Errorf("got %s status in signed url response", signedUrlResponse.Status)
 	}
 
+	s.uploadName = responseData.Name
 	return responseData.URL, nil
 }
 


### PR DESCRIPTION
Now that the SaaS side supports flare shipping, I've found a couple of issues, and tweaks:

- The most important is that we need to set a `Content-Type` header. Otherwise rails won't parse the data and we don't get the extra stuff.
- Rails will return the file name the flare is saved as. I've added that into the json struct.
- Update the output to and unify the call paths
- Set flare to upload by default

I considered, but did not, adjust flare to _also_ print doctor output. I'm on the fence about output in general. So it's still TBD