### PR TITLE
dont delete logs until after successful send

### DIFF
--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -23,7 +23,8 @@ var (
 type SendBuffer struct {
 	logs                              [][]byte
 	size, maxStorageSize, maxSendSize int
-	writeMutex, sendMutex             sync.Mutex
+	sendMutex                         sync.Mutex
+	writeMutex                        sync.RWMutex
 	logger                            log.Logger
 	sender                            sender
 	sendInterval                      time.Duration
@@ -191,8 +192,8 @@ func (sb *SendBuffer) sendAndPurge() error {
 // the provided max size and returns the index of the last log written
 // leaving it up to the caller to delete the logs
 func (sb *SendBuffer) copyLogs(w io.Writer, maxSize int) (int, error) {
-	sb.writeMutex.Lock()
-	defer sb.writeMutex.Unlock()
+	sb.writeMutex.RLock()
+	defer sb.writeMutex.RUnlock()
 
 	size := 0
 	lastLogIndex := 0

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -187,6 +187,9 @@ func (sb *SendBuffer) sendAndPurge() error {
 	return nil
 }
 
+// copyLogs writes to the provided writer until adding another log would exceed
+// the provided max size and returns the index of the last log written
+// leaving it up to the caller to delete the logs
 func (sb *SendBuffer) copyLogs(w io.Writer, maxSize int) (int, error) {
 	sb.writeMutex.Lock()
 	defer sb.writeMutex.Unlock()

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -67,8 +67,8 @@ func TestSendBuffer(t *testing.T) {
 
 			sb := New(
 				&testSender{lastReceived: lastReceivedData, t: t},
-				WithMaxStorageSize(tt.maxStorageSize),
-				WithMaxSendSize(tt.maxSendSize),
+				WithMaxStorageSizeBytes(tt.maxStorageSize),
+				WithMaxSendSizeBytes(tt.maxSendSize),
 			)
 
 			requireStoreSizeEqualsHttpBufferReportedSize(t, sb)
@@ -141,7 +141,7 @@ func TestSendBufferConcurrent(t *testing.T) {
 			testSender := &testSender{lastReceived: &bytes.Buffer{}, t: t}
 			sb := New(
 				testSender,
-				WithMaxSendSize(tt.maxSendSize),
+				WithMaxSendSizeBytes(tt.maxSendSize),
 				// run interval in background quickly
 				WithSendInterval(1*time.Millisecond),
 			)


### PR DESCRIPTION
This _may_ be a first step in getting more observability into enrollment. This updates the send buffer so that it doesn't just drop logs it cant send. Now it will accumulate them and send them when as long as they don't go over the max storage threshold. So it's a bit of a race, but writing the the db would be a race as well ... but we would better be able to predict the winner.

Next steps:
* populate the initial accumulated logs with the device data once received from control server
* turn on debug logging for for X minutes of new launcher run
* look into tracing