### PR TITLE
Allow launcher to run without enrollment secret

### DIFF
--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -1,7 +1,11 @@
 package knapsack
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"os"
 
 	"log/slog"
 
@@ -143,4 +147,20 @@ func (k *knapsack) LatestOsquerydPath(ctx context.Context) string {
 	}
 
 	return latestBin.Path
+}
+
+func (k *knapsack) ReadEnrollSecret() (string, error) {
+	if k.EnrollSecret() != "" {
+		return k.EnrollSecret(), nil
+	}
+
+	if k.EnrollSecretPath() != "" {
+		content, err := os.ReadFile(k.EnrollSecretPath())
+		if err != nil {
+			return "", fmt.Errorf("could not read enroll secret path %s: %w", k.EnrollSecretPath(), err)
+		}
+		return string(bytes.TrimSpace(content)), nil
+	}
+
+	return "", errors.New("enroll secret not set")
 }

--- a/ee/agent/types/knapsack.go
+++ b/ee/agent/types/knapsack.go
@@ -11,4 +11,6 @@ type Knapsack interface {
 	Slogger
 	// LatestOsquerydPath finds the path to the latest osqueryd binary, after accounting for updates.
 	LatestOsquerydPath(ctx context.Context) string
+	// ReadEnrollSecret returns the enroll secret value, checking in various locations.
+	ReadEnrollSecret() (string, error)
 }

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -756,6 +756,30 @@ func (_m *Knapsack) PersistentHostDataStore() types.GetterSetterDeleterIteratorU
 	return r0
 }
 
