### PR TITLE
set RecoveryActionsOnNonCrashFailures flag in svc_config_windows

### DIFF
--- a/cmd/launcher/svc_config_windows.go
+++ b/cmd/launcher/svc_config_windows.go
@@ -4,11 +4,13 @@
 package main
 
 import (
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"context"
+	"log/slog"
+
 	"github.com/kolide/launcher/pkg/launcher"
 
 	"golang.org/x/sys/windows/registry"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
 const (
@@ -25,7 +27,7 @@ const (
 	notFoundInRegistryError = "The system cannot find the file specified."
 )
 
-func checkServiceConfiguration(logger log.Logger, opts *launcher.Options) {
+func checkServiceConfiguration(logger *slog.Logger, opts *launcher.Options) {
 	// If this isn't a Kolide installation, do not update the configuration
 	if opts.KolideServerURL != "k2device.kolide.com" && opts.KolideServerURL != "k2device-preprod.kolide.com" {
 		return
@@ -34,14 +36,23 @@ func checkServiceConfiguration(logger log.Logger, opts *launcher.Options) {
 	// Get launcher service key
 	launcherServiceKey, err := registry.OpenKey(registry.LOCAL_MACHINE, launcherServiceRegistryKeyName, registry.ALL_ACCESS)
 	if err != nil {
-		level.Error(logger).Log("msg", "could not open registry key", "key_name", launcherServiceRegistryKeyName, "err", err)
+		logger.Log(context.TODO(), slog.LevelError,
+			"could not open registry key",
+			"key_name", launcherServiceRegistryKeyName,
+			"err", err,
+		)
+
 		return
 	}
 
 	// Close it once we're done
 	defer func() {
 		if err := launcherServiceKey.Close(); err != nil {
-			level.Error(logger).Log("msg", "could not close registry key", "key_name", launcherServiceRegistryKeyName, "err", err)
+			logger.Log(context.TODO(), slog.LevelError,
+				"could not close registry key",
+				"key_name", launcherServiceRegistryKeyName,
+				"err", err,
+			)
 		}
 	}()
 
@@ -50,11 +61,13 @@ func checkServiceConfiguration(logger log.Logger, opts *launcher.Options) {
 
 	// Check to see if we need to update the service to depend on Dnscache
 	checkDependOnService(launcherServiceKey, logger)
+
+	checkRestartActions(logger)
 }
 
 // checkDelayedAutostart checks the current value of `DelayedAutostart` (whether to wait ~2 minutes
 // before starting the launcher service) and updates it if necessary.
-func checkDelayedAutostart(launcherServiceKey registry.Key, logger log.Logger) {
+func checkDelayedAutostart(launcherServiceKey registry.Key, logger *slog.Logger) {
 	currentDelayedAutostart, _, getDelayedAutostartErr := launcherServiceKey.GetIntegerValue(delayedAutostartName)
 
 	// Can't determine current value, don't update
@@ -69,20 +82,26 @@ func checkDelayedAutostart(launcherServiceKey registry.Key, logger log.Logger) {
 
 	// Turn off delayed autostart
 	if err := launcherServiceKey.SetDWordValue(delayedAutostartName, delayedAutostartDisabled); err != nil {
-		level.Error(logger).Log("msg", "could not turn off DelayedAutostart", "err", err)
+		logger.Log(context.TODO(), slog.LevelError,
+			"could not turn off DelayedAutostart",
+			"err", err,
+		)
 	}
 }
 
 // checkDependOnService checks the current value of `DependOnService` (the list of services that must
 // start before launcher can) and updates it if necessary.
-func checkDependOnService(launcherServiceKey registry.Key, logger log.Logger) {
+func checkDependOnService(launcherServiceKey registry.Key, logger *slog.Logger) {
 	serviceList, _, getServiceListErr := launcherServiceKey.GetStringsValue(dependOnServiceName)
 
 	if getServiceListErr != nil {
 		if getServiceListErr.Error() == notFoundInRegistryError {
 			// `DependOnService` does not exist for this service yet -- we can safely set it to include the Dnscache service.
 			if err := launcherServiceKey.SetStringsValue(dependOnServiceName, []string{dnscacheService}); err != nil {
-				level.Error(logger).Log("msg", "could not set strings value for DependOnService", "err", err)
+				logger.Log(context.TODO(), slog.LevelError,
+					"could not set strings value for DependOnService",
+					"err", err,
+				)
 			}
 			return
 		}
@@ -103,6 +122,62 @@ func checkDependOnService(launcherServiceKey registry.Key, logger log.Logger) {
 	// Set service to depend on Dnscache
 	serviceList = append(serviceList, dnscacheService)
 	if err := launcherServiceKey.SetStringsValue(dependOnServiceName, serviceList); err != nil {
-		level.Error(logger).Log("msg", "could not set strings value for DependOnService", "err", err)
+		logger.Log(context.TODO(), slog.LevelError,
+			"could not set strings value for DependOnService",
+			"err", err,
+		)
 	}
+}
+
+// checkRestartActions checks the current value of our `SERVICE_FAILURE_ACTIONS_FLAG` and
+// sets it to true if required. See https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actions_flag
+func checkRestartActions(logger *slog.Logger) {
+	sman, err := mgr.Connect()
+	if err != nil {
+		logger.Log(context.TODO(), slog.LevelError,
+			"connecting to service control manager",
+			"err", err,
+		)
+
+		return
+	}
+
+	defer sman.Disconnect()
+
+	launcherService, err := sman.OpenService(`LauncherKolideK2Svc`)
+	if err != nil {
+		logger.Log(context.TODO(), slog.LevelError,
+			"opening the launcher service from control manager",
+			"err", err,
+		)
+
+		return
+	}
+
+	defer launcherService.Close()
+
+	curFlag, err := launcherService.RecoveryActionsOnNonCrashFailures()
+	if err != nil {
+		logger.Log(context.TODO(), slog.LevelError,
+			"querying for current RecoveryActionsOnNonCrashFailures flag",
+			"err", err,
+		)
+
+		return
+	}
+
+	if curFlag { // nothing to do, the flag was already set correctly
+		return
+	}
+
+	if err = launcherService.SetRecoveryActionsOnNonCrashFailures(true); err != nil {
+		logger.Log(context.TODO(), slog.LevelError,
+			"setting RecoveryActionsOnNonCrashFailures flag",
+			"err", err,
+		)
+
+		return
+	}
+
+	logger.Log(context.TODO(), slog.LevelInfo, "successfully set RecoveryActionsOnNonCrashFailures flag")
 }

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -102,7 +102,7 @@ func runWindowsSvc(args []string) error {
 	}()
 
 	// Confirm that service configuration is up-to-date
-	checkServiceConfiguration(logger, opts)
+	checkServiceConfiguration(systemSlogger.Logger, opts)
 
 	level.Info(logger).Log(
 		"msg", "launching service",


### PR DESCRIPTION
This makes a few updates to our windows service config at runtime:
- sets the `SERVICE_FAILURE_ACTIONS_FLAG` to true (see docs [here](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actions_flag) for implications)
- wires our systemSlogger multislogger through to update the existing logging