### PR TITLE
Run govulncheck, using GitHub action, in separate job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,9 +58,6 @@ jobs:
     - name: Get dependencies
       run: make deps
 
-    - name: Run govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.1; govulncheck ./...
-
     - name: Set up zig
       if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-    name: lint
+    name: govulncheck
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,38 @@
+name: govulncheck
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: '**'
+  merge_group:
+    types: [checks_requested]
+
+
+jobs:
+  govulncheck:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    name: lint
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+           go-version-file: './go.mod'
+           check-latest: true
+           go-package: ./...
+
+  # This job is here as a github status check -- it allows us to move
+  # the merge dependency from being on all the jobs to this single
+  # one.
+  govulncheck_mergeable:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+    needs:
+      - govulncheck


### PR DESCRIPTION
Provides an alternative to https://github.com/kolide/launcher/pull/1613 -- since we really don't want running `govulncheck` to alter our build state, move it to a separate job entirely