### PR TITLE
Add circleDot capability

### DIFF
--- a/ee/desktop/user/menu/menu_template.go
+++ b/ee/desktop/user/menu/menu_template.go
@@ -8,13 +8,14 @@ import (
 )
 
 const (
-	CurrentMenuVersion string = "0.1.0" // Bump menu version when major changes occur to the TemplateData format
+	CurrentMenuVersion string = "0.1.1" // Bump menu version when major changes occur to the TemplateData format
 
 	// Capabilities queriable via hasCapability
 	funcHasCapability     = "hasCapability"
 	funcRelativeTime      = "relativeTime"
 	errorlessTemplateVars = "errorlessTemplateVars" // capability to evaluate undefined template vars without failing
 	errorlessActions      = "errorlessActions"      // capability to evaluate undefined menu item actions without failing
+	circleDot             = "circleDot"             // capability to use circle-dot icon
 
 	// TemplateData keys
 	LauncherVersion    string = "LauncherVersion"
@@ -55,6 +56,8 @@ func (tp *templateParser) Parse(text string) (string, error) {
 			case errorlessTemplateVars:
 				return true
 			case errorlessActions:
+				return true
+			case circleDot:
 				return true
 			}
 			return false

--- a/ee/desktop/user/menu/menu_template.go
+++ b/ee/desktop/user/menu/menu_template.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	CurrentMenuVersion string = "0.1.1" // Bump menu version when major changes occur to the TemplateData format
+	CurrentMenuVersion string = "0.1.0" // Bump menu version when major changes occur to the TemplateData format
 
 	// Capabilities queriable via hasCapability
 	funcHasCapability     = "hasCapability"

--- a/ee/desktop/user/menu/menu_template_test.go
+++ b/ee/desktop/user/menu/menu_template_test.go
@@ -44,6 +44,18 @@ func Test_Parse(t *testing.T) {
 			output: "This capability is unsupported.",
 		},
 		{
+			name:   "circleDot capability",
+			td:     &TemplateData{},
+			text:   "\"icon\":\"{{if not (hasCapability `circleDot`)}}triangle-exclamation{{else}}circle-dot{{end}}\"",
+			output: "\"icon\":\"circle-dot\"",
+		},
+		{
+			name:   "icon fallback capability",
+			td:     &TemplateData{},
+			text:   "\"icon\":\"{{if not (hasCapability `asOfYetUnknownIconType`)}}triangle-exclamation{{else}}new-icon-type{{end}}\"",
+			output: "\"icon\":\"triangle-exclamation\"",
+		},
+		{
 			name:   "relativeTime 2 hours ago",
 			td:     &TemplateData{LastMenuUpdateTime: time.Now().Add(-2 * time.Hour).Unix()},
 			text:   "This Menu Was Last Updated {{if hasCapability `relativeTime`}}{{relativeTime .LastMenuUpdateTime}}{{else}}never{{end}}.",


### PR DESCRIPTION
Adds a `circleDot` capability to the menu template parser, so that k2 can conditionally pass down the `circle-dot` icon with a fallback icon.

```
"icon":"{{if not (hasCapability `circleDot`)}}triangle-exclamation{{else}}circle-dot{{end}}"
```