### PR TITLE
Enable osquery watchdog for beta channel

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -195,7 +195,7 @@ func commonRunnerOptions(logger log.Logger, k types.Knapsack) []runtime.OsqueryI
 	)
 
 	// Only enable watchdog internally for now
-	enableWatchdog := k.UpdateChannel() == "nightly"
+	enableWatchdog := k.UpdateChannel() == "nightly" || k.UpdateChannel() == "beta"
 
 	return []runtime.OsqueryInstanceOption{
 		runtime.WithKnapsack(k),


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1224

The osquery watchdog has been performing fine for us on the nightly channel. Let's roll it out to beta.