### PR TITLE
Do not spin up desktop process for nobody user

### DIFF
--- a/ee/consoleuser/consoleuser_linux.go
+++ b/ee/consoleuser/consoleuser_linux.go
@@ -13,9 +13,10 @@ import (
 )
 
 type listSessionsResult []struct {
-	Session string `json:"session"`
-	UID     int    `json:"uid"`
-	Seat    string `json:"seat"`
+	Session  string `json:"session"`
+	UID      int    `json:"uid"`
+	Username string `json:"user"`
+	Seat     string `json:"seat"`
 }
 
 func CurrentUids(ctx context.Context) ([]string, error) {
@@ -38,7 +39,7 @@ func CurrentUids(ctx context.Context) ([]string, error) {
 	for _, s := range sessions {
 		// generally human users start at 1000 on linux. 65534 is reserved for https://wiki.ubuntu.com/nobody,
 		// which we don't want to count as a current user.
-		if s.UID < 1000 || s.UID == 65534 {
+		if s.UID < 1000 || s.UID == 65534 || s.Username == "nobody" {
 			continue
 		}
 

--- a/ee/consoleuser/consoleuser_linux.go
+++ b/ee/consoleuser/consoleuser_linux.go
@@ -36,8 +36,9 @@ func CurrentUids(ctx context.Context) ([]string, error) {
 
 	var uids []string
 	for _, s := range sessions {
-		// generally human users start at 1000 on linux
-		if s.UID < 1000 {
+		// generally human users start at 1000 on linux. 65534 is reserved for https://wiki.ubuntu.com/nobody,
+		// which we don't want to count as a current user.
+		if s.UID < 1000 || s.UID == 65534 {
 			continue
 		}
 


### PR DESCRIPTION
launcher appears to be attempting to spin up a desktop process for `nobody` (observed on Debian 12 so far) -- it shouldn't do that. This PR adds an exclusion for the `nobody` user.