### PR TITLE
Speed up launcher startup

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -276,8 +276,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	}
 
 	// Add the log checkpoints to the rungroup, and run it once early, to try to get data into the logs.
+	// The checkpointer can take up to 5 seconds to run, so do this in the background.
 	checkpointer := checkups.NewCheckupLogger(logger, k)
-	checkpointer.Once(ctx)
+	go checkpointer.Once(ctx)
 	runGroup.Add("logcheckpoint", checkpointer.Run, checkpointer.Interrupt)
 
 	// Create a channel for signals

--- a/ee/agent/keys.go
+++ b/ee/agent/keys.go
@@ -41,20 +41,22 @@ func SetupKeys(logger log.Logger, store types.GetterSetterDeleter) error {
 	}
 
 	// Secure Enclave is not currently supported, so don't spend startup time waiting for it to work -- see keys_darwin.go for more details.
-	if runtime.GOOS != "darwin" {
-		err = backoff.WaitFor(func() error {
-			hwKeys, err := setupHardwareKeys(logger, store)
-			if err != nil {
-				return err
-			}
-			hardwareKeys = hwKeys
-			return nil
-		}, 1*time.Second, 250*time.Millisecond)
+	if runtime.GOOS == "darwin" {
+		return nil
+	}
 
+	err = backoff.WaitFor(func() error {
+		hwKeys, err := setupHardwareKeys(logger, store)
 		if err != nil {
-			// Use of hardware keys is not fully implemented as of 2023-02-01, so log an error and move on
-			level.Info(logger).Log("msg", "failed to setting up hardware keys", "err", err)
+			return err
 		}
+		hardwareKeys = hwKeys
+		return nil
+	}, 1*time.Second, 250*time.Millisecond)
+
+	if err != nil {
+		// Use of hardware keys is not fully implemented as of 2023-02-01, so log an error and move on
+		level.Info(logger).Log("msg", "failed to setting up hardware keys", "err", err)
 	}
 
 	return nil

--- a/ee/debug/checkups/checkpoint.go
+++ b/ee/debug/checkups/checkpoint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/ee/agent/types"
-	"github.com/kolide/launcher/pkg/traces"
 )
 
 // logger is an interface that allows mocking of logger
@@ -64,9 +63,6 @@ func (c *logCheckPointer) Interrupt(_ error) {
 }
 
 func (c *logCheckPointer) Once(ctx context.Context) {
-	ctx, span := traces.StartSpan(ctx)
-	defer span.End()
-
 	checkups := checkupsFor(c.knapsack, logSupported)
 
 	for _, checkup := range checkups {


### PR DESCRIPTION
* `Once()` can take up to 5 seconds to run -- don't block on running it
* We can't use the Secure Enclave right now -- stop waiting for up to a second to access it