### PR TITLE
add xdg_runtime_dir env var to gnome extension exec

### DIFF
--- a/ee/debug/checkups/gnome_extensions_linux.go
+++ b/ee/debug/checkups/gnome_extensions_linux.go
@@ -81,6 +81,8 @@ func (c *gnomeExtensions) Run(ctx context.Context, extraWriter io.Writer) error 
 					Gid: uint32(runningUserGid),
 				},
 			}
+
+			cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=/run/user/%s", consoleUser.Uid))
 		}
 
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
adds XDG_RUNTIME_DIR env to gnome extension check so it can run as sudo without needed the -E flag (also should work in flare / doctor)