### PR TITLE
Add package to perform path lookups and validations for commands

### DIFF
--- a/pkg/allowedpaths/cmd.go
+++ b/pkg/allowedpaths/cmd.go
@@ -1,0 +1,85 @@
+package allowedpaths
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// CommandWithLookup should be used when the full path to the command is not known and it is
+// likely to be found in PATH.
+func CommandWithLookup(name string, arg ...string) (*exec.Cmd, error) {
+	fullPathToCommand, err := exec.LookPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("looking up path to %s: %w", name, err)
+	}
+
+	return CommandWithPath(fullPathToCommand, arg...)
+}
+
+// CommandWithPath should be used when the full path to the command is known, or unlikely to be
+// found in PATH.
+func CommandWithPath(fullPathToCommand string, arg ...string) (*exec.Cmd, error) {
+	fullPathToCommand = filepath.Clean(fullPathToCommand)
+
+	if err := pathIsAllowed(fullPathToCommand); err != nil {
+		return nil, fmt.Errorf("path is not allowed: %w", err)
+	}
+
+	return exec.Command(fullPathToCommand, arg...), nil
+}
+
+// CommandContextWithLookup should be used when the full path to the command is not known and it is
+// likely to be found in PATH.
+func CommandContextWithLookup(ctx context.Context, name string, arg ...string) (*exec.Cmd, error) {
+	fullPathToCommand, err := exec.LookPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("looking up path to %s: %w", name, err)
+	}
+
+	return CommandContextWithPath(ctx, fullPathToCommand, arg...)
+}
+
+// CommandContextWithPath should be used when the full path to the command is known, or unlikely to be
+// found in PATH.
+func CommandContextWithPath(ctx context.Context, fullPathToCommand string, arg ...string) (*exec.Cmd, error) {
+	fullPathToCommand = filepath.Clean(fullPathToCommand)
+
+	if err := pathIsAllowed(fullPathToCommand); err != nil {
+		return nil, fmt.Errorf("path is not allowed: %w", err)
+	}
+
+	return exec.CommandContext(ctx, fullPathToCommand, arg...), nil
+}
+
+// pathIsAllowed validates the path to the command against our allowlist.
+func pathIsAllowed(fullPathToCommand string) error {
+	cmdName := strings.ToLower(filepath.Base(fullPathToCommand))
+
+	// We trust the autoupdate libraries to select the correct paths
+	if cmdName == "launcher" || cmdName == "launcher.exe" || cmdName == "osqueryd" || cmdName == "osqueryd.exe" {
+		return nil
+	}
+
+	// Check that we have known paths for the given command
+	knownCmdPaths, ok := knownPaths[cmdName]
+	if !ok {
+		return fmt.Errorf("no known paths for command %s, cannot validate path %s", cmdName, fullPathToCommand)
+	}
+
+	// Check if this path is registered
+	if _, ok := knownCmdPaths[fullPathToCommand]; ok {
+		return nil
+	}
+
+	// Check to make sure the command is at least in a known directory
+	for _, knownPathPrefix := range knownPathPrefixes {
+		if strings.HasPrefix(fullPathToCommand, knownPathPrefix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%s not in known paths and does not have known prefix", fullPathToCommand)
+}

--- a/pkg/allowedpaths/cmd_darwin.go
+++ b/pkg/allowedpaths/cmd_darwin.go
@@ -1,0 +1,81 @@
+//go:build darwin
+// +build darwin
+
+package allowedpaths
+
+var knownPaths = map[string]map[string]bool{
+	"bioutil": {
+		"/usr/bin/bioutil": true,
+	},
+	"diskutil": {
+		"/usr/sbin/diskutil": true,
+	},
+	"falconctl": {
+		"/Applications/Falcon.app/Contents/Resources/falconctl": true,
+	},
+	"firmwarepasswd": {
+		"/usr/sbin/firmwarepasswd": true,
+	},
+	"ifconfig": {
+		"/sbin/ifconfig": true,
+	},
+	"launchctl": {
+		"/bin/launchctl": true,
+	},
+	"lsof": {
+		"/usr/sbin/lsof": true,
+	},
+	"mdfind": {
+		"/usr/bin/mdfind": true,
+	},
+	"netstat": {
+		"/usr/sbin/netstat": true,
+	},
+	"open": {
+		"/usr/bin/open": true,
+	},
+	"pkgutil": {
+		"/usr/sbin/pkgutil": true,
+	},
+	"powermetrics": {
+		"/usr/bin/powermetrics": true,
+	},
+	"profiles": {
+		"/usr/bin/profiles": true,
+	},
+	"ps": {
+		"/bin/ps": true,
+	},
+	"pwpolicy": {
+		"/usr/bin/pwpolicy": true,
+	},
+	"remotectl": {
+		"/usr/libexec/remotectl": true,
+	},
+	"repcli": {
+		"/Applications/VMware Carbon Black Cloud/repcli.bundle/Contents/MacOS/repcli": true,
+	},
+	"scutil": {
+		"/usr/sbin/scutil": true,
+	},
+	"softwareupdate": {
+		"/usr/sbin/softwareupdate": true,
+	},
+	"system_profiler": {
+		"/usr/sbin/system_profiler": true,
+	},
+	"tmutil": {
+		"/usr/bin/tmutil": true,
+	},
+	"zerotier-cli": {
+		"/usr/local/bin/zerotier-cli": true,
+	},
+}
+
+var knownPathPrefixes = []string{
+	"/bin",
+	"/usr/bin",
+	"/usr/libexec",
+	"/usr/local/bin",
+	"/usr/sbin",
+}

--- a/pkg/allowedpaths/cmd_linux.go
+++ b/pkg/allowedpaths/cmd_linux.go
@@ -1,0 +1,60 @@
+//go:build linux
+// +build linux
+
+package allowedpaths
+
+var knownPaths = map[string]map[string]bool{
+	"dpkg": {
+		"/usr/bin/dpkg": true,
+	},
+	"lsof": {
+		"/usr/bin/lsof": true,
+	},
+	"gnome-extensions": {
+		"/usr/bin/gnome-extensions": true,
+	},
+	"gsettings": {
+		"/usr/bin/gsettings": true,
+	},
+	"ifconfig": {
+		"/usr/sbin/ifconfig": true,
+	},
+	"ip": {
+		"/usr/sbin/ip": true,
+	},
+	"loginctl": {
+		"/usr/bin/loginctl": true,
+	},
+	"notify-send": {
+		"/usr/bin/notify-send": true,
+	},
+	"ps": {
+		"/usr/bin/ps": true,
+	},
+	"rpm": {
+		"/bin/rpm": true,
+	},
+	"systemctl": {
+		"/usr/bin/systemctl": true,
+	},
+	"x-www-browser": {
+		"/usr/bin/x-www-browser": true,
+	},
+	"xdg-open": {
+		"/usr/bin/xdg-open": true,
+	},
+	"xrdb": {
+		"/usr/bin/xrdb": true,
+	},
+	"zerotier-cli": {
+		"/usr/local/bin/zerotier-cli": true,
+	},
+}
+
+var knownPathPrefixes = []string{
+	"/bin",
+	"/nix/store", // NixOS support
+	"/usr/bin",
+	"/usr/local/bin",
+	"/usr/sbin",
+}

--- a/pkg/allowedpaths/cmd_test.go
+++ b/pkg/allowedpaths/cmd_test.go
@@ -1,0 +1,201 @@
+package allowedpaths
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandWithLookup(t *testing.T) {
+	t.Parallel()
+
+	var cmdName string
+	if runtime.GOOS == "windows" {
+		cmdName = "powershell.exe"
+	} else {
+		// On Linux and Darwin we expect ps to be available, even on the CI runner
+		cmdName = "ps"
+	}
+
+	cmd, err := CommandWithLookup(cmdName)
+	require.NoError(t, err, "expected to find command")
+	require.True(t, strings.HasSuffix(cmd.Path, cmdName))
+}
+
+func TestCommandWithLookup_NotFound(t *testing.T) {
+	t.Parallel()
+
+	cmdName := "some-cmd"
+	_, err := CommandWithLookup(cmdName)
+	require.Error(t, err, "should not have found cmd")
+}
+
+func TestCommandWithPath_Allowed(t *testing.T) {
+	t.Parallel()
+
+	for cmdName, cmdPaths := range knownPaths {
+		cmdName := cmdName
+		cmdPaths := cmdPaths
+		t.Run(cmdName, func(t *testing.T) {
+			t.Parallel()
+
+			for p := range cmdPaths {
+				cmd, err := CommandWithPath(p)
+				require.NoError(t, err, "expected no error with known path")
+				require.Equal(t, p, cmd.Path)
+			}
+		})
+	}
+}
+
+func TestCommandWithPath_Denied(t *testing.T) {
+	t.Parallel()
+
+	// Unknown command
+	_, err := CommandWithPath(filepath.Join("some", "path", "to", "not-a-real-command"))
+	require.Error(t, err, "expected unknown command to be denylisted")
+
+	// Known command, unknown path
+	for cmdName := range knownPaths {
+		_, err := CommandWithPath(filepath.Join("some", "incorrect", "path", "to", cmdName))
+		require.Error(t, err, "expected unknown path to be denylisted")
+
+		// We don't need to perform this same test against every known path
+		break
+	}
+}
+
+func TestCommandWithPath_AutoupdatePaths(t *testing.T) {
+	t.Parallel()
+
+	for _, b := range []string{"launcher", "launcher.exe", "osqueryd", "osqueryd.exe"} {
+		b := b
+		t.Run(b, func(t *testing.T) {
+			t.Parallel()
+
+			autoupdatedBinaryPath := filepath.Join("some", "autoupdate", "path", "to", b)
+			cmd, err := CommandWithPath(autoupdatedBinaryPath)
+			require.NoError(t, err, "expected autoupdated binaries to be allowed")
+			require.Equal(t, autoupdatedBinaryPath, cmd.Path)
+		})
+	}
+}
+
+func TestCommandWithPath_KnownPrefix(t *testing.T) {
+	t.Parallel()
+
+	for cmdName := range knownPaths {
+		cmdName := cmdName
+		t.Run(cmdName, func(t *testing.T) {
+			t.Parallel()
+
+			for _, p := range knownPathPrefixes {
+				pathToCmdWithKnownPrefix := filepath.Join(p, cmdName)
+				cmd, err := CommandWithPath(pathToCmdWithKnownPrefix)
+				require.NoError(t, err, "expected no error with known command and directory prefix")
+				require.Equal(t, pathToCmdWithKnownPrefix, cmd.Path)
+			}
+		})
+	}
+}
+
+func TestCommandContextWithLookup(t *testing.T) {
+	t.Parallel()
+
+	var cmdName string
+	if runtime.GOOS == "windows" {
+		cmdName = "powershell.exe"
+	} else {
+		// On Linux and Darwin we expect ps to be available, even on the CI runner
+		cmdName = "ps"
+	}
+
+	cmd, err := CommandContextWithLookup(context.TODO(), cmdName)
+	require.NoError(t, err, "expected to find command")
+	require.True(t, strings.HasSuffix(cmd.Path, cmdName))
+	require.NotNil(t, cmd.Cancel, "context not set on command")
+}
+
+func TestCommandContextWithLookup_NotFound(t *testing.T) {
+	t.Parallel()
+
+	cmdName := "some-cmd"
+	_, err := CommandContextWithLookup(context.TODO(), cmdName)
+	require.Error(t, err, "should not have found cmd")
+}
+
+func TestCommandContextWithPath_Allowed(t *testing.T) {
+	t.Parallel()
+
+	for cmdName, cmdPaths := range knownPaths {
+		cmdName := cmdName
+		cmdPaths := cmdPaths
+		t.Run(cmdName, func(t *testing.T) {
+			t.Parallel()
+
+			for p := range cmdPaths {
+				cmd, err := CommandContextWithPath(context.TODO(), p)
+				require.NoError(t, err, "expected no error with known path")
+				require.Equal(t, p, cmd.Path)
+				require.NotNil(t, cmd.Cancel, "context not set on command")
+			}
+		})
+	}
+}
+
+func TestCommandContextWithPath_Denied(t *testing.T) {
+	t.Parallel()
+
+	// Unknown command
+	_, err := CommandContextWithPath(context.TODO(), filepath.Join("some", "path", "to", "not-a-real-command"))
+	require.Error(t, err, "expected unknown command to be denylisted")
+
+	// Known command, unknown path
+	for cmdName := range knownPaths {
+		_, err := CommandContextWithPath(context.TODO(), filepath.Join("some", "incorrect", "path", "to", cmdName))
+		require.Error(t, err, "expected unknown path to be denylisted")
+
+		// We don't need to perform this same test against every known path
+		break
+	}
+}
+
+func TestCommandContextWithPath_AutoupdatePaths(t *testing.T) {
+	t.Parallel()
+
+	for _, b := range []string{"launcher", "launcher.exe", "osqueryd", "osqueryd.exe"} {
+		b := b
+		t.Run(b, func(t *testing.T) {
+			t.Parallel()
+
+			autoupdatedBinaryPath := filepath.Join("some", "autoupdate", "path", "to", b)
+			cmd, err := CommandContextWithPath(context.TODO(), autoupdatedBinaryPath)
+			require.NoError(t, err, "expected autoupdated binaries to be allowed")
+			require.Equal(t, autoupdatedBinaryPath, cmd.Path)
+			require.NotNil(t, cmd.Cancel, "context not set on command")
+		})
+	}
+}
+
+func TestCommandContextWithPath_KnownPrefix(t *testing.T) {
+	t.Parallel()
+
+	for cmdName := range knownPaths {
+		cmdName := cmdName
+		t.Run(cmdName, func(t *testing.T) {
+			t.Parallel()
+
+			for _, p := range knownPathPrefixes {
+				pathToCmdWithKnownPrefix := filepath.Join(p, cmdName)
+				cmd, err := CommandContextWithPath(context.TODO(), pathToCmdWithKnownPrefix)
+				require.NoError(t, err, "expected no error with known command and directory prefix")
+				require.Equal(t, pathToCmdWithKnownPrefix, cmd.Path)
+				require.NotNil(t, cmd.Cancel, "context not set on command")
+			}
+		})
+	}
+}

--- a/pkg/allowedpaths/cmd_windows.go
+++ b/pkg/allowedpaths/cmd_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+// +build windows
+
+package allowedpaths
+
+var knownPaths = map[string]map[string]bool{
+	"cmd.exe": {
+		`C:\Windows\System32\cmd.exe`: true,
+	},
+	"dism.exe": {
+		`C:\Windows\System32\Dism.exe`: true,
+	},
+	"ipconfig.exe": {
+		`C:\Windows\System32\ipconfig.exe`: true,
+	},
+	"powercfg.exe": {
+		`C:\Windows\System32\powercfg.exe`: true,
+	},
+	"powershell.exe": {
+		`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`: true,
+	},
+	"secedit.exe": {
+		`C:\Windows\System32\SecEdit.exe`: true,
+	},
+	"taskkill.exe": {
+		`C:\Windows\System32\taskkill.exe`: true,
+	},
+}
+
+var knownPathPrefixes = []string{
+	`C:\Windows\System32`,
+}


### PR DESCRIPTION
Update all usages of `exec.Command` and `exec.CommandContext` to no longer perform path lookups, instead checking against an allowlist of known paths. In the case where the path cannot be allowlisted (e.g. when using Nix, the install path will be somewhere in `/nix/store`), check for known path prefixes (like `/nix/store`).

Closes https://github.com/kolide/launcher/issues/833

Relates to https://github.com/kolide/launcher/issues/896