### PR TITLE
add dynamic buffer size for log publication

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -36,15 +36,14 @@ import (
 // and servers -- It provides a grpc and jsonrpc interface for
 // osquery. It does not provide any tables.
 type Extension struct {
-	NodeKey       string
-	Opts          ExtensionOpts
-	knapsack      types.Knapsack
-	serviceClient service.KolideService
-	enrollMutex   sync.Mutex
-	done          chan struct{}
-	interrupted   bool
-	slogger       *slog.Logger
-
+	NodeKey             string
+	Opts                ExtensionOpts
+	knapsack            types.Knapsack
+	serviceClient       service.KolideService
+	enrollMutex         sync.Mutex
+	done                chan struct{}
+	interrupted         bool
+	slogger             *slog.Logger
 	logPublicationState *logPublicationState
 }
 

--- a/pkg/osquery/log_publication_state.go
+++ b/pkg/osquery/log_publication_state.go
@@ -16,7 +16,9 @@ const (
 // logPublicationState holds stateful logic to influence the log batch publication size
 // depending on prior successes or failures. The primary intent here is to prevent repeatedly
 // consuming the entire network bandwidth available to devices that are unable to ship
-// the standard maxBytesPerBatch inside of the connection timeout (currently 30 seconds, enforced cloud side)
+// the standard maxBytesPerBatch inside of the connection timeout (currently 30 seconds, enforced cloud side).
+// Note that we always expect these batches to be sent sequentially, BeginBatch -> EndBatch
+// this would need rework (likely state locking and batch ID tracking) to support concurrent batch publications
 type logPublicationState struct {
 	// maxBytesPerBatch is passed in from the extension opts and respected
 	// as a fixed upper limit for batch size, regardless of publication success/failure rates
@@ -24,7 +26,7 @@ type logPublicationState struct {
 	// currentMaxBytesPerBatch represents the (stateful) upper limit being enforced
 	currentMaxBytesPerBatch int
 	// currentBatchBufferFilled is used to indicate when a batch's success can be used
-	// to increase the threshold (we should avoid increasing threshold for a successful partial batch of logs)
+	// to increase the threshold (we only want to increase the threshold after sending full, not partial, batches successfully)
 	currentBatchBufferFilled bool
 	currentBatchStartTime    time.Time
 }
@@ -36,6 +38,9 @@ func NewLogPublicationState(maxBytesPerBatch int) *logPublicationState {
 	}
 }
 
+// BeginBatch sets the opening state before attempting to publish a batch of logs. Specifically, it must
+// - note the time (to determine if an error later was timeout related)
+// - note whether this batch is full (to determine whether success should increase the limit on success later)
 func (lps *logPublicationState) BeginBatch(startTime time.Time, bufferFilled bool) {
 	lps.currentBatchStartTime = startTime
 	lps.currentBatchBufferFilled = bufferFilled

--- a/pkg/osquery/log_publication_state.go
+++ b/pkg/osquery/log_publication_state.go
@@ -1,71 +1,84 @@
 package osquery
 
-import (
-	"container/list"
-)
+import "time"
 
 const (
 	// minBytesPerBatch sets the minimum batch size to 0.5mb as lower bound for correction
-	minBytesPerBatch = 524288
+	minBytesPerBatch int = 524288
 	// batchIncrementAmount (0.5mb) is the incremental increase amount for the target batch
 	// size when previous runs have been successful
-	batchIncrementAmount = 524288
-
-	// batchHistoryLen is the number of logPublicationBatches to retain in our publishedBatches linked list
-	batchHistoryLen = 15
+	batchIncrementAmount int = 524288
+	// maxPublicationDuration is the total time a batch can take without an error triggering a reduction
+	// in the max batch size
+	maxPublicationDuration time.Duration = 20 * time.Second
 )
 
 // logPublicationState holds stateful logic to influence the log batch publication size
 // depending on prior successes or failures. The primary intent here is to prevent repeatedly
 // consuming the entire network bandwidth available to devices that are unable to ship
 // the standard maxBytesPerBatch inside of the connection timeout (currently 30 seconds, enforced cloud side)
-type (
-	logPublicationState struct {
-		// maxBytesPerBatch is passed in from the extension opts and respected
-		// as a fixed upper limit for batch size, regardless of publication success/failure rates
-		maxBytesPerBatch        int
-		currentMaxBytesPerBatch int
-		publishedBatches        *list.List
-	}
-
-	logPublicationBatch struct {
-		batchSizeBytes int
-		timedOut       bool
-	}
-)
+type logPublicationState struct {
+	// maxBytesPerBatch is passed in from the extension opts and respected
+	// as a fixed upper limit for batch size, regardless of publication success/failure rates
+	maxBytesPerBatch int
+	// currentMaxBytesPerBatch represents the (stateful) upper limit being enforced
+	currentMaxBytesPerBatch int
+	// currentBatchBufferFilled is used to indicate when a batch's success can be used
+	// to increase the threshold (we should avoid increasing threshold for a successful partial batch of logs)
+	currentBatchBufferFilled bool
+	currentBatchStartTime    time.Time
+}
 
 func NewLogPublicationState(maxBytesPerBatch int) *logPublicationState {
 	return &logPublicationState{
 		maxBytesPerBatch:        maxBytesPerBatch,
 		currentMaxBytesPerBatch: maxBytesPerBatch,
-		publishedBatches:        list.New(),
 	}
 }
 
-func (lps *logPublicationState) exceedsCurrentBatchThreshold(amountBytes int) bool {
-	return amountBytes > lps.currentMaxBytesPerBatch
+func (lps *logPublicationState) BeginBatch(startTime time.Time, bufferFilled bool) {
+	lps.currentBatchStartTime = startTime
+	lps.currentBatchBufferFilled = bufferFilled
 }
 
-func (lps *logPublicationState) recordBatchSuccess(logs []string) {
-	lps.recordBatch(logs, false)
-	lps.increaseBatchThreshold()
+func (lps *logPublicationState) CurrentValues() map[string]int {
+	return map[string]int{
+		"options_batch_limit_bytes": lps.maxBytesPerBatch,
+		"current_batch_limit_bytes": lps.currentMaxBytesPerBatch,
+	}
 }
 
-func (lps *logPublicationState) recordBatchTimedOut(logs []string) {
-	lps.recordBatch(logs, true)
+func (lps *logPublicationState) EndBatch(logs []string, successful bool) {
+	// ensure we reset all batch state at the end
+	defer func() {
+		lps.currentBatchBufferFilled = false
+		lps.currentBatchStartTime = time.Time{}
+	}()
+
+	// we can always safely decrease the threshold for a failed batch, but
+	// shouldn't increase the threshold for a successful batch unless we've at
+	// least filled the buffer
+	if successful && !lps.currentBatchBufferFilled {
+		return
+	}
+
+	// in practice there could be one of a few different transport or timeout errors that bubble up
+	// depending on network conditions. instead of trying to keep up with all potential errors,
+	// only reduce the threshold if the calls are failing after more than 20 seconds
+	if !successful && time.Since(lps.currentBatchStartTime) < maxPublicationDuration {
+		return
+	}
+
+	if successful {
+		lps.increaseBatchThreshold()
+		return
+	}
+
 	lps.reduceBatchThreshold()
 }
 
-func (lps *logPublicationState) recordBatch(logs []string, timedOut bool) {
-	newLogBatch := &logPublicationBatch{
-		batchSizeBytes: logBatchSize(logs),
-		timedOut: timedOut,
-	}
-
-	lps.publishedBatches.PushBack(newLogBatch)
-	if lps.publishedBatches.Len() > batchHistoryLen {
-		lps.publishedBatches.Remove(lps.publishedBatches.Front())
-	}
+func (lps *logPublicationState) ExceedsCurrentBatchThreshold(amountBytes int) bool {
+	return amountBytes > lps.currentMaxBytesPerBatch
 }
 
 func (lps *logPublicationState) reduceBatchThreshold() {
@@ -73,7 +86,7 @@ func (lps *logPublicationState) reduceBatchThreshold() {
 		return
 	}
 
-	newTargetThreshold := lps.currentMaxBytesPerBatch / 2
+	newTargetThreshold := lps.currentMaxBytesPerBatch - batchIncrementAmount
 	lps.currentMaxBytesPerBatch = maxInt(newTargetThreshold, minBytesPerBatch)
 }
 
@@ -82,16 +95,6 @@ func (lps *logPublicationState) increaseBatchThreshold() {
 		return
 	}
 
-	newTargetThreshold := lps.currentMaxBytesPerBatch * 2
+	newTargetThreshold := lps.currentMaxBytesPerBatch + batchIncrementAmount
 	lps.currentMaxBytesPerBatch = minInt(newTargetThreshold, lps.maxBytesPerBatch)
-}
-
-// logBatchSize determines the total batch size attempted given the published log batch
-func logBatchSize(logs []string) int {
-	totalBatchSize := 0
-	for _, log := range logs {
-		totalBatchSize += len(log)
-	}
-
-	return totalBatchSize
 }

--- a/pkg/osquery/log_publication_state.go
+++ b/pkg/osquery/log_publication_state.go
@@ -1,0 +1,76 @@
+package osquery
+
+const (
+	// set minimum batch size to 0.5 mb as lower bound for correction
+	minBytesPerBatch = 524288
+)
+
+// logPublicationState holds stateful logic to influence the log batch publication size
+// depending on prior successes or failures. The primary intent here is to prevent repeatedly
+// consuming the entire network bandwidth available to devices that are unable to ship
+// the standard maxBytesPerBatch inside of the connection timeout (currently 30 seconds, enforced cloud side)
+type (
+	logPublicationState struct {
+		// maxBytesPerBatch is passed in from the extension opts and respected
+		// as a fixed upper limit for batch size, regardless of publication success/failure rates
+		maxBytesPerBatch            int
+		currentMaxBytesPerBatch     int
+		currentPendingBatch         *logPublicationBatch
+		publishedBatches            []*logPublicationBatch
+	}
+
+	logPublicationBatch struct {
+		batchSizeBytes int
+		timedOut       bool
+	}
+)
+
+func NewLogPublicationState(maxBytesPerBatch int) *logPublicationState {
+	return &logPublicationState{
+		maxBytesPerBatch:        maxBytesPerBatch,
+		currentMaxBytesPerBatch: maxBytesPerBatch,
+		publishedBatches:        make([]*logPublicationBatch, 0),
+	}
+}
+
+func (lps *logPublicationState) exceedsCurrentBatchThreshold(amountBytes int) bool {
+	return amountBytes > lps.currentMaxBytesPerBatch
+}
+
+func (lps *logPublicationState) addPendingBatch(amountBytes int) {
+	lps.currentPendingBatch = &logPublicationBatch{
+		batchSizeBytes: amountBytes,
+	}
+}
+
+func (lps *logPublicationState) noteBatchComplete(timedOut bool) {
+	lps.currentPendingBatch.timedOut = timedOut
+	lps.publishedBatches = append(lps.publishedBatches, lps.currentPendingBatch)
+	if len(lps.publishedBatches) > 10 {
+		lps.publishedBatches = lps.publishedBatches[1:]
+	}
+
+	if timedOut {
+		lps.reduceBatchThreshold()
+	} else {
+		lps.increaseBatchThreshold()
+	}
+}
+
+func (lps *logPublicationState) reduceBatchThreshold() {
+	if lps.currentMaxBytesPerBatch <= minBytesPerBatch {
+		return
+	}
+
+	newTargetThreshold := lps.currentMaxBytesPerBatch / 2
+	lps.currentMaxBytesPerBatch = maxInt(newTargetThreshold, minBytesPerBatch)
+}
+
+func (lps *logPublicationState) increaseBatchThreshold() {
+	if lps.currentMaxBytesPerBatch >= lps.maxBytesPerBatch {
+		return
+	}
+
+	newTargetThreshold := lps.currentMaxBytesPerBatch * 2
+	lps.currentMaxBytesPerBatch = minInt(newTargetThreshold, lps.maxBytesPerBatch)
+}

--- a/pkg/osquery/log_publication_state_test.go
+++ b/pkg/osquery/log_publication_state_test.go
@@ -1,0 +1,123 @@
+//nolint:paralleltest
+package osquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/pkg/service/mock"
+	"github.com/osquery/osquery-go/plugin/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionLogPublicationHappyPath(t *testing.T) {
+	startingBatchLimitBytes := minBytesPerBatch * 4
+	m := &mock.KolideService{
+		PublishLogsFunc: func(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
+			return "", "", false, nil
+		},
+	}
+	db, cleanup := makeTempDB(t)
+	defer cleanup()
+	k := makeKnapsack(t, db)
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{MaxBytesPerBatch: startingBatchLimitBytes})
+	require.Nil(t, err)
+
+	// issue a few successful calls, expect that the batch limit is unchanged from the original opts
+	for i := 0; i < 3; i++ {
+		e.logPublicationState.BeginBatch(time.Now(), true)
+		err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
+		assert.Nil(t, err)
+		assert.Equal(t, e.logPublicationState.currentMaxBytesPerBatch, startingBatchLimitBytes)
+		// always expect that these values are reset between runs
+		assert.Equal(t, time.Time{}, e.logPublicationState.currentBatchStartTime)
+		assert.False(t, e.logPublicationState.currentBatchBufferFilled)
+	}
+}
+
+func TestExtensionLogPublicationRespondsToNetworkTimeouts(t *testing.T) {
+	numberOfPublicationRounds := 3
+	publicationCalledCount := -1
+	// startingBatchLimitBytes is set this way to ensure sufficient room for correction in both directions
+	startingBatchLimitBytes := minBytesPerBatch * (numberOfPublicationRounds + 1)
+	m := &mock.KolideService{
+		PublishLogsFunc: func(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
+			publicationCalledCount++
+			switch {
+			case publicationCalledCount < numberOfPublicationRounds:
+				return "", "", false, errors.New("transport")
+			default:
+				return "", "", false, nil
+			}
+		},
+	}
+	db, cleanup := makeTempDB(t)
+	defer cleanup()
+	k := makeKnapsack(t, db)
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{MaxBytesPerBatch: startingBatchLimitBytes})
+	require.Nil(t, err)
+
+	// expect each subsequent failed call to reduce the batch size until the min threshold is reached
+	expectedMaxValue := e.Opts.MaxBytesPerBatch
+	for i := 0; i < numberOfPublicationRounds; i++ {
+		// set the batch state to have started earlier than the 20 seconds threshold ago
+		e.logPublicationState.BeginBatch(time.Now().Add(-21*time.Second), true)
+		err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
+		assert.NotNil(t, err)
+		assert.Less(t, e.logPublicationState.currentMaxBytesPerBatch, expectedMaxValue)
+		// always expect that these values are reset between runs
+		assert.Equal(t, time.Time{}, e.logPublicationState.currentBatchStartTime)
+		assert.False(t, e.logPublicationState.currentBatchBufferFilled)
+		expectedMaxValue = e.logPublicationState.currentMaxBytesPerBatch
+	}
+
+	// now run a successful publication loop without filling the buffer - we expect
+	// this should have no effect on the current batch size
+	err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedMaxValue, e.logPublicationState.currentMaxBytesPerBatch)
+
+	// this time mark the buffer as filled for subsequent successful calls and expect that we move back up towards the original batch limit
+	for i := 0; i < numberOfPublicationRounds; i++ {
+		e.logPublicationState.BeginBatch(time.Now(), true)
+		err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
+		assert.Nil(t, err)
+		assert.Greater(t, e.logPublicationState.currentMaxBytesPerBatch, expectedMaxValue)
+		// always expect that these values are reset between runs
+		assert.Equal(t, time.Time{}, e.logPublicationState.currentBatchStartTime)
+		assert.False(t, e.logPublicationState.currentBatchBufferFilled)
+		expectedMaxValue = e.logPublicationState.currentMaxBytesPerBatch
+	}
+
+	// lastly expect that we've returned to our baseline state
+	assert.Equal(t, e.logPublicationState.currentMaxBytesPerBatch, startingBatchLimitBytes)
+}
+
+func TestExtensionLogPublicationIgnoresNonTimeoutErrors(t *testing.T) {
+	startingBatchLimitBytes := minBytesPerBatch * 4
+	m := &mock.KolideService{
+		PublishLogsFunc: func(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
+			return "", "", false, errors.New("transport")
+		},
+	}
+	db, cleanup := makeTempDB(t)
+	defer cleanup()
+	k := makeKnapsack(t, db)
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{MaxBytesPerBatch: startingBatchLimitBytes})
+	require.Nil(t, err)
+
+	// issue a few calls that error immediately, expect that the batch limit is unchanged from the original opts
+	for i := 0; i < 3; i++ {
+		e.logPublicationState.BeginBatch(time.Now(), true)
+		err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
+		// we still expect an error, but the batch limitation should not have changed
+		assert.NotNil(t, err)
+		assert.Equal(t, e.logPublicationState.currentMaxBytesPerBatch, startingBatchLimitBytes)
+		// always expect that these values are reset between runs
+		assert.Equal(t, time.Time{}, e.logPublicationState.currentBatchStartTime)
+		assert.False(t, e.logPublicationState.currentBatchBufferFilled)
+	}
+}


### PR DESCRIPTION
These changes are to address the log buffering fragility issue noted [here](https://github.com/kolide/launcher/issues/1312).

The adjustment logic took a few different forms based on testing - i also have a version of this that keeps a queue of latest results if anyone is interested in going down that route let me know (I ended up trimming this down to a more simple mechanism after seeing the complexity there).

I am more than happy to take suggestions on the adjustment logic - it's easy to make the backoff more dramatic if desired but I found it to be safest to keep the changes to small increments, if the network is really in a bad state the batch limit will be adjusted eventually.

### complications/lessons learned

- increasing the batch limit:
    - We publish logs in batches every minute by log type. This means that while some log types may become backlogged others can always publish successfully - causing the batch limit to re-adjust upwards too quickly. To get around this we only increase the limit if the previous batch limit was **both** hit and published successfully.
- decreasing the batch limit:
    - depending on how bad the network connection is and how it is terminated, any number of errors can pop out (not just network/transport errors, sometimes just failures to parse the response) . To get around this we keep track of when the batch was started, and only reduce the limit if an error occurred after a 20 second duration
