### PR TITLE
Ensure we have detailed traces when running checks

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -941,6 +941,9 @@ func (e *Extension) GetQueries(ctx context.Context) (*distributed.GetQueriesResu
 
 // Helper to allow for a single attempt at re-enrollment
 func (e *Extension) getQueriesWithReenroll(ctx context.Context, reenroll bool) (*distributed.GetQueriesResult, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	// Note that we set invalid two ways -- in the return, and via isNodeinvaliderr
 	queries, invalid, err := e.serviceClient.RequestQueries(ctx, e.NodeKey)
 	if isNodeInvalidErr(err) {
@@ -985,6 +988,9 @@ func (e *Extension) WriteResults(ctx context.Context, results []distributed.Resu
 
 // Helper to allow for a single attempt at re-enrollment
 func (e *Extension) writeResultsWithReenroll(ctx context.Context, results []distributed.Result, reenroll bool) error {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	_, _, invalid, err := e.serviceClient.PublishResults(ctx, e.NodeKey, results)
 	if isNodeInvalidErr(err) {
 		invalid = true

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -9,9 +9,9 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"github.com/kolide/kit/contexts/uuid"
-	"github.com/osquery/osquery-go/plugin/distributed"
-
 	pb "github.com/kolide/launcher/pkg/pb/launcher"
+	"github.com/kolide/launcher/pkg/traces"
+	"github.com/osquery/osquery-go/plugin/distributed"
 )
 
 type resultCollection struct {
@@ -158,6 +158,9 @@ func MakePublishResultsEndpoint(svc KolideService) endpoint.Endpoint {
 
 // PublishResults implements KolideService.PublishResults
 func (e Endpoints) PublishResults(ctx context.Context, nodeKey string, results []distributed.Result) (string, string, bool, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	newCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -158,7 +159,8 @@ func (mw logmw) RequestQueries(ctx context.Context, nodeKey string) (res *distri
 		resJSON, _ := json.Marshal(res)
 		uuid, _ := uuid.FromContext(ctx)
 		if err != nil {
-			mw.knapsack.Slogger().Error("failure",
+			mw.knapsack.Slogger().Log(ctx, slog.LevelError,
+				"failure",
 				"method", "RequestQueries",
 				"uuid", uuid,
 				"res", string(resJSON),

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -9,9 +9,9 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/transport/http/jsonrpc"
 	"github.com/kolide/kit/contexts/uuid"
-	"github.com/osquery/osquery-go/plugin/distributed"
-
 	pb "github.com/kolide/launcher/pkg/pb/launcher"
+	"github.com/kolide/launcher/pkg/traces"
+	"github.com/osquery/osquery-go/plugin/distributed"
 )
 
 type queriesRequest struct {
@@ -131,6 +131,9 @@ func MakeRequestQueriesEndpoint(svc KolideService) endpoint.Endpoint {
 
 // RequestQueries implements KolideService.RequestQueries
 func (e Endpoints) RequestQueries(ctx context.Context, nodeKey string) (*distributed.GetQueriesResult, bool, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	newCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 	request := queriesRequest{NodeKey: nodeKey}


### PR DESCRIPTION
Relevant traces can be found by filtering on `code.function:github.com/kolide/launcher/pkg/osquery.(*Extension).GetQueries` or `code.function:github.com/kolide/launcher/pkg/osquery.(*Extension).WriteResults`.