### PR TITLE
Ensure kolide URL is set before doing DNS check

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -96,6 +96,9 @@ func runLauncher(ctx context.Context, cancel func(), slogger, systemSlogger *mul
 	// Note that the SplitN won't work for bare ip6 addresses.
 	if err := backoff.WaitFor(func() error {
 		hostport := strings.SplitN(opts.KolideServerURL, ":", 2)
+		if len(hostport) < 1 {
+			return fmt.Errorf("unable to parse url: %s", opts.KolideServerURL)
+		}
 		_, lookupErr := net.LookupIP(hostport[0])
 		return lookupErr
 	}, 10*time.Second, 1*time.Second); err != nil {


### PR DESCRIPTION
If kolide server URL is empty, we cannot index into it.