### PR TITLE
add osquery restart history to checkups

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -118,6 +118,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&osqConfigConflictCheckup{}, doctorSupported | flareSupported},
 		{&serverDataCheckup{k: k}, doctorSupported | flareSupported | logSupported},
 		{&osqDataCollector{k: k}, doctorSupported | flareSupported},
+		{&osqRestartCheckup{k: k}, doctorSupported | flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/ee/debug/checkups/osquery_restarts.go
+++ b/ee/debug/checkups/osquery_restarts.go
@@ -29,7 +29,7 @@ func (orc *osqRestartCheckup) Run(ctx context.Context, extraFH io.Writer) error 
 
 	restartHistory, err := history.GetHistory()
 	if err != nil && errors.Is(err, history.NoInstancesError{}) {
-		orc.status = Passing
+		orc.status = Informational
 		orc.summary = "No osquery restart history instances available"
 		return nil
 	}

--- a/ee/debug/checkups/osquery_restarts.go
+++ b/ee/debug/checkups/osquery_restarts.go
@@ -30,12 +30,12 @@ func (orc *osqRestartCheckup) Run(ctx context.Context, extraFH io.Writer) error 
 	restartHistory, err := history.GetHistory()
 	if err != nil && errors.Is(err, history.NoInstancesError{}) {
 		orc.status = Passing
-		orc.summary = "No restart history exists"
+		orc.summary = "No osquery restart history instances available"
 		return nil
 	}
 
 	if err != nil {
-		orc.status = Failing
+		orc.status = Erroring
 		orc.summary = "Unable to collect osquery restart history"
 		orc.data["error"] = err.Error()
 		return nil

--- a/ee/debug/checkups/osquery_restarts.go
+++ b/ee/debug/checkups/osquery_restarts.go
@@ -1,0 +1,62 @@
+package checkups
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/pkg/osquery/runtime/history"
+)
+
+type (
+	osqRestartCheckup struct {
+		k       types.Knapsack
+		status  Status
+		summary string
+		data    map[string]any
+	}
+)
+
+func (orc *osqRestartCheckup) Data() any             { return orc.data }
+func (orc *osqRestartCheckup) ExtraFileName() string { return "" }
+func (orc *osqRestartCheckup) Name() string          { return "Osquery Restarts" }
+func (orc *osqRestartCheckup) Status() Status        { return orc.status }
+func (orc *osqRestartCheckup) Summary() string       { return orc.summary }
+
+func (orc *osqRestartCheckup) Run(ctx context.Context, extraFH io.Writer) error {
+	orc.data = make(map[string]any)
+
+	restartHistory, err := history.GetHistory()
+	if err != nil && errors.Is(err, history.NoInstancesError{}) {
+		orc.status = Passing
+		orc.summary = "No restart history exists"
+		return nil
+	}
+
+	if err != nil {
+		orc.status = Failing
+		orc.summary = "Unable to collect osquery restart history"
+		orc.data["error"] = err.Error()
+		return nil
+	}
+
+	results := make([]map[string]string, len(restartHistory))
+
+	for idx, instance := range restartHistory {
+		results[idx] = map[string]string{
+			"start_time":   instance.StartTime,
+			"connect_time": instance.ConnectTime,
+			"exit_time":    instance.ExitTime,
+			"instance_id":  instance.InstanceId,
+			"version":      instance.Version,
+			"errors":       instance.Error,
+		}
+	}
+
+	orc.status = Passing
+	orc.data["history"] = results
+	orc.summary = "Successfully collected osquery restart history"
+
+	return nil
+}


### PR DESCRIPTION
These changes add a checkup to include the osquery restart history instances for doctor + flare.

This should close https://github.com/kolide/launcher/issues/1071
