### PR TITLE
add menu update change detection logs

### DIFF
--- a/ee/desktop/runner/menu_cache.go
+++ b/ee/desktop/runner/menu_cache.go
@@ -1,0 +1,74 @@
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// menuItemCache is used to keep track of the last set of items
+// seen in the menu bar json, to report any changes detected
+type menuItemCache struct {
+	mu          sync.RWMutex
+	cachedItems map[string]struct{}
+}
+
+// menuChangeSet is a simple struct used for reporting changes
+type menuChangeSet struct {
+	Old string `json:"old_label"`
+	New string `json:"new_label"`
+}
+
+func newMenuItemCache() *menuItemCache {
+	return &menuItemCache{
+		cachedItems: make(map[string]struct{}),
+	}
+}
+
+func (m *menuItemCache) recordMenuUpdates(menuData []byte) ([]menuChangeSet, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	menuChanges := make([]menuChangeSet, 0)
+
+	parsedMenu := struct {
+		Items []struct {
+			Label string `json:"label"`
+		} `json:"items"`
+	}{}
+
+	if err := json.Unmarshal(menuData, &parsedMenu); err != nil {
+		return menuChanges, fmt.Errorf("unable to parse menu json for change detection: %w", err)
+	}
+
+	newCachedMenuData := make(map[string]struct{})
+	// first iterate the new menu items, noting any that are new
+	for _, item := range parsedMenu.Items {
+		if item.Label == "" { // skip separator sections
+			continue
+		}
+
+		newCachedMenuData[item.Label] = struct{}{}
+
+		if _, ok := m.cachedItems[item.Label]; ok {
+			continue
+		}
+
+		// append as a change if the section wasn't previously detected
+		menuChanges = append(menuChanges, menuChangeSet{Old: "", New: item.Label})
+	}
+
+	// now iterate the previously cached items, noting any that have been deleted
+	for item := range m.cachedItems {
+		if _, ok := newCachedMenuData[item]; ok {
+			continue
+		}
+
+		menuChanges = append(menuChanges, menuChangeSet{Old: item, New: ""})
+	}
+
+	// reset the cached data for the next run
+	m.cachedItems = newCachedMenuData
+
+	return menuChanges, nil
+}

--- a/ee/desktop/runner/menu_cache_test.go
+++ b/ee/desktop/runner/menu_cache_test.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/base_menu.json
+var baseMenu []byte
+
+//go:embed testdata/menu_pending_registration.json
+var pendingRegistrationMenu []byte
+
+//go:embed testdata/menu_blocked_status.json
+var blockedStatusMenu []byte
+
+func Test_menuItemCache_recordMenuUpdates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args [][]byte
+		want [][]menuChangeSet
+	}{
+		{
+			name: "startup behavior",
+			args: [][]byte{baseMenu},
+			want: [][]menuChangeSet{
+				[]menuChangeSet{ // we always detect new sections on start up
+					{"", "tester@example.test"},
+					{"", "About Kolide..."},
+					{"", "✔ All Good!"},
+					{"", "View Details..."},
+					{"", "Debug"},
+				},
+			},
+		},
+		{
+			name: "new pending registration",
+			args: [][]byte{baseMenu, pendingRegistrationMenu},
+			want: [][]menuChangeSet{
+				[]menuChangeSet{
+					{"", "tester@example.test"},
+					{"", "About Kolide..."},
+					{"", "✔ All Good!"},
+					{"", "View Details..."},
+					{"", "Debug"},
+				},
+				[]menuChangeSet{ // the second run should only view the pending request as new
+					{"", "❗ Pending Registration Request"},
+				},
+			},
+		},
+		{
+			name: "removed pending registration",
+			args: [][]byte{pendingRegistrationMenu, baseMenu},
+			want: [][]menuChangeSet{
+				[]menuChangeSet{
+					{"", "tester@example.test"},
+					{"", "About Kolide..."},
+					{"", "✔ All Good!"},
+					{"", "View Details..."},
+					{"", "❗ Pending Registration Request"},
+					{"", "Debug"},
+				},
+				[]menuChangeSet{ // the second run should only remove the pending request
+					{"❗ Pending Registration Request", ""},
+				},
+			},
+		},
+		{
+			name: "moved to blocked status",
+			args: [][]byte{baseMenu, blockedStatusMenu},
+			want: [][]menuChangeSet{
+				[]menuChangeSet{
+					{"", "tester@example.test"},
+					{"", "About Kolide..."},
+					{"", "✔ All Good!"},
+					{"", "View Details..."},
+					{"", "Debug"},
+				},
+				[]menuChangeSet{ // the second run should detect the status change and the new blocked details section
+					{"", "Device Blocked"},
+					{"", "❌ Fix 2 Failing Checks..."},
+					{"✔ All Good!", ""},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newMenuItemCache()
+			for idx, menuData := range tt.args {
+				got, _ := m.recordMenuUpdates(menuData)
+				require.Equal(t, tt.want[idx], got)
+			}
+		})
+	}
+}

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -360,11 +359,8 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 		return errors.New("data is nil")
 	}
 
-	var dataCopy bytes.Buffer
-	dataTee := io.TeeReader(data, &dataCopy)
-
 	// Replace the menu template file