+// ReadEnrollSecret provides a mock function with given fields:
+func (_m *Knapsack) ReadEnrollSecret() (string, error) {
+	ret := _m.Called()
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (string, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RegisterChangeObserver provides a mock function with given fields: observer, flagKeys
 func (_m *Knapsack) RegisterChangeObserver(observer types.FlagsChangeObserver, flagKeys ...keys.FlagKey) {
 	_va := make([]interface{}, len(flagKeys))

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -402,7 +402,7 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	)
 	span.AddEvent("starting_enrollment")
 
-	enrollSecret, err := e.readEnrollSecret(ctx)
+	enrollSecret, err := e.knapsack.ReadEnrollSecret()
 	if err != nil {
 		return "", true, fmt.Errorf("could not read enroll secret: %w", err)
 	}
@@ -481,26 +481,6 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 
 func (e *Extension) enrolled() bool {
 	return e.NodeKey != ""
-}
-
-// readEnrollSecret checks knapsack's flags to find the correct enroll secret location.
-func (e *Extension) readEnrollSecret(ctx context.Context) (string, error) {
-	_, span := traces.StartSpan(ctx)
-	defer span.End()
-
-	if e.knapsack.EnrollSecret() != "" {
-		return e.knapsack.EnrollSecret(), nil
-	}
-
-	if e.knapsack.EnrollSecretPath() != "" {
-		content, err := os.ReadFile(e.knapsack.EnrollSecretPath())
-		if err != nil {
-			return "", fmt.Errorf("could not read enroll secret path %s: %w", e.knapsack.EnrollSecretPath(), err)
-		}
-		return string(bytes.TrimSpace(content)), nil
-	}
-
-	return "", errors.New("enroll secret not set")
 }
 
 // RequireReenroll clears the existing node key information, ensuring that the

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -76,9 +76,6 @@ const (
 
 // ExtensionOpts is options to be passed in NewExtension
 type ExtensionOpts struct {
-	// EnrollSecret is the (mandatory) enroll secret used for
-	// enrolling with the server.
-	EnrollSecret string
 	// MaxBytesPerBatch is the maximum number of bytes that should be sent in
 	// one batch logging request. Any log larger than this will be dropped.
 	MaxBytesPerBatch int
@@ -111,10 +108,6 @@ func NewExtension(ctx context.Context, client service.KolideService, k types.Kna
 	defer span.End()
 
 	slogger := k.Slogger().With("component", "osquery_extension")
-
-	if opts.EnrollSecret == "" {
-		return nil, errors.New("empty enroll secret")
-	}
 
 	if opts.MaxBytesPerBatch == 0 {
 		opts.MaxBytesPerBatch = defaultMaxBytesPerBatch
@@ -409,6 +402,11 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	)
 	span.AddEvent("starting_enrollment")
 
+	enrollSecret, err := e.readEnrollSecret(ctx)
+	if err != nil {
+		return "", true, fmt.Errorf("could not read enroll secret: %w", err)
+	}
+
 	identifier, err := e.getHostIdentifier()
 	if err != nil {
 		return "", true, fmt.Errorf("generating UUID: %w", err)
@@ -448,7 +446,7 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	}
 	// If no cached node key, enroll for new node key
 	// note that we set invalid two ways. Via the return, _or_ via isNodeInvaliderr
-	keyString, invalid, err := e.serviceClient.RequestEnrollment(ctx, e.Opts.EnrollSecret, identifier, enrollDetails)
+	keyString, invalid, err := e.serviceClient.RequestEnrollment(ctx, enrollSecret, identifier, enrollDetails)
 	if isNodeInvalidErr(err) {
 		invalid = true
 	} else if err != nil {
@@ -481,6 +479,30 @@ func (e *Extension) Enroll(ctx context.Context) (string, bool, error) {
 	return e.NodeKey, false, nil
 }
 
+func (e *Extension) enrolled() bool {
+	return e.NodeKey != ""
+}
+
+// readEnrollSecret checks knapsack's flags to find the correct enroll secret location.
+func (e *Extension) readEnrollSecret(ctx context.Context) (string, error) {
+	_, span := traces.StartSpan(ctx)
+	defer span.End()
+
+	if e.knapsack.EnrollSecret() != "" {
+		return e.knapsack.EnrollSecret(), nil
+	}
+
+	if e.knapsack.EnrollSecretPath() != "" {
+		content, err := os.ReadFile(e.knapsack.EnrollSecretPath())
+		if err != nil {
+			return "", fmt.Errorf("could not read enroll secret path %s: %w", e.knapsack.EnrollSecretPath(), err)
+		}
+		return string(bytes.TrimSpace(content)), nil
+	}
+
+	return "", errors.New("enroll secret not set")
+}
+
 // RequireReenroll clears the existing node key information, ensuring that the
 // next call to Enroll will cause the enrollment process to take place.
 func (e *Extension) RequireReenroll(ctx context.Context) {
@@ -507,6 +529,10 @@ func (e *Extension) GenerateConfigs(ctx context.Context) (map[string]string, err
 		confBytes, _ = e.knapsack.ConfigStore().Get([]byte(configKey))
 
 		if len(confBytes) == 0 {
+			if !e.enrolled() {
+				// Not enrolled yet -- return an empty config
+				return map[string]string{"config": "{}"}, nil
+			}
 			return nil, fmt.Errorf("loading config failed, no cached config: %w", err)
 		}
 		config = string(confBytes)

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -58,7 +58,7 @@ func makeKnapsack(t *testing.T, db *bbolt.DB) types.Knapsack {
 	m.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.New().Logger)
-	m.On("EnrollSecret").Maybe().Return("enroll_secret")
+	m.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 	return m
 }
 
@@ -68,7 +68,7 @@ func TestNewExtensionEmptyEnrollSecret(t *testing.T) {
 	m.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.New().Logger)
-	m.On("EnrollSecret").Maybe().Return("")
+	m.On("ReadEnrollSecret").Maybe().Return("", errors.New("test"))
 
 	// We should be able to make an extension despite an empty enroll secret
 	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{})
@@ -217,7 +217,7 @@ func TestExtensionEnroll(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("Slogger").Return(multislogger.New().Logger)
 	expectedEnrollSecret := "foo_secret"
-	k.On("EnrollSecret").Maybe().Return(expectedEnrollSecret)
+	k.On("ReadEnrollSecret").Maybe().Return(expectedEnrollSecret, nil)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
@@ -355,8 +355,7 @@ func TestGenerateConfigs_CannotEnrollYet(t *testing.T) {
 	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("Slogger").Return(multislogger.New().Logger)
-	k.On("EnrollSecret").Return("")
-	k.On("EnrollSecretPath").Return("")
+	k.On("ReadEnrollSecret").Maybe().Return("", errors.New("test"))
 
 	e, err := NewExtension(context.TODO(), s, k, ExtensionOpts{})
 	require.Nil(t, err)
@@ -533,7 +532,7 @@ func TestExtensionWriteBufferedLogsEmpty(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("BboltDB").Return(db)
 	k.On("Slogger").Return(multislogger.New().Logger).Maybe()
-	k.On("EnrollSecret").Maybe().Return("enroll_secret")
+	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
@@ -572,7 +571,7 @@ func TestExtensionWriteBufferedLogs(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("BboltDB").Return(db)
 	k.On("Slogger").Return(multislogger.New().Logger).Maybe()
-	k.On("EnrollSecret").Maybe().Return("enroll_secret")
+	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
@@ -642,7 +641,7 @@ func TestExtensionWriteBufferedLogsEnrollmentInvalid(t *testing.T) {
 	k.On("OsquerydPath").Maybe().Return("")
 	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	k.On("Slogger").Return(multislogger.New().Logger)
-	k.On("EnrollSecret").Maybe().Return("enroll_secret")
+	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
@@ -1039,7 +1038,7 @@ func TestExtensionGetQueriesEnrollmentInvalid(t *testing.T) {
 	k.On("OsquerydPath").Maybe().Return("")
 	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	k.On("Slogger").Return(multislogger.New().Logger)
-	k.On("EnrollSecret").Return("enroll_secret")
+	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -58,16 +58,22 @@ func makeKnapsack(t *testing.T, db *bbolt.DB) types.Knapsack {
 	m.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.New().Logger)
+	m.On("EnrollSecret").Maybe().Return("enroll_secret")
 	return m
 }
 
 func TestNewExtensionEmptyEnrollSecret(t *testing.T) {
 	m := mocks.NewKnapsack(t)
+	m.On("OsquerydPath").Maybe().Return("")
+	m.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
+	m.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.New().Logger)
+	m.On("EnrollSecret").Maybe().Return("")
 
+	// We should be able to make an extension despite an empty enroll secret
 	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{})
-	assert.NotNil(t, err)
-	assert.Nil(t, e)
+	assert.Nil(t, err)
+	assert.NotNil(t, e)
 }
 
 func TestNewExtensionDatabaseError(t *testing.T) {
@@ -95,7 +101,7 @@ func TestNewExtensionDatabaseError(t *testing.T) {
 	m.On("ConfigStore").Return(agentbbolt.NewStore(log.NewNopLogger(), db, storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.New().Logger).Maybe()
 
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{})
 	assert.NotNil(t, err)
 	assert.Nil(t, e)
 }
@@ -105,7 +111,7 @@ func TestGetHostIdentifier(t *testing.T) {
 	defer cleanup()
 
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	ident, err := e.getHostIdentifier()
@@ -120,7 +126,7 @@ func TestGetHostIdentifier(t *testing.T) {
 	db, cleanup = makeTempDB(t)
 	defer cleanup()
 	k = makeKnapsack(t, db)
-	e, err = NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err = NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	ident, err = e.getHostIdentifier()
@@ -135,7 +141,7 @@ func TestGetHostIdentifierCorruptedData(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	// Put garbage UUID in DB
@@ -164,7 +170,7 @@ func TestExtensionEnrollTransportError(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -184,7 +190,7 @@ func TestExtensionEnrollSecretInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	k := makeKnapsack(t, db)
 	defer cleanup()
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -204,11 +210,16 @@ func TestExtensionEnroll(t *testing.T) {
 			return expectedNodeKey, false, nil
 		},
 	}
-	db, cleanup := makeTempDB(t)
-	defer cleanup()
-	k := makeKnapsack(t, db)
+
+	k := mocks.NewKnapsack(t)
+	k.On("OsquerydPath").Maybe().Return("")
+	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
+	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
+	k.On("Slogger").Return(multislogger.New().Logger)
 	expectedEnrollSecret := "foo_secret"
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: expectedEnrollSecret})
+	k.On("EnrollSecret").Maybe().Return(expectedEnrollSecret)
+
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -227,7 +238,7 @@ func TestExtensionEnroll(t *testing.T) {
 	assert.Equal(t, expectedNodeKey, key)
 	assert.Equal(t, expectedEnrollSecret, gotEnrollSecret)
 
-	e, err = NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: expectedEnrollSecret})
+	e, err = NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	// Still should not re-enroll (because node key stored in DB)
 	key, invalid, err = e.Enroll(context.Background())
@@ -260,7 +271,8 @@ func TestExtensionGenerateConfigsTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	k.ConfigStore().Set([]byte(nodeKeyKey), []byte("some_node_key"))
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -281,7 +293,7 @@ func TestExtensionGenerateConfigsCaching(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -318,7 +330,7 @@ func TestExtensionGenerateConfigsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -328,6 +340,40 @@ func TestExtensionGenerateConfigsEnrollmentInvalid(t *testing.T) {
 	assert.Nil(t, configs)
 	assert.NotNil(t, err)
 	assert.Equal(t, expectedNodeKey, gotNodeKey)
+}
+
+func TestGenerateConfigs_CannotEnrollYet(t *testing.T) {
+	s := &mock.KolideService{
+		RequestConfigFunc: func(ctx context.Context, nodeKey string) (string, bool, error) {
+			// Returns node_invalid
+			return "", true, nil
+		},
+	}
+
+	k := mocks.NewKnapsack(t)
+	k.On("OsquerydPath").Maybe().Return("")
+	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
+	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
+	k.On("Slogger").Return(multislogger.New().Logger)
+	k.On("EnrollSecret").Return("")
+	k.On("EnrollSecretPath").Return("")
+
+	e, err := NewExtension(context.TODO(), s, k, ExtensionOpts{})
+	require.Nil(t, err)
+
+	configs, err := e.GenerateConfigs(context.Background())
+	assert.NotNil(t, configs)
+	assert.Equal(t, map[string]string{"config": "{}"}, configs)
+	assert.Nil(t, err)
+
+	// Should have tried to request config
+	assert.True(t, s.RequestConfigFuncInvoked)
+
+	// On node invalid response, should attempt to retrieve enroll secret
+	k.AssertExpectations(t)
+
+	// Since we can't retrieve the enroll secret, we shouldn't attempt to enroll yet
+	assert.False(t, s.RequestEnrollmentFuncInvoked)
 }
 
 func TestExtensionGenerateConfigs(t *testing.T) {
@@ -341,7 +387,7 @@ func TestExtensionGenerateConfigs(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -360,7 +406,7 @@ func TestExtensionWriteLogsTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
@@ -384,7 +430,7 @@ func TestExtensionWriteLogsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -413,7 +459,7 @@ func TestExtensionWriteLogs(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = expectedNodeKey
 
@@ -487,8 +533,9 @@ func TestExtensionWriteBufferedLogsEmpty(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("BboltDB").Return(db)
 	k.On("Slogger").Return(multislogger.New().Logger).Maybe()
+	k.On("EnrollSecret").Maybe().Return("enroll_secret")
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	// No buffered logs should result in success and no remote action being
@@ -525,8 +572,9 @@ func TestExtensionWriteBufferedLogs(t *testing.T) {
 	k.On("ConfigStore").Return(storageci.NewStore(t, log.NewNopLogger(), storage.ConfigStore.String()))
 	k.On("BboltDB").Return(db)
 	k.On("Slogger").Return(multislogger.New().Logger).Maybe()
+	k.On("EnrollSecret").Maybe().Return("enroll_secret")
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	e.LogString(context.Background(), logger.LogTypeStatus, "status foo")
@@ -594,8 +642,9 @@ func TestExtensionWriteBufferedLogsEnrollmentInvalid(t *testing.T) {
 	k.On("OsquerydPath").Maybe().Return("")
 	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	k.On("Slogger").Return(multislogger.New().Logger)
+	k.On("EnrollSecret").Maybe().Return("enroll_secret")
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	e.LogString(context.Background(), logger.LogTypeStatus, "status foo")
@@ -640,7 +689,6 @@ func TestExtensionWriteBufferedLogsLimit(t *testing.T) {
 	k.On("Slogger").Return(multislogger.New().Logger)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		EnrollSecret:     "enroll_secret",
 		MaxBytesPerBatch: 100,
 	})
 	require.Nil(t, err)
@@ -714,7 +762,6 @@ func TestExtensionWriteBufferedLogsDropsBigLog(t *testing.T) {
 	k.On("Slogger").Return(multislogger.New().Logger)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		EnrollSecret:     "enroll_secret",
 		MaxBytesPerBatch: 15,
 	})
 	require.Nil(t, err)
@@ -799,7 +846,6 @@ func TestExtensionWriteLogsLoop(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	expectedLoggingInterval := 10 * time.Second
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		EnrollSecret:     "enroll_secret",
 		MaxBytesPerBatch: 200,
 		Clock:            mockClock,
 		LoggingInterval:  expectedLoggingInterval,
@@ -928,7 +974,7 @@ func TestExtensionPurgeBufferedLogs(t *testing.T) {
 	k.On("Slogger").Return(multislogger.New().Logger)
 
 	max := 10
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret", MaxBufferedLogs: max})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{MaxBufferedLogs: max})
 	require.Nil(t, err)
 
 	var expectedStatusLogs, expectedResultLogs []string
@@ -965,7 +1011,7 @@ func TestExtensionGetQueriesTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	queries, err := e.GetQueries(context.Background())
@@ -993,8 +1039,9 @@ func TestExtensionGetQueriesEnrollmentInvalid(t *testing.T) {
 	k.On("OsquerydPath").Maybe().Return("")
 	k.On("LatestOsquerydPath", testifymock.Anything).Maybe().Return("")
 	k.On("Slogger").Return(multislogger.New().Logger)
+	k.On("EnrollSecret").Return("enroll_secret")
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -1022,7 +1069,7 @@ func TestExtensionGetQueries(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	queries, err := e.GetQueries(context.Background())
@@ -1041,7 +1088,7 @@ func TestExtensionWriteResultsTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	err = e.WriteResults(context.Background(), []distributed.Result{})
@@ -1065,7 +1112,7 @@ func TestExtensionWriteResultsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -1088,7 +1135,7 @@ func TestExtensionWriteResults(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	expectedResults := []distributed.Result{
@@ -1116,7 +1163,7 @@ func TestLauncherRsaKeys(t *testing.T) {
 	k.On("ConfigStore").Return(configStore)
 	k.On("Slogger").Return(multislogger.New().Logger)
 
-	_, err = NewExtension(context.TODO(), m, k, ExtensionOpts{EnrollSecret: "enroll_secret"})
+	_, err = NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.NoError(t, err)
 
 	key, err := PrivateRSAKeyFromDB(configStore)


### PR DESCRIPTION
### Changes

* launcher runs, instead of immediately shutting down, if it doesn't have an enroll secret
* lay groundwork for platform-specific ways of reading the enrollment secret in the future and for exposing enrollment status to localserver
* attempt enrollment immediately, before rungroups even start

### Details

Before, the osquery extension rungroup could not be created if the enroll secret wasn't present, preventing launcher from starting up at all. Now, if the secret isn't present, launcher will still start, and will just return an empty config to osquery. Whenever the secret becomes available, it will perform enrollment.

I pulled out reading the secret into the knapsack, with the idea being that in the future we could a) expose enrollment status from localserver, and b) have per-platform implementations of this function that would allow us to e.g. read the key from the Windows registry.

This PR also adds an attempt at immediate enrollment in the background, before the rungroups even start. This should hopefully make first-time launcher startup faster.

Relates to https://github.com/kolide/launcher/issues/1473.

### Testing notes

<details>

<summary>In here</summary>

Force reenrollment and remove access to enrollment secret:

```
sudo launchctl unload /Library/LaunchDaemons/com.kolide-k2.launcher.plist
sudo mv /etc/kolide-k2/secret /etc/kolide-k2/secret.bak
sudo rm -rf /var/kolide-k2/k2device-preprod.kolide.com
sudo mkdir /var/kolide-k2/k2device-preprod.kolide.com
sudo chmod -R 0755 /var/kolide-k2/*
sudo launchctl load /Library/LaunchDaemons/com.kolide-k2.launcher.plist
```

Confirm that launcher starts up and that the osquery process starts up.

Eventually, make the secret available:

```
sudo mv /etc/kolide-k2/secret.bak /etc/kolide-k2/secret
```

Observe launcher immediately complete enrollment.

</details>