### PR TITLE
Don't select launcher version under v1.4.1 on stable

### DIFF
--- a/ee/tuf/library_lookup_test.go
+++ b/ee/tuf/library_lookup_test.go
@@ -141,7 +141,7 @@ func Test_mostRecentVersion(t *testing.T) {
 			tufci.CopyBinary(t, secondVersionPath)
 			require.NoError(t, os.Chmod(secondVersionPath, 0755))
 
-			latest, err := mostRecentVersion(context.TODO(), binary, testBaseDir)
+			latest, err := mostRecentVersion(context.TODO(), binary, testBaseDir, "nightly")
 			require.NoError(t, err, "did not expect error getting most recent version")
 			require.Equal(t, secondVersionPath, latest.Path)
 			require.Equal(t, secondVersion, latest.Version)
@@ -173,7 +173,7 @@ func Test_mostRecentVersion_DoesNotReturnInvalidExecutables(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(secondVersionPath), 0755))
 			os.WriteFile(secondVersionPath, []byte{}, 0755)
 
-			latest, err := mostRecentVersion(context.TODO(), binary, testBaseDir)
+			latest, err := mostRecentVersion(context.TODO(), binary, testBaseDir, "nightly")
 			require.NoError(t, err, "did not expect error getting most recent version")
 			require.Equal(t, firstVersionPath, latest.Path)
 			require.Equal(t, firstVersion, latest.Version)
@@ -192,10 +192,43 @@ func Test_mostRecentVersion_ReturnsErrorOnNoUpdatesDownloaded(t *testing.T) {
 			// Create update directories
 			testBaseDir := t.TempDir()
 
-			_, err := mostRecentVersion(context.TODO(), binary, testBaseDir)
+			_, err := mostRecentVersion(context.TODO(), binary, testBaseDir, "nightly")
 			require.Error(t, err, "should have returned error when there are no available updates")
 		})
 	}
+}
+
+func Test_mostRecentVersion_requiresLauncher_v1_4_1(t *testing.T) {
+	t.Parallel()
+
+	testBaseDir := t.TempDir()
+
+	// Create a version in the update library that is too old
+	firstVersionTarget := "launcher-1.2.3.tar.gz"
+	firstVersionPath, _ := pathToTargetVersionExecutable(binaryLauncher, firstVersionTarget, testBaseDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(firstVersionPath), 0755))
+	tufci.CopyBinary(t, firstVersionPath)
+	require.NoError(t, os.Chmod(firstVersionPath, 0755))
+
+	_, err := mostRecentVersion(context.TODO(), binaryLauncher, testBaseDir, "stable")
+	require.Error(t, err, "should not select launcher version under v1.4.1")
+}
+
+func Test_mostRecentVersion_acceptsLauncher_v1_4_1(t *testing.T) {
+	t.Parallel()
+
+	testBaseDir := t.TempDir()
+
+	// Create a version in the update library that is too old
+	firstVersionTarget := "launcher-1.4.1.tar.gz"
+	firstVersionPath, _ := pathToTargetVersionExecutable(binaryLauncher, firstVersionTarget, testBaseDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(firstVersionPath), 0755))
+	tufci.CopyBinary(t, firstVersionPath)
+	require.NoError(t, os.Chmod(firstVersionPath, 0755))
+
+	latest, err := mostRecentVersion(context.TODO(), binaryLauncher, testBaseDir, "stable")
+	require.NoError(t, err, "should be able to select launcher version equal to v1.4.1")
+	require.Equal(t, firstVersionPath, latest.Path)
 }
 
 func Test_usingNewAutoupdater_DatabaseNotExist(t *testing.T) {


### PR DESCRIPTION
If a user has a recent launcher version (e.g. 1.4.4) in their legacy autoupdate library _and_ this recent launcher version is not the current stable (e.g. we roll back from 1.4.4 to 1.4.2) _and_ their new autoupdate library has versions that are only _older_ than 1.4.1 (e.g. 1.3.2), they can get stuck in a loop on startup:

1. The older installed version of launcher bootstraps itself to the newest version in the legacy library v1.4.4
2. v1.4.4 recognizes that it's not on the the release version v1.4.2, so falls back to loading the newest version in the new autoupdate library, v1.3.2
3. v1.3.2 does not know it should use the new autoupdate library yet, so it goes back through and bootstraps itself to the newest version in the legacy library, v1.4.4
4. Repeat 2-3