### PR TITLE
Add `containedctx` as a linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   enable:
     - bodyclose
+    - containedctx
     - unused
     - gofmt
     - govet
@@ -36,5 +37,5 @@ issues:
   exclude-rules:
     # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
     - linters:
-      - paralleltest
+        - paralleltest
       text: "does not use range value in test Run"

--- a/cmd/launcher/internal/updater/updater.go
+++ b/cmd/launcher/internal/updater/updater.go
@@ -66,7 +66,7 @@ func NewUpdater(
 
 	updateCmd := &updaterCmd{
 		updater:                 updater,
-		ctx:                     ctx,
+		ctx:                     ctx, // nolint:containedctx
 		cancel:                  cancel,
 		stopChan:                make(chan bool),
 		config:                  config,
@@ -86,7 +86,7 @@ type updater interface {
 
 type updaterCmd struct {
 	updater                 updater
-	ctx                     context.Context
+	ctx                     context.Context // nolint:containedctx
 	cancel                  context.CancelFunc
 	stopChan                chan bool
 	stopExecution           func()

--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -35,7 +35,7 @@ type action struct {
 }
 
 type actionqueue struct {
-	ctx                   context.Context
+	ctx                   context.Context // nolint:containedctx
 	actors                map[string]actor
 	store                 types.KVStore
 	oldNotificationsStore types.KVStore

--- a/pkg/debug/checkups/dns_test.go
+++ b/pkg/debug/checkups/dns_test.go
@@ -26,13 +26,9 @@ func Test_dnsCheckup_Run(t *testing.T) {
 		ips []string
 		err error
 	}
-	type args struct {
-		ctx context.Context
-	}
 	tests := []struct {
 		name                  string
 		fields                fields
-		args                  args
 		knapsackReturns       map[string]any
 		onLookupHostReturns   map[string]resolution
 		expectedStatus        Status
@@ -45,7 +41,6 @@ func Test_dnsCheckup_Run(t *testing.T) {
 				k:        typesMocks.NewKnapsack(t),
 				resolver: mocks.NewHostResolver(t),
 			},
-			args: args{context.Background()},
 			knapsackReturns: map[string]interface{}{
 				"KolideServerURL":      "https://kolide-server.example.com",
 				"ControlServerURL":     "https://control-server.example.com",
@@ -69,7 +64,6 @@ func Test_dnsCheckup_Run(t *testing.T) {
 				k:        typesMocks.NewKnapsack(t),
 				resolver: mocks.NewHostResolver(t),
 			},
-			args: args{context.Background()},
 			knapsackReturns: map[string]interface{}{
 				"KolideServerURL":      "https://kolide-server.example.com",
 				"ControlServerURL":     "https://control-server.example.com",
@@ -93,7 +87,6 @@ func Test_dnsCheckup_Run(t *testing.T) {
 				k:        typesMocks.NewKnapsack(t),
 				resolver: mocks.NewHostResolver(t),
 			},
-			args: args{context.Background()},
 			knapsackReturns: map[string]interface{}{
 				"KolideServerURL":      "https://kolide-server.example.com",
 				"ControlServerURL":     "https://control-server.example.com",
@@ -131,7 +124,7 @@ func Test_dnsCheckup_Run(t *testing.T) {
 				data:     tt.fields.data,
 				resolver: tt.fields.resolver,
 			}
-			if err := dc.Run(tt.args.ctx, io.Discard); err != nil {
+			if err := dc.Run(context.Background(), io.Discard); err != nil {
 				t.Errorf("dnsCheckup.Run() error = %v", err)
 				return
 			}

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -242,7 +242,7 @@ type OsqueryInstance struct {
 	// the following are instance artifacts that are created and held as a result
 	// of launching an osqueryd process
 	errgroup                *errgroup.Group
-	doneCtx                 context.Context
+	doneCtx                 context.Context // nolint:containedctx
 	cancel                  context.CancelFunc
 	cmd                     *exec.Cmd
 	emsLock                 sync.RWMutex // Lock for extensionManagerServers

--- a/pkg/osquery/tables/airport/table_darwin.go
+++ b/pkg/osquery/tables/airport/table_darwin.go
@@ -45,7 +45,7 @@ func TablePlugin(logger log.Logger) *table.Plugin {
 }
 
 type airportExecutor struct {
-	ctx    context.Context
+	ctx    context.Context // nolint:containedctx
 	logger log.Logger
 	paths  []string
 }

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -55,7 +55,7 @@ type TraceExporter struct {
 	disableIngestTLS          bool
 	enabled                   bool
 	traceSamplingRate         float64
-	ctx                       context.Context
+	ctx                       context.Context // nolint:containedctx
 	cancel                    context.CancelFunc
 	interrupted               bool
 }


### PR DESCRIPTION
Context should not be in structs. And, we should lint for it.