### PR TITLE
add new meddlesome processes to quarantine checkup

### DIFF
--- a/ee/debug/checkups/quarantine.go
+++ b/ee/debug/checkups/quarantine.go
@@ -73,6 +73,9 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 			`virus`,
 			`quarantine`,
 			`snitch`,
+			`action1`,
+			`nessus`,
+			`dnsfilter`,
 			// carbon black possible processes
 			`cbagent`,
 			`carbonblack`,


### PR DESCRIPTION
Adds `action1`, `nessus`, and `dnsfilter` for reporting in meddlesome process check