### PR TITLE
use slogger on local server, add span_id id to logs, add kolide session id to logs

### DIFF
--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -233,7 +233,7 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 			},
 		}
 
-		// setting the newReq context to the current request context context
+		// setting the newReq context to the current request context
 		// allows the trace to continue to the inner request,
 		// maintains the same lifetime as the original request,
 		// allows same ctx values such as session id to be passed to the inner request

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -27,6 +27,7 @@ const (
 	timestampValidityRange             = 150
 	kolideKryptoEccHeader20230130Value = "2023-01-30"
 	kolideKryptoHeaderKey              = "X-Kolide-Krypto"
+	kolideSessionIdHeaderKey           = "X-Kolide-Session"
 )
 
 type v2CmdRequestType struct {
@@ -186,9 +187,9 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 		}
 
 		// set the kolide session id if it exists, this also the saml session id
-		kolideSessionId, ok := cmdReq.CallbackHeaders[multislogger.KolideSessionIdKey.String()]
+		kolideSessionId, ok := cmdReq.CallbackHeaders[kolideSessionIdHeaderKey]
 		if ok && len(kolideSessionId) > 0 {
-			span.SetAttributes(attribute.String(multislogger.KolideSessionIdKey.String(), kolideSessionId[0]))
+			span.SetAttributes(attribute.String(kolideSessionIdHeaderKey, kolideSessionId[0]))
 			r = r.WithContext(context.WithValue(r.Context(), multislogger.KolideSessionIdKey, kolideSessionId[0]))
 		}
 

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -139,7 +139,7 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		spanCtx, span := traces.StartSpan(r.Context())
-		r = r.WithContext(context.WithValue(spanCtx, multislogger.SpanIdKey, span.SpanContext().SpanID().String()))
+		r = r.WithContext(spanCtx)
 
 		defer span.End()
 

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -129,8 +129,9 @@ func (e *kryptoEcMiddleware) sendCallback(req *http.Request, data *callbackDataS
 		resp.Body.Close()
 	}
 
-	e.slogger.Log(req.Context(), slog.LevelDebug, "finished callback",
-		"response-status", resp.Status,
+	e.slogger.Log(req.Context(), slog.LevelDebug,
+		"finished callback",
+		"response_status", resp.Status,
 	)
 }
 

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -187,9 +187,9 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 		}
 
 		// set the kolide session id if it exists, this also the saml session id
-		kolideSessionId, ok := cmdReq.CallbackHeaders[multislogger.KolideSessionIdKey]
+		kolideSessionId, ok := cmdReq.CallbackHeaders[multislogger.KolideSessionIdKey.String()]
 		if ok && len(kolideSessionId) > 0 {
-			span.SetAttributes(attribute.String(multislogger.KolideSessionIdKey, kolideSessionId[0]))
+			span.SetAttributes(attribute.String(multislogger.KolideSessionIdKey.String(), kolideSessionId[0]))
 			r = r.WithContext(context.WithValue(r.Context(), multislogger.KolideSessionIdKey, kolideSessionId[0]))
 		}
 

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -37,7 +37,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 
 	koldieSessionId := ulid.New()
 	cmdReqCallBackHeaders := map[string][]string{
-		multislogger.KolideSessionIdKey.String(): {koldieSessionId},
+		kolideSessionIdHeaderKey: {koldieSessionId},
 	}
 	cmdReqBody := []byte(randomStringWithSqlCharacters(t, 100000))
 

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -37,7 +37,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 
 	koldieSessionId := ulid.New()
 	cmdReqCallBackHeaders := map[string][]string{
-		multislogger.KolideSessionIdKey: {koldieSessionId},
+		multislogger.KolideSessionIdKey.String(): {koldieSessionId},
 	}
 	cmdReqBody := []byte(randomStringWithSqlCharacters(t, 100000))
 
@@ -181,9 +181,9 @@ func TestKryptoEcMiddleware(t *testing.T) {
 						return
 					}
 
-					require.Contains(t, logBytes.String(), multislogger.KolideSessionIdKey)
+					require.Contains(t, logBytes.String(), multislogger.KolideSessionIdKey.String())
 					require.Contains(t, logBytes.String(), koldieSessionId)
-					require.Contains(t, logBytes.String(), multislogger.SpanIdKey)
+					require.Contains(t, logBytes.String(), multislogger.SpanIdKey.String())
 
 					require.Equal(t, http.StatusOK, rr.Code)
 					require.NotEmpty(t, rr.Body.String())

