### PR TITLE
serverDataCheckup requires datastore access and therefore should not run during doctor

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -116,7 +116,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&dnsCheckup{k: k}, doctorSupported | flareSupported | logSupported},
 		{&tufCheckup{k: k}, doctorSupported | flareSupported},
 		{&osqConfigConflictCheckup{}, doctorSupported | flareSupported},
-		{&serverDataCheckup{k: k}, doctorSupported | flareSupported | logSupported},
+		{&serverDataCheckup{k: k}, flareSupported | logSupported},
 		{&osqDataCollector{k: k}, doctorSupported | flareSupported},
 		{&osqRestartCheckup{k: k}, doctorSupported | flareSupported},
 		{&uninstallHistoryCheckup{k: k}, flareSupported},


### PR DESCRIPTION
Running `launcher doctor` will always result in the following output:

```
⚠️	Server Data: no server_data store in knapsack
```

Since `doctor` runs standalone rather than in-situ, it does not have data store access. This gives the above output. This is confusing to end users, who may assume that this is an actual issue with their launcher installation. We should just not run this checkup during doctor.