### PR TITLE
Lock to govulncheck@v1.0.1 temporarily to avoid dirty tags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,12 +65,6 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: goto-bus-stop/setup-zig@v2
 
-    - name: version troubleshooting
-      run: |
-        git describe --tags --always --dirty
-        git status
-        git diff HEAD
-
     - name: Build
       run: make -j2 github-build
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,6 +65,12 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: goto-bus-stop/setup-zig@v2
 
+    - name: version troubleshooting
+      run: |
+        git describe --tags --always --dirty
+        git status
+        git diff HEAD
+
     - name: Build
       run: make -j2 github-build
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
       run: make deps
 
     - name: Run govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest; govulncheck ./...
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.1; govulncheck ./...
 
     - name: Set up zig
       if: ${{ contains(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
Noticed this morning that all of our our latest builds are tagged with `-dirty`. This doesn't appear to have anything to do with changes we've made in our CI.

Through troubleshooting, I narrowed it down to the [Jan 16 govulncheck v1.0.2 release](https://pkg.go.dev/golang.org/x/vuln@v1.0.2/cmd/govulncheck) -- installing and running this version modifies `go.sum`, which results in a dirty state immediately before the build process, which runs `git describe ...` to set launcher version.

I think the issue is not https://github.com/golang/go/issues/65130, but maybe similar/related.

Other options to consider besides locking to v1.0.1:

* We could move the govulncheck step after the build step in our CI
* We could run `go mod tidy` immediately after running govulncheck