### PR TITLE
Include logs in test failure when TUF autoupdater doesn't shut down/restart within 5 seconds

### DIFF
--- a/pkg/autoupdate/tuf/autoupdate_test.go
+++ b/pkg/autoupdate/tuf/autoupdate_test.go
@@ -116,7 +116,7 @@ func TestExecute_launcherUpdate(t *testing.T) {
 	shutdownDeadline := time.Now().Add(5 * time.Second).Unix()
 	for {
 		if time.Now().Unix() > shutdownDeadline {
-			t.Error("autoupdater did not shut down within 5 seconds")
+			t.Error("autoupdater did not shut down within 5 seconds -- logs: ", logBytes.String())
 			t.FailNow()
 		}
 
@@ -341,7 +341,7 @@ func TestExecute_downgrade(t *testing.T) {
 	shutdownDeadline := time.Now().Add(5 * time.Second).Unix()
 	for {
 		if time.Now().Unix() > shutdownDeadline {
-			t.Error("autoupdater did not restart osquery within 5 seconds")
+			t.Error("autoupdater did not restart osquery within 5 seconds -- logs: ", logBytes.String())
 			t.FailNow()
 		}
 


### PR DESCRIPTION
I've seen this test failure fairly frequently: https://github.com/kolide/launcher/actions/runs/6852148852/job/18630008978

Not sure why it's happening -- it doesn't happen locally -- so I'm including the autoupdater logs in the test failure message in order to figure it out.