### PR TITLE
Ensure localserver's runAsyncdWorkers shuts down on rungroup shutdown

### DIFF
--- a/ee/debug/checkups/quarantine.go
+++ b/ee/debug/checkups/quarantine.go
@@ -182,7 +182,7 @@ func (q *quarantine) checkDirs(extraFh io.Writer, currentDepth, maxDepth int, di
 }
 
 func (q *quarantine) logMeddlesomeProccesses(ctx context.Context, extraFh io.Writer, containsSubStrings []string) error {
-	fmt.Fprint(extraFh, "\npossilby meddlesome processes:\n")
+	fmt.Fprint(extraFh, "\npossibly meddlesome processes:\n")
 	foundMeddlesomeProcesses := false
 
 	ps, err := process.ProcessesWithContext(ctx)

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -47,6 +47,7 @@ type localServer struct {
 	tlsCerts     []tls.Certificate
 	querier      Querier
 	kolideServer string
+	cancel       context.CancelFunc
 
 	myKey                 *rsa.PrivateKey
 	myLocalDbSigner       crypto.Signer
@@ -214,30 +215,43 @@ func (ls *localServer) runAsyncdWorkers() time.Time {
 	return time.Now()
 }
 
+var (
+	pollInterval        = 15 * time.Minute
+	recalculateInterval = 24 * time.Hour
+)
+
 func (ls *localServer) Start() error {
 	// Spawn background workers. The information gathered here is not critical for DT flow- so to reduce early osquery contention
 	// we wait for <pollInterval> and before starting and then only rerun if the previous run was unsuccessful,
 	// or has been greater than <recalculateInterval>. Note that this polling is merely a check against time,
 	// we don't repopulate this data nearly so often. (But we poll frequently to account for the difference between
 	// wall clock time, and sleep time)
-	const (
-		pollInterval        = 15 * time.Minute
-		recalculateInterval = 24 * time.Hour
-	)
+
+	var ctx context.Context
+	ctx, ls.cancel = context.WithCancel(context.Background())
 
 	go func() {
 		var lastRun time.Time
 
-		ctx := context.TODO()
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
 
 		// note that this will trigger the check for the first time after pollInterval (not immediately)
-		for range time.Tick(pollInterval) {
-			if time.Since(lastRun) > recalculateInterval {
-				lastRun = ls.runAsyncdWorkers()
-				if lastRun.IsZero() {
-					ls.slogger.Log(ctx, slog.LevelDebug,
-						"runAsyncdWorkers unsuccessful, will retry in the future",
-					)
+		for {
+			select {
+			case <-ctx.Done():
+				ls.slogger.Log(ctx, slog.LevelDebug,
+					"runAsyncdWorkers received shutdown signal",
+				)
+				return
+			case <-ticker.C:
+				if time.Since(lastRun) > recalculateInterval {
+					lastRun = ls.runAsyncdWorkers()
+					if lastRun.IsZero() {
+						ls.slogger.Log(ctx, slog.LevelDebug,
+							"runAsyncdWorkers unsuccessful, will retry in the future",
+						)
+					}
 				}
 			}
 		}
@@ -247,8 +261,6 @@ func (ls *localServer) Start() error {
 	if err != nil {
 		return fmt.Errorf("starting listener: %w", err)
 	}
-
-	ctx := context.TODO()
 
 	if ls.tlsCerts != nil && len(ls.tlsCerts) > 0 {
 		ls.slogger.Log(ctx, slog.LevelDebug,
@@ -301,6 +313,8 @@ func (ls *localServer) Interrupt(_ error) {
 			"err", err,
 		)
 	}
+
+	ls.cancel()
 }
 
 func (ls *localServer) startListener() (net.Listener, error) {
@@ -360,8 +374,8 @@ func (ls *localServer) preflightCorsHandler(next http.Handler) http.Handler {
 
 func (ls *localServer) rateLimitHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ls.limiter.Allow() == false {
-			http.Error(w, http.StatusText(429), http.StatusTooManyRequests)
+		if !ls.limiter.Allow() {
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 
 			ls.slogger.Log(r.Context(), slog.LevelError,
 				"over rate limit",

--- a/ee/localserver/server_test.go
+++ b/ee/localserver/server_test.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/ee/localserver/mocks"
 	"github.com/kolide/launcher/pkg/agent/storage"
 	storageci "github.com/kolide/launcher/pkg/agent/storage/ci"
-	"github.com/kolide/launcher/pkg/agent/types/mocks"
+	typesmocks "github.com/kolide/launcher/pkg/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,13 +23,25 @@ func TestInterrupt_Multiple(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, osquery.SetupLauncherKeys(c))
 
-	k := mocks.NewKnapsack(t)
+	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("ConfigStore").Return(c)
 	k.On("Slogger").Return(multislogger.New().Logger)
 
+	// Override the poll and recalculate interval for the test so we can be sure that the async workers
+	// do run, but then stop running on shutdown
+	pollInterval = 2 * time.Second
+	recalculateInterval = 100 * time.Millisecond
+
+	// Create the localserver
 	ls, err := New(k)
 	require.NoError(t, err)
+
+	// Set the querier
+	querier := mocks.NewQuerier(t)
+	// On a 2-sec interval, letting the server run for 3 seconds, we should see only one query
+	querier.On("Query", mock.Anything).Return(nil, nil).Once()
+	ls.SetQuerier(querier)
 
 	// Let the server run for a bit
 	go ls.Start()
@@ -61,4 +75,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	}
 
 	require.Equal(t, expectedInterrupts, receivedInterrupts)
+
+	k.AssertExpectations(t)
+	querier.AssertExpectations(t)
 }


### PR DESCRIPTION
Cleans up goroutine on rungroup shutdown.