### PR TITLE
Log stack trace for panic when possible

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kolide/launcher/pkg/log/locallogger"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/log/teelogger"
+	"github.com/pkg/errors"
 )
 
 func main() {
@@ -131,6 +132,12 @@ func main() {
 				"msg", "panic occurred",
 				"err", r,
 			)
+			if err, ok := r.(error); ok {
+				level.Info(logger).Log(
+					"msg", "panic stack trace",
+					"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
+				)
+			}
 			time.Sleep(time.Second)
 		}
 	}()

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kolide/launcher/pkg/log/locallogger"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/log/teelogger"
+	"github.com/pkg/errors"
 
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
@@ -115,6 +116,12 @@ func runWindowsSvc(args []string) error {
 				"msg", "panic occurred in windows service",
 				"err", r,
 			)
+			if err, ok := r.(error); ok {
+				level.Info(logger).Log(
+					"msg", "panic stack trace",
+					"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
+				)
+			}
 			time.Sleep(time.Second)
 		}
 	}()


### PR DESCRIPTION
Currently, we don't get the stack trace when logging panics, which can make it tough to track down some of them (like the example below, `runtime error: index out of range [100] with length 1`). This PR adds the stack trace to a new log message whenever it's possible to include.

Example:

```
{
    "caller":"log.go:124",
    "err":"runtime error: index out of range [100] with length 1",
    "msg":"panic occurred",
    "severity":"info",
    "ts":"2024-01-08T20:29:17.651657Z"
}
{
    "caller":"log.go:124",
    "msg":"panic stack trace",
    "severity":"info",
    "stack_trace":"runtime error: index out of range [100] with length 1\nmain.main.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/main.go:138\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:914\nruntime.goPanicIndex\n\t/usr/local/go/src/runtime/panic.go:114\nmain.runLauncher.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/launcher.go:102\ngithub.com/kolide/launcher/pkg/backoff.WaitFor\n\t/Users/rebeccamahany-horton/Repos/launcher/pkg/backoff/waitfor.go:27\nmain.runLauncher\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/launcher.go:97\nmain.main\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/main.go:147\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:267\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1197",
    "ts":"2024-01-08T20:29:17.651719Z"
}
```