### PR TITLE
Hardcode use_tuf_autoupdater in startup settings so that v1.5.3 can use it

### DIFF
--- a/ee/agent/startupsettings/writer.go
+++ b/ee/agent/startupsettings/writer.go
@@ -61,6 +61,7 @@ func (s *startupSettingsWriter) setFlags() error {
 	for flag, getter := range s.storedFlags {
 		updatedFlags[flag.String()] = getter()
 	}
+	updatedFlags["use_tuf_autoupdater"] = "enabled" // Hardcode for backwards compatibility
 
 	if _, err := s.kvStore.Update(updatedFlags); err != nil {
 		return fmt.Errorf("updating flags: %w", err)

--- a/ee/agent/startupsettings/writer_test.go
+++ b/ee/agent/startupsettings/writer_test.go
@@ -37,6 +37,10 @@ func TestOpenWriter_NewDatabase(t *testing.T) {
 	require.NoError(t, err, "getting startup value")
 	require.Equal(t, updateChannelVal, string(v1), "incorrect flag value")
 
+	v2, err := s.kvStore.Get([]byte("use_tuf_autoupdater"))
+	require.NoError(t, err, "getting startup value")
+	require.Equal(t, "enabled", string(v2), "incorrect flag value")
+
 	require.NoError(t, s.Close(), "closing startup db")
 }
 


### PR DESCRIPTION
v1.5.3 still needs this flag, so it should not be removed from the startup settings. Instead, hardcode it to always be set.