### PR TITLE
Small improvements to logging and flares

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # set line endings got go files. Mostly needed for golang-ci
 *.go text eol=lf
 
+# go.sum merges can just concat. Cuts down on merge conflicts
+go.sum merge=union

--- a/ee/debug/checkups/init_logs_windows.go
+++ b/ee/debug/checkups/init_logs_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 func writeInitLogs(ctx context.Context, logZip *zip.Writer) error {
-	cmdStr := `Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='launcher'} | ForEach-Object { $_.Message }`
+	cmdStr := `Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='launcher'} | ConvertTo-Json`
 	cmd, err := allowedcmd.Powershell(ctx, cmdStr)
 	if err != nil {
 		return fmt.Errorf("creating powershell command: %w", err)

--- a/ee/debug/checkups/services_windows.go
+++ b/ee/debug/checkups/services_windows.go
@@ -239,7 +239,7 @@ func gatherServiceManagerEvents(ctx context.Context, z *zip.Writer) error {
 		return fmt.Errorf("creating eventlog-Get-WinEvent.json: %w", err)
 	}
 
-	filterExpression := fmt.Sprintf(`'@{LogName='System'; ProviderName='Service Control Manager'; Data=%s}'`, kolideSvcName)
+	filterExpression := fmt.Sprintf(`@{LogName='System'; ProviderName='Service Control Manager'; Data='%s'}`, kolideSvcName)
 
 	cmdArgs := []string{
 		"Get-WinEvent",

--- a/ee/debug/checkups/services_windows.go
+++ b/ee/debug/checkups/services_windows.go
@@ -239,7 +239,7 @@ func gatherServiceManagerEvents(ctx context.Context, z *zip.Writer) error {
 		return fmt.Errorf("creating eventlog-Get-WinEvent.json: %w", err)
 	}
 
-	filterExpression := fmt.Sprintf(`@{LogName='System'; ProviderName='Service Control Manager'; Data=%s}`, kolideSvcName)
+	filterExpression := fmt.Sprintf(`'@{LogName='System'; ProviderName='Service Control Manager'; Data=%s}'`, kolideSvcName)
 
 	cmdArgs := []string{
 		"Get-WinEvent",

--- a/ee/debug/checkups/services_windows.go
+++ b/ee/debug/checkups/services_windows.go
@@ -254,7 +254,8 @@ func gatherServiceManagerEvents(ctx context.Context, z *zip.Writer) error {
 		return fmt.Errorf("creating powershell command: %w", err)
 	}
 	hideWindow(cmd)
-	cmd.Stdout = out // write directly to zip
+	cmd.Stdout = out
+	cmd.Stderr = out
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("running Get-WinEvent: error %w", err)
 	}
@@ -284,7 +285,8 @@ func gatherServiceManagerEventLogs(ctx context.Context, z *zip.Writer) error {
 		return fmt.Errorf("creating powershell command: %w", err)
 	}
 	hideWindow(getEventLogCmd)
-	getEventLogCmd.Stdout = eventLogOut // write directly to zip
+	getEventLogCmd.Stdout = eventLogOut
+	getEventLogCmd.Stderr = eventLogOut
 	if err := getEventLogCmd.Run(); err != nil {
 		return fmt.Errorf("running Get-EventLog: error %w", err)
 	}

--- a/ee/debug/checkups/services_windows.go
+++ b/ee/debug/checkups/services_windows.go
@@ -102,6 +102,10 @@ func (s *servicesCheckup) Run(ctx context.Context, extraWriter io.Writer) error 
 		return fmt.Errorf("gathering service manager event logs: %w", err)
 	}
 
+	if err := gatherServiceManagerEvents(ctx, extraZip); err != nil {
+		return fmt.Errorf("gathering service manager events: %w", err)
+	}
+
 	return nil
 }
 
@@ -228,10 +232,38 @@ func gatherServices(z *zip.Writer, serviceManager *mgr.Mgr) error {
 	return nil
 }
 
-func gatherServiceManagerEventLogs(ctx context.Context, z *zip.Writer) error {
-	eventLogOut, err := z.Create("eventlog.txt")
+// gatherServiceManagerEvents uses Get-WinEvent to fetch the service manager logs. This might be newer than Get-EventLog
+func gatherServiceManagerEvents(ctx context.Context, z *zip.Writer) error {
+	out, err := z.Create("eventlog-Get-WinEvent.json")
 	if err != nil {
-		return fmt.Errorf("creating eventlog.txt: %w", err)
+		return fmt.Errorf("creating eventlog-Get-WinEvent.json: %w", err)
+	}
+
+	cmdArgs := []string{
+		"Get-WinEvent",
+		`-FilterHashtable @{LogName='System'; ProviderName='Service Control Manager'}`,
+		"|",
+		"ForEach-Object { $_.Message }",
+	}
+
+	cmd, err := allowedcmd.Powershell(ctx, cmdArgs...)
+	if err != nil {
+		return fmt.Errorf("creating powershell command: %w", err)
+	}
+	hideWindow(cmd)
+	cmd.Stdout = out // write directly to zip
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running Get-WinEvent: error %w", err)
+	}
+
+	return nil
+}
+
+// gatherServiceManagerEventLogs uses Get-EventLog to getch service manager logs. This might be a legacy path
+func gatherServiceManagerEventLogs(ctx context.Context, z *zip.Writer) error {
+	eventLogOut, err := z.Create("eventlog-Get-EventLog.txt")
+	if err != nil {
+		return fmt.Errorf("creating eventlog-Get-EventLog.txt: %w", err)
 	}
 
 	cmdletArgs := []string{

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -389,6 +391,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -429,6 +433,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -438,6 +444,9 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
 golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -184,6 +184,11 @@ func (s *grpcServer) PublishResults(ctx context.Context, req *pb.ResultCollectio
 func (mw logmw) PublishResults(ctx context.Context, nodeKey string, results []distributed.Result) (message, errcode string, reauth bool, err error) {
 	defer func(begin time.Time) {
 		resJSON, _ := json.Marshal(results)
+		resTruncated := string(resJSON[:200])
+		if len(resJSON) > 200 {
+			resTruncated += "..."
+		}
+
 		uuid, _ := uuid.FromContext(ctx)
 
 		if message == "" {
@@ -197,7 +202,9 @@ func (mw logmw) PublishResults(ctx context.Context, nodeKey string, results []di
 		mw.knapsack.Slogger().Log(ctx, levelForError(err), message, // nolint:sloglint // it's fine to not have a constant or literal here
 			"method", "PublishResults",
 			"uuid", uuid,
-			"results", string(resJSON),
+			"results_truncated", resTruncated,
+			"result_count", len(results),
+			"result_size", len(resJSON),
 			"errcode", errcode,
 			"reauth", reauth,
 			"err", err,


### PR DESCRIPTION
Some tweaks as I debug things

- Gather service manager logs via 2 patterns. I think the new one provides better data, but I'm not so sure I want to remove the old one
- Don't log the full results during `PublishLogs`. They are too big and cause our log files to rotate way too fast. 
- Use json for things
- set a merge strategy on go.sum to reduce conflicts