### PR TITLE
Use unique pid file for osquery per launcher run

### DIFF
--- a/ee/agent/timemachine/timemachine_darwin_test.go
+++ b/ee/agent/timemachine/timemachine_darwin_test.go
@@ -5,6 +5,7 @@ package timemachine
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/stretchr/testify/require"
@@ -52,10 +54,11 @@ func TestAddExclusions(t *testing.T) {
 		"osquery.autoload":                      true,
 		"osquery.db/":                           true,
 		"osquery.pid":                           true,
-		"osquery.sock":                          true,
-		"osquery.sock.51807":                    true,
-		"osquery.sock.63071":                    true,
-		"osqueryd-tuf/":                         true,
+		fmt.Sprintf("osquery-%s.pid", ulid.New()): true,
+		"osquery.sock":       true,
+		"osquery.sock.51807": true,
+		"osquery.sock.63071": true,
+		"osqueryd-tuf/":      true,
 
 		// these should NOT be excluded
 		"launcher-tuf/":                     false,

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -393,7 +393,8 @@ func calculateOsqueryPaths(opts osqueryOptions) (*osqueryFilePaths, error) {
 
 	extensionAutoloadPath := filepath.Join(opts.rootDirectory, "osquery.autoload")
 
-	// We want to use a unique pidfile per launcher run to avoid file locking issues
+	// We want to use a unique pidfile per launcher run to avoid file locking issues.
+	// See: https://github.com/kolide/launcher/issues/1599
 	osqueryFilePaths := &osqueryFilePaths{
 		pidfilePath:           filepath.Join(opts.rootDirectory, fmt.Sprintf("osquery-%s.pid", ulid.New())),
 		databasePath:          filepath.Join(opts.rootDirectory, "osquery.db"),

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/backoff"
@@ -392,8 +393,9 @@ func calculateOsqueryPaths(opts osqueryOptions) (*osqueryFilePaths, error) {
 
 	extensionAutoloadPath := filepath.Join(opts.rootDirectory, "osquery.autoload")
 
+	// We want to use a unique pidfile per launcher run to avoid file locking issues
 	osqueryFilePaths := &osqueryFilePaths{
-		pidfilePath:           filepath.Join(opts.rootDirectory, "osquery.pid"),
+		pidfilePath:           filepath.Join(opts.rootDirectory, fmt.Sprintf("osquery-%s.pid", ulid.New())),
 		databasePath:          filepath.Join(opts.rootDirectory, "osquery.db"),
 		augeasPath:            filepath.Join(opts.rootDirectory, "augeas-lenses"),
 		extensionSocketPath:   extensionSocketPath,

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -630,6 +630,24 @@ func (r *Runner) launchOsqueryInstance() error {
 		return o.doneCtx.Err()
 	})
 
+	// Clean up PID file on shutdown
+	o.errgroup.Go(func() error {
+		defer r.slogger.Log(ctx, slog.LevelInfo,
+			"exiting errgroup",
+			"errgroup", "cleanup PID file",
+		)
+
+		<-o.doneCtx.Done()
+		if err := os.Remove(paths.pidfilePath); err != nil {
+			r.slogger.Log(ctx, slog.LevelInfo,
+				"could not remove PID file",
+				"pid_file", paths.pidfilePath,
+				"err", "err",
+			)
+		}
+		return o.doneCtx.Err()
+	})
+
 	return nil
 }
 

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -642,7 +642,7 @@ func (r *Runner) launchOsqueryInstance() error {
 			r.slogger.Log(ctx, slog.LevelInfo,
 				"could not remove PID file",
 				"pid_file", paths.pidfilePath,
-				"err", "err",
+				"err", err,
 			)
 		}
 		return o.doneCtx.Err()

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -103,7 +103,7 @@ func TestCalculateOsqueryPaths(t *testing.T) {
 func TestCreateOsqueryCommand(t *testing.T) {
 	t.Parallel()
 	paths := &osqueryFilePaths{
-		pidfilePath:           "/foo/bar/osquery.pid",
+		pidfilePath:           "/foo/bar/osquery-abcd.pid",
 		databasePath:          "/foo/bar/osquery.db",
 		extensionSocketPath:   "/foo/bar/osquery.sock",
 		extensionAutoloadPath: "/foo/bar/osquery.autoload",


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1599 (hopefully)