### PR TITLE
[TUF] Retry executable checks and directory renames on update download

### DIFF
--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -220,7 +220,7 @@ func (ulm *updateLibraryManager) moveVerifiedUpdate(binary autoupdatableBinary, 
 		return fmt.Errorf("could not patch executable: %w", err)
 	}
 
-	// Validate the executable -- the exectuable check will occasionally time out, especially on Windows,
+	// Validate the executable -- the executable check will occasionally time out, especially on Windows,
 	// and we aren't in a rush here, so we retry a couple times.
 	if err := backoff.WaitFor(func() error {
 		return autoupdate.CheckExecutable(context.TODO(), executableLocation(stagedVersionedDirectory, binary), "--version")


### PR DESCRIPTION
This is another attempt to address some of the most frequent errors in the logs that I see with the new autoupdater; they are both almost entirely Windows issues.

First:

```
could not download updates: [
  could not download update for launcher:
    could not add release launcher-x.y.z.tar.gz for binary launcher to library:
      could not move verified update:
        could not move staged target launcher-x.y.z.tar.gz from <root-dir>\updates\launcher\x.y.z-timestamp to <root-dir>\updates\launcher\x.y.z:
          rename <root_dir>\updates\launcher\x.y.z-timestamp C:\Program Files\Kolide\Launcher-kolide-k2\data\updates\launcher\x.y.z:
            Access is denied.
]
```

Second:

```
could not download updates: [
  could not download update for launcher:
    could not add release launcher-x.y.z.tar.gz for binary launcher to library:
      could not move verified update:
        could not verify executable:
          timeout when checking executable:
            context deadline exceeded
]
```

Per some [previous investigation](https://github.com/kolide/launcher/pull/1546), these appear to both be timing issues, so I'm throwing some more retries in. This is a safe time to retry -- it just delays when launcher will load the new binary, but won't delay launcher startup. And it's better than having to wait another autoupdate interval to retry the download again.