### PR TITLE
Discard "update now" requests during initial autoupdate delay

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -283,9 +283,11 @@ func (ta *TufAutoupdater) Interrupt(_ error) {
 func (ta *TufAutoupdater) Do(data io.Reader) error {
 	if !ta.initialDelayLock.TryLock() {
 		ta.slogger.Log(context.TODO(), slog.LevelWarn,
-			"received update request during initial delay",
+			"received update request during initial delay, discarding",
 		)
-		return errors.New("cannot perform update during initial delay")
+		// We don't return an error because there's no need for the actionqueue to retry this request --
+		// we're going to perform an autoupdate check as soon as we exit the delay anyway.
+		return nil
 	}
 
 	var updateRequest controlServerAutoupdateRequest

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -730,12 +730,12 @@ func TestDo_WillNotExecuteDuringInitialDelay(t *testing.T) {
 	// Start the autoupdater, then make the control server request right away, during the initial delay
 	go autoupdater.Execute()
 	time.Sleep(100 * time.Millisecond)
-	require.Error(t, autoupdater.Do(data), "expected error making request during initial delay")
+	require.NoError(t, autoupdater.Do(data), "should not have received error when performing request during initial delay")
 
 	// Give autoupdater a chance to run
 	time.Sleep(initialDelay + interval)
 
-	// Assert expectation that we added the expected `testReleaseVersion` to the updates library
+	// Assert expectation that we did not add the expected `testReleaseVersion` to the updates library
 	mockLibraryManager.AssertExpectations(t)
 
 	// Confirm we pulled all config items as expected


### PR DESCRIPTION
Currently, if the autoupdater receives an "autoupdate now" request during its initial delay, it returns an error to the actionqueue so that the action will be retried later. This isn't actually useful -- as soon as the autoupdater exits its initial delay, it will perform an update check, so there's no need to retry the action. This also results in some annoying logs.

This PR adjusts that behavior so that these requests are discarded.