### PR TITLE
Increase sleep in time machine test

### DIFF
--- a/ee/agent/timemachine/timemachine_darwin_test.go
+++ b/ee/agent/timemachine/timemachine_darwin_test.go
@@ -85,7 +85,7 @@ func TestAddExclusions(t *testing.T) {
 	// we've seen some flake in CI here where the exclusions have not been
 	// updated by the time we perform assertions, so sleep for a bit to give
 	// OS some time to catch up
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// ensure the files are included / excluded as expected
 	for fileName, shouldBeExcluded := range shouldBeExcluded {


### PR DESCRIPTION
Still seeing this test fail sometimes in CI, so going to try bumping up the sleep