### PR TITLE
Add log when the rungroup has completed shutdown

### DIFF
--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -76,6 +76,8 @@ func (g *Group) Run() error {
 		level.Debug(g.logger).Log("msg", "successfully interrupted actor", "actor", e.errorSourceName, "index", i)
 	}
 
+	level.Debug(g.logger).Log("msg", "done shutting own actors", "actor_count", len(g.actors), "initial_err", initialActorErr.err)
+
 	// Return the original error.
 	return initialActorErr.err
 }

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -63,6 +63,7 @@ func (g *Group) Run() error {
 	// Wait for the first actor to stop.
 	initialActorErr := <-errors
 	level.Debug(g.logger).Log("msg", "received interrupt error from first actor -- shutting down other actors", "err", initialActorErr)
+	defer level.Debug(g.logger).Log("msg", "done shutting down actors", "actor_count", len(g.actors), "initial_err", initialActorErr)
 
 	// Signal all actors to stop.
 	for _, a := range g.actors {
@@ -75,8 +76,6 @@ func (g *Group) Run() error {
 		e := <-errors
 		level.Debug(g.logger).Log("msg", "successfully interrupted actor", "actor", e.errorSourceName, "index", i)
 	}
-
-	level.Debug(g.logger).Log("msg", "done shutting own actors", "actor_count", len(g.actors), "initial_err", initialActorErr.err)
 
 	// Return the original error.
 	return initialActorErr.err


### PR DESCRIPTION
I'm not totally sure this isn't duplicated in a caller, but....