### PR TITLE
update version string format for darwin builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build/darwin.%/Kolide.app: build/darwin.%/launcher
 	cp $@/../launcher $@/Contents/MacOS/
 	mkdir -p $@/Contents/Resources
 	cp tools/images/Kolide.icns $@/Contents/Resources
-	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION}/g' tools/packaging/LauncherTemplate_Info.plist > $@/Contents/Info.plist
+	sed 's/VERSIONPLACEHOLDER/${RELEASE_VERSION_SHORT}/g' tools/packaging/LauncherTemplate_Info.plist > $@/Contents/Info.plist
 	cp tools/packaging/embedded.provisionprofile $@/Contents/
 	cp tools/packaging/entitlements.plist $@/../
 
@@ -121,6 +121,8 @@ rel-launcherapp: $(foreach arch, $(DARWIN_ARCHES), build/darwin.$(arch)/Kolide.a
 ##
 
 RELEASE_VERSION = $(shell git describe --tags --always --dirty)
+# RELEASE_VERSION_SHORT contains only <major>.<minor>.<patch>
+RELEASE_VERSION_SHORT = $(shell git describe --tags --always --dirty | sed -En 's/v([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+).*/\1.\2.\3/p')
 
 release:
 	@echo "Run 'make release-phase1' on the m1 machine"

--- a/pkg/packaging/detectLauncherVersion_test.go
+++ b/pkg/packaging/detectLauncherVersion_test.go
@@ -31,26 +31,55 @@ func TestFormatVersion(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {
-		in  string
-		out string
+		in       string
+		platform PlatformFlavor
+		out      string
 	}{
 		{
-			in:  "0.9.2-26-g6146437",
-			out: "0.9.2.26",
+			in:       "0.9.2-26-g6146437",
+			platform: Windows,
+			out:      "0.9.2.26",
 		},
 		{
-			in:  "0.9.3-44",
-			out: "0.9.3.44",
+			in:       "0.9.3-44",
+			platform: Windows,
+			out:      "0.9.3.44",
 		},
 
 		{
-			in:  "0.9.5",
-			out: "0.9.5.0",
+			in:       "0.9.5",
+			platform: Windows,
+			out:      "0.9.5.0",
+		},
+		{
+			in:       "0.9.2-26-g6146437",
+			platform: Darwin,
+			out:      "0.9.2",
+		},
+		{
+			in:       "0.9.3-44",
+			platform: Darwin,
+			out:      "0.9.3",
+		},
+		{
+			in:       "v0.9.5",
+			platform: Darwin,
+			out:      "0.9.5",
+		},
+		{
+			in:       "v10.8.2-1002df",
+			platform: Darwin,
+			out:      "10.8.2",
+		},
+		{
+			in:       "0.9.2-26-g6146437",
+			platform: Linux,
+			out:      "0.9.2-26-g6146437",
 		},
 	}
 
 	for _, tt := range tests {
-		version, err := formatVersion(tt.in)
+		version, err := formatVersion(tt.in, tt.platform)
 		require.NoError(t, err)
 		require.Equal(t, tt.out, version)
 	}


### PR DESCRIPTION
This cleans up the `CFBundleVersion` string added to the macOS `Info.plist` to adhere to the apple standards (i.e. `<major>.<minor>.<patch>`)
Additional context is in the originating issue here: https://github.com/kolide/launcher/issues/1428