-	dataBytes, err := io.ReadAll(dataTee)
+	dataBytes, err := io.ReadAll(data)
 	if err != nil {
 		return fmt.Errorf("error reading control data: %w", err)
 	}

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -127,6 +127,8 @@ type DesktopUsersProcessesRunner struct {
 	runnerServer *runnerserver.RunnerServer
 	// osVersion is the version of the OS cached in new
 	osVersion string
+	// cachedMenuData is the cached label values of the currently displayed menu data, used for detecting changes
+	cachedMenuData *menuItemCache
 }
 
 // processRecord is used to track spawned desktop processes.
@@ -163,6 +165,7 @@ func New(k types.Knapsack, messenger runnerserver.Messenger, opts ...desktopUser
 		usersFilesRoot:         agent.TempPath("kolide-desktop"),
 		processSpawningEnabled: k.DesktopEnabled(),
 		knapsack:               k,
+		cachedMenuData:         newMenuItemCache(),
 	}
 
 	runner.slogger = k.Slogger().With("component", "desktop_runner")
@@ -474,6 +477,21 @@ func (r *DesktopUsersProcessesRunner) generateMenuFile() error {
 	// any desktop user processes, either when they refresh, or when they are spawned.
 	if err := r.writeSharedFile(r.menuPath(), parsedMenuDataBytes); err != nil {
 		return err
+	}
+
+	menuChanges, err := r.cachedMenuData.recordMenuUpdates(parsedMenuDataBytes)
+	if err != nil {
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
+			"error recording updates to cached menu items",
+			"err", err,
+		)
+	}
+
+	if len(menuChanges) > 0 {
+		r.slogger.Log(context.TODO(), slog.LevelInfo,
+			"detected changes to menu bar items",
+			"changes", menuChanges,
+		)
 	}
 
 	return nil

--- a/ee/desktop/runner/testdata/base_menu.json
+++ b/ee/desktop/runner/testdata/base_menu.json
@@ -1,0 +1,54 @@
+{
+    "icon": "default",
+    "tooltip": "Kolide - Device Status: All Good",
+    "items": [
+        {
+            "label": "tester@example.test",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://example.com/docs/about/overview"
+                }
+            },
+            "label": "About Kolide...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "✔ All Good!",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://app.example.com/1dsfsdfsdfsd"
+                }
+            },
+            "label": "View Details...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "Debug",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        }
+    ]
+}

--- a/ee/desktop/runner/testdata/menu_blocked_status.json
+++ b/ee/desktop/runner/testdata/menu_blocked_status.json
@@ -1,0 +1,91 @@
+{
+    "icon": "circle-x",
+    "tooltip": "Kolide - Device Status: Blocked",
+    "items": [
+        {
+            "label": "tester@example.test",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://example.com/docs/about/overview"
+                }
+            },
+            "label": "About Kolide...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "Device Blocked",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://app.example.com/sdkfgjfdjgidfgd"
+                }
+            },
+            "label": "❌ Fix 2 Failing Checks...",
+            "tooltip": null,
+            "disabled": false,
+            "items": [
+                {
+                    "action": {
+                        "type": "open-url",
+                        "action": {
+                            "url": "https://app.example.com/sdkfgjfdjgidfgd"
+                        }
+                    },
+                    "label": "❌ something pretty bad",
+                    "tooltip": null,
+                    "disabled": false,
+                    "items": []
+                },
+                {
+                    "action": {
+                        "type": "open-url",
+                        "action": {
+                            "url": "https://app.example.com/sdkfgjfdjgidfgd"
+                        }
+                    },
+                    "label": "❌ even worse",
+                    "tooltip": null,
+                    "disabled": false,
+                    "items": []
+                }
+            ]
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://app.example.com/1dsfsdfsdfsd"
+                }
+            },
+            "label": "View Details...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "Debug",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        }
+    ]
+}

--- a/ee/desktop/runner/testdata/menu_pending_registration.json
+++ b/ee/desktop/runner/testdata/menu_pending_registration.json
@@ -1,0 +1,69 @@
+{
+    "icon": "default",
+    "tooltip": "Kolide - Device Status: All Good",
+    "items": [
+        {
+            "label": "tester@example.test",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://example.com/docs/about/overview"
+                }
+            },
+            "label": "About Kolide...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "✔ All Good!",
+            "tooltip": null,
+            "disabled": true,
+            "items": []
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://app.example.com/1dsfsdfsdfsd"
+                }
+            },
+            "label": "View Details...",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "action": {
+                "type": "open-url",
+                "action": {
+                    "url": "https://auth.example.com/device/registrations/sdihfosdfosidf"
+                }
+            },
+            "label": "❗ Pending Registration Request",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        },
+        {
+            "separator": true
+        },
+        {
+            "label": "Debug",
+            "tooltip": null,
+            "disabled": false,
+            "items": []
+        }
+    ]
+}


### PR DESCRIPTION
This add a `menuItemCache` to the desktop runner to detect when changes to the top level items occur for the menu bar data.

Within the menu template that is sent down, there are several timestamps and links that change regularly but are not meaningful for our change detection purposes. The simplest approach I found to filtering this noise was to catalog the top level items by label, and note any changes there. This will provide us with a record of any major changes (pending registrations, device status change, etc) without being too noisy. This logic is fairly isolated and easy to update if anyone has better ideas for detection or if there's more we'd want to track