### PR TITLE
Don't autoupdate in modern standby

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -452,7 +452,9 @@ func (ta *TufAutoupdater) checkForUpdate(binariesToCheck []autoupdatableBinary) 
 	ta.updateLock.Lock()
 	defer ta.updateLock.Unlock()
 
-	// Skip autoupdating when Windows is sleeping
+	// Skip autoupdating when Windows is sleeping. The Service Manager often has trouble with starting up
+	// launcher while sleeping, so skipping the check is our safest option to keep launcher running
+	// and functional.
 	if ta.knapsack.InModernStandby() {
 		ta.slogger.Log(context.TODO(), slog.LevelInfo,
 			"skipping autoupdate while in modern standby",

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -452,6 +452,11 @@ func (ta *TufAutoupdater) checkForUpdate(binariesToCheck []autoupdatableBinary) 
 	ta.updateLock.Lock()
 	defer ta.updateLock.Unlock()
 
+	// Skip autoupdating when Windows is sleeping
+	if ta.knapsack.InModernStandby() {
+		return nil
+	}
+
 	// Attempt an update a couple times before returning an error -- sometimes we just hit caching issues.
 	errs := make([]error, 0)
 	successfulUpdate := false

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -454,6 +454,9 @@ func (ta *TufAutoupdater) checkForUpdate(binariesToCheck []autoupdatableBinary) 
 
 	// Skip autoupdating when Windows is sleeping
 	if ta.knapsack.InModernStandby() {
+		ta.slogger.Log(context.TODO(), slog.LevelInfo,
+			"skipping autoupdate while in modern standby",
+		)
 		return nil
 	}
 


### PR DESCRIPTION
The Service Manager has trouble restarting launcher when Windows is sleeping -- so, don't perform any autoupdates that will trigger restarts while the device is in Modern Standby.