### PR TITLE
Remove os.Exit in favor of more graceful shutdown when osquery instance can't be restarted

### DIFF
--- a/cmd/launcher/extension.go
+++ b/cmd/launcher/extension.go
@@ -118,21 +118,24 @@ func createExtensionRuntime(ctx context.Context, k types.Knapsack, launcherClien
 		return runner.Restart()
 	}
 
+	osqCtx, osqCancel := context.WithCancel(ctx)
+
 	return &actorQuerier{
 			Actor: actor.Actor{
 				// and the methods for starting and stopping the extension
 				Execute: func() error {
 					// Attempt to enroll before starting up osquery. If we can't enroll now, don't error out --
 					// we'll attempt again the first time osquery calls launcher plugins.
-					_, invalid, err := ext.Enroll(ctx)
+					_, invalid, err := ext.Enroll(osqCtx)
 					if err != nil {
 						level.Debug(logger).Log("msg", "error performing enrollment", "err", err)
 					} else if invalid {
 						level.Debug(logger).Log("msg", "invalid enroll secret", "err", err)
 					}
 
-					// Start the osqueryd instance
-					if err := runner.Start(); err != nil {
+					// Start the osqueryd instance -- pass in cancel so the osquery runner can let
+					// this function know to stop waiting when the runner shuts down
+					if err := runner.Start(osqCancel); err != nil {
 						return fmt.Errorf("launching osquery instance: %w", err)
 					}
 
@@ -142,7 +145,7 @@ func createExtensionRuntime(ctx context.Context, k types.Knapsack, launcherClien
 
 						// TODO: remove when underlying libs are refactored
 						// everything exits right now, so block this actor on the context finishing
-						<-ctx.Done()
+						<-osqCtx.Done()
 						return nil
 					}
 
@@ -156,7 +159,7 @@ func createExtensionRuntime(ctx context.Context, k types.Knapsack, launcherClien
 
 					// TODO: remove when underlying libs are refactored
 					// everything exits right now, so block this actor on the context finishing
-					<-ctx.Done()
+					<-osqCtx.Done()
 					return nil
 				},
 				Interrupt: func(_ error) {
@@ -167,6 +170,7 @@ func createExtensionRuntime(ctx context.Context, k types.Knapsack, launcherClien
 							level.Debug(logger).Log("msg", "error shutting down runtime", "err", err, "stack", fmt.Sprintf("%+v", err))
 						}
 					}
+					osqCancel()
 				},
 			},
 			querier: runner.Query,

--- a/cmd/launcher/run_socket.go
+++ b/cmd/launcher/run_socket.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -48,7 +49,8 @@ func runSocket(args []string) error {
 		opts = append(opts, runtime.WithOsqueryExtensionPlugins(table.LauncherTables(nil)...))
 	}
 
-	runner, err := runtime.LaunchInstance(opts...)
+	_, cancel := context.WithCancel(context.Background())
+	runner, err := runtime.LaunchInstance(cancel, opts...)
 	if err != nil {
 		return fmt.Errorf("creating osquery instance: %w", err)
 	}

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -138,7 +138,7 @@ func runWindowsSvc(args []string) error {
 		return err
 	}
 
-	level.Debug(logger).Log("msg", "Service exited", "version", version.Version().Version)
+	level.Debug(logger).Log("msg", "service exited", "version", version.Version().Version)
 	time.Sleep(time.Second)
 
 	return nil

--- a/pkg/execwrapper/exec_windows.go
+++ b/pkg/execwrapper/exec_windows.go
@@ -5,7 +5,6 @@ package execwrapper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -32,24 +31,24 @@ func Exec(ctx context.Context, argv0 string, argv []string, envv []string) error
 	)
 
 	// Now run it. This is faking exec, we need to distinguish
-	// between a failure to execute, and a failure in in the called program.
+	// between a failure to execute, and a failure in the called program.
 	// I think https://github.com/golang/go/issues/26539 adds this functionality.
 	err := cmd.Run()
 
 	if cmd.ProcessState.ExitCode() == -1 {
 		if err == nil {
-			return fmt.Errorf("Unknown error trying to exec %s (and nil err)", strings.Join(cmd.Args, " "))
+			return fmt.Errorf("unknown error trying to exec %s (and nil err)", strings.Join(cmd.Args, " "))
 		}
-		return fmt.Errorf("Unknown error trying to exec %s: %w", strings.Join(cmd.Args, " "), err)
+		return fmt.Errorf("unknown error trying to exec %s: %w", strings.Join(cmd.Args, " "), err)
 	}
 
 	if err != nil {
 		level.Info(logger).Log(
 			"msg", "got error on exec",
 			"err", err,
+			"exit_code", cmd.ProcessState.ExitCode(),
 		)
 	}
-	os.Exit(cmd.ProcessState.ExitCode())
-	return errors.New("Exec shouldn't have gotten here.")
 
+	return fmt.Errorf("error trying to exec %s: exit code %d: %w", strings.Join(cmd.Args, " "), cmd.ProcessState.ExitCode(), err)
 }

