### PR TITLE
Add rfm history to allowed falconctl options

### DIFF
--- a/ee/tables/crowdstrike/falconctl/table.go
+++ b/ee/tables/crowdstrike/falconctl/table.go
@@ -31,6 +31,7 @@ var (
 		"--metadata-query",
 		"--rfm-reason",
 		"--rfm-state",
+		"--rfm-history",
 		"--tags",
 		"--version",
 	}


### PR DESCRIPTION
We learned [here](https://kolide.slack.com/archives/CFPMXV7CZ/p1707141659982979) that there's a third mode (aside kernel and reduced functionality) that we do not currently consider. We can determine this third mode, user mode, by looking at the rfm history. 

This PR adds `--rfm-history` to the allowedOptions for falconctl, which looks like this:

```sudo /opt/CrowdStrike/falconctl -g --rfm-history
rfm-history={[0 (newest)] kernel backend, not in RFM, rfm-reason=None, code=0x0; [1] kernel backend, in RFM, rfm-reason=Modules file was not found, code=0xC0000034; [2] kernel backend, in RFM, rfm-reason=Modules file was not found, code=0xC0000034}.```