### PR TITLE
populate device id attributes to buffered logs before turning on shipping

### DIFF
--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -206,7 +206,12 @@ func (ls *LogShipper) updateDevideIdentifyingAttributes() error {
 		deviceInfo[key] = string(v)
 	}
 
-	ls.shippingLogger = log.With(ls.shippingLogger, deviceInfo)
+	var deviceInfoKvps []any
+	for k, v := range deviceInfo {
+		deviceInfoKvps = append(deviceInfoKvps, k, v)
+	}
+
+	ls.shippingLogger = log.With(ls.shippingLogger, deviceInfoKvps)
 
 	var additionalSlogAttrs []slog.Attr
 	for k, v := range deviceInfo {

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -203,9 +203,10 @@ func (ls *LogShipper) updateDevideIdentifyingAttributes() error {
 			return fmt.Errorf("no value for %s in server provided data", key)
 		}
 
-		ls.shippingLogger = log.With(ls.shippingLogger, key, string(v))
 		deviceInfo[key] = string(v)
 	}
+
+	ls.shippingLogger = log.With(ls.shippingLogger, deviceInfo)
 
 	var additionalSlogAttrs []slog.Attr
 	for k, v := range deviceInfo {

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -120,6 +120,10 @@ func (ls *LogShipper) Ping() {
 func (ls *LogShipper) Run() error {
 	<-ls.startShippingChan
 
+	ls.knapsack.Slogger().Log(context.Background(), slog.LevelInfo,
+		"starting log shipping",
+	)
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ls.stopFuncMutex.Lock()

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -119,6 +119,10 @@ func (ls *LogShipper) Ping() {
 }
 
 func (ls *LogShipper) Run() error {
+	ls.knapsack.Slogger().Log(context.Background(), slog.LevelInfo,
+		"log shipper set up, waiting for required data to start shipping",
+	)
+
 	<-ls.startShippingChan
 
 	ls.knapsack.Slogger().Log(context.Background(), slog.LevelInfo,

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -2,7 +2,10 @@ package logshipper
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"sync"
@@ -35,9 +38,10 @@ type LogShipper struct {
 	knapsack            types.Knapsack
 	stopFunc            context.CancelFunc
 	stopFuncMutex       sync.Mutex
-	isShippingEnabled   bool
+	isShippingStarted   bool
 	slogLevel           *slog.LevelVar
 	additionalSlogAttrs []slog.Attr
+	startShippingChan   chan struct{}
 }
 
 func New(k types.Knapsack, baseLogger log.Logger) *LogShipper {
@@ -57,6 +61,7 @@ func New(k types.Knapsack, baseLogger log.Logger) *LogShipper {
 		knapsack:            k,
 		stopFuncMutex:       sync.Mutex{},
 		additionalSlogAttrs: make([]slog.Attr, 0),
+		startShippingChan:   make(chan struct{}),
 	}
 
 	ls.slogLevel = new(slog.LevelVar)
@@ -76,65 +81,45 @@ func (ls *LogShipper) FlagsChanged(flagKeys ...keys.FlagKey) {
 
 // Ping gets the latest token and endpoint from knapsack and updates the sender
 func (ls *LogShipper) Ping() {
-	// set up new auth token
-	token, _ := ls.knapsack.TokenStore().Get(storage.ObservabilityIngestAuthTokenKey)
-	ls.sender.authtoken = string(token)
+	ls.updateLogShippingLevel()
 
-	parsedUrl, err := url.Parse(ls.knapsack.LogIngestServerURL())
-	if err != nil {
-		// If we have a bad endpoint, just disable for now.
-		// It will get renabled when control server sends a
-		// valid endpoint.
-		ls.sender.endpoint = ""
+	if err := ls.updateSenderAuthToken(); err != nil {
 		level.Debug(ls.baseLogger).Log(
-			"msg", "error parsing log ingest server url, shipping disabled",
+			"msg", "updating auth token",
 			"err", err,
-			"log_ingest_url", ls.knapsack.LogIngestServerURL(),
 		)
-	} else if parsedUrl != nil {
-		ls.sender.endpoint = parsedUrl.String()
+		return
 	}
 
-	startingLevel := ls.slogLevel.Level()
-	sendInterval := defaultSendInterval
-
-	switch ls.knapsack.LogShippingLevel() {
-	case "debug":
-		ls.slogLevel.Set(slog.LevelDebug)
-		// if we using debug level logging, send logs more frequently
-		sendInterval = debugSendInterval
-	case "info":
-		ls.slogLevel.Set(slog.LevelInfo)
-	case "warn":
-		ls.slogLevel.Set(slog.LevelWarn)
-	case "error":
-		ls.slogLevel.Set(slog.LevelError)
-	case "default":
-		ls.knapsack.Slogger().Error("unrecognized flag value for log shipping level",
-			"flag_value", ls.knapsack.LogShippingLevel(),
-			"current_log_level", ls.slogLevel.String(),
+	if err := ls.updateLogIngestURL(); err != nil {
+		level.Debug(ls.baseLogger).Log(
+			"msg", "updating log ingest url",
+			"err", err,
 		)
+		return
 	}
 
-	if startingLevel != ls.slogLevel.Level() {
-		ls.knapsack.Slogger().Info("log shipping level changed",
-			"old_log_level", startingLevel.String(),
-			"new_log_level", ls.slogLevel.Level().String(),
-			"send_interval", sendInterval.String(),
+	if err := ls.updateDevideIdentifyingAttributes(); err != nil {
+		level.Debug(ls.baseLogger).Log(
+			"msg", "updating device identifying attributes",
+			"err", err,
 		)
+		return
 	}
 
-	ls.sendBuffer.SetSendInterval(sendInterval)
-
-	ls.isShippingEnabled = ls.sender.endpoint != ""
-	ls.addDeviceIdentifyingAttributesToLogger()
-
-	if !ls.isShippingEnabled {
-		ls.sendBuffer.DeleteAllData()
+	if ls.isShippingStarted {
+		return
 	}
+
+	ls.isShippingStarted = true
+	go func() {
+		ls.startShippingChan <- struct{}{}
+	}()
 }
 
 func (ls *LogShipper) Run() error {
+	<-ls.startShippingChan
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ls.stopFuncMutex.Lock()
@@ -154,10 +139,6 @@ func (ls *LogShipper) Stop(_ error) {
 }
 
 func (ls *LogShipper) Log(keyvals ...interface{}) error {
-	if !ls.isShippingEnabled {
-		return nil
-	}
-
 	filterResults(keyvals...)
 	return ls.shippingLogger.Log(keyvals...)
 }
@@ -192,42 +173,142 @@ func filterResults(keyvals ...interface{}) {
 	}
 }
 
-// addDeviceIdentifyingAttributesToLogger gets device identifiers from the server-provided
+// updateDevideIdentifyingAttributes gets device identifiers from the server-provided
 // data and adds them as attributes on the logger.
-func (ls *LogShipper) addDeviceIdentifyingAttributesToLogger() {
-	additionalSlogAttrs := make([]slog.Attr, 0)
+func (ls *LogShipper) updateDevideIdentifyingAttributes() error {
+	deviceInfo := make(map[string]string)
 
 	versionInfo := version.Version()
+	deviceInfo["version"] = versionInfo.Version
 	ls.shippingLogger = log.With(ls.shippingLogger, "version", versionInfo.Version)
-	additionalSlogAttrs = append(additionalSlogAttrs, slog.String("version", versionInfo.Version))
 
-	if deviceId, err := ls.knapsack.ServerProvidedDataStore().Get([]byte("device_id")); err != nil {
-		level.Debug(ls.baseLogger).Log("msg", "could not get device id", "err", err)
-	} else {
-		ls.shippingLogger = log.With(ls.shippingLogger, "k2_device_id", string(deviceId))
-		additionalSlogAttrs = append(additionalSlogAttrs, slog.String("k2_device_id", string(deviceId)))
+	for _, key := range []string{"device_id", "munemo", "organization_id", "serial_number"} {
+		v, err := ls.fetchServerProvidedData(key)
+		if err != nil {
+			return err
+		}
+
+		ls.shippingLogger = log.With(ls.shippingLogger, key, string(v))
+		deviceInfo[key] = string(v)
 	}
 
-	if munemo, err := ls.knapsack.ServerProvidedDataStore().Get([]byte("munemo")); err != nil {
-		level.Debug(ls.baseLogger).Log("msg", "could not get munemo", "err", err)
-	} else {
-		ls.shippingLogger = log.With(ls.shippingLogger, "k2_munemo", string(munemo))
-		additionalSlogAttrs = append(additionalSlogAttrs, slog.String("k2_munemo", string(munemo)))
-	}
-
-	if orgId, err := ls.knapsack.ServerProvidedDataStore().Get([]byte("organization_id")); err != nil {
-		level.Debug(ls.baseLogger).Log("msg", "could not get organization id", "err", err)
-	} else {
-		ls.shippingLogger = log.With(ls.shippingLogger, "k2_organization_id", string(orgId))
-		additionalSlogAttrs = append(additionalSlogAttrs, slog.String("k2_organization_id", string(orgId)))
-	}
-
-	if serialNumber, err := ls.knapsack.ServerProvidedDataStore().Get([]byte("serial_number")); err != nil {
-		level.Debug(ls.baseLogger).Log("msg", "could not get serial number", "err", err)
-	} else {
-		ls.shippingLogger = log.With(ls.shippingLogger, "serial_number", string(serialNumber))
-		additionalSlogAttrs = append(additionalSlogAttrs, slog.String("serial_number", string(serialNumber)))
+	var additionalSlogAttrs []slog.Attr
+	for k, v := range deviceInfo {
+		additionalSlogAttrs = append(additionalSlogAttrs, slog.String(k, v))
 	}
 
 	ls.additionalSlogAttrs = additionalSlogAttrs
+
+	// if we are already shipping, dont update send buffer data
+	if ls.isShippingStarted {
+		return nil
+	}
+
+	// if this is the first time we've gotten device data, update the send buffer
+	// logs to include it
+	ls.sendBuffer.UpdateData(func(in io.Reader, out io.Writer) error {
+		var logMap map[string]interface{}
+
+		if err := json.NewDecoder(in).Decode(&logMap); err != nil {
+			ls.shippingLogger.Log(
+				"msg", "failed to decode log data",
+				"err", err,
+			)
+
+			return err
+		}
+
+		for k, v := range deviceInfo {
+			logMap[k] = v
+		}
+
+		if err := json.NewEncoder(out).Encode(logMap); err != nil {
+			ls.shippingLogger.Log(
+				"msg", "failed to encode log data",
+				"err", err,
+			)
+
+			return err
+		}
+
+		return nil
+	})
+
+	return nil
+}
+
+func (ls *LogShipper) fetchServerProvidedData(key string) ([]byte, error) {
+	v, err := ls.knapsack.ServerProvidedDataStore().Get([]byte(key))
+	if err != nil {
+		return nil, fmt.Errorf("could not get %s from server provided data: %w", key, err)
+	}
+
+	if len(v) == 0 {
+		return nil, fmt.Errorf("no value for %s in server provided data", key)
+	}
+
+	return v, nil
+}
+
+func (ls *LogShipper) updateSenderAuthToken() error {
+	token, err := ls.knapsack.TokenStore().Get(storage.ObservabilityIngestAuthTokenKey)
+	if err != nil {
+		return err
+	}
+
+	if len(token) == 0 {
+		return fmt.Errorf("no token found")
+	}
+
+	ls.sender.authtoken = string(token)
+	return nil
+}
+
+func (ls *LogShipper) updateLogIngestURL() error {
+	parsedUrl, err := url.Parse(ls.knapsack.LogIngestServerURL())
+
+	if err != nil {
+		return err
+	}
+
+	if parsedUrl == nil || parsedUrl.String() == "" {
+		ls.sender.endpoint = ""
+		return errors.New("log ingest url is empty")
+	}
+
+	ls.sender.endpoint = parsedUrl.String()
+	return nil
+}
+
+func (ls *LogShipper) updateLogShippingLevel() {
+	startingLevel := ls.slogLevel.Level()
+	sendInterval := defaultSendInterval
+
+	switch ls.knapsack.LogShippingLevel() {
+	case "debug":
+		ls.slogLevel.Set(slog.LevelDebug)
+		// if we using debug level logging, send logs more frequently
+		sendInterval = debugSendInterval
+	case "info":
+		ls.slogLevel.Set(slog.LevelInfo)
+	case "warn":
+		ls.slogLevel.Set(slog.LevelWarn)
+	case "error":
+		ls.slogLevel.Set(slog.LevelError)
+	case "default":
+		ls.knapsack.Slogger().Error("unrecognized flag value for log shipping level",
+			"flag_value", ls.knapsack.LogShippingLevel(),
+			"current_log_level", ls.slogLevel.String(),
+		)
+	}
+
+	if startingLevel != ls.slogLevel.Level() {
+		ls.knapsack.Slogger().Info("log shipping level changed",
+			"old_log_level", startingLevel.String(),
+			"new_log_level", ls.slogLevel.Level().String(),
+			"send_interval", sendInterval.String(),
+		)
+	}
+
+	ls.sendBuffer.SetSendInterval(sendInterval)
 }

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -79,7 +79,8 @@ func (ls *LogShipper) FlagsChanged(flagKeys ...keys.FlagKey) {
 	ls.Ping()
 }
 
-// Ping gets the latest token and endpoint from knapsack and updates the sender
+// Ping collects all data required to be able to start shipping logs,
+// and starts the shipping process once all data has been collected.
 func (ls *LogShipper) Ping() {
 	ls.updateLogShippingLevel()
 
@@ -178,7 +179,9 @@ func filterResults(keyvals ...interface{}) {
 }
 
 // updateDevideIdentifyingAttributes gets device identifiers from the server-provided
-// data and adds them as attributes on the logger.
+// data and adds them as attributes on the logger. If shipping has not yet started and
+// there are logs in the buffer, the device identifiers are added to the logs in the
+// buffer.
 func (ls *LogShipper) updateDevideIdentifyingAttributes() error {
 	deviceInfo := make(map[string]string)
 

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -82,13 +82,19 @@ func (sb *SendBuffer) Write(in []byte) (int, error) {
 	defer sb.writeMutex.Unlock()
 
 	if len(in) == 0 {
-		return 0, nil
+		sb.logger.Log(
+			"msg", "dropped data because element was empty",
+			"method", "UpdateData",
+		)
+
+		return len(in), nil
 	}
 
 	// if the single data piece is larger than the max send size, drop it and log
 	if len(in) > sb.maxSendSizeBytes {
 		sb.logger.Log(
 			"msg", "dropped data because element greater than max send size",
+			"method", "Write",
 			"size_of_data_bytes", len(in),
 			"max_send_size_bytes", sb.maxSendSizeBytes,
 			"head", string(in)[0:minInt(len(in), 100)],
@@ -103,11 +109,14 @@ func (sb *SendBuffer) Write(in []byte) (int, error) {
 
 		sb.logger.Log(
 			"msg", "reached capacity, dropping all data and starting over",
+			"method", "Write",
 			"size_of_data_bytes", len(in),
 			"buffer_size_bytes", sb.size,
 			"size_plus_data_bytes", sb.size+len(in),
 			"max_size", sb.maxStorageSizeBytes,
 		)
+
+		return len(in), nil
 	}
 
 	// If we don't make a copy of the data, we get data loss in the logs array.
@@ -148,6 +157,94 @@ func (sb *SendBuffer) SetSendInterval(sendInterval time.Duration) {
 	sb.sendTicker.Reset(sendInterval)
 }
 
+func (sb *SendBuffer) UpdateData(f func(in io.Reader, out io.Writer) error) {
+	sb.writeMutex.Lock()
+	defer sb.writeMutex.Unlock()
+
+	var indexesToDelete []int
+
+	for i := 0; i < len(sb.logs); i++ {
+		in := bytes.NewReader(sb.logs[i])
+		out := &bytes.Buffer{}
+
+		// subtract original size
+		sb.size -= in.Len()
+		sb.logs[i] = nil
+
+		// do the update
+		if err := f(in, out); err != nil {
+			indexesToDelete = append(indexesToDelete, i)
+
+			sb.logger.Log(
+				"msg", "dropped data because update function failed",
+				"method", "UpdateData",
+				"err", err,
+			)
+
+			continue
+		}
+
+		outLen := out.Len()
+
+		// if the new length is 0, mark for deletion
+		if outLen == 0 {
+			indexesToDelete = append(indexesToDelete, i)
+
+			sb.logger.Log(
+				"msg", "dropped data because element was empty",
+				"method", "UpdateData",
+			)
+
+			continue
+		}
+
+		// if new size excceds max send size, mark for deletion
+		if outLen > sb.maxSendSizeBytes {
+			indexesToDelete = append(indexesToDelete, i)
+
+			// log it
+			sb.logger.Log(
+				"msg", "dropped data because element greater than max send size",
+				"method", "UpdateData",
+				"size_of_data_bytes", out.Len(),
+				"max_send_size_bytes", sb.maxSendSizeBytes,
+				"head", string(out.Bytes())[0:minInt(outLen, 100)],
+			)
+
+			continue
+		}
+
+		// if new size exceeds max storage size, mark for deletion
+		if outLen+sb.size > sb.maxStorageSizeBytes {
+			indexesToDelete = append(indexesToDelete, i)
+
+			// log it
+			sb.logger.Log(
+				"msg", "dropped data because buffer full",
+				"method", "UpdateData",
+				"size_of_data_bytes", outLen,
+				"buffer_size_bytes", sb.size,
+				"size_plus_data_bytes", sb.size+outLen,
+				"max_size", sb.maxStorageSizeBytes,
+				"head", string(out.Bytes())[0:minInt(outLen, 100)],
+			)
+
+			continue
+		}
+
+		// update log and size
+		sb.logs[i] = out.Bytes()
+		sb.size += outLen
+	}
+
+	// remove indexes marked for deletion
+	for i := 0; i < len(indexesToDelete); i++ {
+		// shift left by i each time we delete an element to accout for decreased length
+		indexesToDelete := indexesToDelete[i] - i
+		sb.logs = append(sb.logs[:indexesToDelete], sb.logs[indexesToDelete+1:]...)
+	}
+}
+
 func (sb *SendBuffer) DeleteAllData() {
 	sb.writeMutex.Lock()
 	defer sb.writeMutex.Unlock()
@@ -176,9 +273,6 @@ func (sb *SendBuffer) sendAndPurge() error {
 		sb.logger.Log("msg", "failed to send, will retry", "err", err)
 		return nil
 	}
-	// TODO: populate logs with device data (id, serial, munemo, orgid) when we
-	// get first set of control data with device info before shipping
-
 	// testing on a new enrollment in debug mode, log size hit 130K bytes
 	// before enrollment completed and was able to ship logs
 	// 2023-11-16

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -409,11 +409,14 @@ func TestUpdateData(t *testing.T) {
 			},
 			expectedLogs: [][]byte{
 				[]byte("0"),
+				[]byte("1"),
 				[]byte("2"),
+				[]byte("3"),
 				[]byte("4"),
+				[]byte("5"),
 			},
-			expectedSize:     3,
-			expectedLogCount: 3,
+			expectedSize:     6,
+			expectedLogCount: 6,
 		},
 	}
 

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -281,7 +281,6 @@ func TestUpdateData(t *testing.T) {
 				[]byte("5"),
 			},
 			updateFunction: func(in io.Reader, out io.Writer) error {
-				// add 10 to the even numbers
 				data, err := io.ReadAll(in)
 				require.NoError(t, err)
 
@@ -348,10 +347,7 @@ func TestUpdateData(t *testing.T) {
 				data, err := io.ReadAll(in)
 				require.NoError(t, err)
 
-				// convert data to int
 				numStr := string(data)
-
-				// convert to int
 				num, err := strconv.Atoi(numStr)
 				require.NoError(t, err)
 

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -230,6 +231,183 @@ func requireStoreSizeEqualsHttpBufferReportedSize(t *testing.T, sb *SendBuffer) 
 	}
 
 	require.Equal(t, sb.size, storeSize, "actual store size should match buffer size")
+}
+
+func TestUpdateData(t *testing.T) {
+	tests := []struct {
+		name             string
+		maxStorageSize   int
+		maxSendSize      int
+		initialLogs      [][]byte
+		updateFunction   func(in io.Reader, out io.Writer) error
+		expectedLogs     [][]byte
+		expectedSize     int
+		expectedLogCount int
+	}{
+		{
+			name:           "happy path",
+			maxSendSize:    5,
+			maxStorageSize: 10,
+			initialLogs: [][]byte{
+				[]byte("abcde"),
+				[]byte("fghij"),
+			},
+			updateFunction: func(in io.Reader, out io.Writer) error {
+				data, err := io.ReadAll(in)
+				require.NoError(t, err)
+				_, err = out.Write(bytes.ToUpper(data))
+				require.NoError(t, err)
+				return err
+			},
+			expectedLogs: [][]byte{
+				[]byte("ABCDE"),
+				[]byte("FGHIJ"),
+			},
+			expectedSize:     10,
+			expectedLogCount: 2,
+		},
+		{
+			name:           "exceeds max send size",
+			maxSendSize:    1,
+			maxStorageSize: 10,
+			initialLogs: [][]byte{
+				[]byte("0"),
+				[]byte("1"),
+				[]byte("2"),
+				[]byte("3"),
+				[]byte("4"),
+				[]byte("5"),
+			},
+			updateFunction: func(in io.Reader, out io.Writer) error {
+				// add 10 to the even numbers
+				data, err := io.ReadAll(in)
+				require.NoError(t, err)
+
+				// convert data to int
+				numStr := string(data)
+
+				// convert to int
+				num, err := strconv.Atoi(numStr)
+				require.NoError(t, err)
+
+				// if even, make it exceed max send size
+				if num%2 == 0 {
+					_, err := out.Write([]byte("TOO_BIG"))
+					require.NoError(t, err)
+					return err
+				}
+
+				_, err = out.Write([]byte(fmt.Sprint(num)))
+				require.NoError(t, err)
+				return err
+			},
+			expectedLogs: [][]byte{
+				[]byte("1"),
+				[]byte("3"),
+				[]byte("5"),
+			},
+			expectedSize:     3,
+			expectedLogCount: 3,
+		},
+		{
+			name:           "exceeds max storage size",
+			maxSendSize:    10,
+			maxStorageSize: 10,
+			initialLogs: [][]byte{
+				[]byte("01234"),
+				[]byte("01234"),
+			},
+			updateFunction: func(in io.Reader, out io.Writer) error {
+				// this should cause second log to be deleted since the first update
+				// will put it over the threshold
+				_, err := out.Write([]byte("0123456789"))
+				require.NoError(t, err)
+				return err
+			},
+			expectedLogs: [][]byte{
+				[]byte("0123456789"),
+			},
+			expectedSize:     10,
+			expectedLogCount: 1,
+		},
+		{
+			name:           "zero lengths",
+			maxSendSize:    1,
+			maxStorageSize: 10,
+			initialLogs: [][]byte{
+				[]byte("0"),
+				[]byte("1"),
+				[]byte("2"),
+				[]byte("3"),
+				[]byte("4"),
+				[]byte("5"),
+			},
+			updateFunction: func(in io.Reader, out io.Writer) error {
+				// add 10 to the even numbers
+				data, err := io.ReadAll(in)
+				require.NoError(t, err)
+
+				// convert data to int
+				numStr := string(data)
+
+				// convert to int
+				num, err := strconv.Atoi(numStr)
+				require.NoError(t, err)
+
+				// if odd, set it to zero
+				if num%2 != 0 {
+					_, err := out.Write(make([]byte, 0))
+					require.NoError(t, err)
+					return err
+				}
+
+				_, err = out.Write([]byte(fmt.Sprint(num)))
+				require.NoError(t, err)
+				return err
+			},
+			expectedLogs: [][]byte{
+				[]byte("0"),
+				[]byte("2"),
+				[]byte("4"),
+			},
+			expectedSize:     3,
+			expectedLogCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			testSender := &testSender{lastReceived: &bytes.Buffer{}, t: t}
+			sb := New(
+				testSender,
+				WithMaxSendSizeBytes(tt.maxSendSize),
+				WithMaxStorageSizeBytes(tt.maxStorageSize),
+			)
+
+			for _, log := range tt.initialLogs {
+				_, err := sb.Write(log)
+				require.NoError(err)
+			}
+
+			sb.UpdateData(tt.updateFunction)
+
+			require.Equal(tt.expectedLogs, sb.logs, "logs not as expected")
+			require.Equal(tt.expectedSize, sb.size, "size not as expected")
+			require.Equal(tt.expectedLogCount, len(sb.logs), "log count not as expected")
+			requireStoreSizeEqualsHttpBufferReportedSize(t, sb)
+		})
+	}
+}
+
+// Helper function to calculate the total length of logs
+func lenLogs(logs [][]byte) int {
+	totalLen := 0
+	for _, log := range logs {
+		totalLen += len(log)
+	}
+	return totalLen
 }
 
 type testSender struct {

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -234,6 +234,8 @@ func requireStoreSizeEqualsHttpBufferReportedSize(t *testing.T, sb *SendBuffer) 
 }
 
 func TestUpdateData(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name             string
 		maxStorageSize   int
@@ -343,7 +345,6 @@ func TestUpdateData(t *testing.T) {
 				[]byte("5"),
 			},
 			updateFunction: func(in io.Reader, out io.Writer) error {
-				// add 10 to the even numbers
 				data, err := io.ReadAll(in)
 				require.NoError(t, err)
 
@@ -376,7 +377,10 @@ func TestUpdateData(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			require := require.New(t)
 
 			testSender := &testSender{lastReceived: &bytes.Buffer{}, t: t}
@@ -399,15 +403,6 @@ func TestUpdateData(t *testing.T) {
 			requireStoreSizeEqualsHttpBufferReportedSize(t, sb)
 		})
 	}
-}
-
-// Helper function to calculate the total length of logs
-func lenLogs(logs [][]byte) int {
-	totalLen := 0
-	for _, log := range logs {
-		totalLen += len(log)
-	}
-	return totalLen
 }
 
 type testSender struct {


### PR DESCRIPTION
* log shipper waits until it has all device id attributes before shipping
* populates buffered logs with device id attributes before sending