### PR TITLE
Add timeout to rungroup shutdown

### DIFF
--- a/pkg/rungroup/rungroup_test.go
+++ b/pkg/rungroup/rungroup_test.go
@@ -21,7 +21,7 @@ func TestRun_MultipleActors(t *testing.T) {
 
 	testRunGroup := NewRunGroup(log.NewNopLogger())
 
-	groupReceivedInterrupts := make(chan struct{})
+	groupReceivedInterrupts := make(chan struct{}, 3)
 
 	// First actor waits for interrupt and alerts groupReceivedInterrupts when it's interrupted
 	firstActorInterrupt := make(chan struct{})
@@ -52,23 +52,189 @@ func TestRun_MultipleActors(t *testing.T) {
 		anotherActorInterrupt <- struct{}{}
 	})
 
+	runCompleted := make(chan struct{})
 	go func() {
 		err := testRunGroup.Run()
+		runCompleted <- struct{}{}
 		require.Error(t, err)
 	}()
 
+	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
+	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	interruptCheckTimer := time.NewTicker(runDuration)
+	defer interruptCheckTimer.Stop()
+
 	receivedInterrupts := 0
+	gotRunCompleted := false
 	for {
-		if receivedInterrupts >= 3 {
+		if gotRunCompleted {
 			break
 		}
+
 		select {
 		case <-groupReceivedInterrupts:
 			receivedInterrupts += 1
-		case <-time.After(3 * time.Second):
-			t.Error("did not receive expected interrupts within reasonable time")
+		case <-runCompleted:
+			gotRunCompleted = true
+		case <-interruptCheckTimer.C:
+			t.Errorf("did not receive expected interrupts within reasonable time, got %d", receivedInterrupts)
+			t.FailNow()
 		}
 	}
 
+	require.True(t, gotRunCompleted, "rungroup.Run did not terminate within time limit")
+
 	require.Equal(t, 3, receivedInterrupts)
+}
+
+func TestRun_MultipleActors_InterruptTimeout(t *testing.T) {
+	t.Parallel()
+
+	testRunGroup := NewRunGroup(log.NewNopLogger())
+
+	groupReceivedInterrupts := make(chan struct{}, 3)
+
+	// First actor waits for interrupt and alerts groupReceivedInterrupts when it's interrupted
+	firstActorInterrupt := make(chan struct{})
+	testRunGroup.Add("firstActor", func() error {
+		<-firstActorInterrupt
+		return nil
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+		firstActorInterrupt <- struct{}{}
+	})
+
+	// Second actor returns error on `execute`, and then alerts groupReceivedInterrupts when it's interrupted
+	expectedError := errors.New("test error from interruptingActor")
+	testRunGroup.Add("interruptingActor", func() error {
+		time.Sleep(1 * time.Second)
+		return expectedError
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+	})
+
+	// Third actor blocks in interrupt for longer than the interrupt timeout
+	blockingActorInterrupt := make(chan struct{})
+	testRunGroup.Add("blockingActor", func() error {
+		<-blockingActorInterrupt
+		return nil
+	}, func(error) {
+		time.Sleep(4 * interruptTimeout)
+		groupReceivedInterrupts <- struct{}{}
+		blockingActorInterrupt <- struct{}{}
+	})
+
+	runCompleted := make(chan struct{})
+	go func() {
+		err := testRunGroup.Run()
+		require.Error(t, err)
+		runCompleted <- struct{}{}
+	}()
+
+	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
+	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	interruptCheckTimer := time.NewTicker(runDuration)
+	defer interruptCheckTimer.Stop()
+
+	receivedInterrupts := 0
+	gotRunCompleted := false
+	for {
+		if gotRunCompleted {
+			break
+		}
+
+		select {
+		case <-groupReceivedInterrupts:
+			receivedInterrupts += 1
+		case <-runCompleted:
+			gotRunCompleted = true
+		case <-interruptCheckTimer.C:
+			t.Errorf("did not receive expected interrupts within reasonable time, got %d", receivedInterrupts)
+			t.FailNow()
+		}
+	}
+
+	require.True(t, gotRunCompleted, "rungroup.Run did not terminate within time limit")
+
+	// We only want two interrupts -- we should not be waiting on the blocking actor
+	require.Equal(t, 2, receivedInterrupts)
+}
+
+func TestRun_MultipleActors_ExecuteReturnTimeout(t *testing.T) {
+	t.Parallel()
+
+	testRunGroup := NewRunGroup(log.NewNopLogger())
+
+	groupReceivedInterrupts := make(chan struct{}, 3)
+	// Keep track of when `execute`s return so we give testRunGroup.Run enough time to do its thing
+	groupReceivedExecuteReturns := make(chan struct{}, 2)
+
+	// First actor waits for interrupt and alerts groupReceivedInterrupts when it's interrupted
+	firstActorInterrupt := make(chan struct{})
+	testRunGroup.Add("firstActor", func() error {
+		<-firstActorInterrupt
+		groupReceivedExecuteReturns <- struct{}{}
+		return nil
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+		firstActorInterrupt <- struct{}{}
+	})
+
+	// Second actor returns error on `execute`, and then alerts groupReceivedInterrupts when it's interrupted
+	expectedError := errors.New("test error from interruptingActor")
+	testRunGroup.Add("interruptingActor", func() error {
+		time.Sleep(1 * time.Second)
+		groupReceivedExecuteReturns <- struct{}{}
+		return expectedError
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+	})
+
+	// Third actor never signals to `execute` to return
+	blockingActorInterrupt := make(chan struct{})
+	testRunGroup.Add("blockingActor", func() error {
+		<-blockingActorInterrupt                  // will never happen
+		groupReceivedExecuteReturns <- struct{}{} // will never happen
+		return nil
+	}, func(error) {
+		groupReceivedInterrupts <- struct{}{}
+	})
+
+	runCompleted := make(chan struct{})
+	go func() {
+		err := testRunGroup.Run()
+		runCompleted <- struct{}{}
+		require.Error(t, err)
+	}()
+
+	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
+	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	interruptCheckTimer := time.NewTicker(runDuration)
+	defer interruptCheckTimer.Stop()
+
+	// Make sure all three actors are interrupted, and that two of them terminate their execute
+	receivedInterrupts := 0
+	receivedExecuteReturns := 0
+	gotRunCompleted := false
+	for {
+		if gotRunCompleted {
+			break
+		}
+
+		select {
+		case <-groupReceivedInterrupts:
+			receivedInterrupts += 1
+		case <-groupReceivedExecuteReturns:
+			receivedExecuteReturns += 1
+		case <-runCompleted:
+			gotRunCompleted = true
+		case <-interruptCheckTimer.C:
+			t.Errorf("did not receive expected interrupts within reasonable time, got %d", receivedInterrupts)
+			t.FailNow()
+		}
+	}
+
+	require.True(t, gotRunCompleted, "rungroup.Run did not terminate within time limit")
+	require.Equal(t, 3, receivedInterrupts)
+	require.Equal(t, 2, receivedExecuteReturns)
 }


### PR DESCRIPTION
Ensure that the rungroup will still exit in a timely manner even if a rungroup actor a) doesn't interrupt in a timely manner or b) doesn't terminate its execution function in a timely manner. This prevents any rungroup actor from holding launcher in a suspended state, where it isn't doing anything but also isn't exiting in order to reload itself.