### PR TITLE
update desktop runner to include WINDIR as env var

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -774,6 +774,8 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		fmt.Sprintf("RUNNER_SERVER_URL=%s", r.runnerServer.Url()),
 		fmt.Sprintf("RUNNER_SERVER_AUTH_TOKEN=%s", r.runnerServer.RegisterClient(uid)),
 		fmt.Sprintf("DEBUG=%v", r.knapsack.Debug()),
+		// needed for windows to find various allowed commands
+		fmt.Sprintf("WINDIR=%s", os.Getenv("WINDIR")),
 		"LAUNCHER_SKIP_UPDATES=true", // We already know that we want to run the version of launcher in `executablePath`, so there's no need to perform lookups
 	}
 


### PR DESCRIPTION
windows desktop was throwing error when opening a url, this should fix

the error:
```json
{"caller":":0","component":"desktop_users_processes_runner","level":"debug","msg":"{\"URL\":\"REDACTED\",\"caller\":\"action_open_url.go:14\",\"err\":\"creating command: not found: System32\\\\cmd.exe\",\"msg\":\"failed to perform action\",\"session_pid\":828,\"severity\":\"error\",\"subprocess\":\"desktop\",\"ts\":\"2023-11-29T15:32:54.8592464Z\",\"uid\":\"S-1-5-21-4057651538-1258869191-560081613-1001\"}","session_pid":15012,"subprocess":"desktop","ts":"2023-11-29T15:32:54.8592464Z","uid":"James-Win-HP\\james"}
```