### PR TITLE
skip secure enclave signing tests when `SKIP_SECURE_ENCLAVE_TESTS` is set

### DIFF
--- a/cmd/launcher/secure_enclave_test.go
+++ b/cmd/launcher/secure_enclave_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	testWrappedEnvVarKey = "SECURE_ENCLAVE_TEST_WRAPPED"
-	macOsAppResourceDir  = "../../ee/secureenclavesigner/test_app_resources"
+	testWrappedEnvVarKey                  = "SECURE_ENCLAVE_TEST_WRAPPED"
+	testSkipSecureEnclaveTestingEnvVarKey = "SKIP_SECURE_ENCLAVE_TESTS"
+	macOsAppResourceDir                   = "../../ee/secureenclavesigner/test_app_resources"
 )
 
 // TestSecureEnclaveTestRunner creates a MacOS app with the binary of this packages tests, then signs the app with entitlements and runs the tests.
@@ -35,6 +36,10 @@ func TestSecureEnclaveTestRunner(t *testing.T) {
 
 	if os.Getenv(testWrappedEnvVarKey) != "" {
 		t.Skipf("\nskipping because %s env var was not empty, this is the execution of the codesigned app with entitlements", testWrappedEnvVarKey)
+	}
+
+	if os.Getenv(testSkipSecureEnclaveTestingEnvVarKey) != "" {
+		t.Skipf("\nskipping because %s env var was set", testSkipSecureEnclaveTestingEnvVarKey)
 	}
 
 	t.Log("\nexecuting wrapped tests with codesigned app and entitlements")

--- a/ee/secureenclavesigner/secureenclavesigner_test.go
+++ b/ee/secureenclavesigner/secureenclavesigner_test.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	testWrappedEnvVarKey = "SECURE_ENCLAVE_TEST_WRAPPED"
-	macOsAppResourceDir  = "./test_app_resources"
+	testWrappedEnvVarKey                  = "SECURE_ENCLAVE_TEST_WRAPPED"
+	testSkipSecureEnclaveTestingEnvVarKey = "SKIP_SECURE_ENCLAVE_TESTS"
+	macOsAppResourceDir                   = "./test_app_resources"
 )
 
 func WithBinaryPath(p string) opt {
@@ -36,6 +37,10 @@ func TestSecureEnclaveSigner(t *testing.T) {
 
 	if os.Getenv("CI") != "" {
 		t.Skipf("\nskipping because %s env var was not empty, this is being run in a CI environment without access to secure enclave", testWrappedEnvVarKey)
+	}
+
+	if os.Getenv(testSkipSecureEnclaveTestingEnvVarKey) != "" {
+		t.Skipf("\nskipping because %s env var was set", testSkipSecureEnclaveTestingEnvVarKey)
 	}
 
 	// put the root dir somewhere else if you want to persist the signed macos app bundle

--- a/ee/secureenclavesigner/test_app_resources/readme.md
+++ b/ee/secureenclavesigner/test_app_resources/readme.md
@@ -23,3 +23,8 @@ In order to succesfully sign the app with entitlements, there are a few steps th
 2. Add you device to the developer account using the "Provisioning UDID" found at Desktop Menu Applie Icon> About This Mac > More Info > System Report https://developer.apple.com/account/resources/devices/list
 3. Create a provisioing profile that includes the device https://developer.apple.com/account/resources/profiles/list ... should probably include all devices on the team and be updated in the repo
 4. Replace the `embedded.provisionprofile` file with the new profile
+
+## Skipping Tests
+
+- To skip these tests (e.g. while running tests on a machine which is not included in the provisioning profile), you can set the `SKIP_SECURE_ENCLAVE_TESTS` environment variable to any non-empty value
+    - `SKIP_SECURE_ENCLAVE_TESTS=y make test`


### PR DESCRIPTION
This is to allow someone to run tests on a device that is not set up according to the docs [here](https://github.com/kolide/launcher/blob/main/ee/secureenclavesigner/test_app_resources/readme.md#running-tests).

example usage:
`make test SKIP_SECURE_ENCLAVE_TESTS=y`