### PR TITLE
Replace logger with slogger in library lookup and osquery instance

### DIFF
--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kolide/kit/logutil"
 	"github.com/kolide/launcher/cmd/launcher/internal"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/tuf"
@@ -34,8 +33,6 @@ func runInteractive(args []string) error {
 		return err
 	}
 
-	logger := logutil.NewServerLogger(*flDebug)
-
 	slogLevel := slog.LevelInfo
 	if *flDebug {
 		slogLevel = slog.LevelDebug
@@ -47,7 +44,7 @@ func runInteractive(args []string) error {
 
 	osquerydPath := *flOsquerydPath
 	if osquerydPath == "" {
-		latestOsquerydBinary, err := tuf.CheckOutLatestWithoutConfig("osqueryd", logger)
+		latestOsquerydBinary, err := tuf.CheckOutLatestWithoutConfig("osqueryd", slogger)
 		if err != nil {
 			osquerydPath = launcher.FindOsquery()
 			if osquerydPath == "" {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -328,7 +328,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		osqueryruntime.WithOsquerydBinary(k.OsquerydPath()),
 		osqueryruntime.WithRootDirectory(k.RootDirectory()),
 		osqueryruntime.WithOsqueryExtensionPlugins(table.LauncherTables(k)...),
-		osqueryruntime.WithLogger(logger),
+		osqueryruntime.WithSlogger(k.Slogger().With("component", "osquery_instance")),
 		osqueryruntime.WithOsqueryVerbose(k.OsqueryVerbose()),
 		osqueryruntime.WithOsqueryFlags(k.OsqueryFlags()),
 		osqueryruntime.WithStdout(kolidelog.NewOsqueryLogAdapter(

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -140,7 +140,11 @@ func (k *knapsack) getKVStore(storeType storage.Store) types.KVStore {
 }
 
 func (k *knapsack) LatestOsquerydPath(ctx context.Context) string {
-	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), k.Slogger())
+	slogger := k.Slogger()
+	if slogger == nil {
+		slogger = multislogger.New().Logger
+	}
+	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), slogger)
 	if err != nil {
 		return autoupdate.FindNewest(ctx, k.OsquerydPath())
 	}

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -9,7 +9,6 @@ import (
 
 	"log/slog"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/agent/storage"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/tuf"
@@ -141,7 +140,7 @@ func (k *knapsack) getKVStore(storeType storage.Store) types.KVStore {
 }
 
 func (k *knapsack) LatestOsquerydPath(ctx context.Context) string {
-	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), log.NewNopLogger())
+	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), k.Slogger())
 	if err != nil {
 		return autoupdate.FindNewest(ctx, k.OsquerydPath())
 	}

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -42,6 +42,13 @@ type knapsack struct {
 }
 
 func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB, slogger, systemSlogger *multislogger.MultiSlogger) *knapsack {
+	if slogger == nil {
+		slogger = multislogger.New()
+	}
+	if systemSlogger == nil {
+		systemSlogger = multislogger.New()
+	}
+
 	k := &knapsack{
 		db:            db,
 		flags:         flags,
@@ -140,11 +147,7 @@ func (k *knapsack) getKVStore(storeType storage.Store) types.KVStore {
 }
 
 func (k *knapsack) LatestOsquerydPath(ctx context.Context) string {
-	slogger := k.Slogger()
-	if slogger == nil {
-		slogger = multislogger.New().Logger
-	}
-	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), slogger)
+	latestBin, err := tuf.CheckOutLatest(ctx, "osqueryd", k.RootDirectory(), k.UpdateDirectory(), k.UpdateChannel(), k.Slogger())
 	if err != nil {
 		return autoupdate.FindNewest(ctx, k.OsquerydPath())
 	}

--- a/ee/debug/checkups/tuf.go
+++ b/ee/debug/checkups/tuf.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/tuf"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
 type (
@@ -196,14 +196,16 @@ func (tc *tufCheckup) selectedVersions() map[string]map[string]string {
 		"osqueryd": make(map[string]string),
 	}
 
-	if launcherVersion, err := tuf.CheckOutLatestWithoutConfig("launcher", log.NewNopLogger()); err != nil {
+	nopLogger := multislogger.New().Logger
+
+	if launcherVersion, err := tuf.CheckOutLatestWithoutConfig("launcher", nopLogger); err != nil {
 		selectedVersions["launcher"]["path"] = fmt.Sprintf("error checking out latest version: %v", err)
 	} else {
 		selectedVersions["launcher"]["path"] = launcherVersion.Path
 		selectedVersions["launcher"]["version"] = launcherVersion.Version
 	}
 
-	if osquerydVersion, err := tuf.CheckOutLatestWithoutConfig("osqueryd", log.NewNopLogger()); err != nil {
+	if osquerydVersion, err := tuf.CheckOutLatestWithoutConfig("osqueryd", nopLogger); err != nil {
 		selectedVersions["osqueryd"]["path"] = fmt.Sprintf("error checking out latest version: %v", err)
 	} else {
 		selectedVersions["osqueryd"]["path"] = osquerydVersion.Path

--- a/ee/tuf/library_lookup_test.go
+++ b/ee/tuf/library_lookup_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	tufci "github.com/kolide/launcher/ee/tuf/ci"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +45,7 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) {
 			require.NoError(t, os.Chmod(tooRecentPath, 0755))
 
 			// Check it
-			latest, err := CheckOutLatest(context.TODO(), binary, rootDir, "", "nightly", log.NewNopLogger())
+			latest, err := CheckOutLatest(context.TODO(), binary, rootDir, "", "nightly", multislogger.New().Logger)
 			require.NoError(t, err, "unexpected error on checking out latest")
 			require.Equal(t, executablePath, latest.Path)
 			require.Equal(t, executableVersion, latest.Version)
@@ -72,7 +72,7 @@ func TestCheckOutLatest_withoutTufRepository(t *testing.T) {
 			require.NoError(t, err, "did not make test binary")
 
 			// Check it
-			latest, err := CheckOutLatest(context.TODO(), binary, rootDir, "", "nightly", log.NewNopLogger())
+			latest, err := CheckOutLatest(context.TODO(), binary, rootDir, "", "nightly", multislogger.New().Logger)
 			require.NoError(t, err, "unexpected error on checking out latest")
 			require.Equal(t, executablePath, latest.Path)
 			require.Equal(t, executableVersion, latest.Version)

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,11 +15,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/backoff"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go"
@@ -135,11 +135,11 @@ func WithStderr(w io.Writer) OsqueryInstanceOption {
 	}
 }
 
-// WithLogger is a functional option which allows the user to pass a log.Logger
+// WithSlogger is a functional option which allows the user to pass a *slog.Logger
 // to be used for logging osquery instance status.
-func WithLogger(logger log.Logger) OsqueryInstanceOption {
+func WithSlogger(slogger *slog.Logger) OsqueryInstanceOption {
 	return func(i *OsqueryInstance) {
-		i.logger = logger
+		i.slogger = slogger
 	}
 }
 
@@ -222,8 +222,8 @@ func WithKnapsack(k types.Knapsack) OsqueryInstanceOption {
 // OsqueryInstance is the type which represents a currently running instance
 // of osqueryd.
 type OsqueryInstance struct {
-	opts   osqueryOptions
-	logger log.Logger
+	opts    osqueryOptions
+	slogger *slog.Logger
 	// the following are instance artifacts that are created and held as a result
 	// of launching an osqueryd process
 	errgroup                *errgroup.Group
@@ -358,7 +358,7 @@ func newInstance() *OsqueryInstance {
 	i.cancel = cancel
 	i.errgroup, i.doneCtx = errgroup.WithContext(ctx)
 
-	i.logger = log.NewNopLogger()
+	i.slogger = multislogger.New().Logger
 
 	i.startFunc = func(cmd *exec.Cmd) error {
 		return cmd.Start()
@@ -544,9 +544,10 @@ func (o *OsqueryInstance) StartOsqueryClient(paths *osqueryFilePaths) (*osquery.
 // startOsqueryExtensionManagerServer takes a set of plugins, creates
 // an osquery.NewExtensionManagerServer for them, and then starts it.
 func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socketPath string, client *osquery.ExtensionManagerClient, plugins []osquery.OsqueryPlugin) error {
-	logger := log.With(o.logger, "extensionMangerServer", name)
-
-	level.Debug(logger).Log("msg", "Starting startOsqueryExtensionManagerServer")
+	o.slogger.Log(context.TODO(), slog.LevelDebug,
+		"starting startOsqueryExtensionManagerServer",
+		"extension_name", name,
+	)
 
 	var extensionManagerServer *osquery.ExtensionManagerServer
 	if err := backoff.WaitFor(func() error {
@@ -559,7 +560,11 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 		)
 		return newErr
 	}, socketOpenTimeout, socketOpenInterval); err != nil {
-		level.Debug(logger).Log("msg", "could not create an extension server", "err", err)
+		o.slogger.Log(context.TODO(), slog.LevelDebug,
+			"could not create an extension server",
+			"extension_name", name,
+			"err", err,
+		)
 		return fmt.Errorf("could not create an extension server: %w", err)
 	}
 
@@ -572,10 +577,18 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 
 	// Start!
 	o.errgroup.Go(func() error {
-		defer level.Info(o.logger).Log("msg", "exiting errgroup", "errgroup", "run extension manager server", "extension_name", name)
+		defer o.slogger.Log(context.TODO(), slog.LevelDebug,
+			"exiting errgroup",
+			"errgroup", "run extension manager server",
+			"extension_name", name,
+		)
 
 		if err := extensionManagerServer.Start(); err != nil {
-			level.Info(logger).Log("msg", "Extension manager server startup got error", "err", err, "extension_name", name)
+			o.slogger.Log(context.TODO(), slog.LevelInfo,
+				"extension manager server startup got error",
+				"err", err,
+				"extension_name", name,
+			)
 			return fmt.Errorf("running extension server: %w", err)
 		}
 		return errors.New("extension manager server exited")
@@ -583,13 +596,23 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 
 	// register a shutdown routine
 	o.errgroup.Go(func() error {
-		defer level.Info(o.logger).Log("msg", "exiting errgroup", "errgroup", "shut down extension manager server", "extension_name", name)
+		defer o.slogger.Log(context.TODO(), slog.LevelDebug,
+			"exiting errgroup",
+			"errgroup", "shut down extension manager server",
+			"extension_name", name,
+		)
 
 		<-o.doneCtx.Done()
-		level.Debug(logger).Log("msg", "Starting extension shutdown")
+
+		o.slogger.Log(context.TODO(), slog.LevelDebug,
+			"exiting errgroup",
+			"errgroup", "starting extension shutdown",
+			"extension_name", name,
+		)
+
 		if err := extensionManagerServer.Shutdown(context.TODO()); err != nil {
-			level.Info(o.logger).Log(
-				"msg", "Got error while shutting down extension server",
+			o.slogger.Log(context.TODO(), slog.LevelInfo,
+				"got error while shutting down extension server",
 				"err", err,
 				"extension_name", name,
 			)
@@ -597,7 +620,10 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 		return o.doneCtx.Err()
 	})
 
-	level.Debug(logger).Log("msg", "Clean finish startOsqueryExtensionManagerServer")
+	o.slogger.Log(context.TODO(), slog.LevelDebug,
+		"clean finish startOsqueryExtensionManagerServer",
+		"extension_name", name,
+	)
 
 	return nil
 }

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kolide/launcher/ee/tuf"
 	"github.com/kolide/launcher/pkg/autoupdate"
 	"github.com/kolide/launcher/pkg/backoff"
-	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/osquery/table"
 	"github.com/kolide/launcher/pkg/traces"
@@ -316,14 +315,14 @@ func (r *Runner) launchOsqueryInstance() error {
 	// FindNewest uses context as a way to get a logger, so we need to
 	// create and pass a ctxlog in.
 	var currentOsquerydBinaryPath string
-	currentOsquerydBinary, err := tuf.CheckOutLatest(ctx, "osqueryd", o.opts.rootDirectory, o.opts.updateDirectory, o.opts.updateChannel, o.logger)
+	currentOsquerydBinary, err := tuf.CheckOutLatest(ctx, "osqueryd", o.opts.rootDirectory, o.opts.updateDirectory, o.opts.updateChannel, r.slogger)
 	if err != nil {
 		r.slogger.Log(ctx, slog.LevelDebug,
 			"could not get latest version of osqueryd from new autoupdate library, falling back",
 			"err", err,
 		)
 		currentOsquerydBinaryPath = autoupdate.FindNewest(
-			ctxlog.NewContext(ctx, o.logger),
+			ctx,
 			o.opts.binaryPath,
 			autoupdate.DeleteOldUpdates(),
 		)

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -670,7 +670,7 @@ func TestOsquerySlowStart(t *testing.T) {
 		WithKnapsack(k),
 		WithRootDirectory(rootDirectory),
 		WithOsquerydBinary(testOsqueryBinaryDirectory),
-		WithLogger(log.NewLogfmtLogger(&logBytes)),
+		WithSlogger(slogger.Logger),
 		WithStartFunc(func(cmd *exec.Cmd) error {
 			err := cmd.Start()
 			if err != nil {


### PR DESCRIPTION
This completes the work necessary to pull the old `logger` completely out of the osquery runtime.