### PR TITLE
Set up tracing as early as possible to capture initial traces

### DIFF
--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"runtime"
 	"sync"
 	"time"
 
-	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/storage"
 	"github.com/kolide/launcher/ee/agent/types"
@@ -64,29 +62,14 @@ type TraceExporter struct {
 
 // NewTraceExporter sets up our traces to be exported via OTLP over HTTP.
 // On interrupt, the provider will be shut down.
-func NewTraceExporter(ctx context.Context, k types.Knapsack) (*TraceExporter, error) {
-	// Set all the attributes that we know we can get first
-	attrs := []attribute.KeyValue{
-		semconv.ServiceName(applicationName),
-		semconv.ServiceVersion(version.Version().Version),
-	}
-
-	if archAttr, ok := archAttributeMap[runtime.GOARCH]; ok {
-		attrs = append(attrs, archAttr)
-	}
-
+func NewTraceExporter(ctx context.Context, k types.Knapsack, initialTraceBuffer *InitialTraceBuffer) (*TraceExporter, error) {
 	currentToken, _ := k.TokenStore().Get(storage.ObservabilityIngestAuthTokenKey)
-
 	ctx, cancel := context.WithCancel(ctx)
 
 	t := &TraceExporter{
-		providerLock: sync.Mutex{},
-		bufSpanProcessor: &bufspanprocessor.BufSpanProcessor{
-			MaxBufferedSpans: 500,
-		},
+		providerLock:              sync.Mutex{},
 		knapsack:                  k,
 		slogger:                   k.Slogger().With("component", "trace_exporter"),
-		attrs:                     attrs,
 		attrLock:                  sync.RWMutex{},
 		ingestClientAuthenticator: newClientAuthenticator(string(currentToken), k.DisableTraceIngestTLS()),
 		ingestAuthToken:           string(currentToken),
@@ -97,6 +80,17 @@ func NewTraceExporter(ctx context.Context, k types.Knapsack) (*TraceExporter, er
 		batchTimeout:              k.TraceBatchTimeout(),
 		ctx:                       ctx,
 		cancel:                    cancel,
+	}
+
+	if initialTraceBuffer != nil {
+		t.provider = initialTraceBuffer.provider
+		t.bufSpanProcessor = initialTraceBuffer.bufSpanProcessor
+		t.attrs = initialTraceBuffer.attrs
+	} else {
+		t.bufSpanProcessor = &bufspanprocessor.BufSpanProcessor{
+			MaxBufferedSpans: 500,
+		}
+		t.attrs = initialAttrs()
 	}
 
 	// Observe changes to trace configuration to know when to start/stop exporting, and when
@@ -114,27 +108,13 @@ func NewTraceExporter(ctx context.Context, k types.Knapsack) (*TraceExporter, er
 
 	t.addDeviceIdentifyingAttributes()
 
-	// Set the provider with as many resource attributes as we can get immediately
-	t.setNewGlobalProvider(true)
-
 	return t, nil
 }
 
 func (t *TraceExporter) SetOsqueryClient(client osquery.Querier) {
 	t.osqueryClient = client
 
-	// In the background, wait for osquery to be ready so that we can fetch more resource
-	// attributes for our traces, then replace the provider with a new one.
-	go func() {
-		t.addAttributesFromOsquery()
-
-		// we don't want to rebuild the exporter here because we may drop
-		// buffered spans, so we just replace the provider
-		t.setNewGlobalProvider(false)
-		t.slogger.Log(context.TODO(), slog.LevelDebug,
-			"successfully replaced global provider after adding osquery attributes",
-		)
-	}()
+	go t.addAttributesFromOsquery()
 }
 
 // addDeviceIdentifyingAttributes gets device identifiers from the server-provided
@@ -320,9 +300,15 @@ func (t *TraceExporter) setNewGlobalProvider(rebuildExporter bool) {
 	t.ingestUrl = t.knapsack.TraceIngestServerURL()
 }
 
-// Execute is a no-op -- the exporter is already running in the background. The TraceExporter
-// otherwise only responds to control server events.
+// Execute begins exporting traces, if exporting is enabled.
 func (t *TraceExporter) Execute() error {
+	if t.enabled {
+		t.setNewGlobalProvider(true)
+		t.slogger.Log(context.TODO(), slog.LevelDebug,
+			"successfully replaced global provider after adding more attributes",
+		)
+	}
+
 	<-t.ctx.Done()
 	return nil
 }

--- a/pkg/traces/exporter/exporter_test.go
+++ b/pkg/traces/exporter/exporter_test.go
@@ -58,7 +58,7 @@ func TestNewTraceExporter(t *testing.T) { //nolint:paralleltest
 		},
 	}, nil)
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack)
+	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
 	traceExporter.SetOsqueryClient(osqueryClient)
 	require.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestNewTraceExporter_exportNotEnabled(t *testing.T) {
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
 	mockKnapsack.On("Slogger").Return(multislogger.New().Logger)
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack)
+	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, nil)
 	require.NoError(t, err)
 
 	// Confirm we didn't set a provider
