### PR TITLE
update windows data dir installation

### DIFF
--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -39,7 +39,7 @@ func DefaultPath(path defaultPath) string {
 	if runtime.GOOS == "windows" {
 		switch path {
 		case RootDirectory:
-			return "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data"
+			return "C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data"
 		case WindowsConfigDirectory:
 			return "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf"
 		case BinDirectory:

--- a/pkg/packagekit/assets/main.wxs
+++ b/pkg/packagekit/assets/main.wxs
@@ -70,6 +70,7 @@
 	Level="1"
 	Display="hidden">
       <ComponentGroupRef Id="AppFiles" />
+      <ComponentGroupRef Id="AppData" />
     </Feature>
 
     <Feature

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -137,7 +137,7 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 		wixArgs = append(wixArgs, wix.WithService(launcherService))
 	}
 
-	wixTool, err := wix.New(po.Root, mainWxsContent.Bytes(), wixArgs...)
+	wixTool, err := wix.New(po.Root, po.Identifier, mainWxsContent.Bytes(), wixArgs...)
 	if err != nil {
 		return fmt.Errorf("making wixTool: %w", err)
 	}

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -11,21 +11,23 @@ import (
 	"strings"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 )
 
 type wixTool struct {
-	wixPath        string     // Where is wix installed
-	packageRoot    string     // What's the root of the packaging files?
-	buildDir       string     // The wix tools want to work in a build dir.
-	msArch         string     // What's the Microsoft architecture name?
-	services       []*Service // array of services.
-	dockerImage    string     // If in docker, what image?
-	skipValidation bool       // Skip light validation. Seems to be needed for running in 32bit wine environments.
-	skipCleanup    bool       // Skip cleaning temp dirs. Useful when debugging wix generation
-	cleanDirs      []string   // directories to rm on cleanup
-	ui             bool       // whether or not to include a ui
-	extraFiles     []extraFile
+	wixPath         string     // Where is wix installed
+	packageRoot     string     // What's the root of the packaging files?
+	packageDataRoot string     // What's the root for the data directory packaging files?
+	buildDir        string     // The wix tools want to work in a build dir.
+	msArch          string     // What's the Microsoft architecture name?
+	services        []*Service // array of services.
+	dockerImage     string     // If in docker, what image?
+	skipValidation  bool       // Skip light validation. Seems to be needed for running in 32bit wine environments.
+	skipCleanup     bool       // Skip cleaning temp dirs. Useful when debugging wix generation
+	cleanDirs       []string   // directories to rm on cleanup
+	ui              bool       // whether or not to include a ui
+	extraFiles      []extraFile
 
 	execCC func(context.Context, string, ...string) *exec.Cmd // Allows test overrides
 }
@@ -169,6 +171,10 @@ func (wo *wixTool) Cleanup() {
 // Package will run through the wix steps to produce a resulting
 // package. The path for the resultant package will be returned.
 func (wo *wixTool) Package(ctx context.Context) (string, error) {
+	if err := wo.setupDataDir(ctx); err != nil {
+		return "", fmt.Errorf("adding data file stubs: %w", err)
+	}
+
 	if err := wo.heat(ctx); err != nil {
 		return "", fmt.Errorf("running heat: %w", err)
 	}
@@ -236,6 +242,56 @@ func (wo *wixTool) addServices(ctx context.Context) error {
 	return nil
 }
 
+// setupDataDir handles the windows data directory setup by pre-creating any files
+// that we want to ensure are cleaned up on uninstall.
+// this is handled before the other heat/candle/light calls because we must issue
+// a separate heat call to harvest the data directory in ProgramData instead of Program Files
+func (wo *wixTool) setupDataDir(ctx context.Context) error {
+	var err error
+	wo.packageDataRoot, err = os.MkdirTemp("", "package.packageDataRoot")
+	if err != nil {
+		return fmt.Errorf("unable to create temporary packaging data directory: %w", err)
+	}
+
+	wo.cleanDirs = append(wo.cleanDirs, wo.packageDataRoot)
+
+	dataFilesPath := filepath.Join(wo.packageDataRoot, "Launcher-kolide-k2", "data")
+
+	if err := os.MkdirAll(dataFilesPath, fsutil.DirMode); err != nil {
+		return fmt.Errorf("create base data dir error for wix harvest: %w", err)
+	}
+
+	// touch these known file names before harvest to ensure they're cleaned up on uninstall
+	dataFilenames := []string{"launcher.db", "metadata.json"}
+
+	for _, fname := range dataFilenames {
+		newPath := filepath.Join(dataFilesPath, fname)
+		newFile, err := os.Create(newPath)
+		if err != nil {
+			return err
+		}
+
+		newFile.Close()
+	}
+
+	_, err = wo.execOut(ctx,
+		filepath.Join(wo.wixPath, "heat.exe"),
+		"dir", wo.packageDataRoot,
+		"-nologo",
+		"-gg", "-g1",
+		"-srd",
+		"-sfrag",
+		"-ke",
+		"-cg", "AppData",
+		"-template", "fragment",
+		"-dr", "DATADIR",
+		"-var", "var.SourceDataDir",
+		"-out", "AppData.wxs",
+	)
+
+	return nil
+}
+
 // heat invokes wix's heat command. This examines a directory and
 // "harvests" the files into an xml structure. See
 // http://wixtoolset.org/documentation/manual/v3/overview/heat.html
@@ -259,6 +315,7 @@ func (wo *wixTool) heat(ctx context.Context) error {
 		"-var", "var.SourceDir",
 		"-out", "AppFiles.wxs",
 	)
+
 	return err
 }
 
@@ -271,9 +328,11 @@ func (wo *wixTool) candle(ctx context.Context) error {
 		"-nologo",
 		"-arch", wo.msArch,
 		"-dSourceDir="+wo.packageRoot,
+		"-dSourceDataDir="+wo.packageDataRoot,
 		"-ext", "WixUtilExtension",
 		"Installer.wxs",
 		"AppFiles.wxs",
+		"AppData.wxs",
 	)
 	return err
 }
@@ -286,8 +345,10 @@ func (wo *wixTool) light(ctx context.Context) error {
 		"-nologo",
 		"-dcl:high", // compression level
 		"-dSourceDir=" + wo.packageRoot,
+		"-dSourceDataDir=" + wo.packageDataRoot,
 		"-ext", "WixUtilExtension",
 		"AppFiles.wixobj",
+		"AppData.wixobj",
 		"Installer.wixobj",
 		"-out", "out.msi",
 	}
@@ -315,6 +376,7 @@ func (wo *wixTool) execOut(ctx context.Context, argv0 string, args ...string) (s
 		"run",
 		"--entrypoint", "",
 		"-v", fmt.Sprintf("%s:%s", wo.packageRoot, wo.packageRoot),
+		"-v", fmt.Sprintf("%s:%s", wo.packageDataRoot, wo.packageDataRoot),
 		"-v", fmt.Sprintf("%s:%s", wo.buildDir, wo.buildDir),
 		"-w", wo.buildDir,
 		wo.dockerImage,

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -289,7 +289,7 @@ func (wo *wixTool) setupDataDir(ctx context.Context) error {
 		"-out", "AppData.wxs",
 	)
 
-	return nil
+	return err
 }
 
 // heat invokes wix's heat command. This examines a directory and

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -28,7 +28,7 @@ type wixTool struct {
 	cleanDirs       []string   // directories to rm on cleanup
 	ui              bool       // whether or not to include a ui
 	extraFiles      []extraFile
-	identifier      string     // the package identifier used for directory path creation (e.g. kolide-k2)
+	identifier      string // the package identifier used for directory path creation (e.g. kolide-k2)
 
 	execCC func(context.Context, string, ...string) *exec.Cmd // Allows test overrides
 }

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -264,7 +264,7 @@ func (wo *wixTool) setupDataDir(ctx context.Context) error {
 	}
 
 	// touch these known file names before harvest to ensure they're cleaned up on uninstall
-	dataFilenames := []string{"launcher.db", "metadata.json"}
+	dataFilenames := []string{"launcher.db", "metadata.json", "kv.sqlite"}
 
 	for _, fname := range dataFilenames {
 		newPath := filepath.Join(dataFilesPath, fname)

--- a/pkg/packagekit/wix/wix_test.go
+++ b/pkg/packagekit/wix/wix_test.go
@@ -42,6 +42,7 @@ func TestWixPackage(t *testing.T) {
 	require.NoError(t, err)
 
 	wixTool, err := New(packageRoot,
+		"test-identifier",
 		mainWxsContent,
 		As32bit(),                 // wine is 32bit
 		SkipValidation(),          // wine can't validate

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -125,7 +125,7 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 
 	launcherMapFlags := map[string]string{
 		"hostname":           p.Hostname,
-		"root_directory":     p.canonicalizePath(p.rootDir),
+		"root_directory":     p.canonicalizeRootDir(p.rootDir),
 		"osqueryd_path":      p.canonicalizePath(filepath.Join(p.binDir, "osqueryd")),
 		"enroll_secret_path": p.canonicalizePath(filepath.Join(p.confDir, "secret")),
 	}
@@ -736,12 +736,19 @@ func (p *PackageOptions) setupDirectories() error {
 		// to take that into account for the guid generation.
 		p.binDir = filepath.Join("Launcher-"+p.Identifier, "bin")
 		p.confDir = filepath.Join("Launcher-"+p.Identifier, "conf")
+		// we handle the data directory setup differently for windows before final package generation,
+		// see wix/wix.go's setupDataDir method for additional context
 		p.rootDir = filepath.Join("Launcher-"+p.Identifier, "data")
 	default:
 		return fmt.Errorf("unknown platform %s", string(p.target.Platform))
 	}
 
 	for _, d := range []string{p.binDir, p.confDir, p.rootDir} {
+		// don't create the root (data) directory for windows before heat can run
+		if p.target.Platform == Windows && d == p.rootDir {
+			continue
+		}
+
 		if err := os.MkdirAll(filepath.Join(p.packageRoot, d), fsutil.DirMode); err != nil {
 			return fmt.Errorf("create dir (%s) for %s: %w", d, p.target.String(), err)
 		}
@@ -784,4 +791,16 @@ func (p *PackageOptions) canonicalizePath(path string) string {
 	}
 
 	return filepath.Join(`C:\Program Files\Kolide`, path)
+}
+
+// canonicalizeRootDir functions similarly to canonicalizePath above,
+// only impacting MSI targets. This is broken out from canonicalizePath
+// because for windows the full path to the root directory should be expanded
+// into ProgramData
+func (p *PackageOptions) canonicalizeRootDir(path string) string {
+	if p.target.Package != Msi {
+		return path
+	}
+
+	return filepath.Join(`C:\ProgramData\Kolide`, path)
 }


### PR DESCRIPTION
There are two pieces to this update:
 1) breaks the windows installation out into:
   - `C:\Program Files\Kolide\Launcher-[IDENTIFIER]\`
     - Still contains the `bin` and `conf` directories
   - `C:\ProgramData\Kolide\Launcher-[IDENTIFIER]\`
     - Now contains the `data` directory
     - Still functions as the `rootDir`, containing all updates
2) creates an empty `launcher.db` file in the `data` directory
  - doing this (along with any other files we want to add for cleanup) before the harvest tool (heat.exe) is run ensures that the launcher.db is cleaned up when an uninstall is initiated

Ideally we would integrate the wix [RemoveFolderEx](https://wixtoolset.org/docs/v3/xsd/util/removefolderex/) util extension into the wix-generated files (along with some registry updates) to achieve full cleanup, but this did not work as advertised after several attempts. Our cleanup complications come from arbitrarily nested directories containing filenames which are unknown at the time of harvest (e.g. rotated logs, updates, etc.). But because we are specifically concerned with the launcher.db cleanup, ensuring that file is present is enough for forward progress here.

Another option we can look into in the future if additional cleanup is needed is the wix [CustomAction](https://wixtoolset.org/docs/schema/wxs/customaction/) element. There are some reports of successful cleanup on this type of install structure using a separate removal script via CustomAction.

Including a quick logical overview of the changes here because it took me a bit to understand how wix works and how we integrate it within the build process - note that this is especially confusing because wix operates off of relative paths, expanded internally at build time, while the linux and darwin build processes are able to nest full paths within their respective root build directories back at the level of pkg/packaging/packaging.go. This makes it difficult to cleanly share as much logic as we would like between platform builds, and largely shaped this approach methodology in order to prevent excessive changes within the linux/darwin builds.

- within pkg/packaging/packaging.go, we needed to ensure the windows rootDir would point at ProgramData (see `canonicalizeRootDir` for the flag file generation
  - we also needed to prevent the data (root) dir from being created at this level for MSI targets to give the logic in pkg/pkgkit/wix/wix.go the chance to set up a separate data directory for harvest (in `ProgramData`)
- within pkg/pkgkit/wix/wix.go, we set up this directory and add any additional files we want to be included in the registry for cleanup on uninstall
  - we then run heat for `DATADIR` (expanded by wix into the `ProgramData` directory) with our pre-created file stubs, and include the newly generated component group from the main wix template

### Testing

To test locally (outside of CI builds) I'd recommend using git bash to build on a windows machine directly (otherwise you will need to make some modifications to the commands below).

Navigate to your launcher directory within git bash and pull down this branch. Most build setup should be identical to other platforms (i.e. `make deps && make`).

Note your existing enroll secret and replace in the command below: `cat C:/Program\ Files/Kolide/Launcher-kolide-k2/conf/secret`

Run the following to build an MSI for local installation:
```
./build/package-builder.exe make -debug=true -transport=jsonrpc -hostname=k2device-preprod.kolide.com -output_dir=./build/ -identifier=kolide-k2 -launcher_version=./build/launcher.exe -enroll_secret="<TAKEN_FROM_ABOVE>" -i-am-a-kolide-customer
```

Uninstall your existing Launcher installation from Control-Panel and ensure a fresh installation by removing all of `C:/Program\ Files/Kolide`.

Your new build for testing should be installable from `./build/launcher.windows-service-msi.msi`


