### PR TITLE
add database reset history to uninstall and add uninstall history checkup

### DIFF
--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -130,7 +130,7 @@ func GetResetRecords(ctx context.Context, k types.Knapsack) ([]dbResetRecord, er
 func ResetDatabase(ctx context.Context, k types.Knapsack, resetReason string) error {
 	backup, err := prepareDatabaseResetRecords(ctx, k, resetReason)
 	if err != nil {
-		k.Slogger().Log(ctx, slog.LevelWarn, "could not prepare db reset records", "err", err)
+		k.Slogger().Log(ctx, slog.LevelError, "could not prepare db reset records", "err", err)
 		return err
 	}
 

--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kolide/launcher/pkg/traces"
 )
 
-type DBResetRecord struct {
+type dbResetRecord struct {
 	NodeKey        string   `json:"node_key"`
 	PubKeys        [][]byte `json:"pub_keys"`
 	Serial         string   `json:"serial"`
@@ -105,8 +105,8 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 	}
 }
 
-func GetResetRecords(ctx context.Context, k types.Knapsack) ([]DBResetRecord, error) {
-	resetRecords := make([]DBResetRecord, 0)
+func GetResetRecords(ctx context.Context, k types.Knapsack) ([]dbResetRecord, error) {
+	resetRecords := make([]dbResetRecord, 0)
 	if k.PersistentHostDataStore() == nil {
 		return resetRecords, UninitializedStorageError{}
 	}
@@ -322,7 +322,7 @@ func prepareDatabaseResetRecords(ctx context.Context, k types.Knapsack, resetRea
 		k.Slogger().Log(ctx, slog.LevelWarn, "could not get tombstone id from store", "err", err)
 	}
 
-	dataToStore := DBResetRecord{
+	dataToStore := dbResetRecord{
 		NodeKey:        string(nodeKey),
 		PubKeys:        [][]byte{localPubKey},
 		Serial:         string(serial),

--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kolide/launcher/pkg/traces"
 )
 
-type dbResetRecord struct {
+type DBResetRecord struct {
 	NodeKey        string   `json:"node_key"`
 	PubKeys        [][]byte `json:"pub_keys"`
 	Serial         string   `json:"serial"`
@@ -35,7 +35,7 @@ var (
 	hostDataKeyHardwareUuid = []byte("hardware_uuid")
 	hostDataKeyMunemo       = []byte("munemo")
 
-	hostDataKeyResetRecords = []byte("reset_records")
+	HostDataKeyResetRecords = []byte("reset_records")
 )
 
 const (
@@ -274,7 +274,7 @@ func prepareDatabaseResetRecords(ctx context.Context, k types.Knapsack, resetRea
 		k.Slogger().Log(ctx, slog.LevelWarn, "could not get tombstone id from store", "err", err)
 	}
 
-	dataToStore := dbResetRecord{
+	dataToStore := DBResetRecord{
 		NodeKey:        string(nodeKey),
 		PubKeys:        [][]byte{localPubKey},
 		Serial:         string(serial),
@@ -287,15 +287,15 @@ func prepareDatabaseResetRecords(ctx context.Context, k types.Knapsack, resetRea
 		ResetReason:    resetReason,
 	}
 
-	previousHostData, err := k.PersistentHostDataStore().Get(hostDataKeyResetRecords)
+	previousHostData, err := k.PersistentHostDataStore().Get(HostDataKeyResetRecords)
 	if err != nil {
 		return nil, fmt.Errorf("getting previous host data from store: %w", err)
 	}
 
-	var hostDataCollection []dbResetRecord
+	var hostDataCollection []DBResetRecord
 	if len(previousHostData) == 0 {
 		// No previous database resets
-		hostDataCollection = []dbResetRecord{dataToStore}
+		hostDataCollection = []DBResetRecord{dataToStore}
 	} else {
 		if err := json.Unmarshal(previousHostData, &hostDataCollection); err != nil {
 			return nil, fmt.Errorf("unmarshalling previous host data: %w", err)
@@ -345,7 +345,7 @@ func ResetDatabase(ctx context.Context, k types.Knapsack, resetReason string) er
 	}
 
 	// Store the backup data
-	if err := k.PersistentHostDataStore().Set(hostDataKeyResetRecords, backup); err != nil {
+	if err := k.PersistentHostDataStore().Set(HostDataKeyResetRecords, backup); err != nil {
 		k.Slogger().Log(ctx, slog.LevelWarn, "could not store db reset records", "err", err)
 		return err
 	}

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -364,7 +364,7 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 				require.NotNil(t, dataRaw, "old host data not set in store")
 
 				// Confirm that it contains reasonable data
-				var d []DBResetRecord
+				var d []dbResetRecord
 				require.NoError(t, json.Unmarshal(dataRaw, &d), "old host data in unexpected format")
 
 				// We should only have one backup
@@ -502,7 +502,7 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 
 	// Confirm that it contains reasonable data: we should have one backup
 	// with the first munemo in it
-	var d []DBResetRecord
+	var d []dbResetRecord
 	require.NoError(t, json.Unmarshal(dataRaw, &d), "old host data in unexpected format")
 	require.Equal(t, 1, len(d), "unexpected number of backups")
 	require.Equal(t, string(firstMunemoValue), d[0].Munemo, "munemo does not match")
@@ -537,7 +537,7 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 	// Confirm that it contains reasonable data: we should have two backups
 	// now -- the first should have the first munemo in it, and the second
 	// should have the second.
-	var dNew []DBResetRecord
+	var dNew []dbResetRecord
 	require.NoError(t, json.Unmarshal(newDataRaw, &dNew), "old host data in unexpected format")
 	require.Equal(t, 2, len(dNew), "unexpected number of backups")
 	require.Equal(t, string(firstMunemoValue), dNew[0].Munemo, "first backup munemo does not match")

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -359,7 +359,7 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 			// Confirm backup occurred, if database got wiped
 			if tt.expectDatabaseWipe {
 				// Confirm the old_host_data key exists in the data store
-				dataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
+				dataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
 				require.NoError(t, err, "could not get old host data from test store")
 				require.NotNil(t, dataRaw, "old host data not set in store")
 
@@ -496,7 +496,7 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 	DetectAndRemediateHardwareChange(context.TODO(), mockKnapsack)
 
 	// Confirm the old_host_data key exists in the data store
-	dataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
+	dataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
 	require.NoError(t, err, "could not get old host data from test store")
 	require.NotNil(t, dataRaw, "old host data not set in store")
 
@@ -530,7 +530,7 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 	DetectAndRemediateHardwareChange(context.TODO(), mockKnapsack)
 
 	// Confirm the old_host_data key exists in the data store
-	newDataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
+	newDataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
 	require.NoError(t, err, "could not get old host data from test store")
 	require.NotNil(t, dataRaw, "old host data not set in store")
 

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -359,12 +359,12 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 			// Confirm backup occurred, if database got wiped
 			if tt.expectDatabaseWipe {
 				// Confirm the old_host_data key exists in the data store
-				dataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
+				dataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
 				require.NoError(t, err, "could not get old host data from test store")
 				require.NotNil(t, dataRaw, "old host data not set in store")
 
 				// Confirm that it contains reasonable data
-				var d []dbResetRecord
+				var d []DBResetRecord
 				require.NoError(t, json.Unmarshal(dataRaw, &d), "old host data in unexpected format")
 
 				// We should only have one backup
@@ -496,13 +496,13 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 	DetectAndRemediateHardwareChange(context.TODO(), mockKnapsack)
 
 	// Confirm the old_host_data key exists in the data store
-	dataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
+	dataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
 	require.NoError(t, err, "could not get old host data from test store")
 	require.NotNil(t, dataRaw, "old host data not set in store")
 
 	// Confirm that it contains reasonable data: we should have one backup
 	// with the first munemo in it
-	var d []dbResetRecord
+	var d []DBResetRecord
 	require.NoError(t, json.Unmarshal(dataRaw, &d), "old host data in unexpected format")
 	require.Equal(t, 1, len(d), "unexpected number of backups")
 	require.Equal(t, string(firstMunemoValue), d[0].Munemo, "munemo does not match")
@@ -530,14 +530,14 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 	DetectAndRemediateHardwareChange(context.TODO(), mockKnapsack)
 
 	// Confirm the old_host_data key exists in the data store
-	newDataRaw, err := testHostDataStore.Get(hostDataKeyResetRecords)
+	newDataRaw, err := testHostDataStore.Get(HostDataKeyResetRecords)
 	require.NoError(t, err, "could not get old host data from test store")
 	require.NotNil(t, dataRaw, "old host data not set in store")
 
 	// Confirm that it contains reasonable data: we should have two backups
 	// now -- the first should have the first munemo in it, and the second
 	// should have the second.
-	var dNew []dbResetRecord
+	var dNew []DBResetRecord
 	require.NoError(t, json.Unmarshal(newDataRaw, &dNew), "old host data in unexpected format")
 	require.Equal(t, 2, len(dNew), "unexpected number of backups")
 	require.Equal(t, string(firstMunemoValue), dNew[0].Munemo, "first backup munemo does not match")

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -119,7 +119,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&serverDataCheckup{k: k}, doctorSupported | flareSupported | logSupported},
 		{&osqDataCollector{k: k}, doctorSupported | flareSupported},
 		{&osqRestartCheckup{k: k}, doctorSupported | flareSupported},
-		{&uninstallHistoryCheckup{k: k}, doctorSupported | flareSupported},
+		{&uninstallHistoryCheckup{k: k}, flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -119,6 +119,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&serverDataCheckup{k: k}, doctorSupported | flareSupported | logSupported},
 		{&osqDataCollector{k: k}, doctorSupported | flareSupported},
 		{&osqRestartCheckup{k: k}, doctorSupported | flareSupported},
+		{&uninstallHistoryCheckup{k: k}, doctorSupported | flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/ee/debug/checkups/uninstall_history.go
+++ b/ee/debug/checkups/uninstall_history.go
@@ -2,8 +2,11 @@ package checkups
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"time"
 
+	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/types"
 )
 
@@ -24,6 +27,50 @@ func (hc *uninstallHistoryCheckup) Summary() string       { return hc.summary }
 
 func (hc *uninstallHistoryCheckup) Run(ctx context.Context, extraFH io.Writer) error {
 	hc.data = make(map[string]any)
+	if hc.k.PersistentHostDataStore() == nil {
+		hc.status = Informational
+		hc.summary = "Unable to access uninstall history"
+		return nil
+	}
+
+	resetRecordsRaw, err := hc.k.PersistentHostDataStore().Get(agent.HostDataKeyResetRecords)
+	if err != nil {
+		hc.status = Erroring
+		hc.summary = "Unable to gather previous host data from store"
+		hc.data["error"] = err.Error()
+		return nil
+	}
+
+	var resetRecords []agent.DBResetRecord
+	if len(resetRecordsRaw) == 0 {
+		hc.status = Informational
+		hc.summary = "No installation history exists for this device"
+		return nil
+	}
+
+	if err := json.Unmarshal(resetRecordsRaw, &resetRecords); err != nil {
+		hc.status = Erroring
+		hc.summary = "Unable to unmarshal previous host data from store"
+		hc.data["error"] = err.Error()
+		return nil
+	}
+
+	for _, uninstallRecord := range resetRecords {
+		resetTimeKey := time.Unix(uninstallRecord.ResetTimestamp, 0)
+		hc.data[resetTimeKey.Format(time.RFC3339)] = map[string]any{
+			"serial":          uninstallRecord.Serial,
+			"hardware_uuid":   uninstallRecord.HardwareUUID,
+			"munemo":          uninstallRecord.Munemo,
+			"device_id":       uninstallRecord.DeviceID,
+			"remote_ip":       uninstallRecord.RemoteIP,
+			"tombstone_id":    uninstallRecord.TombstoneID,
+			"reset_timestamp": resetTimeKey,
+			"reset_reason":    uninstallRecord.ResetReason,
+		}
+	}
+
+	hc.status = Passing
+	hc.summary = "Successfully collected uninstallation history"
 
 	return nil
 }

--- a/ee/debug/checkups/uninstall_history.go
+++ b/ee/debug/checkups/uninstall_history.go
@@ -1,0 +1,29 @@
+package checkups
+
+import (
+	"context"
+	"io"
+
+	"github.com/kolide/launcher/ee/agent/types"
+)
+
+type (
+	uninstallHistoryCheckup struct {
+		k       types.Knapsack
+		status  Status
+		summary string
+		data    map[string]any
+	}
+)
+
+func (hc *uninstallHistoryCheckup) Data() any             { return hc.data }
+func (hc *uninstallHistoryCheckup) ExtraFileName() string { return "" }
+func (hc *uninstallHistoryCheckup) Name() string          { return "Uninstall History" }
+func (hc *uninstallHistoryCheckup) Status() Status        { return hc.status }
+func (hc *uninstallHistoryCheckup) Summary() string       { return hc.summary }
+
+func (hc *uninstallHistoryCheckup) Run(ctx context.Context, extraFH io.Writer) error {
+	hc.data = make(map[string]any)
+
+	return nil
+}

--- a/ee/debug/checkups/uninstall_history.go
+++ b/ee/debug/checkups/uninstall_history.go
@@ -61,7 +61,7 @@ func (hc *uninstallHistoryCheckup) Run(ctx context.Context, extraFH io.Writer) e
 		}
 	}
 
-	hc.status = Passing
+	hc.status = Informational
 	hc.summary = "Successfully collected uninstallation history"
 
 	return nil

--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -10,6 +10,10 @@ import (
 	"github.com/kolide/launcher/ee/agent/types"
 )
 
+const (
+	resetReasonUninstallRequested = "remote uninstall requested"
+)
+
 // Uninstall just removes the enroll secret file and wipes the database.
 // Logs errors, but does not return them, because we want to try each step independently.
 // If exitOnCompletion is true, it will also disable launcher autostart and exit.
@@ -23,9 +27,9 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 		)
 	}
 
-	if err := agent.WipeDatabase(ctx, k); err != nil {
+	if err := agent.ResetDatabase(ctx, k, resetReasonUninstallRequested); err != nil {
 		slogger.Log(ctx, slog.LevelError,
-			"wiping database",
+			"resetting database",
 			"err", err,
 		)
 	}

--- a/ee/uninstall/uninstall_test.go
+++ b/ee/uninstall/uninstall_test.go
@@ -2,7 +2,6 @@ package uninstall
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,12 +94,8 @@ func TestUninstall(t *testing.T) {
 			// the expectation of 1 here is coming from the single remaining reset_records key
 			// see agent.ResetDatabase for additional context
 			require.Equal(t, 1, itemsFound)
-			resetRecordsRaw, err := testHostDataStore.Get(agent.HostDataKeyResetRecords)
+			resetRecords, err := agent.GetResetRecords(context.TODO(), k)
 			require.NoError(t, err, "could not get reset records from test store")
-			var resetRecords []agent.DBResetRecord
-			require.Greater(t, len(resetRecordsRaw), 0, "did not expect reset records to be empty")
-			err = json.Unmarshal(resetRecordsRaw, &resetRecords)
-			require.NoError(t, err, "expected to be able to unmarshal reset records")
 			require.Equal(t, 1, len(resetRecords), "expected reset records to contain exactly 1 uninstallation record")
 			// now check the individual bits we want to ensure are migrated to the reset record
 			resetRecord := resetRecords[0]


### PR DESCRIPTION
These changes rework the remote uninstall path to utilize the database reset record functionality (added to support remediation for hardware changes). Now, an uninstallation will first take a record of the previous database before resetting.

This also adds an Uninstall History checkup, which will read from the reset records key to report if any previous uninstallations/resets have been recorded.