### PR TITLE
[TUF] Add flag for TUF autoupdater rollout

### DIFF
--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -500,6 +500,15 @@ func (fc *FlagController) UpdateDirectory() string {
 	).get(fc.getControlServerValue(keys.UpdateDirectory))
 }
 
+func (fc *FlagController) SetUseTUFAutoupdater(enabled bool) error {
+	return fc.setControlServerValue(keys.UseTUFAutoupdater, boolToBytes(enabled))
+}
+func (fc *FlagController) UseTUFAutoupdater() bool {
+	return NewBoolFlagValue(
+		WithDefaultBool(false),
+	).get(fc.getControlServerValue(keys.UseTUFAutoupdater))
+}
+
 func (fc *FlagController) SetExportTraces(enabled bool) error {
 	return fc.setControlServerValue(keys.ExportTraces, boolToBytes(enabled))
 }

--- a/ee/agent/flags/keys/keys.go
+++ b/ee/agent/flags/keys/keys.go
@@ -44,6 +44,7 @@ const (
 	MirrorServerURL                 FlagKey = "mirror_url"
 	AutoupdateInterval              FlagKey = "autoupdate_interval"
 	UpdateChannel                   FlagKey = "update_channel"
+	UseTUFAutoupdater               FlagKey = "use_tuf_autoupdater"
 	NotaryPrefix                    FlagKey = "notary_prefix"
 	AutoupdateInitialDelay          FlagKey = "autoupdater_initial_delay"
 	UpdateDirectory                 FlagKey = "update_directory"

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -419,6 +419,13 @@ func (k *knapsack) UpdateDirectory() string {
 	return k.flags.UpdateDirectory()
 }
 
+func (k *knapsack) SetUseTUFAutoupdater(enabled bool) error {
+	return k.flags.SetUseTUFAutoupdater(enabled)
+}
+func (k *knapsack) UseTUFAutoupdater() bool {
+	return k.flags.UseTUFAutoupdater()
+}
+
 func (k *knapsack) SetExportTraces(enabled bool) error {
 	return k.flags.SetExportTraces(enabled)
 }

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -185,6 +185,10 @@ type Flags interface {
 	SetUpdateDirectory(directory string) error
 	UpdateDirectory() string
 
+	// UseTUFAutoupdater controls whether launcher uses the new TUF autoupdater instead of the legacy autoupdater
+	SetUseTUFAutoupdater(enabled bool) error
+	UseTUFAutoupdater() bool
+
 	// ExportTraces enables exporting our traces
 	SetExportTraces(enabled bool) error
 	SetExportTracesOverride(value bool, duration time.Duration)

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -1160,6 +1160,20 @@ func (_m *Flags) SetUpdateDirectory(directory string) error {
 	return r0
 }
 
+// SetUseTUFAutoupdater provides a mock function with given fields: enabled
+func (_m *Flags) SetUseTUFAutoupdater(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetWatchdogDelaySec provides a mock function with given fields: sec
 func (_m *Flags) SetWatchdogDelaySec(sec int) error {
 	ret := _m.Called(sec)
@@ -1309,6 +1323,20 @@ func (_m *Flags) UpdateDirectory() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// UseTUFAutoupdater provides a mock function with given fields:
+func (_m *Flags) UseTUFAutoupdater() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -1352,6 +1352,20 @@ func (_m *Knapsack) SetUpdateDirectory(directory string) error {
 	return r0
 }
 
+// SetUseTUFAutoupdater provides a mock function with given fields: enabled
+func (_m *Knapsack) SetUseTUFAutoupdater(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetWatchdogDelaySec provides a mock function with given fields: sec
 func (_m *Knapsack) SetWatchdogDelaySec(sec int) error {
 	ret := _m.Called(sec)
@@ -1565,6 +1579,20 @@ func (_m *Knapsack) UpdateDirectory() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// UseTUFAutoupdater provides a mock function with given fields:
+func (_m *Knapsack) UseTUFAutoupdater() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954

Adds a control server flag for a gradual rollout of the new TUF autoupdater.