### PR TITLE
Don't use reserved version key in logs

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -577,7 +577,7 @@ func runOsqueryVersionCheck(ctx context.Context, slogger *slog.Logger, osquerydP
 
 	slogger.Log(ctx, slog.LevelDebug,
 		"checked osqueryd version",
-		"version", outTrimmed,
+		"osqueryd_version", outTrimmed,
 		"execution_time_ms", executionTimeMs,
 		"osqueryd_path", osquerydPath,
 	)

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -318,7 +318,7 @@ func (ta *TufAutoupdater) checkForUpdate() error {
 			ta.slogger.Log(context.TODO(), slog.LevelInfo,
 				"update downloaded",
 				"binary", binary,
-				"version", downloadedUpdateVersion,
+				"binary_version", downloadedUpdateVersion,
 			)
 			updatesDownloaded[binary] = versionFromTarget(binary, downloadedUpdateVersion)
 		}

--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -192,7 +192,7 @@ func CheckOutLatest(ctx context.Context, binary autoupdatableBinary, rootDirecto
 	update, err := findExecutableFromRelease(ctx, binary, LocalTufDirectory(rootDirectory), channel, updateDirectory)
 	if err == nil {
 		span.AddEvent("found_latest_from_release")
-		level.Info(logger).Log("msg", "found executable matching current release", "path", update.Path, "version", update.Version)
+		level.Info(logger).Log("msg", "found executable matching current release", "executable_path", update.Path, "executable_version", update.Version)
 		return update, nil
 	}
 

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -191,10 +191,10 @@ func (ls *LogShipper) updateDevideIdentifyingAttributes() error {
 	deviceInfo := make(map[string]string)
 
 	versionInfo := version.Version()
-	deviceInfo["version"] = versionInfo.Version
+	deviceInfo["launcher_version"] = versionInfo.Version
 	deviceInfo["os"] = runtime.GOOS
 
-	ls.shippingLogger = log.With(ls.shippingLogger, "version", versionInfo.Version)
+	ls.shippingLogger = log.With(ls.shippingLogger, "launcher_version", versionInfo.Version)
 
 	for _, key := range []string{"device_id", "munemo", "organization_id", "serial_number"} {
 		v, err := ls.knapsack.ServerProvidedDataStore().Get([]byte(key))


### PR DESCRIPTION
The logshipper adds a `version` key for current launcher version to logs, so using `version` keys elsewhere means we miss out on that logshipper data.