### PR TITLE
Fix "object file was built for newer macOS version than being linked" error in build step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
     - name: Check out code
@@ -210,7 +210,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0 # need a full checkout for `git describe`
 
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v3
       with:
         go-version-file: './go.mod'
         check-latest: true
@@ -54,9 +54,6 @@ jobs:
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-
-    - name: Get dependencies
-      run: make deps
 
     - name: Run govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.1; govulncheck ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0 # need a full checkout for `git describe`
 
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: './go.mod'
         check-latest: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,8 +55,8 @@ jobs:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-    - name: Run govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.1; govulncheck ./...
+    - name: Get dependencies
+      run: make deps
 
     - name: Set up zig
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -77,6 +77,9 @@ jobs:
     - name: App Bundle
       run: make github-launcherapp
       if: ${{ contains(matrix.os, 'macos') }}
+
+    - name: Run govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.1; govulncheck ./...
 
     - name: Test
       run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,13 +44,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -87,7 +87,7 @@ jobs:
       run: make test
 
     - name: Cache build output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -111,7 +111,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -141,7 +141,7 @@ jobs:
     needs: version_baseline
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -188,7 +188,7 @@ jobs:
     needs: exec_testing
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ matrix.artifactos }}-${{ github.run_id }}
@@ -230,13 +230,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-13
+          - macos-12
           - windows-latest
     steps:
     - name: Check out code
@@ -210,7 +210,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-13
+          - macos-12
           - windows-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,13 +44,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -63,9 +63,7 @@ jobs:
       uses: goto-bus-stop/setup-zig@v2
 
     - name: Build
-      run: |
-        make build_launcher_noop_amd64
-        make build_launcher_noop_arm64
+      run: make -j2 github-build
 
     - name: Check macOS build target
       if: contains(matrix.os, 'macos')
@@ -84,7 +82,7 @@ jobs:
       run: make test
 
     - name: Cache build output
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -108,7 +106,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v3
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -138,7 +136,7 @@ jobs:
     needs: version_baseline
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v3
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -185,7 +183,7 @@ jobs:
     needs: exec_testing
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v3
       with:
         path: ./build
         key: ${{ matrix.artifactos }}-${{ github.run_id }}
@@ -227,13 +225,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,9 @@ jobs:
       uses: goto-bus-stop/setup-zig@v2
 
     - name: Build
-      run: make -j2 github-build
+      run: |
+        make build_launcher_noop_amd64
+        make build_launcher_noop_arm64
 
     - name: Check macOS build target
       if: contains(matrix.os, 'macos')


### PR DESCRIPTION
Try to fix persistent build issue:

```
ld: warning: object file (/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/go-link-1359000262/000020.o) was built for newer macOS version (12.0) than being linked (11.0)
```

Example: https://github.com/kolide/launcher/actions/runs/7995248348/job/21835133063?pr=1612

Somehow this is a govulncheck issue again. Since this is the [second time](https://github.com/kolide/launcher/pull/1554) that running govulncheck ahead of the build has created issues with the build, I am moving the govulncheck step to after the build is complete.