### PR TITLE
[TUF] Use use_tuf_autoupdater in startupsettings to determine whether to use new autoupdater

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -444,9 +444,9 @@ func runLauncher(ctx context.Context, cancel func(), slogger, systemSlogger *mul
 		runGroup.Add("tufAutoupdater", tufAutoupdater.Execute, tufAutoupdater.Interrupt)
 	}
 
-	// Run the legacy autoupdater only if autoupdating is enabled and the given channel hasn't moved
-	// to the new autoupdater yet.
-	if k.Autoupdate() && !tuf.ChannelUsesNewAutoupdater(k.UpdateChannel()) {
+	// Run the legacy autoupdater only if autoupdating is enabled and the new autoupdater
+	// is not yet in use.
+	if k.Autoupdate() && !k.UseTUFAutoupdater() {
 		osqueryUpdaterconfig := &updater.UpdaterConfig{
 			Logger:             logger,
 			RootDirectory:      rootDirectory,

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -57,7 +57,7 @@ func main() {
 	// fork-bombing itself. This is an ENV, because there's no
 	// good way to pass it through the flags.
 	if !env.Bool("LAUNCHER_SKIP_UPDATES", false) {
-		if tuf.UsingNewAutoupdater() {
+		if tuf.ShouldUseNewAutoupdater(ctx) {
 			runNewerLauncherIfAvailable(ctx, logger)
 		} else {
 			newerBinary, err := autoupdate.FindNewestSelf(ctx)

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -322,7 +322,7 @@ func (ta *TufAutoupdater) checkForUpdate() error {
 
 	// Only perform restarts if we're configured to use this new autoupdate library,
 	// to prevent performing unnecessary restarts.
-	if !ChannelUsesNewAutoupdater(ta.knapsack.UpdateChannel()) {
+	if !ta.knapsack.UseTUFAutoupdater() {
 		return nil
 	}
 

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -74,6 +74,7 @@ func TestExecute_launcherUpdate(t *testing.T) {
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
 	mockKnapsack.On("LocalDevelopmentPath").Return("")
+	mockKnapsack.On("UseTUFAutoupdater").Return(true)
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater
@@ -163,6 +164,7 @@ func TestExecute_launcherUpdate_noRestartIfUsingLegacyAutoupdater(t *testing.T) 
 	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UseTUFAutoupdater").Return(false)
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater
@@ -235,6 +237,7 @@ func TestExecute_osquerydUpdate(t *testing.T) {
 	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UseTUFAutoupdater").Return(true)
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater
@@ -308,6 +311,7 @@ func TestExecute_downgrade(t *testing.T) {
 	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UseTUFAutoupdater").Return(true)
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater
@@ -392,6 +396,7 @@ func TestExecute_withInitialDelay(t *testing.T) {
 	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UseTUFAutoupdater").Return(true).Maybe()
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater
@@ -455,6 +460,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	mockKnapsack.On("TufServerURL").Return(testMetadataServer.URL)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UseTUFAutoupdater").Return(true).Maybe()
 	mockQuerier := newMockQuerier(t)
 
 	// Set up autoupdater


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/954

Check the sqlite database for the `use_tuf_autoupdater` flag (added in [this PR](https://github.com/kolide/launcher/pull/1524), stored in the sqlite database in [this PR](https://github.com/kolide/launcher/pull/1515)) to determine whether launcher should use the new autoupdater or not.