### PR TITLE
Add revive linter and enable superfluous-else rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - sqlclosecheck
     - unconvert
     - paralleltest
+    - revive
   disable:
     - errcheck
     - gosec
@@ -32,6 +33,13 @@ linters-settings:
     ignore: github.com/go-kit/kit/log:Log
   gofmt:
     simplify: false
+  revive:
+    rules:
+      - name: superfluous-else
+        severity: warning
+        disabled: false
+        arguments:
+          - "preserveScope"
 
 issues:
   exclude-rules:

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -75,9 +75,9 @@ func main() {
 					logutil.Fatal(logger, err, "exec")
 				}
 				panic("how")
-			} else {
-				level.Debug(logger).Log("msg", "Nothing new")
 			}
+
+			level.Debug(logger).Log("msg", "Nothing new")
 		}
 	}
 

--- a/ee/desktop/runner/runner_linux.go
+++ b/ee/desktop/runner/runner_linux.go
@@ -126,9 +126,6 @@ func (r *DesktopUsersProcessesRunner) userEnvVars(ctx context.Context, uid strin
 			envVars["DISPLAY"] = r.displayFromXwayland(ctx, int32(uidInt))
 
 			break
-		} else {
-			// Not a graphical session
-			continue
 		}
 	}
 


### PR DESCRIPTION
Adds https://github.com/mgechev/revive -- https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else

Example error message:

```
% golangci-lint run      
cmd/launcher/main.go:78:11: superfluous-else: if block ends with call to panic function, so drop this else and outdent its block (revive)
			} else {
				level.Debug(logger).Log("msg", "Nothing new")
			}
```