### PR TITLE
Control server can set update channel for autoupdater

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -16,7 +16,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -322,11 +321,7 @@ func (ta *TufAutoupdater) Do(data io.Reader) error {
 // FlagsChanged satisfies the FlagsChangeObserver interface, allowing the autoupdater
 // to respond to changes to autoupdate-related settings.
 func (ta *TufAutoupdater) FlagsChanged(flagKeys ...keys.FlagKey) {
-	if !slices.Contains(flagKeys, keys.UpdateChannel) {
-		return
-	}
-
-	// No change
+	// No change -- this is the only setting we currently care about.
 	if ta.updateChannel == ta.knapsack.UpdateChannel() {
 		return
 	}


### PR DESCRIPTION
Allows the control server to set the update channel via agent flags, and have the autoupdater apply that change immediately and on subsequent launcher restarts as well.