### PR TITLE
Ensure desktop runner shuts down within rungroup interrupt timeout, and log shutdown completion

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -282,7 +282,7 @@ func (r *DesktopUsersProcessesRunner) Interrupt(_ error) {
 	}
 
 	r.slogger.Log(ctx, slog.LevelInfo,
-		"shutdown complete",
+		"desktop runner shutdown complete",
 	)
 }
 

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -33,8 +33,8 @@ type (
 )
 
 const (
-	interruptTimeout     = 5 * time.Second // How long for all actors to return from their `interrupt` function
-	executeReturnTimeout = 5 * time.Second // After interrupted, how long for all actors to exit their `execute` functions
+	interruptTimeout     = 10 * time.Second // How long for all actors to return from their `interrupt` function
+	executeReturnTimeout = 5 * time.Second  // After interrupted, how long for all actors to exit their `execute` functions
 )
 
 func NewRunGroup(slogger *slog.Logger) *Group {

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -33,7 +33,7 @@ type (
 )
 
 const (
-	interruptTimeout     = 10 * time.Second // How long for all actors to return from their `interrupt` function
+	InterruptTimeout     = 10 * time.Second // How long for all actors to return from their `interrupt` function
 	executeReturnTimeout = 5 * time.Second  // After interrupted, how long for all actors to exit their `execute` functions
 )
 
@@ -107,7 +107,7 @@ func (g *Group) Run() error {
 		}(a)
 	}
 
-	interruptCtx, interruptCancel := context.WithTimeout(context.Background(), interruptTimeout)
+	interruptCtx, interruptCancel := context.WithTimeout(context.Background(), InterruptTimeout)
 	defer interruptCancel()
 
 	// Wait for interrupts to complete, but only until we hit our interruptCtx timeout

--- a/pkg/rungroup/rungroup_test.go
+++ b/pkg/rungroup/rungroup_test.go
@@ -60,7 +60,7 @@ func TestRun_MultipleActors(t *testing.T) {
 	}()
 
 	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
-	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	runDuration := 1*time.Second + InterruptTimeout + executeReturnTimeout + 1*time.Second
 	interruptCheckTimer := time.NewTicker(runDuration)
 	defer interruptCheckTimer.Stop()
 
@@ -119,7 +119,7 @@ func TestRun_MultipleActors_InterruptTimeout(t *testing.T) {
 		<-blockingActorInterrupt
 		return nil
 	}, func(error) {
-		time.Sleep(4 * interruptTimeout)
+		time.Sleep(4 * InterruptTimeout)
 		groupReceivedInterrupts <- struct{}{}
 		blockingActorInterrupt <- struct{}{}
 	})
@@ -132,7 +132,7 @@ func TestRun_MultipleActors_InterruptTimeout(t *testing.T) {
 	}()
 
 	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
-	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	runDuration := 1*time.Second + InterruptTimeout + executeReturnTimeout + 1*time.Second
 	interruptCheckTimer := time.NewTicker(runDuration)
 	defer interruptCheckTimer.Stop()
 
@@ -208,7 +208,7 @@ func TestRun_MultipleActors_ExecuteReturnTimeout(t *testing.T) {
 	}()
 
 	// 1 second before interrupt, waiting for interrupt, and waiting for execute return, plus a little buffer
-	runDuration := 1*time.Second + interruptTimeout + executeReturnTimeout + 1*time.Second
+	runDuration := 1*time.Second + InterruptTimeout + executeReturnTimeout + 1*time.Second
 	interruptCheckTimer := time.NewTicker(runDuration)
 	defer interruptCheckTimer.Stop()
 


### PR DESCRIPTION
- Increase rungroup interrupt timeout to give a little more time for desktop shutdown
- Ensure that desktop process requests respect shutdown timeout
- Log successful desktop runner interrupt