### PR TITLE
Don't run the initial runner, regardless of launcher flags

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -186,7 +186,7 @@ func NewExtension(ctx context.Context, client service.KolideService, k types.Kna
 		slogger:    k.Slogger().With("component", "initial_runner"),
 		identifier: identifier,
 		store:      k.InitialResultsStore(),
-		enabled:    opts.RunDifferentialQueriesImmediately,
+		enabled:    false, // currently, we don't want to run the initial runner, even if the flag is set
 	}
 
 	return &Extension{

--- a/pkg/osquery/initial-runner.go
+++ b/pkg/osquery/initial-runner.go
@@ -22,6 +22,12 @@ type initialRunner struct {
 }
 
 func (i *initialRunner) Execute(configBlob string, writeFn func(ctx context.Context, l logger.LogType, results []string, reeenroll bool) error) error {
+	if !i.enabled {
+		i.slogger.Log(context.TODO(), slog.LevelDebug,
+			"initial runner not enabled",
+		)
+		return nil
+	}
 	var config OsqueryConfig
 	if err := json.Unmarshal([]byte(configBlob), &config); err != nil {
 		return fmt.Errorf("unmarshal osquery config blob: %w", err)
@@ -48,9 +54,6 @@ func (i *initialRunner) Execute(configBlob string, writeFn func(ctx context.Cont
 
 	var initialRunResults []OsqueryResultLog
 	for packName, pack := range config.Packs {
-		if !i.enabled { // only execute them when the plugin is enabled.
-			break
-		}
 		for query, queryContent := range pack.Queries {
 			queryName := fmt.Sprintf("pack:%s:%s", packName, query)
 			if _, ok := toRun[queryName]; !ok {


### PR DESCRIPTION
Even if `with_initial_runner` is set, we don't want to run the initial runner.