@@ -118,9 +118,7 @@ func TestNewTraceExporter_exportNotEnabled(t *testing.T) {
 	mockKnapsack.AssertExpectations(t)
 }
 
-func TestInterrupt_Multiple(t *testing.T) {
-	t.Parallel()
-
+func TestInterrupt_Multiple(t *testing.T) { //nolint:paralleltest
 	tokenStore := testTokenStore(t)
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("TokenStore").Return(tokenStore)
@@ -133,7 +131,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
 	mockKnapsack.On("Slogger").Return(multislogger.New().Logger)
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack)
+	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
 	require.NoError(t, err)
 	mockKnapsack.AssertExpectations(t)
 

--- a/pkg/traces/exporter/initial_trace_buffer.go
+++ b/pkg/traces/exporter/initial_trace_buffer.go
@@ -1,0 +1,65 @@
+package exporter
+
+import (
+	"runtime"
+
+	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/pkg/traces/bufspanprocessor"
+	osquerygotraces "github.com/osquery/osquery-go/traces"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+type InitialTraceBuffer struct {
+	provider         *sdktrace.TracerProvider
+	bufSpanProcessor *bufspanprocessor.BufSpanProcessor
+	attrs            []attribute.KeyValue // resource attributes, identifying this device + installation
+}
+
+func NewInitialTraceBuffer() *InitialTraceBuffer {
+	attrs := initialAttrs()
+
+	defaultResource := resource.Default()
+	r, err := resource.Merge(
+		defaultResource,
+		resource.NewWithAttributes(defaultResource.SchemaURL(), attrs...),
+	)
+	if err != nil {
+		r = resource.Default()
+	}
+
+	bufferedSpanProcessor := &bufspanprocessor.BufSpanProcessor{
+		MaxBufferedSpans: 500,
+	}
+
+	newProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(bufferedSpanProcessor),
+		sdktrace.WithResource(r),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(1.0))),
+	)
+
+	otel.SetTracerProvider(newProvider)
+	osquerygotraces.SetTracerProvider(newProvider)
+
+	return &InitialTraceBuffer{
+		provider:         newProvider,
+		bufSpanProcessor: bufferedSpanProcessor,
+		attrs:            attrs,
+	}
+}
+
+func initialAttrs() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(applicationName),
+		semconv.ServiceVersion(version.Version().Version),
+	}
+
+	if archAttr, ok := archAttributeMap[runtime.GOARCH]; ok {
+		attrs = append(attrs, archAttr)
+	}
+
+	return attrs
+}


### PR DESCRIPTION
Create an initial trace buffer (plus tracer provider, etc) as soon as possible in runLauncher, before knapsack/osquery client are available. Transfer buffer and attrs to trace exporter once available.