### PR TITLE
add nftables allowedCommand and exec table

### DIFF
--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -87,6 +87,10 @@ func NixEnv(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/nix/var/nix/profiles/default/bin/nix-env", arg...)
 }
 
+func Nftables(ctx context.Context, arg ...string) (*exec.Cmd, error) {
+	return validatedCommand(ctx, "/usr/sbin/nft", arg...)
+}
+
 func Nmcli(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/nmcli", arg...)
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -58,6 +58,7 @@ func platformSpecificTables(logger log.Logger, currentOsquerydBinaryPath string)
 		dataflattentable.NewExecAndParseTable(logger, "kolide_pacman_upgradeable", pacman_upgradeable.Parser, allowedcmd.Pacman, []string{"-Qu"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_rpm_version_info", rpm.Parser, allowedcmd.Rpm, []string{"-qai"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(logger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.TablePluginExec(logger, "kolide_nftables", dataflattentable.JsonType, allowedcmd.Nftables, []string{"-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
 		zfs.ZfsPropertiesPlugin(logger),
 		zfs.ZpoolPropertiesPlugin(logger),
 	}


### PR DESCRIPTION
This adds a new exec table containing the json output of nftables (`nft`).
Here is an example of the general structure of various types after enabling `ufw` on a standard ubuntu 22.04 installation:

Tables:
```
osquery> select * from kolide_nftables where parent LIKE '%/table' limit 10;
+---------------------------+--------------------+--------+--------+-------+
| fullkey                   | parent             | key    | value  | query |
+---------------------------+--------------------+--------+--------+-------+
| nftables/1/table/family   | nftables/1/table   | family | inet   | *     |
| nftables/1/table/name     | nftables/1/table   | name   | filter | *     |
| nftables/1/table/handle   | nftables/1/table   | handle | 1      | *     |
| nftables/5/table/family   | nftables/5/table   | family | ip     | *     |
| nftables/5/table/name     | nftables/5/table   | name   | filter | *     |
| nftables/5/table/handle   | nftables/5/table   | handle | 2      | *     |
| nftables/107/table/family | nftables/107/table | family | ip6    | *     |
| nftables/107/table/name   | nftables/107/table | name   | filter | *     |
| nftables/107/table/handle | nftables/107/table | handle | 3      | *     |
+---------------------------+--------------------+--------+--------+-------+
```

Chains:
```
osquery> select * from kolide_nftables where parent LIKE '%/chain' limit 10;
+-------------------------+------------------+--------+--------+-------+
| fullkey                 | parent           | key    | value  | query |
+-------------------------+------------------+--------+--------+-------+
| nftables/2/chain/table  | nftables/2/chain | table  | filter | *     |
| nftables/2/chain/name   | nftables/2/chain | name   | input  | *     |
| nftables/2/chain/handle | nftables/2/chain | handle | 1      | *     |
| nftables/2/chain/type   | nftables/2/chain | type   | filter | *     |
| nftables/2/chain/hook   | nftables/2/chain | hook   | input  | *     |
| nftables/2/chain/prio   | nftables/2/chain | prio   | 0      | *     |
| nftables/2/chain/policy | nftables/2/chain | policy | accept | *     |
| nftables/2/chain/family | nftables/2/chain | family | inet   | *     |
| nftables/3/chain/policy | nftables/3/chain | policy | accept | *     |
| nftables/3/chain/family | nftables/3/chain | family | inet   | *     |
+-------------------------+------------------+--------+--------+-------+
```

Rules:
```
osquery> select * from kolide_nftables where parent LIKE '%/rule' limit 10;
+-------------------------+------------------+--------+------------------+-------+
| fullkey                 | parent           | key    | value            | query |
+-------------------------+------------------+--------+------------------+-------+
| nftables/10/rule/table  | nftables/10/rule | table  | filter           | *     |
| nftables/10/rule/chain  | nftables/10/rule | chain  | ufw-before-input | *     |
| nftables/10/rule/handle | nftables/10/rule | handle | 98               | *     |
| nftables/10/rule/family | nftables/10/rule | family | ip               | *     |
| nftables/11/rule/family | nftables/11/rule | family | ip               | *     |
| nftables/11/rule/table  | nftables/11/rule | table  | filter           | *     |
| nftables/11/rule/chain  | nftables/11/rule | chain  | ufw-before-input | *     |
| nftables/11/rule/handle | nftables/11/rule | handle | 100              | *     |
| nftables/12/rule/family | nftables/12/rule | family | ip               | *     |
| nftables/12/rule/table  | nftables/12/rule | table  | filter           | *     |
+-------------------------+------------------+--------+------------------+-------+
```


