### PR TITLE
Ensure logshipper is available to anywhere pulling logger out of ctx

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -175,6 +175,7 @@ func runLauncher(ctx context.Context, cancel func(), opts *launcher.Options) err
 		logShipper = logshipper.New(k, logger)
 		logger = teelogger.New(logger, logShipper)
 		logger = log.With(logger, "caller", log.Caller(5))
+		ctx = ctxlog.NewContext(ctx, logger) // Set the logger back in the ctx
 	}
 
 	// construct the appropriate http client based on security settings


### PR DESCRIPTION
I noticed we weren't shipping osquery extension logs -- this is because the logshipper isn't set back into the ctx, and the osquery extension pulls the logger [from there](https://github.com/kolide/launcher/blob/main/cmd/launcher/extension.go#L47). There are a couple other places that pull the logger from the ctx as well.

This PR updates to set the logger back into the ctx after we update it to use the logshipper.