--- a/pkg/execwrapper/exec_windows.go
+++ b/pkg/execwrapper/exec_windows.go
@@ -5,6 +5,7 @@ package execwrapper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,24 +32,24 @@ func Exec(ctx context.Context, argv0 string, argv []string, envv []string) error
 	)
 
 	// Now run it. This is faking exec, we need to distinguish
-	// between a failure to execute, and a failure in the called program.
+	// between a failure to execute, and a failure in in the called program.
 	// I think https://github.com/golang/go/issues/26539 adds this functionality.
 	err := cmd.Run()
 
 	if cmd.ProcessState.ExitCode() == -1 {
 		if err == nil {
-			return fmt.Errorf("unknown error trying to exec %s (and nil err)", strings.Join(cmd.Args, " "))
+			return fmt.Errorf("Unknown error trying to exec %s (and nil err)", strings.Join(cmd.Args, " "))
 		}
-		return fmt.Errorf("unknown error trying to exec %s: %w", strings.Join(cmd.Args, " "), err)
+		return fmt.Errorf("Unknown error trying to exec %s: %w", strings.Join(cmd.Args, " "), err)
 	}
 
 	if err != nil {
 		level.Info(logger).Log(
 			"msg", "got error on exec",
 			"err", err,
-			"exit_code", cmd.ProcessState.ExitCode(),
 		)
 	}
+	os.Exit(cmd.ProcessState.ExitCode())
+	return errors.New("Exec shouldn't have gotten here.")
 
-	return fmt.Errorf("error trying to exec %s: exit code %d: %w", strings.Join(cmd.Args, " "), cmd.ProcessState.ExitCode(), err)
 }

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -64,9 +64,9 @@ type Runner struct {
 //			 	 tables.NewPlugin("foobar", custom.FoobarColumns, custom.FoobarGenerate),
 //	    ),
 //	  )
-func LaunchInstance(opts ...OsqueryInstanceOption) (*Runner, error) {
+func LaunchInstance(cancel context.CancelFunc, opts ...OsqueryInstanceOption) (*Runner, error) {
 	runner := newRunner(opts...)
-	if err := runner.Start(); err != nil {
+	if err := runner.Start(cancel); err != nil {
 		return nil, err
 	}
 	return runner, nil
@@ -79,7 +79,7 @@ func LaunchUnstartedInstance(opts ...OsqueryInstanceOption) *Runner {
 	return runner
 }
 
-func (r *Runner) Start() error {
+func (r *Runner) Start(cancel context.CancelFunc) error {
 	if err := r.launchOsqueryInstance(); err != nil {
 		return fmt.Errorf("starting instance: %w", err)
 	}
@@ -97,6 +97,7 @@ func (r *Runner) Start() error {
 				if err := r.instance.stats.Exited(nil); err != nil {
 					level.Info(r.instance.logger).Log("msg", "error recording osquery instance exit to history", "err", err)
 				}
+				cancel() // let the extension know to shut down
 				return
 			default:
 				// Don't block
@@ -132,6 +133,7 @@ func (r *Runner) Start() error {
 						"err", err,
 					)
 				}
+				cancel() // let the extension know to shut down
 				return
 			}
 

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -122,10 +122,17 @@ func (r *Runner) Start() error {
 			}
 			if err := r.launchOsqueryInstance(); err != nil {
 				level.Info(r.instance.logger).Log(
-					"msg", "fatal error restarting instance",
+					"msg", "fatal error restarting instance, shutting down",
 					"err", err,
 				)
-				os.Exit(1)
+				r.instanceLock.Unlock()
+				if err := r.Shutdown(); err != nil {
+					level.Error(r.instance.logger).Log(
+						"msg", "could not perform shutdown",
+						"err", err,
+					)
+				}
+				return
 			}
 
 			r.instanceLock.Unlock()

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -215,7 +215,9 @@ func TestBadBinaryPath(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary("/foobar"),
@@ -232,7 +234,9 @@ func TestWithOsqueryFlags(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
@@ -260,7 +264,9 @@ func TestSimplePath(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
@@ -283,7 +289,9 @@ func TestMultipleShutdowns(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
@@ -333,7 +341,9 @@ func TestOsqueryDies(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
@@ -419,7 +429,9 @@ func TestExtensionSocketPath(t *testing.T) {
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithExtensionSocketPath(extensionSocketPath),
@@ -452,7 +464,9 @@ func TestOsquerySlowStart(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err := LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
@@ -496,7 +510,9 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, teardown func()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	_, cancel := context.WithCancel(context.TODO())
 	runner, err = LaunchInstance(
+		cancel,
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1387

The osquery runner currently calls os.Exit when the osquery instance dies and it cannot start a new one. In this case, the rungroup actors will never get a chance to shut down gracefully.

I've updated so that the osquery runner instead signals the osquery extension rungroup to exit its `Execute` function, allowing for a regular shutdown of all rungroup actors.