### PR TITLE
More staticcheck + lint updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,28 +7,24 @@ linters:
   enable:
     - bodyclose
     - containedctx
-    - unused
+    - forbidigo
     - gofmt
     - govet
+    - ineffassign
     - misspell
     - nakedret
-    - sqlclosecheck
-    - unconvert
     - paralleltest
-    - forbidigo
-    - sloglint
     - revive
+    - sloglint
+    - sqlclosecheck
+    - staticcheck
+    - unconvert
+    - unused
   disable:
     - errcheck
     - gosec
     - gosimple
-    - ineffassign
-    - interfacer
-    - maligned
     - noctx
-    - staticcheck
-    - structcheck
-    - varcheck
 
 linters-settings:
   errcheck:
@@ -67,6 +63,8 @@ linters-settings:
         disabled: false
       - name: confusing-naming
         disabled: false
+  staticcheck:
+    checks: ["all"]
 
 issues:
   exclude-rules:

--- a/ee/keyidentifier/keyidentifier.go
+++ b/ee/keyidentifier/keyidentifier.go
@@ -136,7 +136,7 @@ func (kIdentifer *KeyIdentifier) attemptPem(keyBytes []byte) (*KeyInfo, error) {
 
 	case "PRIVATE KEY":
 		// RFC5208 - https://tools.ietf.org/html/rfc5208
-		ki.Encrypted = boolPtr(x509.IsEncryptedPEMBlock(block))
+		ki.Encrypted = boolPtr(x509.IsEncryptedPEMBlock(block)) // nolint:staticcheck
 		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
 			switch assertedKey := key.(type) {
 			case *rsa.PrivateKey:

--- a/ee/tables/crowdstrike/falconctl/parser.go
+++ b/ee/tables/crowdstrike/falconctl/parser.go
@@ -63,9 +63,7 @@ func parseOptions(reader io.Reader) (any, error) {
 				kv[1] = strings.Trim(kv[1], `" `)
 
 				// Remove parenthetical note about an unset default
-				if strings.HasSuffix(kv[1], " (unset default)") {
-					kv[1] = kv[1][:len(kv[1])-len(" (unset default)")]
-				}
+				kv[1] = strings.TrimSuffix(kv[1], " (unset default)")
 
 				if lastKey == "rfm-reason" && kv[0] == "code" {
 					kv[0] = "rfm-reason-code"

--- a/ee/tables/wifi_networks/wifi_networks.go
+++ b/ee/tables/wifi_networks/wifi_networks.go
@@ -53,7 +53,7 @@ func TablePlugin(logger log.Logger) *table.Plugin {
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 	var results []map[string]string
 	var output bytes.Buffer

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -325,7 +325,7 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		return nil, errors.New("both enroll_secret and enroll_secret_path were defined")
 	}
 
-	updateChannel := autoupdate.Stable
+	var updateChannel autoupdate.UpdateChannel
 	switch *flUpdateChannel {
 	case "", "stable":
 		updateChannel = autoupdate.Stable

--- a/pkg/log/eventlog/writer_windows.go
+++ b/pkg/log/eventlog/writer_windows.go
@@ -31,9 +31,16 @@ func openHandle(host, source string) (h windows.Handle, err error) {
 	}
 	var s *uint16
 	if host != "" {
-		s = syscall.UTF16PtrFromString(host)
+		s, err = syscall.UTF16PtrFromString(host)
+		if err != nil {
+			return h, err
+		}
 	}
-	h, err = windows.RegisterEventSource(s, syscall.UTF16PtrFromString(source))
+	srcPtr, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return h, err
+	}
+	h, err = windows.RegisterEventSource(s, srcPtr)
 	return h, err
 }
 
@@ -46,7 +53,11 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(p []byte) (n int, err error) {
-	ss := []*uint16{syscall.UTF16PtrFromString(string(p))}
+	ptr, err := syscall.UTF16PtrFromString(string(p))
+	if err != nil {
+		return 0, err
+	}
+	ss := []*uint16{ptr}
 	// always report as Info. Launcher logs as either info or debug, but the event log does not
 	// appear to have a debug level.
 	err = windows.ReportEvent(w.handle, windows.EVENTLOG_INFORMATION_TYPE, 0, 1, 0, 1, 0, &ss[0], nil)

--- a/pkg/log/eventlog/writer_windows.go
+++ b/pkg/log/eventlog/writer_windows.go
@@ -31,9 +31,9 @@ func openHandle(host, source string) (h windows.Handle, err error) {
 	}
 	var s *uint16
 	if host != "" {
-		s = syscall.StringToUTF16Ptr(host)
+		s = syscall.UTF16PtrFromString(host)
 	}
-	h, err = windows.RegisterEventSource(s, syscall.StringToUTF16Ptr(source))
+	h, err = windows.RegisterEventSource(s, syscall.UTF16PtrFromString(source))
 	return h, err
 }
 
@@ -46,7 +46,7 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(p []byte) (n int, err error) {
-	ss := []*uint16{syscall.StringToUTF16Ptr(string(p))}
+	ss := []*uint16{syscall.UTF16PtrFromString(string(p))}
 	// always report as Info. Launcher logs as either info or debug, but the event log does not
 	// appear to have a debug level.
 	err = windows.ReportEvent(w.handle, windows.EVENTLOG_INFORMATION_TYPE, 0, 1, 0, 1, 0, &ss[0], nil)

--- a/pkg/osquery/table/program_icons_windows.go
+++ b/pkg/osquery/table/program_icons_windows.go
@@ -55,10 +55,10 @@ func generateUninstallerProgramIcons() []map[string]string {
 	for key, paths := range uninstallRegPaths {
 		for _, path := range paths {
 			key, err := registry.OpenKey(key, path, registry.READ)
-			defer key.Close()
 			if err != nil {
 				continue
 			}
+			defer key.Close()
 
 			iconPath, _, err := key.GetStringValue("DisplayIcon")
 			icon, err := parseIcoFile(iconPath)
@@ -93,10 +93,10 @@ func generateInstallersProgramIcons() []map[string]string {
 	for key, paths := range productRegPaths {
 		for _, path := range paths {
 			key, err := registry.OpenKey(key, path, registry.READ)
-			defer key.Close()
 			if err != nil {
 				continue
 			}
+			defer key.Close()
 
 			iconPath, _, err := key.GetStringValue("ProductIcon")
 			icon, err := parseIcoFile(iconPath)

--- a/pkg/osquery/table/program_icons_windows.go
+++ b/pkg/osquery/table/program_icons_windows.go
@@ -61,6 +61,9 @@ func generateUninstallerProgramIcons() []map[string]string {
 			defer key.Close()
 
 			iconPath, _, err := key.GetStringValue("DisplayIcon")
+			if err != nil {
+				continue
+			}
 			icon, err := parseIcoFile(iconPath)
 			if err != nil {
 				continue
@@ -99,6 +102,9 @@ func generateInstallersProgramIcons() []map[string]string {
 			defer key.Close()
 
 			iconPath, _, err := key.GetStringValue("ProductIcon")
+			if err != nil {
+				continue
+			}
 			icon, err := parseIcoFile(iconPath)
 			if err != nil {
 				continue
@@ -126,6 +132,9 @@ func generateInstallersProgramIcons() []map[string]string {
 func parseIcoFile(fullPath string) (icon, error) {
 	var programIcon icon
 	expandedPath, err := registry.ExpandString(fullPath)
+	if err != nil {
+		return programIcon, err
+	}
 	icoReader, err := os.Open(expandedPath)
 	if err != nil {
 		return programIcon, err

--- a/pkg/osquery/table/user_avatar_darwin.go
+++ b/pkg/osquery/table/user_avatar_darwin.go
@@ -81,9 +81,7 @@ func (t *userAvatarTable) generateAvatars(ctx context.Context, queryContext tabl
 		}
 	} else {
 		usernamesString := C.LocalUsers()
-		for _, posixName := range strings.Split(C.GoString(usernamesString), " ") {
-			usernames = append(usernames, posixName)
-		}
+		usernames = append(usernames, strings.Split(C.GoString(usernamesString), " ")...)
 	}
 
 	var results []map[string]string

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -30,7 +30,7 @@ const (
 type StartType string
 
 const (
-	StartAuto     StartType = "auto"
+	StartAuto     StartType = "auto" // nolint:staticcheck // TODO FIXME
 	StartDemand             = "demand"
 	StartDisabled           = "disabled"
 	StartBoot               = "boot"


### PR DESCRIPTION
* Fix some more lint errors
* Remove deprecated linters from our golangci-lint linters
* Enable staticcheck linter in golangci-lint
* Enable ineffassign