### PR TITLE
Add filesystem and full path data to lsblk table

### DIFF
--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -46,7 +46,7 @@ func platformTables(logger log.Logger, currentOsquerydBinaryPath string) []osque
 			[]string{"--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
 		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
-			allowedcmd.Lsblk, []string{"-J"},
+			allowedcmd.Lsblk, []string{"-fJp"},
 		),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),


### PR DESCRIPTION
Related to #9159

Small change to add some additional output to our lsblk parsing. The `f` option adds filesystem data and the `p` option returns the full device path for the device name instead of the basename.