--- a/ee/localserver/request-controlservice_test.go
+++ b/ee/localserver/request-controlservice_test.go
@@ -12,6 +12,7 @@ import (
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
 	"github.com/kolide/launcher/pkg/agent/types"
 	"github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,7 @@ func Test_localServer_requestAccelerateControlFunc(t *testing.T) {
 		m := mocks.NewKnapsack(t)
 		m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 		m.On("KolideServerURL").Return("localhost")
+		m.On("Slogger").Return(multislogger.New().Logger)
 		return m
 	}
 
@@ -47,6 +49,7 @@ func Test_localServer_requestAccelerateControlFunc(t *testing.T) {
 				m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 				m.On("KolideServerURL").Return("localhost")
 				m.On("SetControlRequestIntervalOverride", 250*time.Millisecond, 1*time.Second)
+				m.On("Slogger").Return(multislogger.New().Logger)
 				return m
 			},
 		},

--- a/ee/localserver/request-id_test.go
+++ b/ee/localserver/request-id_test.go
@@ -15,6 +15,7 @@ import (
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
 	"github.com/kolide/launcher/pkg/agent/types"
 	typesMocks "github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,7 @@ func Test_localServer_requestIdHandler(t *testing.T) {
 	mockKnapsack := typesMocks.NewKnapsack(t)
 	mockKnapsack.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	mockKnapsack.On("KolideServerURL").Return("localhost")
+	mockKnapsack.On("Slogger").Return(multislogger.New().Logger)
 
 	var logBytes bytes.Buffer
 	server := testServer(t, mockKnapsack, &logBytes)

--- a/ee/localserver/request-query_test.go
+++ b/ee/localserver/request-query_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/storage"
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
 	typesMocks "github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/osquery/osquery-go/plugin/distributed"
 	"github.com/stretchr/testify/require"
 )
