### PR TITLE
Configure GitHub's release notes autogeneration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking-change"
+    - title: Table Changes
+      labels:
+        - "component:table"
+    - title: General
+      labels:
+        - "*"
+    - title: Build and Package
+      labels:
+        - "component:build&packaging"


### PR DESCRIPTION
As it turns out, GitHub has some [optionality](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) for how it auto generates release notes.

This is an initial attempt towards using it.

It means we'll need to be a little more dedicated about labels (at least the ones that configure release notes). But we can evolve that. Or even lint it. I'm not totally sure of the categories yet. These are roughly the ones we've used in the past. 

I'm also not sure if the `label: "*"` can be in the middle there, or if we'll need to think harder. But it seems like an easy thing to try. 