### PR TITLE
[slogger] Replace logger with slogger in dataflatten/exec

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,9 +66,7 @@ jobs:
       uses: goto-bus-stop/setup-zig@v2
 
     - name: Build
-      run: |
-        go clean -cache
-        make -j2 github-build
+      run: make -j2 github-build
 
     - name: Check macOS build target
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,9 @@ jobs:
       uses: goto-bus-stop/setup-zig@v2
 
     - name: Build
-      run: make -j2 github-build
+      run: |
+        go clean -cache
+        make -j2 github-build
 
     - name: Check macOS build target
       if: contains(matrix.os, 'macos')

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ build_%: ARCHARG = $(if $(ARCH), --arch $(ARCH))
 build_%: GOARG = $(if $(CROSSGOPATH), --go $(CROSSGOPATH))
 build_%: GOBUILD = $(if $(CROSSGOPATH), $(CROSSGOPATH), go)
 build_%: .pre-build
+	$(GOBUILD) clean -cache
 	$(GOBUILD) run cmd/make/make.go -targets=$(TARGET) -linkstamp $(OSARG) $(ARCHARG) $(GOARG)
 
 fake_%: TARGET =  $(word 2, $(subst _, ,$@))

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ build_%: ARCHARG = $(if $(ARCH), --arch $(ARCH))
 build_%: GOARG = $(if $(CROSSGOPATH), --go $(CROSSGOPATH))
 build_%: GOBUILD = $(if $(CROSSGOPATH), $(CROSSGOPATH), go)
 build_%: .pre-build
-	$(GOBUILD) clean -cache
 	$(GOBUILD) run cmd/make/make.go -targets=$(TARGET) -linkstamp $(OSARG) $(ARCHARG) $(GOARG)
 
 fake_%: TARGET =  $(word 2, $(subst _, ,$@))

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -80,7 +80,7 @@ func runInteractive(args []string) error {
 		flOsqueryFlags = append(flOsqueryFlags, fmt.Sprintf("tls_server_certs=%s", certs))
 	}
 
-	osqueryProc, extensionsServer, err := interactive.StartProcess(logger, rootDir, osquerydPath, flOsqueryFlags)
+	osqueryProc, extensionsServer, err := interactive.StartProcess(rootDir, osquerydPath, flOsqueryFlags)
 	if err != nil {
 		return fmt.Errorf("error starting osqueryd: %s", err)
 	}

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/kolide/launcher/ee/tuf"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/launcher"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery/interactive"
 )
 
@@ -33,6 +35,15 @@ func runInteractive(args []string) error {
 	}
 
 	logger := logutil.NewServerLogger(*flDebug)
+
+	slogLevel := slog.LevelInfo
+	if *flDebug {
+		slogLevel = slog.LevelDebug
+	}
+
+	slogger := multislogger.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slogLevel,
+	})).Logger
 
 	osquerydPath := *flOsquerydPath
 	if osquerydPath == "" {
@@ -80,7 +91,7 @@ func runInteractive(args []string) error {
 		flOsqueryFlags = append(flOsqueryFlags, fmt.Sprintf("tls_server_certs=%s", certs))
 	}
 
-	osqueryProc, extensionsServer, err := interactive.StartProcess(rootDir, osquerydPath, flOsqueryFlags)
+	osqueryProc, extensionsServer, err := interactive.StartProcess(slogger, rootDir, osquerydPath, flOsqueryFlags)
 	if err != nil {
 		return fmt.Errorf("error starting osqueryd: %s", err)
 	}

--- a/ee/dataflatten/examples/flatten/main.go
+++ b/ee/dataflatten/examples/flatten/main.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/kolide/kit/logutil"
 	"github.com/kolide/launcher/ee/dataflatten"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/peterbourgon/ff/v3"
 )
 
@@ -40,12 +40,13 @@ func main() {
 		checkError(fmt.Errorf("parsing flags: %w", err))
 	}
 
-	logger := logutil.NewCLILogger(*flDebug)
-
 	opts := []dataflatten.FlattenOpts{
-		dataflatten.WithLogger(logger),
+		dataflatten.WithSlogger(multislogger.New().Logger),
 		dataflatten.WithNestedPlist(),
 		dataflatten.WithQuery(strings.Split(*flQuery, `/`)),
+	}
+	if *flDebug {
+		opts = append(opts, dataflatten.WithDebugLogging())
 	}
 
 	rows := []dataflatten.Row{}

--- a/ee/dataflatten/flatten.go
+++ b/ee/dataflatten/flatten.go
@@ -211,6 +211,7 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 				if !ok {
 					innerslogger.Log(context.TODO(), fl.logLevel,
 						"keyName not in map",
+						"key_name", keyName,
 					)
 					continue
 				}

--- a/ee/dataflatten/flatten.go
+++ b/ee/dataflatten/flatten.go
@@ -39,16 +39,17 @@ package dataflatten
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/groob/plist"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 
 	howett "howett.net/plist"
 )
@@ -69,7 +70,7 @@ type Flattener struct {
 	expandNestedPlist bool
 	includeNestedRaw  bool
 	includeNils       bool
-	logger            log.Logger
+	slogger           *slog.Logger
 	query             []string
 	queryKeyDenoter   string
 	queryWildcard     string
@@ -93,14 +94,14 @@ func WithNestedPlist() FlattenOpts {
 	}
 }
 
