### PR TITLE
Fall back to finding DISPLAY from display server process

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -485,13 +485,11 @@ func (r *DesktopUsersProcessesRunner) writeDefaultMenuTemplateFile() {
 }
 
 func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
-	/*
-		if !r.processSpawningEnabled {
-			// Desktop is disabled, kill any existing desktop user processes
-			r.killDesktopProcesses()
-			return nil
-		}
-	*/
+	if !r.processSpawningEnabled {
+		// Desktop is disabled, kill any existing desktop user processes
+		r.killDesktopProcesses()
+		return nil
+	}
 
 	executablePath, err := r.determineExecutablePath()
 	if err != nil {

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -485,11 +485,13 @@ func (r *DesktopUsersProcessesRunner) writeDefaultMenuTemplateFile() {
 }
 
 func (r *DesktopUsersProcessesRunner) runConsoleUserDesktop() error {
-	if !r.processSpawningEnabled {
-		// Desktop is disabled, kill any existing desktop user processes
-		r.killDesktopProcesses()
-		return nil
-	}
+	/*
+		if !r.processSpawningEnabled {
+			// Desktop is disabled, kill any existing desktop user processes
+			r.killDesktopProcesses()
+			return nil
+		}
+	*/
 
 	executablePath, err := r.determineExecutablePath()
 	if err != nil {


### PR DESCRIPTION
This PR provides menu bar app support for Debian 11/12 + Cinnamon.

At least over Chrome Remote Desktop, `loginctl show-session` doesn't have a `Display` property for Debian 11/12 + Cinnamon -- but we can do similar to what we do for Wayland, and find the x display from the Xorg or Xvfb process.