### PR TITLE
Update `package-builder` for EE license

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -215,7 +215,7 @@ jobs:
 
     - name: package
       id: run-package-builder
-      run: ${{ steps.build.outputs.binary }} make -debug --hostname=localhost --enroll_secret=secret --launcher_version=nightly --osquery_version=nightly --output_dir=./
+      run: ${{ steps.build.outputs.binary }} make --i-am-a-kolide-customer --debug --hostname=localhost --enroll_secret=secret --launcher_version=nightly --osquery_version=nightly --output_dir=./
 
     - name: Test install macOS
       if: ${{ contains(matrix.os, 'macos') }}

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -44,6 +44,11 @@ var defaultWixPath = wix.FindWixInstall()
 func runMake(args []string) error {
 	flagset := flag.NewFlagSet("macos", flag.ExitOnError)
 	var (
+		flKolideUsage = flagset.Bool(
+			"i-am-a-kolide-customer",
+			false,
+			"Certify that I am a Kolide customer and in compliance with the terms of the EE license",
+		)
 		flDebug = flagset.Bool(
 			"debug",
 			false,
@@ -181,6 +186,12 @@ func runMake(args []string) error {
 	flagset.Usage = usageFor(flagset, "package-builder make [flags]")
 	if err := flagset.Parse(args); err != nil {
 		return err
+	}
+
+	if !*flKolideUsage {
+		fmt.Fprintf(os.Stderr, "\nThe Kolide Agent is for use with the Kolide Service.\n")
+		fmt.Fprintf(os.Stderr, "See https://github.com/kolide/launcher/blob/main/ee/LICENSE\n")
+		return errors.New("")
 	}
 
 	logger := log.NewJSONLogger(os.Stderr)


### PR DESCRIPTION
As much of our code is now EE licensed, `package-builder` no longer makes sense if you're not a customer. However, it is quite helpful in CI. So instead of removing it, I opted to add a command line flag.