### PR TITLE
linux uninstall and docs updates

### DIFF
--- a/cmd/launcher/uninstall_linux.go
+++ b/cmd/launcher/uninstall_linux.go
@@ -49,6 +49,7 @@ func removeLauncher(ctx context.Context, identifier string) error {
 	pathsToRemove := []string{
 		fmt.Sprintf("/var/%s", identifier),
 		fmt.Sprintf("/etc/%s", identifier),
+		fmt.Sprintf("/usr/local/%s", identifier),
 	}
 
 	// Now remove the paths used for launcher/osquery binaries and app data

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -74,4 +74,5 @@ sudo rm /Library/LaunchDaemons/com.kolide.launcher.plist
 sudo rm -r /usr/local/kolide
 sudo rm -r /var/kolide
 sudo rm -r /etc/kolide
+sudo pkgutil --forget com.kolide.launcher
 ```

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -1,9 +1,13 @@
 # Uninstalling Osquery Launcher
 
-> [!NOTE]  
+> [!NOTE]
 > This documents are for an open source launcher install. If you're looking for official instructions on how to uninstall
 > Kolide Agent, try https://www.kolide.com/docs/using-kolide/agent/removal-instructions
 
+> [!NOTE]
+> All paths noted on this page are based off of the identifier used at the time of package creation.
+> The paths listed here assume an identifier of `kolide`. If you use a different identifier you will
+> need to update any paths accordingly
 
 ## Linux
 
@@ -33,7 +37,7 @@ To remove `launcher` and **remove** configuration files, run the following:
 sudo dpkg --purge launcher
 ```
 
-`dpkg --purge` will not delete directories which are not empty. As a result you might see a warning which looks like: 
+`dpkg --purge` will not delete directories which are not empty. As a result you might see a warning which looks like:
 
 ```
 dpkg: warning: while removing launcher, directory '/usr/local/kolide/bin' not empty so not removed
@@ -41,6 +45,12 @@ dpkg: warning: while removing launcher, directory '/var/kolide/launcher.example.
 ```
 
 Based on the configurations used when the Launcher package was created, the specific paths printed may look slightly different. In any case, these left over directories mentioned in the `dpkg` warning can be removed with `sudo rm -rf`.
+
+Directories:
+
+- `/usr/local/kolide`
+- `/var/kolide`
+- `/etc/kolide`
 
 ## macOS
 
@@ -50,6 +60,7 @@ Directories:
 
 - `/usr/local/kolide`
 - `/var/kolide`
+- `/var/log/kolide`
 - `/etc/kolide`
 
 Files:


### PR DESCRIPTION
After looking into cleaning up the various uninstall processes, the lift for windows was significantly different than the rest, so the linux updates have been broken off here.

This ensures that the `/usr/local/[identifier]` is also cleaned up when `sudo launcher uninstall` is run, and makes some small updates to the OS uninstallation docs