@@ -57,6 +58,7 @@ func Test_localServer_requestQueryHandler(t *testing.T) {
 			mockKnapsack := typesMocks.NewKnapsack(t)
 			mockKnapsack.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 			mockKnapsack.On("KolideServerURL").Return("localhost")
+			mockKnapsack.On("Slogger").Return(multislogger.New().Logger)
 
 			//go:generate mockery --name Querier
 			// https://github.com/vektra/mockery <-- cli tool to generate mocks for usage with testify
@@ -222,6 +224,7 @@ func Test_localServer_requestRunScheduledQueryHandler(t *testing.T) {
 			mockKnapsack := typesMocks.NewKnapsack(t)
 			mockKnapsack.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 			mockKnapsack.On("KolideServerURL").Return("localhost")
+			mockKnapsack.On("Slogger").Return(multislogger.New().Logger)
 
 			// set up mock querier
 			mockQuerier := mocks.NewQuerier(t)

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -97,7 +97,7 @@ func New(k types.Knapsack, opts ...LocalServerOption) (*localServer, error) {
 	}
 	ls.myKey = privateKey
 
-	ecKryptoMiddleware := newKryptoEcMiddleware(ls.logger, ls.myLocalDbSigner, ls.myLocalHardwareSigner, *ls.serverEcKey)
+	ecKryptoMiddleware := newKryptoEcMiddleware(k.Slogger(), ls.myLocalDbSigner, ls.myLocalHardwareSigner, *ls.serverEcKey)
 	ecAuthedMux := http.NewServeMux()
 	ecAuthedMux.HandleFunc("/", http.NotFound)
 	ecAuthedMux.Handle("/acceleratecontrol", ls.requestAccelerateControlHandler())

--- a/ee/localserver/server_test.go
+++ b/ee/localserver/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kolide/launcher/pkg/agent/storage"
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
 	"github.com/kolide/launcher/pkg/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	k := mocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("ConfigStore").Return(c)
+	k.On("Slogger").Return(multislogger.New().Logger)
 
 	ls, err := New(k)
 	require.NoError(t, err)

--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"errors"
-	"strings"
 	"sync"
 	"time"
 
@@ -491,19 +490,21 @@ func (fc *FlagController) SetLogShippingLevel(level string) error {
 	return fc.setControlServerValue(keys.LogShippingLevel, []byte(level))
 }
 func (fc *FlagController) LogShippingLevel() string {
-	return NewStringFlagValue(
-		WithDefaultString("error"),
-		WithSanitizer(func(value string) string {
-			value = strings.ToLower(value)
 
-			switch value {
-			case "debug", "warn", "error":
-				return value
-			default:
-				return "info"
-			}
-		}),
-	).get(fc.getControlServerValue(keys.LogShippingLevel))
+	return "debug"
+	// return NewStringFlagValue(
+	// 	WithDefaultString("error"),
+	// 	WithSanitizer(func(value string) string {
+	// 		value = strings.ToLower(value)
+
+	// 		switch value {
+	// 		case "debug", "warn", "error":
+	// 			return value
+	// 		default:
+	// 			return "info"
+	// 		}
+	// 	}),
+	// ).get(fc.getControlServerValue(keys.LogShippingLevel))
 }
 
 func (fc *FlagController) SetTraceIngestServerURL(url string) error {

--- a/pkg/agent/flags/flag_controller.go
+++ b/pkg/agent/flags/flag_controller.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -490,21 +491,19 @@ func (fc *FlagController) SetLogShippingLevel(level string) error {
 	return fc.setControlServerValue(keys.LogShippingLevel, []byte(level))
 }
 func (fc *FlagController) LogShippingLevel() string {
+	return NewStringFlagValue(
+		WithDefaultString("error"),
+		WithSanitizer(func(value string) string {
+			value = strings.ToLower(value)
 
-	return "debug"
-	// return NewStringFlagValue(
-	// 	WithDefaultString("error"),
-	// 	WithSanitizer(func(value string) string {
-	// 		value = strings.ToLower(value)
-
-	// 		switch value {
-	// 		case "debug", "warn", "error":
-	// 			return value
-	// 		default:
-	// 			return "info"
-	// 		}
-	// 	}),
-	// ).get(fc.getControlServerValue(keys.LogShippingLevel))
+			switch value {
+			case "debug", "warn", "error":
+				return value
+			default:
+				return "info"
+			}
+		}),
+	).get(fc.getControlServerValue(keys.LogShippingLevel))
 }
 
 func (fc *FlagController) SetTraceIngestServerURL(url string) error {

--- a/pkg/agent/knapsack/knapsack.go
+++ b/pkg/agent/knapsack/knapsack.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/pkg/agent/flags/keys"
 	"github.com/kolide/launcher/pkg/agent/storage"
 	"github.com/kolide/launcher/pkg/agent/types"
@@ -30,6 +31,7 @@ type knapsack struct {
 	db *bbolt.DB
 
 	slogger, systemSlogger *multislogger.MultiSlogger
+	launcherRunId          string
 
 	// This struct is a work in progress, and will be iteratively added to as needs arise.
 	// Some potential future additions include:
@@ -43,6 +45,7 @@ func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB
 		stores:        stores,
 		slogger:       slogger,
 		systemSlogger: systemSlogger,
+		launcherRunId: ulid.New(),
 	}
 
 	return k
@@ -59,6 +62,7 @@ func (k *knapsack) SystemSlogger() *slog.Logger {
 
 func (k *knapsack) AddSlogHandler(handler ...slog.Handler) {
 	k.slogger.AddHandler(handler...)
+	k.slogger.Logger = k.slogger.Logger.With("launcher_run_id", k.launcherRunId)
 
 	// also send system logs to the same handlers
 	k.systemSlogger.AddHandler(handler...)

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -8,10 +8,16 @@ import (
 	slogmulti "github.com/samber/slog-multi"
 )
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return string(c)
+}
+
 const (
 	// KolideSessionIdKey this the also the saml session id
-	KolideSessionIdKey = "X-Kolide-Session"
-	SpanIdKey          = "span_id"
+	KolideSessionIdKey contextKey = "X-Kolide-Session"
+	SpanIdKey          contextKey = "span_id"
 )
 
 type MultiSlogger struct {
@@ -55,7 +61,7 @@ func utcTimeMiddleware(ctx context.Context, record slog.Record, next func(contex
 	return next(ctx, record)
 }
 
-var ctxValueKeysToAdd = []string{
+var ctxValueKeysToAdd = []contextKey{
 	SpanIdKey,
 	KolideSessionIdKey,
 }
@@ -64,10 +70,11 @@ func ctxValuesMiddleWare(ctx context.Context, record slog.Record, next func(cont
 	for _, key := range ctxValueKeysToAdd {
 		if v := ctx.Value(key); v != nil {
 			record.AddAttrs(slog.Attr{
-				Key:   key,
+				Key:   key.String(),
 				Value: slog.AnyValue(v),
 			})
 		}
 	}
+
 	return next(ctx, record)
 }

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -8,16 +8,23 @@ import (
 	slogmulti "github.com/samber/slog-multi"
 )
 
-type contextKey string
+type contextKey int
 
 func (c contextKey) String() string {
-	return string(c)
+	switch c {
+	case KolideSessionIdKey:
+		return "kolide_session_id"
+	case SpanIdKey:
+		return "span_id"
+	default:
+		return "unknown"
+	}
 }
 
 const (
 	// KolideSessionIdKey this the also the saml session id
-	KolideSessionIdKey contextKey = "X-Kolide-Session"
-	SpanIdKey          contextKey = "span_id"
+	KolideSessionIdKey contextKey = iota
+	SpanIdKey
 )
 
 type MultiSlogger struct {

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -8,6 +8,12 @@ import (
 	slogmulti "github.com/samber/slog-multi"
 )
 
+const (
+	// KolideSessionIdKey this the also the saml session id
+	KolideSessionIdKey = "X-Kolide-Session"
+	SpanIdKey          = "span_id"
+)
+
 type MultiSlogger struct {
 	*slog.Logger
 	handlers []slog.Handler
@@ -50,8 +56,8 @@ func utcTimeMiddleware(ctx context.Context, record slog.Record, next func(contex
 }
 
 var ctxValueKeysToAdd = []string{
-	"span_id",
-	"saml_session_id",
+	SpanIdKey,
+	KolideSessionIdKey,
 }
 
 func ctxValuesMiddleWare(ctx context.Context, record slog.Record, next func(context.Context, slog.Record) error) error {

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -42,7 +42,9 @@ func New(h ...slog.Handler) *MultiSlogger {
 	return ms
 }
 
-// AddHandler adds a handler to the multislogger
+// AddHandler adds a handler to the multislogger, this creates a branch new
+// slog.Logger under the the hood, mean any attributes added with
+// Logger.With will be lost
 func (m *MultiSlogger) AddHandler(handler ...slog.Handler) {
 	m.handlers = append(m.handlers, handler...)
 

--- a/pkg/log/multislogger/multislogger_test.go
+++ b/pkg/log/multislogger/multislogger_test.go
@@ -54,14 +54,14 @@ func TestMultiSlogger(t *testing.T) {
 
 	// ensure that span_id gets added as an attribute when present in context
 	spanId := ulid.New()
-	ctx := context.WithValue(context.Background(), "span_id", spanId)
+	ctx := context.WithValue(context.Background(), SpanIdKey, spanId)
 	multislogger.Logger.Log(ctx, slog.LevelDebug, "info_with_interesting_ctx_value")
 
 	require.Contains(t, debugLogBuf.String(), "info_with_interesting_ctx_value", "should be in debug log since it's debug level")
-	requireContainsAttribute(t, &debugLogBuf, "span_id", spanId)
+	requireContainsAttribute(t, &debugLogBuf, SpanIdKey.String(), spanId)
 
 	require.Contains(t, shipperBuf.String(), "info_with_interesting_ctx_value", "should now be in shipper log since it's new handler was set to debug level")
-	requireContainsAttribute(t, &shipperBuf, "span_id", spanId)
+	requireContainsAttribute(t, &shipperBuf, SpanIdKey.String(), spanId)
 	clearBufsFn()
 }
 

--- a/pkg/traces/traces.go
+++ b/pkg/traces/traces.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -48,7 +49,9 @@ func StartSpan(ctx context.Context, keyVals ...interface{}) (context.Context, tr
 
 	opts = append(opts, trace.WithAttributes(buildAttributes(callerFile, keyVals...)...))
 
-	return otel.Tracer(instrumentationPkg).Start(ctx, spanName, opts...)
+	spanCtx, span := otel.Tracer(instrumentationPkg).Start(ctx, spanName, opts...)
+	spanCtx = context.WithValue(spanCtx, multislogger.SpanIdKey, span.SpanContext().SpanID().String())
+	return spanCtx, span
 }
 
 // SetError records the error on the span and sets the span's status to error.


### PR DESCRIPTION
This PR:

* updates localserver to use slogger
* adds span id as ctx value for all spans which is picked up by multislogger middleware and added to logs
* add launcher_run_id to logs, ulid to identify single run of launcher
* add kolide session (saml id) to local server requests
* update multislogger middleware to use unexported types for ctx keys (per golang documentation)