### PR TITLE
Remove autoloaded extensions

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -348,7 +348,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			kolidelog.WithLevel(slog.LevelInfo),
 		)),
 		osqueryruntime.WithAugeasLensFunction(augeas.InstallLenses),
-		osqueryruntime.WithAutoloadedExtensions(k.AutoloadedExtensions()...),
 		osqueryruntime.WithUpdateDirectory(k.UpdateDirectory()),
 		osqueryruntime.WithUpdateChannel(k.UpdateChannel()),
 		osqueryruntime.WithConfigPluginFlag("kolide_grpc"),

--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -153,10 +153,6 @@ func (fc *FlagController) overrideFlag(key keys.FlagKey, duration time.Duration,
 	fc.overrides[key].Start(key, value, duration, overrideExpired)
 }
 
-func (fc *FlagController) AutoloadedExtensions() []string {
-	return fc.cmdLineOpts.AutoloadedExtensions
-}
-
 func (fc *FlagController) SetKolideServerURL(url string) error {
 	return fc.setControlServerValue(keys.KolideServerURL, []byte(url))
 }

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -11,10 +11,6 @@ type Flags interface {
 	// Registers an observer to receive messages when the specified keys change.
 	RegisterChangeObserver(observer FlagsChangeObserver, flagKeys ...keys.FlagKey)
 
-	// AutoloadedExtensions to load with osquery, expected to be in same
-	// directory as launcher binary.
-	AutoloadedExtensions() []string
-
 	// KolideServerURL is the URL of the management server to connect to.
 	SetKolideServerURL(url string) error
 	KolideServerURL() string

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -16,22 +16,6 @@ type Flags struct {
 	mock.Mock
 }
 
-// AutoloadedExtensions provides a mock function with given fields:
-func (_m *Flags) AutoloadedExtensions() []string {
-	ret := _m.Called()
-
-	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	return r0
-}
-
 // Autoupdate provides a mock function with given fields:
 func (_m *Flags) Autoupdate() bool {
 	ret := _m.Called()

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -52,22 +52,6 @@ func (_m *Knapsack) AgentFlagsStore() types.GetterSetterDeleterIteratorUpdater {
 	return r0
 }
 
-// AutoloadedExtensions provides a mock function with given fields:
-func (_m *Knapsack) AutoloadedExtensions() []string {
-	ret := _m.Called()
-
-	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	return r0
-}
-
 // Autoupdate provides a mock function with given fields:
 func (_m *Knapsack) Autoupdate() bool {
 	ret := _m.Called()

--- a/pkg/autoupdate/findnew.go
+++ b/pkg/autoupdate/findnew.go
@@ -251,7 +251,7 @@ func FindNewest(ctx context.Context, fullBinaryPath string, opts ...newestOption
 func getUpdateDir(fullBinaryPath string) string {
 	if strings.Contains(fullBinaryPath, ".app") {
 		binary := filepath.Base(fullBinaryPath)
-		return filepath.Join(FindBaseDir(fullBinaryPath), binary+updateDirSuffix)
+		return filepath.Join(findBaseDir(fullBinaryPath), binary+updateDirSuffix)
 	}
 
 	// These are cases that shouldn't really happen. But, this is
@@ -317,10 +317,10 @@ func getPossibleUpdates(ctx context.Context, updateDir, binaryName string) ([]st
 	return possibleUpdates, nil
 }
 
-// FindBaseDir takes a binary path, that may or may not include the
+// findBaseDir takes a binary path, that may or may not include the
 // update directory, and returns the base directory. It's used by the
 // launcher runtime in finding the various binaries.
-func FindBaseDir(path string) string {
+func findBaseDir(path string) string {
 	if path == "" {
 		return ""
 	}

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -106,7 +106,7 @@ func TestFindBaseDir(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		require.Equal(t, tt.out, FindBaseDir(tt.in), "input: %s", tt.in)
+		require.Equal(t, tt.out, findBaseDir(tt.in), "input: %s", tt.in)
 	}
 }
 

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -21,9 +21,6 @@ import (
 
 // Options is the set of options that may be configured for Launcher.
 type Options struct {
-	// AutoloadedExtensions to load with osquery, expected to be in same
-	// directory as launcher binary.
-	AutoloadedExtensions []string
 	// KolideServerURL is the URL of the management server to connect to.
 	KolideServerURL string
 	// KolideHosted true if using Kolide SaaS settings
@@ -205,7 +202,6 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 
 	var (
 		// Primary options
-		flAutoloadedExtensions            ArrayFlags
 		flCertPins                        = flagset.String("cert_pins", "", "Comma separated, hex encoded SHA256 hashes of pinned subject public key info")
 		flControlRequestInterval          = flagset.Duration("control_request_interval", 60*time.Second, "The interval at which the control server requests will be made")
 		flEnrollSecret                    = flagset.String("enroll_secret", "", "The enroll secret that is used in your environment")
@@ -270,7 +266,9 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 	)
 
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
-	flagset.Var(&flAutoloadedExtensions, "autoloaded_extension", "extension paths to autoload, filename without path may be used in same directory as launcher")
+
+	// Deprecated array
+	flagset.Var(&ArrayFlags{}, "autoloaded_extension", "DEPRECATED")
 
 	ffOpts := []ff.Option{
 		ff.WithConfigFileFlag("config"),
@@ -393,7 +391,6 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		LocalDevelopmentPath:               *flLocalDevelopmentPath,
 		TraceIngestServerURL:               *flTraceIngestServerURL,
 		DisableTraceIngestTLS:              *flDisableIngestTLS,
-		AutoloadedExtensions:               flAutoloadedExtensions,
 		IAmBreakingEELicense:               *flIAmBreakingEELicense,
 		InsecureTLS:                        *flInsecureTLS,
 		InsecureTransport:                  *flInsecureTransport,

--- a/pkg/launcher/options_test.go
+++ b/pkg/launcher/options_test.go
@@ -233,12 +233,11 @@ func getArgsAndResponse() (map[string]string, *Options) {
 
 	// includes both `-` and `--` for variety.
 	args := map[string]string{
-		"--hostname":            randomHostname,
-		"-autoupdate_interval":  "48h",
-		"-logging_interval":     fmt.Sprintf("%ds", randomInt),
-		"-osqueryd_path":        windowsAddExe("/dev/null"),
-		"-transport":            "grpc",
-		"-autoloaded_extension": "some-extension.ext",
+		"--hostname":           randomHostname,
+		"-autoupdate_interval": "48h",
+		"-logging_interval":    fmt.Sprintf("%ds", randomInt),
+		"-osqueryd_path":       windowsAddExe("/dev/null"),
+		"-transport":           "grpc",
 	}
 
 	opts := &Options{
@@ -260,7 +259,6 @@ func getArgsAndResponse() (map[string]string, *Options) {
 		OsqueryHealthcheckStartupDelay:  10 * time.Minute,
 		Transport:                       "grpc",
 		UpdateChannel:                   "stable",
-		AutoloadedExtensions:            []string{"some-extension.ext"},
 		DelayStart:                      0 * time.Second,
 		WatchdogEnabled:                 false,
 		WatchdogDelaySec:                120,

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -256,18 +256,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		return fmt.Errorf("could not calculate osquery file paths: %w", err)
 	}
 
-	for _, path := range paths.extensionPaths {
-		// The extensions files should be owned by the process's UID or by root.
-		// Osquery will refuse to load the extension otherwise.
-		if err := ensureProperPermissions(o, path); err != nil {
-			r.slogger.Log(ctx, slog.LevelInfo,
-				"unable to ensure proper permissions on extension path",
-				"path", path,
-				"err", err,
-			)
-		}
-	}
-
 	// Populate augeas lenses, if requested
 	if o.opts.augeasLensFunc != nil {
 		if err := os.MkdirAll(paths.augeasPath, 0755); err != nil {

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -5,12 +5,9 @@ package runtime
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
-
-	"github.com/go-kit/kit/log/level"
 )
 
 func setpgid() *syscall.SysProcAttr {
@@ -35,32 +32,4 @@ func platformArgs() []string {
 
 func isExitOk(err error) bool {
 	return false
-}
-
-func ensureProperPermissions(o *OsqueryInstance, path string) error {
-	fd, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat-ing path: %w", err)
-	}
-	sys := fd.Sys().(*syscall.Stat_t)
-	isRootOwned := (sys.Uid == 0)
-	isProcOwned := (sys.Uid == uint32(os.Geteuid()))
-
-	if isRootOwned || isProcOwned {
-		return nil
-	}
-
-	level.Info(o.logger).Log(
-		"msg", "unsafe permissions detected on path",
-		"path", path,
-	)
-
-	// chown the path. This could potentially be insecure, since
-	// we're basically chown-ing whatever is there to root, but a certain
-	// level of privilege is needed to place something in the launcher root
-	// directory.
-	if err = os.Chown(path, os.Getuid(), os.Getgid()); err != nil {
-		return fmt.Errorf("attempting to chown path: %w", err)
-	}
-	return nil
 }

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -81,7 +81,3 @@ func isExitOk(err error) bool {
 	}
 	return false
 }
-
-func ensureProperPermissions(o *OsqueryInstance, path string) error {
-	return nil
-}

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -101,52 +101,6 @@ func TestCalculateOsqueryPaths(t *testing.T) {
 	require.Equal(t, binDir, filepath.Dir(paths.extensionAutoloadPath))
 }
 
-func TestCalculateOsqueryPathsWithAutoloadedExtensions(t *testing.T) {
-	t.Parallel()
-	binDir, err := getBinDir()
-	require.NoError(t, err)
-
-	extensionPaths := make([]string, 0)
-
-	for _, extension := range []string{"extensionInExecDir1", "extensionInExecDir2"} {
-		// create file at each extension path
-		extensionPath := filepath.Join(binDir, extension)
-		require.NoError(t, os.WriteFile(extensionPath, []byte("{}"), 0644))
-		extensionPaths = append(extensionPaths, extensionPath)
-	}
-
-	nonExecDir := t.TempDir()
-	for _, extension := range []string{"extensionNotInExecDir1", "extensionNotInExecDir2"} {
-		// create file at each extension path
-		extensionPath := filepath.Join(nonExecDir, extension)
-		require.NoError(t, os.WriteFile(extensionPath, []byte("{}"), 0644))
-		extensionPaths = append(extensionPaths, extensionPath)
-	}
-
-	paths, err := calculateOsqueryPaths(osqueryOptions{
-		rootDirectory:        binDir,
-		autoloadedExtensions: []string{"extensionInExecDir1", "extensionInExecDir2", filepath.Join(nonExecDir, "extensionNotInExecDir1"), filepath.Join(nonExecDir, "extensionNotInExecDir2")},
-	})
-
-	require.NoError(t, err)
-
-	// ensure that all of our resulting artifact files are in the rootDir that we
-	// dictated
-	require.Equal(t, binDir, filepath.Dir(paths.pidfilePath))
-	require.Equal(t, binDir, filepath.Dir(paths.databasePath))
-	require.Equal(t, binDir, filepath.Dir(paths.extensionSocketPath))
-	require.Equal(t, binDir, filepath.Dir(paths.extensionAutoloadPath))
-
-	osqueryAutoloadFilePath := filepath.Join(binDir, "osquery.autoload")
-	// read each line of the autoload file into a string array
-	bytes, err := os.ReadFile(osqueryAutoloadFilePath)
-	require.NoError(t, err)
-	autoloadFileLines := strings.Split(string(bytes), "\n")
-
-	// add empty string to extensions path array so it matches the last line of autoloaded file
-	assert.ElementsMatch(t, append(extensionPaths, ""), autoloadFileLines)
-}
-
 func TestCreateOsqueryCommand(t *testing.T) {
 	t.Parallel()
 	paths := &osqueryFilePaths{


### PR DESCRIPTION
We can't expect to find autoloaded extensions based on the current executable anymore, because the current executable may live in the new updates directory outside of the install (bin) directory. We don't use this flag and we don't imagine that it has widespread use elsewhere either, so we're opting to remove it.