-// WithLogger sets the logger to use
-func WithLogger(logger log.Logger) FlattenOpts {
-	if logger == nil {
+// WithSlogger sets the slogger to use
+func WithSlogger(slogger *slog.Logger) FlattenOpts {
+	if slogger == nil {
 		return func(_ *Flattener) {}
 	}
 
 	return func(fl *Flattener) {
-		fl.logger = logger
+		fl.slogger = slogger
 	}
 }
 
@@ -131,7 +132,7 @@ func WithQuery(q []string) FlattenOpts {
 func Flatten(data interface{}, opts ...FlattenOpts) ([]Row, error) {
 	fl := &Flattener{
 		rows:            []Row{},
-		logger:          log.NewNopLogger(),
+		slogger:         multislogger.New().Logger,
 		queryWildcard:   `*`,
 		queryKeyDenoter: `#`,
 	}
@@ -141,7 +142,7 @@ func Flatten(data interface{}, opts ...FlattenOpts) ([]Row, error) {
 	}
 
 	if !fl.debugLogging {
-		fl.logger = level.NewFilter(fl.logger, level.AllowInfo())
+		// TODO RM
 	}
 
 	if err := fl.descend([]string{}, data, 0); err != nil {
@@ -155,10 +156,10 @@ func Flatten(data interface{}, opts ...FlattenOpts) ([]Row, error) {
 func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 	queryTerm, isQueryMatched := fl.queryAtDepth(depth)
 
-	logger := log.With(fl.logger,
+	slogger := fl.slogger.With(
 		"caller", "descend",
 		"depth", depth,
-		"rows-so-far", len(fl.rows),
+		"rows_so_far", len(fl.rows),
 		"query", queryTerm,
 		"path", strings.Join(path, "/"),
 	)
@@ -167,7 +168,10 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 	case []interface{}:
 		for i, e := range v {
 			pathKey := strconv.Itoa(i)
-			level.Debug(logger).Log("msg", "checking an array", "indexStr", pathKey)
+			slogger.Log(context.TODO(), slog.LevelDebug,
+				"checking an array",
+				"index_str", pathKey,
+			)
 
 			// If the queryTerm starts with
 			// queryKeyDenoter, then we want to rewrite
@@ -183,25 +187,33 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 				keyQuery := strings.SplitN(strings.TrimPrefix(queryTerm, fl.queryKeyDenoter), "=>", 2)
 				keyName := keyQuery[0]
 
-				innerlogger := log.With(logger, "arraykeyname", keyName)
-				level.Debug(logger).Log("msg", "attempting to coerce array into map")
+				innerslogger := slogger.With("array_key_name", keyName)
+				innerslogger.Log(context.TODO(), slog.LevelDebug,
+					"attempting to coerce array into map",
+				)
 
 				e, ok := e.(map[string]interface{})
 				if !ok {
-					level.Debug(innerlogger).Log("msg", "can't coerce into map")
+					innerslogger.Log(context.TODO(), slog.LevelDebug,
+						"can't coerce into map",
+					)
 					continue
 				}
 
 				// Is keyName in this array?
 				val, ok := e[keyName]
 				if !ok {
-					level.Debug(innerlogger).Log("msg", "keyName not in map")
+					innerslogger.Log(context.TODO(), slog.LevelDebug,
+						"keyName not in map",
+					)
 					continue
 				}
 
 				pathKey, ok = val.(string)
 				if !ok {
-					level.Debug(innerlogger).Log("msg", "can't coerce pathKey val into string")
+					innerslogger.Log(context.TODO(), slog.LevelDebug,
+						"can't coerce pathKey val into string",
+					)
 					continue
 				}
 
@@ -209,7 +221,9 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			}
 
 			if !(isQueryMatched || fl.queryMatchArrayElement(e, i, queryTerm)) {
-				level.Debug(logger).Log("msg", "query not matched")
+				slogger.Log(context.TODO(), slog.LevelDebug,
+					"query not matched",
+				)
 				continue
 			}
 
@@ -218,7 +232,9 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			}
 		}
 	case map[string]interface{}:
-		level.Debug(logger).Log("msg", "checking a map")
+		slogger.Log(context.TODO(), slog.LevelDebug,
+			"checking a map",
+		)
 		for k, e := range v {
 			// Check that the key name matches. If not, skip this entire
 			// branch of the map
@@ -231,7 +247,9 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 			}
 		}
 	case []map[string]interface{}:
-		level.Debug(logger).Log("msg", "checking an array of maps")
+		slogger.Log(context.TODO(), slog.LevelDebug,
+			"checking an array of maps",
+		)
 		for i, e := range v {
 			if err := fl.descend(append(path, strconv.Itoa(i)), e, depth+1); err != nil {
 				return fmt.Errorf("flattening array of maps: %w", err)
@@ -240,7 +258,9 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 	case nil:
 		// Because we want to filter nils out, we do _not_ examine isQueryMatched here
 		if !(fl.queryMatchNil(queryTerm)) {
-			level.Debug(logger).Log("msg", "query not matched")
+			slogger.Log(context.TODO(), slog.LevelDebug,
+				"query not matched",
+			)
 			return nil
 		}
 		fl.rows = append(fl.rows, NewRow(path, ""))
@@ -250,7 +270,7 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 		// Most string like data comes in this way
 		return fl.descendMaybePlist(path, v, depth)
 	default:
-		if err := fl.handleStringLike(logger, path, v, depth); err != nil {
+		if err := fl.handleStringLike(slogger, path, v, depth); err != nil {
 			return fmt.Errorf("flattening at path %v: %w", path, err)
 		}
 	}
@@ -260,7 +280,7 @@ func (fl *Flattener) descend(path []string, data interface{}, depth int) error {
 // handleStringLike is called when we finally have an object we think
 // can be converted to a string. It uses the depth to compare against
 // the query, and returns a stringify'ed value
-func (fl *Flattener) handleStringLike(logger log.Logger, path []string, v interface{}, depth int) error {
+func (fl *Flattener) handleStringLike(slogger *slog.Logger, path []string, v interface{}, depth int) error {
 	queryTerm, isQueryMatched := fl.queryAtDepth(depth)
 
 	stringValue, err := stringify(v)
@@ -269,7 +289,9 @@ func (fl *Flattener) handleStringLike(logger log.Logger, path []string, v interf
 	}
 
 	if !(isQueryMatched || fl.queryMatchString(stringValue, queryTerm)) {
-		level.Debug(logger).Log("msg", "query not matched")
+		slogger.Log(context.TODO(), slog.LevelDebug,
+			"query not matched",
+		)
 		return nil
 	}
 
@@ -281,37 +303,45 @@ func (fl *Flattener) handleStringLike(logger log.Logger, path []string, v interf
 // embedded plist. In the case of failures, it falls back to treating
 // it like a plain string.
 func (fl *Flattener) descendMaybePlist(path []string, data []byte, depth int) error {
-	logger := log.With(fl.logger,
+	slogger := fl.slogger.With(
 		"caller", "descendMaybePlist",
 		"depth", depth,
-		"rows-so-far", len(fl.rows),
+		"rows_so_far", len(fl.rows),
 		"path", strings.Join(path, "/"),
 	)
 
 	// Skip if we're not expanding nested plists
 	if !fl.expandNestedPlist {
-		return fl.handleStringLike(logger, path, data, depth)
+		return fl.handleStringLike(slogger, path, data, depth)
 	}
 
 	// Skip if this doesn't look like a plist.
 	if !isPlist(data) {
-		return fl.handleStringLike(logger, path, data, depth)
+		return fl.handleStringLike(slogger, path, data, depth)
 	}
 
 	// Looks like a plist. Try parsing it
-	level.Debug(logger).Log("msg", "Parsing inner plist")
+	slogger.Log(context.TODO(), slog.LevelDebug,
+		"parsing inner plist",
+	)
 
 	var innerData interface{}
 
 	if err := plist.Unmarshal(data, &innerData); err != nil {
-		level.Info(logger).Log("msg", "plist parsing failed", "err", err)
-		return fl.handleStringLike(logger, path, data, depth)
+		slogger.Log(context.TODO(), slog.LevelInfo,
+			"plist parsing failed",
+			"err", err,
+		)
+		return fl.handleStringLike(slogger, path, data, depth)
 	}
 
 	// have a parsed plist. Descend and return from here.
 	if fl.includeNestedRaw {
-		if err := fl.handleStringLike(logger, append(path, "_raw"), data, depth); err != nil {
-			level.Error(logger).Log("msg", "Failed to add _raw key", "err", err)
+		if err := fl.handleStringLike(slogger, append(path, "_raw"), data, depth); err != nil {
+			slogger.Log(context.TODO(), slog.LevelError,
+				"failed to add _raw key",
+				"err", err,
+			)
 		}
 	}
 
@@ -337,9 +367,9 @@ func (fl *Flattener) queryMatchNil(queryTerm string) bool {
 // We use `=>` as something that is reasonably intuitive, and not very
 // likely to occur on it's own. Unfortunately, `==` shows up in base64
 func (fl *Flattener) queryMatchArrayElement(data interface{}, arrIndex int, queryTerm string) bool {
-	logger := log.With(fl.logger,
+	slogger := fl.slogger.With(
 		"caller", "queryMatchArrayElement",
-		"rows-so-far", len(fl.rows),
+		"rows_so_far", len(fl.rows),
 		"query", queryTerm,
 		"arrIndex", arrIndex,
 	)
@@ -353,11 +383,15 @@ func (fl *Flattener) queryMatchArrayElement(data interface{}, arrIndex int, quer
 
 	// If the queryTerm is an int, then we expect to match the index
 	if queryIndex, err := strconv.Atoi(queryTerm); err == nil {
-		level.Debug(logger).Log("msg", "using numeric index comparison")
+		slogger.Log(context.TODO(), slog.LevelDebug,
+			"using numeric index comparison",
+		)
 		return queryIndex == arrIndex
 	}
 
-	level.Debug(logger).Log("msg", "checking data type")
+	slogger.Log(context.TODO(), slog.LevelDebug,
+		"checking data type",
+	)
 
 	switch dataCasted := data.(type) {
 	case []interface{}:

--- a/ee/dataflatten/flatten.go
+++ b/ee/dataflatten/flatten.go
@@ -110,10 +110,10 @@ func WithSlogger(slogger *slog.Logger) FlattenOpts {
 	}
 }
 
-// WithDebugLogging enables debug logging. With debug logs,
-// dataflatten is very verbose. This can overwhelm the other launcher
-// logs. As we're not generally debugging this library, the default is
-// to not enable debug logging.
+// WithDebugLogging enables debug logging intended for development use.
+// With debug logs, dataflatten is very verbose. This can overwhelm the
+// other launcher logs. As we're not generally debugging this library,
+// the default is to not enable debug logging.
 func WithDebugLogging() FlattenOpts {
 	return func(fl *Flattener) {
 		fl.debugLogging = true

--- a/ee/tables/airport/table_darwin_test.go
+++ b/ee/tables/airport/table_darwin_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/airport/mocks"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/log/multislogger"
@@ -101,7 +100,7 @@ func Test_generateAirportData_HappyPath(t *testing.T) {
 				constraints["query"] = []string{tt.query}
 			}
 
-			got, err := generateAirportData(tablehelpers.MockQueryContext(constraints), executor, multislogger.New().Logger, log.NewNopLogger())
+			got, err := generateAirportData(tablehelpers.MockQueryContext(constraints), executor, multislogger.New().Logger)
 			require.NoError(t, err)
 
 			executor.AssertExpectations(t)
@@ -219,7 +218,7 @@ func Test_generateAirportData_EdgeCases(t *testing.T) {
 
 			executor.On("Exec", mock.Anything).Return(tt.execReturn()).Once()
 
-			got, err := generateAirportData(tt.args.queryContext, executor, multislogger.New().Logger, log.NewNopLogger())
+			got, err := generateAirportData(tt.args.queryContext, executor, multislogger.New().Logger)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/ee/tables/crowdstrike/falcon_kernel_check/table.go
+++ b/ee/tables/crowdstrike/falcon_kernel_check/table.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"regexp"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -17,10 +16,9 @@ import (
 
 type Table struct {
 	slogger *slog.Logger
-	logger  log.Logger // preserved only for temporary use in tablehelpers.Exec
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("kernel"),
 		table.IntegerColumn("supported"),
@@ -31,14 +29,13 @@ func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
 
 	t := &Table{
 		slogger: slogger.With("table", tableName),
-		logger:  log.With(logger, "table", tableName),
 	}
 
 	return table.NewPlugin(tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	output, err := tablehelpers.Exec(ctx, t.logger, 5, allowedcmd.FalconKernelCheck, []string{}, false)
+	output, err := tablehelpers.Exec(ctx, t.slogger, 5, allowedcmd.FalconKernelCheck, []string{}, false)
 	if err != nil {
 		t.slogger.Log(ctx, slog.LevelInfo,
 			"exec failed",

--- a/ee/tables/crowdstrike/falconctl/table_test.go
+++ b/ee/tables/crowdstrike/falconctl/table_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/log/multislogger"
@@ -68,7 +67,6 @@ func TestOptionRestrictions(t *testing.T) {
 
 			testTable := &falconctlOptionsTable{
 				slogger:  multislogger.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{Level: slog.LevelDebug})).Logger,
-				logger:   log.NewLogfmtLogger(&logBytes),
 				execFunc: noopExec,
 			}
 
@@ -88,7 +86,7 @@ func TestOptionRestrictions(t *testing.T) {
 	}
 }
 
-func noopExec(_ context.Context, log log.Logger, _ int, _ allowedcmd.AllowedCommand, args []string, _ bool) ([]byte, error) {
-	log.Log("exec", "exec-in-test", "args", strings.Join(args, " "))
+func noopExec(ctx context.Context, slogger *slog.Logger, _ int, _ allowedcmd.AllowedCommand, args []string, _ bool) ([]byte, error) {
+	slogger.Log(ctx, slog.LevelInfo, "exec-in-test", "args", strings.Join(args, " "))
 	return []byte{}, nil
 }

--- a/ee/tables/dataflattentable/exec_and_parse.go
+++ b/ee/tables/dataflattentable/exec_and_parse.go
@@ -64,10 +64,6 @@ func NewExecAndParseTable(slogger *slog.Logger, tableName string, p parser, cmd 
 		opt(t)
 	}
 
-	if t.tabledebug {
-		// TODO RM
-	}
-
 	return table.NewPlugin(t.tableName, Columns(), t.generate)
 }
 
@@ -95,6 +91,9 @@ func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryCont
 		flattenOpts := []dataflatten.FlattenOpts{
 			dataflatten.WithSlogger(t.slogger),
 			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
+		}
+		if t.tabledebug {
+			flattenOpts = append(flattenOpts, dataflatten.WithDebugLogging())
 		}
 
 		flattened, err := t.flattener.FlattenBytes(execOutput, flattenOpts...)

--- a/ee/tables/dataflattentable/tables_test.go
+++ b/ee/tables/dataflattentable/tables_test.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,13 +20,13 @@ import (
 func TestDataFlattenTablePlist_Animals(t *testing.T) {
 	t.Parallel()
 
-	logger := log.NewNopLogger()
+	slogger := multislogger.New().Logger
 
 	// Test plist parsing both the json and xml forms
 	testTables := map[string]Table{
-		"plist": {logger: logger, flattenFileFunc: dataflatten.PlistFile},
-		"xml":   {logger: logger, flattenFileFunc: dataflatten.PlistFile},
-		"json":  {logger: logger, flattenFileFunc: dataflatten.JsonFile},
+		"plist": {slogger: slogger, flattenFileFunc: dataflatten.PlistFile},
+		"xml":   {slogger: slogger, flattenFileFunc: dataflatten.PlistFile},
+		"json":  {slogger: slogger, flattenFileFunc: dataflatten.JsonFile},
 	}
 
 	var tests = []struct {
@@ -85,7 +85,7 @@ func TestDataFlattenTablePlist_Animals(t *testing.T) {
 func TestDataFlattenTables(t *testing.T) {
 	t.Parallel()
 
-	logger := log.NewNopLogger()
+	slogger := multislogger.New().Logger
 
 	var tests = []struct {
 		testTables   map[string]Table
@@ -96,18 +96,18 @@ func TestDataFlattenTables(t *testing.T) {
 	}{
 		// xml
 		{
-			testTables:   map[string]Table{"xml": {logger: logger, flattenFileFunc: dataflatten.XmlFile}},
+			testTables:   map[string]Table{"xml": {slogger: slogger, flattenFileFunc: dataflatten.XmlFile}},
 			testFile:     path.Join("testdata", "simple.xml"),
 			expectedRows: 6,
 		},
 		{
-			testTables:   map[string]Table{"xml": {logger: logger, flattenFileFunc: dataflatten.XmlFile}},
+			testTables:   map[string]Table{"xml": {slogger: slogger, flattenFileFunc: dataflatten.XmlFile}},
 			testFile:     path.Join("testdata", "simple.xml"),
 			queries:      []string{"simple/Items"},
 			expectedRows: 3,
 		},
 		{
-			testTables:   map[string]Table{"xml": {logger: logger, flattenFileFunc: dataflatten.XmlFile}},
+			testTables:   map[string]Table{"xml": {slogger: slogger, flattenFileFunc: dataflatten.XmlFile}},
 			testFile:     path.Join("testdata", "simple.xml"),
 			queries:      []string{"this/does/not/exist"},
 			expectNoData: true,
@@ -115,18 +115,18 @@ func TestDataFlattenTables(t *testing.T) {
 
 		// ini
 		{
-			testTables:   map[string]Table{"ini": {logger: logger, flattenFileFunc: dataflatten.IniFile}},
+			testTables:   map[string]Table{"ini": {slogger: slogger, flattenFileFunc: dataflatten.IniFile}},
 			testFile:     path.Join("testdata", "secdata.ini"),
 			expectedRows: 87,
 		},
 		{
-			testTables:   map[string]Table{"ini": {logger: logger, flattenFileFunc: dataflatten.IniFile}},
+			testTables:   map[string]Table{"ini": {slogger: slogger, flattenFileFunc: dataflatten.IniFile}},
 			testFile:     path.Join("testdata", "secdata.ini"),
 			queries:      []string{"Registry Values"},
 			expectedRows: 59,
 		},
 		{
-			testTables:   map[string]Table{"ini": {logger: logger, flattenFileFunc: dataflatten.IniFile}},
+			testTables:   map[string]Table{"ini": {slogger: slogger, flattenFileFunc: dataflatten.IniFile}},
 			testFile:     path.Join("testdata", "secdata.ini"),
 			queries:      []string{"this/does/not/exist"},
 			expectNoData: true,

--- a/ee/tables/dev_table_tooling/table.go
+++ b/ee/tables/dev_table_tooling/table.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -20,11 +19,10 @@ type allowedCommand struct {
 }
 
 type Table struct {
-	logger  log.Logger // preserved temporarily only for tablehelpers.Exec usage
 	slogger *slog.Logger
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("name"),
 		table.TextColumn("args"),
@@ -36,7 +34,6 @@ func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
 
 	t := &Table{
 		slogger: slogger.With("table", tableName),
-		logger:  log.With(logger, "table", tableName),
 	}
 
 	return table.NewPlugin(tableName, columns, t.generate)
@@ -70,7 +67,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			"error":  "",
 		}
 
-		if output, err := tablehelpers.Exec(ctx, t.logger, 30, cmd.bin, cmd.args, false); err != nil {
+		if output, err := tablehelpers.Exec(ctx, t.slogger, 30, cmd.bin, cmd.args, false); err != nil {
 			t.slogger.Log(ctx, slog.LevelInfo,
 				"execution failed",
 				"name", name,

--- a/ee/tables/dev_table_tooling/table_test.go
+++ b/ee/tables/dev_table_tooling/table_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +34,7 @@ func Test_generate(t *testing.T) {
 		},
 	}
 
-	table := Table{logger: log.NewNopLogger(), slogger: multislogger.New().Logger}
+	table := Table{slogger: multislogger.New().Logger}
 
 	for _, tt := range tests {
 		tt := tt

--- a/ee/tables/dsim_default_associations/dsim_default_associations.go
+++ b/ee/tables/dsim_default_associations/dsim_default_associations.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
@@ -24,16 +23,14 @@ import (
 
 type Table struct {
 	slogger *slog.Logger
-	logger  log.Logger // preserved only for temporary use in dataflattentable and tablehelpers.Exec
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns()
 
 	t := &Table{
 		slogger: slogger.With("table", "kolide_dsim_default_associations"),
-		logger:  logger,
 	}
 
 	return table.NewPlugin("kolide_dsim_default_associations", columns, t.generate)
@@ -53,7 +50,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 		flattenOpts := []dataflatten.FlattenOpts{
-			dataflatten.WithLogger(t.logger),
+			dataflatten.WithSlogger(t.slogger),
 			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 		}
 

--- a/ee/tables/filevault/filevault.go
+++ b/ee/tables/filevault/filevault.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -19,24 +18,22 @@ import (
 
 type Table struct {
 	slogger *slog.Logger
-	logger  log.Logger // preserved only for temporary use in tablehelpers.Exec
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("status"),
 	}
 
 	t := &Table{
 		slogger: slogger.With("table", "kolide_filevault"),
-		logger:  logger,
 	}
 
 	return table.NewPlugin("kolide_filevault", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	output, err := tablehelpers.Exec(ctx, t.logger, 10, allowedcmd.Fdesetup, []string{"status"}, false)
+	output, err := tablehelpers.Exec(ctx, t.slogger, 10, allowedcmd.Fdesetup, []string{"status"}, false)
 	if err != nil {
 		t.slogger.Log(ctx, slog.LevelInfo,
 			"fdesetup failed",

--- a/ee/tables/firmwarepasswd/firmwarepasswd.go
+++ b/ee/tables/firmwarepasswd/firmwarepasswd.go
@@ -11,37 +11,36 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 type Table struct {
-	logger log.Logger
-	parser *OutputParser
+	slogger *slog.Logger
+	parser  *OutputParser
 }
 
-func TablePlugin(logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.IntegerColumn("option_roms_allowed"),
 		table.IntegerColumn("password_enabled"),
 		table.TextColumn("mode"),
 	}
 
-	t := New(logger)
+	t := New(slogger.With("table", "kolide_firmwarepasswd"))
 
 	return table.NewPlugin("kolide_firmwarepasswd", columns, t.generate)
 
 }
 
-func New(logger log.Logger) *Table {
-	parser := NewParser(logger,
+func New(slogger *slog.Logger) *Table {
+	parser := NewParser(slogger,
 		[]Matcher{
 			{
 				Match:   func(in string) bool { return strings.HasPrefix(in, "Password Enabled: ") },
@@ -61,8 +60,8 @@ func New(logger log.Logger) *Table {
 		})
 
 	return &Table{
-		logger: level.NewFilter(logger, level.AllowInfo()),
-		parser: parser,
+		slogger: slogger,
+		parser:  parser,
 	}
 
 }
@@ -73,8 +72,8 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	for _, mode := range []string{"-check", "-mode"} {
 		output := new(bytes.Buffer)
 		if err := t.runFirmwarepasswd(ctx, mode, output); err != nil {
-			level.Info(t.logger).Log(
-				"msg", "Error running firmware password",
+			t.slogger.Log(ctx, slog.LevelInfo,
+				"error running firmware password",
 				"command", mode,
 				"err", err,
 			)
@@ -118,8 +117,8 @@ func (t *Table) runFirmwarepasswd(ctx context.Context, subcommand string, output
 	cmd.Stdout = output
 
 	if err := cmd.Run(); err != nil {
-		level.Debug(t.logger).Log(
-			"msg", "Error running firmwarepasswd",
+		t.slogger.Log(ctx, slog.LevelDebug,
+			"error running firmwarepasswd",
 			"stderr", strings.TrimSpace(stderr.String()),
 			"stdout", strings.TrimSpace(output.String()),
 			"err", err,

--- a/ee/tables/firmwarepasswd/firmwarepasswd_test.go
+++ b/ee/tables/firmwarepasswd/firmwarepasswd_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +50,7 @@ func TestParser(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		parser := New(log.NewNopLogger()).parser
+		parser := New(multislogger.New().Logger).parser
 
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()

--- a/ee/tables/macos_software_update/available_products_table.go
+++ b/ee/tables/macos_software_update/available_products_table.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
@@ -27,14 +26,13 @@ import (
 var productsData []map[string]interface{}
 var cachedTime time.Time
 
-func AvailableProducts(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func AvailableProducts(slogger *slog.Logger) *table.Plugin {
 	columns := dataflattentable.Columns()
 
 	tableName := "kolide_macos_available_products"
 
 	t := &Table{
 		slogger: slogger.With("table", tableName),
-		logger:  log.With(logger, "table", tableName),
 	}
 
 	return table.NewPlugin(tableName, columns, t.generateAvailableProducts)
@@ -46,7 +44,7 @@ func (t *Table) generateAvailableProducts(ctx context.Context, queryContext tabl
 	data := getProducts()
 
 	for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
-		flattened, err := dataflatten.Flatten(data, dataflatten.WithLogger(t.logger), dataflatten.WithQuery(strings.Split(dataQuery, "/")))
+		flattened, err := dataflatten.Flatten(data, dataflatten.WithSlogger(t.slogger), dataflatten.WithQuery(strings.Split(dataQuery, "/")))
 		if err != nil {
 			t.slogger.Log(ctx, slog.LevelInfo,
 				"error flattening data",

--- a/ee/tables/macos_software_update/recommended_updates_table_test.go
+++ b/ee/tables/macos_software_update/recommended_updates_table_test.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_generateRecommendedUpdatesHappyPath(t *testing.T) {
 	t.Parallel()
-	table := Table{logger: log.NewNopLogger()}
+	table := Table{slogger: multislogger.New().Logger}
 
 	_, err := table.generate(context.Background(), tablehelpers.MockQueryContext(nil))
 

--- a/ee/tables/mdmclient/mdmclient_test.go
+++ b/ee/tables/mdmclient/mdmclient_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +42,7 @@ func TestTransformOutput(t *testing.T) {
 		},
 	}
 
-	table := Table{logger: log.NewNopLogger()}
+	table := Table{slogger: multislogger.New().Logger}
 
 	for _, tt := range tests {
 		tt := tt

--- a/ee/tables/nix_env/upgradeable/upgradeable.go
+++ b/ee/tables/nix_env/upgradeable/upgradeable.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
@@ -26,18 +25,16 @@ const allowedCharacters = "0123456789"
 
 type Table struct {
 	slogger *slog.Logger
-	logger  log.Logger // preserved only for temporary use in dataflattentable/etc
 	execCC  allowedcmd.AllowedCommand
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("uid"),
 	)
 
 	t := &Table{
 		slogger: slogger.With("table", "kolide_nix_upgradeable"),
-		logger:  logger,
 		execCC:  allowedcmd.NixEnv,
 	}
 
@@ -65,7 +62,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			}
 
 			flattenOpts := []dataflatten.FlattenOpts{
-				dataflatten.WithLogger(t.logger),
+				dataflatten.WithSlogger(t.slogger),
 				dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 			}
 

--- a/ee/tables/profiles/profiles.go
+++ b/ee/tables/profiles/profiles.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
@@ -38,11 +37,10 @@ var (
 
 type Table struct {
 	slogger   *slog.Logger
-	logger    log.Logger // preserved only for temporary use in dataflattentable and tablehelpers.Exec
 	tableName string
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	// profiles options. See `man profiles`. These may not be needed,
 	// we use `show -all` as the default, and it probably covers
 	// everything.
@@ -54,7 +52,6 @@ func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
 
 	t := &Table{
 		slogger:   slogger.With("table", "kolide_profiles"),
-		logger:    logger,
 		tableName: "kolide_profiles",
 	}
 
@@ -104,7 +101,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 						return nil, fmt.Errorf("Unknown user argument: %s", user)
 					}
 
-					output, err := tablehelpers.Exec(ctx, t.logger, 30, allowedcmd.Profiles, profileArgs, false)
+					output, err := tablehelpers.Exec(ctx, t.slogger, 30, allowedcmd.Profiles, profileArgs, false)
 					if err != nil {
 						t.slogger.Log(ctx, slog.LevelInfo,
 							"ioreg exec failed",
@@ -121,7 +118,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 					}
 
 					flattenOpts := []dataflatten.FlattenOpts{
-						dataflatten.WithLogger(t.logger),
+						dataflatten.WithSlogger(t.slogger),
 						dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 					}
 

--- a/ee/tables/pwpolicy/pwpolicy.go
+++ b/ee/tables/pwpolicy/pwpolicy.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
@@ -29,12 +28,11 @@ const pwpolicyCmd = "getaccountpolicies"
 
 type Table struct {
 	slogger   *slog.Logger
-	logger    log.Logger // preserved only for temporary use in dataflattentable and tablehelpers.Exec
 	tableName string
 	execCC    allowedcmd.AllowedCommand
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		table.TextColumn("username"),
@@ -42,7 +40,6 @@ func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
 
 	t := &Table{
 		slogger:   slogger.With("table", "kolide_pwpolicy"),
-		logger:    logger,
 		tableName: "kolide_pwpolicy",
 		execCC:    allowedcmd.Pwpolicy,
 	}
@@ -71,7 +68,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			}
 
 			flattenOpts := []dataflatten.FlattenOpts{
-				dataflatten.WithLogger(t.logger),
+				dataflatten.WithSlogger(t.slogger),
 				dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 			}
 

--- a/ee/tables/pwpolicy/pwpolicy_test.go
+++ b/ee/tables/pwpolicy/pwpolicy_test.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,6 @@ func TestQueries(t *testing.T) {
 		tt := tt
 		testTable := &Table{
 			slogger: multislogger.New().Logger,
-			logger:  log.NewNopLogger(),
 			execCC:  execFaker(tt.file),
 		}
 

--- a/ee/tables/spotlight/spotlight.go
+++ b/ee/tables/spotlight/spotlight.go
@@ -13,14 +13,12 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 type spotlightTable struct {
-	logger  log.Logger // preserved only temporarily for tablehelpers.Exec usage
 	slogger *slog.Logger
 }
 
@@ -32,14 +30,13 @@ Example Query:
 	AS f JOIN kolide_spotlight ON spotlight.path = f.path
 	AND spotlight.query = "kMDItemKint = 'Agile Keychain'";
 */
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("query"),
 		table.TextColumn("path"),
 	}
 
 	t := &spotlightTable{
-		logger:  logger,
 		slogger: slogger.With("table", "kolide_spotlight"),
 	}
 
@@ -60,7 +57,7 @@ func (t *spotlightTable) generate(ctx context.Context, queryContext table.QueryC
 		query = []string{where}
 	}
 
-	out, err := tablehelpers.Exec(ctx, t.logger, 120, allowedcmd.Mdfind, query, false)
+	out, err := tablehelpers.Exec(ctx, t.slogger, 120, allowedcmd.Mdfind, query, false)
 	if err != nil {
 		return nil, fmt.Errorf("call mdfind: %w", err)
 	}

--- a/ee/tables/systemprofiler/systemprofiler.go
+++ b/ee/tables/systemprofiler/systemprofiler.go
@@ -44,8 +44,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/groob/plist"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
@@ -79,11 +77,10 @@ type Result struct {
 
 type Table struct {
 	slogger   *slog.Logger
-	logger    log.Logger // preserved only for temporary use in dataflattentable and tablehelpers.Exec
 	tableName string
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := dataflattentable.Columns(
 		table.TextColumn("parentdatatype"),
 		table.TextColumn("datatype"),
@@ -92,7 +89,6 @@ func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
 
 	t := &Table{
 		slogger:   slogger.With("table", "kolide_system_profiler"),
-		logger:    level.NewFilter(logger, level.AllowInfo()),
 		tableName: "kolide_system_profiler",
 	}
 
@@ -159,7 +155,7 @@ func (t *Table) getRowsFromOutput(ctx context.Context, dataQuery, detailLevel st
 	var results []map[string]string
 
 	flattenOpts := []dataflatten.FlattenOpts{
-		dataflatten.WithLogger(t.logger),
+		dataflatten.WithSlogger(t.slogger),
 		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 

--- a/ee/tables/tablehelpers/exec.go
+++ b/ee/tables/tablehelpers/exec.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/pkg/traces"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,7 +26,7 @@ import (
 // `possibleBins` can be either a list of command names, or a list of paths to commands.
 // Where reasonable, `possibleBins` should be command names only, so that we can perform
 // lookup against PATH.
-func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, execCmd allowedcmd.AllowedCommand, args []string, includeStderr bool) ([]byte, error) {
+func Exec(ctx context.Context, slogger *slog.Logger, timeoutSeconds int, execCmd allowedcmd.AllowedCommand, args []string, includeStderr bool) ([]byte, error) {
 	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
 
@@ -53,8 +52,8 @@ func Exec(ctx context.Context, logger log.Logger, timeoutSeconds int, execCmd al
 		cmd.Stderr = &stderr
 	}
 
-	level.Debug(logger).Log(
-		"msg", "execing",
+	slogger.Log(ctx, slog.LevelDebug,
+		"execing",
 		"cmd", cmd.String(),
 	)
 

--- a/ee/tables/tablehelpers/exec_test.go
+++ b/ee/tables/tablehelpers/exec_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +32,7 @@ func TestExec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	logger := log.NewNopLogger()
+	slogger := multislogger.New().Logger
 
 	for _, tt := range tests {
 		tt := tt
@@ -42,7 +42,7 @@ func TestExec(t *testing.T) {
 			if tt.timeout == 0 {
 				tt.timeout = 30
 			}
-			output, err := Exec(ctx, logger, tt.timeout, tt.bin, tt.args, false)
+			output, err := Exec(ctx, slogger, tt.timeout, tt.bin, tt.args, false)
 			if tt.err {
 				assert.Error(t, err)
 				assert.Empty(t, output)

--- a/ee/tables/tdebug/gc.go
+++ b/ee/tables/tdebug/gc.go
@@ -8,7 +8,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
@@ -20,16 +19,14 @@ const (
 )
 
 type gcTable struct {
-	logger  log.Logger // preserved only for temporary dataflattentable use
 	slogger *slog.Logger
 	stats   debug.GCStats
 }
 
-func LauncherGcInfo(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func LauncherGcInfo(slogger *slog.Logger) *table.Plugin {
 	columns := dataflattentable.Columns()
 
 	t := &gcTable{
-		logger:  logger,
 		slogger: slogger.With("table", gcTableName),
 	}
 
@@ -58,7 +55,7 @@ func (t *gcTable) generate(ctx context.Context, queryContext table.QueryContext)
 
 		flatData, err := dataflatten.Json(
 			jsonBytes,
-			dataflatten.WithLogger(t.logger),
+			dataflatten.WithSlogger(t.slogger),
 			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 		)
 		if err != nil {

--- a/ee/tables/windowsupdatetable/windowsupdate.go
+++ b/ee/tables/windowsupdatetable/windowsupdate.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
@@ -29,21 +28,18 @@ const (
 
 type Table struct {
 	slogger   *slog.Logger
-	logger    log.Logger // preserved only for temporary use in dataflattentable
 	queryFunc queryFuncType
 	name      string
 }
 
-func TablePlugin(mode tableMode, slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(mode tableMode, slogger *slog.Logger) *table.Plugin {
 
 	columns := dataflattentable.Columns(
 		table.TextColumn("locale"),
 		table.IntegerColumn("is_default"),
 	)
 
-	t := &Table{
-		logger: logger,
-	}
+	t := &Table{}
 
 	switch mode {
 	case UpdatesTable:
@@ -129,7 +125,7 @@ func (t *Table) searchLocale(ctx context.Context, locale string, queryContext ta
 
 func (t *Table) flattenOutput(dataQuery string, searchResults interface{}) ([]dataflatten.Row, error) {
 	flattenOpts := []dataflatten.FlattenOpts{
-		dataflatten.WithLogger(t.logger),
+		dataflatten.WithSlogger(t.slogger),
 		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 

--- a/ee/tables/windowsupdatetable/windowsupdate_test.go
+++ b/ee/tables/windowsupdatetable/windowsupdate_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +30,7 @@ func TestTable(t *testing.T) {
 			t.Parallel()
 
 			table := Table{
-				logger:    log.NewNopLogger(),
+				slogger:   multislogger.New().Logger,
 				queryFunc: tt.queryFunc,
 			}
 

--- a/ee/tables/wmitable/wmitable_test.go
+++ b/ee/tables/wmitable/wmitable_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +16,7 @@ import (
 func TestQueries(t *testing.T) {
 	t.Parallel()
 
-	wmiTable := Table{logger: log.NewNopLogger(), slogger: multislogger.New().Logger}
+	wmiTable := Table{slogger: multislogger.New().Logger}
 
 	var tests = []struct {
 		name        string

--- a/ee/tables/xfconf/xfconf.go
+++ b/ee/tables/xfconf/xfconf.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
@@ -29,13 +28,11 @@ var xfconfChannelXmlPath string = filepath.Join("xfce4", "xfconf", "xfce-perchan
 
 type xfconfTable struct {
 	slogger *slog.Logger
-	logger  log.Logger // preserved temporarily for use in dataflattentable and tablehelpers.Exec
 }
 
-func TablePlugin(slogger *slog.Logger, logger log.Logger) *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	t := &xfconfTable{
 		slogger: slogger.With("table", "kolide_xfconf"),
-		logger:  logger,
 	}
 
 	return table.NewPlugin("kolide_xfconf", dataflattentable.Columns(table.TextColumn("username"), table.TextColumn("path")), t.generate)
@@ -191,7 +188,7 @@ func (t *xfconfTable) getCombinedFlattenedConfig(u *user.User, userConfig map[st
 	var results []map[string]string
 
 	flattenOpts := []dataflatten.FlattenOpts{
-		dataflatten.WithLogger(t.logger),
+		dataflatten.WithSlogger(t.slogger),
 		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
 	}
 

--- a/ee/tables/xfconf/xfconf_test.go
+++ b/ee/tables/xfconf/xfconf_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -24,7 +23,6 @@ func Test_getUserConfig(t *testing.T) {
 	tmpDefaultDir, tmpUserDir := setUpConfigFiles(t)
 
 	xfconf := xfconfTable{
-		logger:  log.NewNopLogger(),
 		slogger: multislogger.New().Logger,
 	}
 

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -2,6 +2,7 @@ package interactive
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/augeas"
-	"github.com/kolide/launcher/pkg/log/multislogger"
 	osqueryRuntime "github.com/kolide/launcher/pkg/osquery/runtime"
 	"github.com/kolide/launcher/pkg/osquery/table"
 	osquery "github.com/osquery/osquery-go"
@@ -17,7 +17,7 @@ import (
 
 const extensionName = "com.kolide.launcher_interactive"
 
-func StartProcess(rootDir, osquerydPath string, osqueryFlags []string) (*os.Process, *osquery.ExtensionManagerServer, error) {
+func StartProcess(slogger *slog.Logger, rootDir, osquerydPath string, osqueryFlags []string) (*os.Process, *osquery.ExtensionManagerServer, error) {
 
 	if err := os.MkdirAll(rootDir, fsutil.DirMode); err != nil {
 		return nil, nil, fmt.Errorf("creating root dir for interactive mode: %w", err)
@@ -58,7 +58,7 @@ func StartProcess(rootDir, osquerydPath string, osqueryFlags []string) (*os.Proc
 		return nil, nil, fmt.Errorf("error waiting for osquery to create socket: %w", err)
 	}
 
-	extensionServer, err := loadExtensions(socketPath, osquerydPath)
+	extensionServer, err := loadExtensions(slogger, socketPath, osquerydPath)
 	if err != nil {
 		err = fmt.Errorf("error loading extensions: %w", err)
 
@@ -100,7 +100,7 @@ func buildOsqueryFlags(socketPath, augeasLensesPath string, osqueryFlags []strin
 	return flags
 }
 
-func loadExtensions(socketPath string, osquerydPath string) (*osquery.ExtensionManagerServer, error) {
+func loadExtensions(slogger *slog.Logger, socketPath string, osquerydPath string) (*osquery.ExtensionManagerServer, error) {
 	client, err := osquery.NewClient(socketPath, 10*time.Second, osquery.MaxWaitTime(10*time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("error creating osquery client: %w", err)
@@ -117,7 +117,7 @@ func loadExtensions(socketPath string, osquerydPath string) (*osquery.ExtensionM
 		return extensionManagerServer, fmt.Errorf("error creating extension manager server: %w", err)
 	}
 
-	extensionManagerServer.RegisterPlugin(table.PlatformTables(multislogger.New().Logger, osquerydPath)...)
+	extensionManagerServer.RegisterPlugin(table.PlatformTables(slogger, osquerydPath)...)
 
 	if err := extensionManagerServer.Start(); err != nil {
 		return nil, fmt.Errorf("error starting extension manager server: %w", err)

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/packaging"
 	"github.com/stretchr/testify/require"
 )
@@ -83,7 +84,7 @@ func TestProc(t *testing.T) {
 			require.NoError(t, downloadOsquery(rootDir))
 			osquerydPath := filepath.Join(rootDir, "osqueryd")
 
-			proc, _, err := StartProcess(rootDir, osquerydPath, tt.osqueryFlags)
+			proc, _, err := StartProcess(multislogger.New().Logger, rootDir, osquerydPath, tt.osqueryFlags)
 
 			if tt.errContainsStr != "" {
 				require.Error(t, err)

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/pkg/packaging"
 	"github.com/stretchr/testify/require"
@@ -84,7 +83,7 @@ func TestProc(t *testing.T) {
 			require.NoError(t, downloadOsquery(rootDir))
 			osquerydPath := filepath.Join(rootDir, "osqueryd")
 
-			proc, _, err := StartProcess(log.NewNopLogger(), rootDir, osquerydPath, tt.osqueryFlags)
+			proc, _, err := StartProcess(rootDir, osquerydPath, tt.osqueryFlags)
 
 			if tt.errContainsStr != "" {
 				require.Error(t, err)

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -528,7 +528,7 @@ func (r *Runner) launchOsqueryInstance() error {
 			"errgroup", "kolide extension manager server launch",
 		)
 
-		plugins := table.PlatformTables(r.knapsack.Slogger().With("component", "platform_tables"), o.logger, currentOsquerydBinaryPath)
+		plugins := table.PlatformTables(r.knapsack.Slogger().With("component", "platform_tables"), currentOsquerydBinaryPath)
 
 		if len(plugins) == 0 {
 			return nil

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -6,7 +6,6 @@ package table
 import (
 	"log/slog"
 
-	"github.com/go-kit/kit/log"
 	"github.com/knightsc/system_policy/osquery/table/kextpolicy"
 	"github.com/knightsc/system_policy/osquery/table/legacyexec"
 	"github.com/kolide/launcher/ee/allowedcmd"
@@ -40,7 +39,7 @@ const (
 	screenlockQuery    = "select enabled, grace_period from screenlock"
 )
 
-func platformSpecificTables(slogger *slog.Logger, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	munki := munki.New()
 
 	// This table uses undocumented APIs, There is some discussion at the
@@ -83,49 +82,49 @@ func platformSpecificTables(slogger *slog.Logger, logger log.Logger, currentOsqu
 		keychainItemsTable,
 		appicons.AppIcons(),
 		ChromeLoginKeychainInfo(slogger),
-		firmwarepasswd.TablePlugin(logger),
+		firmwarepasswd.TablePlugin(slogger),
 		GDriveSyncConfig(slogger),
 		GDriveSyncHistoryInfo(slogger),
 		MDMInfo(),
 		macos_software_update.MacOSUpdate(),
-		macos_software_update.RecommendedUpdates(slogger, logger),
-		macos_software_update.AvailableProducts(slogger, logger),
+		macos_software_update.RecommendedUpdates(slogger),
+		macos_software_update.AvailableProducts(slogger),
 		MachoInfo(),
-		spotlight.TablePlugin(slogger, logger),
+		spotlight.TablePlugin(slogger),
 		TouchIDUserConfig(slogger),
 		TouchIDSystemConfig(slogger),
 		UserAvatar(slogger),
-		ioreg.TablePlugin(slogger, logger),
-		profiles.TablePlugin(slogger, logger),
-		airport.TablePlugin(slogger, logger),
+		ioreg.TablePlugin(slogger),
+		profiles.TablePlugin(slogger),
+		airport.TablePlugin(slogger),
 		kextpolicy.TablePlugin(),
-		filevault.TablePlugin(slogger, logger),
-		mdmclient.TablePlugin(slogger, logger),
-		apple_silicon_security_policy.TablePlugin(slogger, logger),
+		filevault.TablePlugin(slogger),
+		mdmclient.TablePlugin(slogger),
+		apple_silicon_security_policy.TablePlugin(slogger),
 		legacyexec.TablePlugin(),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_diskutil_list", dataflattentable.PlistType, allowedcmd.Diskutil, []string{"list", "-plist"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_falconctl_stats", dataflattentable.PlistType, allowedcmd.Falconctl, []string{"stats", "-p"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_apfs_list", dataflattentable.PlistType, allowedcmd.Diskutil, []string{"apfs", "list", "-plist"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_apfs_users", dataflattentable.PlistType, allowedcmd.Diskutil, []string{"apfs", "listUsers", "/", "-plist"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_tmutil_destinationinfo", dataflattentable.PlistType, allowedcmd.Tmutil, []string{"destinationinfo", "-X"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_powermetrics", dataflattentable.PlistType, allowedcmd.Powermetrics, []string{"-n", "1", "-f", "plist"}),
 		screenlockTable,
-		pwpolicy.TablePlugin(slogger, logger),
-		systemprofiler.TablePlugin(slogger, logger),
+		pwpolicy.TablePlugin(slogger),
+		systemprofiler.TablePlugin(slogger),
 		munki.ManagedInstalls(),
 		munki.MunkiReport(),
-		dataflattentable.TablePluginExec(logger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
-		zfs.ZfsPropertiesPlugin(slogger, logger),
-		zfs.ZpoolPropertiesPlugin(slogger, logger),
+		dataflattentable.TablePluginExec(slogger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
+		zfs.ZfsPropertiesPlugin(slogger),
+		zfs.ZpoolPropertiesPlugin(slogger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -6,7 +6,6 @@ package table
 import (
 	"log/slog"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/crowdstrike/falcon_kernel_check"
 	"github.com/kolide/launcher/ee/tables/crowdstrike/falconctl"
@@ -31,41 +30,41 @@ import (
 	osquery "github.com/osquery/osquery-go"
 )
 
-func platformSpecificTables(slogger *slog.Logger, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
-		cryptsetup.TablePlugin(slogger, logger),
+		cryptsetup.TablePlugin(slogger),
 		gsettings.Settings(slogger),
 		gsettings.Metadata(slogger),
-		nix_env_upgradeable.TablePlugin(slogger, logger),
+		nix_env_upgradeable.TablePlugin(slogger),
 		secureboot.TablePlugin(slogger),
 		xrdb.TablePlugin(slogger),
 		fscrypt_info.TablePlugin(slogger),
-		falcon_kernel_check.TablePlugin(slogger, logger),
-		falconctl.NewFalconctlOptionTable(slogger, logger),
-		xfconf.TablePlugin(slogger, logger),
+		falcon_kernel_check.TablePlugin(slogger),
+		falconctl.NewFalconctlOptionTable(slogger),
+		xfconf.TablePlugin(slogger),
 
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_nmcli_wifi", dataflattentable.KeyValueType,
 			allowedcmd.Nmcli,
 			[]string{"--mode=multiline", "--fields=all", "device", "wifi", "list"},
 			dataflattentable.WithKVSeparator(":")),
-		dataflattentable.TablePluginExec(logger, "kolide_lsblk", dataflattentable.JsonType,
+		dataflattentable.TablePluginExec(slogger, "kolide_lsblk", dataflattentable.JsonType,
 			allowedcmd.Lsblk, []string{"-fJp"},
 		),
-		dataflattentable.TablePluginExec(logger, "kolide_wsone_uem_status_enroll", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--enroll"}),
-		dataflattentable.TablePluginExec(logger, "kolide_wsone_uem_status_dependency", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--dependency"}),
-		dataflattentable.TablePluginExec(logger, "kolide_wsone_uem_status_profile", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--profile"}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_dpkg_version_info", dpkg.Parser, allowedcmd.Dpkg, []string{"-p"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_pacman_group", pacman_group.Parser, allowedcmd.Pacman, []string{"-Qg"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_pacman_version_info", pacman_info.Parser, allowedcmd.Pacman, []string{"-Qi"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_pacman_upgradeable", pacman_upgradeable.Parser, allowedcmd.Pacman, []string{"-Qu"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_rpm_version_info", rpm.Parser, allowedcmd.Rpm, []string{"-qai"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.TablePluginExec(logger, "kolide_nftables", dataflattentable.JsonType, allowedcmd.Nftables, []string{"-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
-		zfs.ZfsPropertiesPlugin(slogger, logger),
-		zfs.ZpoolPropertiesPlugin(slogger, logger),
+		dataflattentable.TablePluginExec(slogger, "kolide_wsone_uem_status_enroll", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--enroll"}),
+		dataflattentable.TablePluginExec(slogger, "kolide_wsone_uem_status_dependency", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--dependency"}),
+		dataflattentable.TablePluginExec(slogger, "kolide_wsone_uem_status_profile", dataflattentable.JsonType, allowedcmd.Ws1HubUtil, []string{"status", "--profile"}),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_falconctl_systags", simple_array.New("systags"), allowedcmd.Falconctl, []string{"-g", "--systags"}),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_apt_upgradeable", apt.Parser, allowedcmd.Apt, []string{"list", "--upgradeable"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_dnf_upgradeable", dnf.Parser, allowedcmd.Dnf, []string{"check-update"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_dpkg_version_info", dpkg.Parser, allowedcmd.Dpkg, []string{"-p"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_pacman_group", pacman_group.Parser, allowedcmd.Pacman, []string{"-Qg"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_pacman_version_info", pacman_info.Parser, allowedcmd.Pacman, []string{"-Qi"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_pacman_upgradeable", pacman_upgradeable.Parser, allowedcmd.Pacman, []string{"-Qu"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_rpm_version_info", rpm.Parser, allowedcmd.Rpm, []string{"-qai"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.TablePluginExec(slogger, "kolide_nftables", dataflattentable.JsonType, allowedcmd.Nftables, []string{"-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
+		zfs.ZfsPropertiesPlugin(slogger),
+		zfs.ZpoolPropertiesPlugin(slogger),
 	}
 }

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -6,7 +6,6 @@ package table
 import (
 	"log/slog"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/dsim_default_associations"
@@ -18,15 +17,15 @@ import (
 	osquery "github.com/osquery/osquery-go"
 )
 
-func platformSpecificTables(slogger *slog.Logger, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		ProgramIcons(),
-		dsim_default_associations.TablePlugin(slogger, logger),
-		secedit.TablePlugin(slogger, logger),
-		wifi_networks.TablePlugin(slogger, logger),
-		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, slogger, logger),
-		windowsupdatetable.TablePlugin(windowsupdatetable.HistoryTable, slogger, logger),
-		wmitable.TablePlugin(slogger, logger),
-		dataflattentable.NewExecAndParseTable(logger, "kolide_dsregcmd", dsregcmd.Parser, allowedcmd.Dsregcmd, []string{`/status`}),
+		dsim_default_associations.TablePlugin(slogger),
+		secedit.TablePlugin(slogger),
+		wifi_networks.TablePlugin(slogger),
+		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, slogger),
+		windowsupdatetable.TablePlugin(windowsupdatetable.HistoryTable, slogger),
+		wmitable.TablePlugin(slogger),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_dsregcmd", dsregcmd.Parser, allowedcmd.Dsregcmd, []string{`/status`}),
 	}
 }

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kolide/launcher/ee/tables/tdebug"
 	"github.com/kolide/launcher/ee/tables/tufinfo"
 
-	"github.com/go-kit/kit/log"
 	osquery "github.com/osquery/osquery-go"
 )
 
@@ -37,7 +36,7 @@ func LauncherTables(k types.Knapsack) []osquery.OsqueryPlugin {
 }
 
 // PlatformTables returns all tables for the launcher build platform.
-func PlatformTables(slogger *slog.Logger, logger log.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
+func PlatformTables(slogger *slog.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	// Common tables to all platforms
 	tables := []osquery.OsqueryPlugin{
 		ChromeLoginDataEmails(slogger),
@@ -46,23 +45,23 @@ func PlatformTables(slogger *slog.Logger, logger log.Logger, currentOsquerydBina
 		OnePasswordAccounts(slogger),
 		SlackConfig(slogger),
 		SshKeys(slogger),
-		cryptoinfotable.TablePlugin(slogger, logger),
-		dev_table_tooling.TablePlugin(slogger, logger),
+		cryptoinfotable.TablePlugin(slogger),
+		dev_table_tooling.TablePlugin(slogger),
 		firefox_preferences.TablePlugin(slogger),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_zerotier_info", dataflattentable.JsonType, allowedcmd.ZerotierCli, []string{"info"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_zerotier_networks", dataflattentable.JsonType, allowedcmd.ZerotierCli, []string{"listnetworks"}),
-		dataflattentable.TablePluginExec(logger,
+		dataflattentable.TablePluginExec(slogger,
 			"kolide_zerotier_peers", dataflattentable.JsonType, allowedcmd.ZerotierCli, []string{"listpeers"}),
-		tdebug.LauncherGcInfo(slogger, logger),
+		tdebug.LauncherGcInfo(slogger),
 	}
 
 	// The dataflatten tables
-	tables = append(tables, dataflattentable.AllTablePlugins(logger)...)
+	tables = append(tables, dataflattentable.AllTablePlugins(slogger)...)
 
 	// add in the platform specific ones (as denoted by build tags)
-	tables = append(tables, platformSpecificTables(slogger, logger, currentOsquerydBinaryPath)...)
+	tables = append(tables, platformSpecificTables(slogger, currentOsquerydBinaryPath)...)
 
 	return tables
 }


### PR DESCRIPTION
Last step for removing logger from Kolide tables -- replaces logger with slogger in dataflatten/exec.