### PR TITLE
Pass system multislogger through to all launcher subcommands

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -19,12 +19,13 @@ import (
 	"github.com/kolide/launcher/ee/desktop/user/notify"
 	userserver "github.com/kolide/launcher/ee/desktop/user/server"
 	"github.com/kolide/launcher/pkg/authedclient"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/rungroup"
 	"github.com/kolide/systray"
 	"github.com/peterbourgon/ff/v3"
 )
 
-func runDesktop(args []string) error {
+func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 	var (
 		flagset    = flag.NewFlagSet("kolide desktop", flag.ExitOnError)
 		flhostname = flagset.String(

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
-func runDoctor(args []string) error {
+func runDoctor(systemMultiSlogger *multislogger.MultiSlogger, args []string) error {
 	attachConsole()
 	defer detachConsole()
 
@@ -33,12 +33,13 @@ func runDoctor(args []string) error {
 		slogLevel = slog.LevelDebug
 	}
 
-	slogger := multislogger.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	// Add handler to write to stdout
+	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slogLevel,
 		AddSource: true,
-	})).Logger
+	}))
 
-	flagController := flags.NewFlagController(slogger, nil, fcOpts...)
+	flagController := flags.NewFlagController(systemMultiSlogger.Logger, nil, fcOpts...)
 	k := knapsack.New(nil, flagController, nil, nil, nil)
 
 	w := os.Stdout //tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -100,7 +100,7 @@ func runFlare(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		return err
 	}
 
-	systemMultiSlogger.Logger.Log(ctx, slog.LevelInfo,
+	systemMultiSlogger.Log(ctx, slog.LevelInfo,
 		"flare creation complete",
 		"status", successMessage,
 		"file", flareDest.Name(),

--- a/cmd/launcher/run_compactdb.go
+++ b/cmd/launcher/run_compactdb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
-func runCompactDb(args []string) error {
+func runCompactDb(systemMultiSlogger *multislogger.MultiSlogger, args []string) error {
 	opts, err := launcher.ParseOptions("compactdb", args)
 	if err != nil {
 		return err
@@ -28,10 +28,11 @@ func runCompactDb(args []string) error {
 		slogLevel = slog.LevelDebug
 	}
 
-	slogger := multislogger.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	// Add handler to write to stdout
+	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slogLevel,
 		AddSource: true,
-	})).Logger
+	}))
 
 	boltPath := filepath.Join(opts.RootDirectory, "launcher.db")
 
@@ -40,7 +41,7 @@ func runCompactDb(args []string) error {
 		return err
 	}
 
-	slogger.Log(context.TODO(), slog.LevelInfo,
+	systemMultiSlogger.Logger.Log(context.TODO(), slog.LevelInfo,
 		"done compacting, safe to remove old db",
 		"path", oldDbPath,
 	)

--- a/cmd/launcher/run_compactdb.go
+++ b/cmd/launcher/run_compactdb.go
@@ -41,7 +41,7 @@ func runCompactDb(systemMultiSlogger *multislogger.MultiSlogger, args []string) 
 		return err
 	}
 
-	systemMultiSlogger.Logger.Log(context.TODO(), slog.LevelInfo,
+	systemMultiSlogger.Log(context.TODO(), slog.LevelInfo,
 		"done compacting, safe to remove old db",
 		"path", oldDbPath,
 	)

--- a/cmd/launcher/run_download_osquery.go
+++ b/cmd/launcher/run_download_osquery.go
@@ -10,11 +10,12 @@ import (
 	"time"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/packaging"
 )
 
 // runDownloadOsquery downloads the stable osquery to the provided path. It's meant for use in out CI pipeline.
-func runDownloadOsquery(args []string) error {
+func runDownloadOsquery(_ *multislogger.MultiSlogger, args []string) error {
 	fs := flag.NewFlagSet("launcher download-osquery", flag.ExitOnError)
 
 	var (

--- a/cmd/launcher/run_query.go
+++ b/cmd/launcher/run_query.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/env"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	osquerygo "github.com/osquery/osquery-go"
 )
 
@@ -17,7 +18,7 @@ type queryFile struct {
 	Queries map[string]string `json:"queries"`
 }
 
-func runQuery(args []string) error {
+func runQuery(_ *multislogger.MultiSlogger, args []string) error {
 	flagset := flag.NewFlagSet("launcher query", flag.ExitOnError)
 	var (
 		flQueries = flagset.String(

--- a/cmd/launcher/run_socket.go
+++ b/cmd/launcher/run_socket.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/table"
 )
 
-func runSocket(args []string) error {
+func runSocket(systemMultiSlogger *multislogger.MultiSlogger, args []string) error {
 	flagset := flag.NewFlagSet("launcher socket", flag.ExitOnError)
 	var (
 		flPath = flagset.String(
@@ -59,12 +59,13 @@ func runSocket(args []string) error {
 	if err != nil {
 		return err
 	}
-	slogger := multislogger.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	// Add handler to write to stdout
+	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	})).Logger
+	}))
 	fcOpts := []flags.Option{flags.WithCmdLineOpts(cmdlineopts)}
-	flagController := flags.NewFlagController(slogger, inmemory.NewStore(), fcOpts...)
+	flagController := flags.NewFlagController(systemMultiSlogger.Logger, inmemory.NewStore(), fcOpts...)
 	k := knapsack.New(nil, flagController, nil, nil, nil)
 	runner := runtime.New(k, opts...)
 	go runner.Run()

--- a/cmd/launcher/secure_enclave_darwin.go
+++ b/cmd/launcher/secure_enclave_darwin.go
@@ -11,13 +11,14 @@ import (
 	"github.com/kolide/krypto/pkg/echelper"
 	"github.com/kolide/krypto/pkg/secureenclave"
 	"github.com/kolide/launcher/ee/secureenclavesigner"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
 // runSecureEnclave performs either a create-key operation using the secure enclave.
 // It's available as a separate command because launcher runs as root by default and since it's
 // not in a user security context, it can't use the secure enclave directly. However, this command
 // can be run in the user context using launchctl.
-func runSecureEnclave(args []string) error {
+func runSecureEnclave(_ *multislogger.MultiSlogger, args []string) error {
 	// currently we are just creating key, but plan to add sign command in future
 	if len(args) < 1 {
 		return errors.New("not enough arguments, expect create_key")

--- a/cmd/launcher/secure_enclave_other.go
+++ b/cmd/launcher/secure_enclave_other.go
@@ -3,8 +3,12 @@
 
 package main
 
-import "errors"
+import (
+	"errors"
 
-func runSecureEnclave(args []string) error {
+	"github.com/kolide/launcher/pkg/log/multislogger"
+)
+
+func runSecureEnclave(_ *multislogger.MultiSlogger, args []string) error {
 	return errors.New("not implemented on non darwin platforms")
 }

--- a/cmd/launcher/secure_enclave_test.go
+++ b/cmd/launcher/secure_enclave_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kolide/krypto/pkg/echelper"
 	"github.com/kolide/launcher/ee/secureenclavesigner"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,7 +107,7 @@ func TestSecureEnclaveCmd(t *testing.T) { //nolint:paralleltest
 
 	os.Stdout = pipeWriter
 
-	require.NoError(t, runSecureEnclave([]string{secureenclavesigner.CreateKeyCmd}))
+	require.NoError(t, runSecureEnclave(multislogger.New(), []string{secureenclavesigner.CreateKeyCmd}))
 	require.NoError(t, pipeWriter.Close())
 
 	var buf bytes.Buffer

--- a/cmd/launcher/svc.go
+++ b/cmd/launcher/svc.go
@@ -6,15 +6,17 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
-func runWindowsSvc(args []string) error {
+func runWindowsSvc(_ *multislogger.MultiSlogger, _ []string) error {
 	fmt.Println("This isn't windows")
 	os.Exit(1)
 	return nil
 }
 
-func runWindowsSvcForeground(args []string) error {
+func runWindowsSvcForeground(_ *multislogger.MultiSlogger, _ []string) error {
 	fmt.Println("This isn't windows")
 	os.Exit(1)
 	return nil

--- a/cmd/launcher/uninstall.go
+++ b/cmd/launcher/uninstall.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/peterbourgon/ff/v3"
 )
 
 // Specific to Unix platforms, matching only standard-looking identifiers
 var identifierRegexp = regexp.MustCompile(`^\/var\/([-a-zA-Z0-9]*)\/.*\.kolide\.com`)
 
-func runUninstall(args []string) error {
+func runUninstall(_ *multislogger.MultiSlogger, args []string) error {
 	var (
 		flagset         = flag.NewFlagSet("kolide uninstaller", flag.ExitOnError)
 		flRootDirectory = flagset.String("root_directory", "", "The location of the local database, pidfiles, etc.")

--- a/pkg/log/locallogger/locallogger.go
+++ b/pkg/log/locallogger/locallogger.go
@@ -3,11 +3,8 @@ package locallogger
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -50,26 +47,6 @@ func (ll localLogger) Log(keyvals ...interface{}) error {
 
 func (ll localLogger) Writer() io.Writer {
 	return ll.writer
-}
-
-func CleanUpRenamedDebugLogs(cleanupPath string, logger log.Logger) {
-	// We renamed the debug log file from debug.log to debug.json for compatibility with support tools.
-	// Check to see if we have any of the old debug.log files still hanging around, and clean them up
-	// if so. The current one is always named debug.log, and rotated files are in the format
-	// `debug-<date>.log.gz`. We do not return an error if we can't clean up these files -- it's not
-	// a big deal.
-	legacyDebugLogPattern := filepath.Join(cleanupPath, "debug*.log*")
-	filesToCleanUp, err := filepath.Glob(legacyDebugLogPattern)
-	if err != nil {
-		level.Error(logger).Log("msg", "could not glob for legacy debug log files to clean up", "pattern", legacyDebugLogPattern, "err", err)
-		return
-	}
-
-	for _, fileToCleanUp := range filesToCleanUp {
-		if err := os.Remove(fileToCleanUp); err != nil {
-			level.Error(logger).Log("msg", "could not clean up legacy debug log file", "file", fileToCleanUp, "err", err)
-		}
-	}
 }
 
 // filterResults filteres out the osquery results,

--- a/pkg/log/locallogger/locallogger_test.go
+++ b/pkg/log/locallogger/locallogger_test.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/kolide/kit/stringutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,39 +71,4 @@ func TestKitLogging(t *testing.T) {
 		assert.Equal(t, v, contents[k])
 	}
 
-}
-
-func TestCleanUpRenamedDebugLogs(t *testing.T) {
-	t.Parallel()
-
-	tempDir := t.TempDir()
-
-	// Create two files that should be cleaned up and one that should not
-	legacyDebugLogPath := filepath.Join(tempDir, "debug.log")
-	legacyDebugLogRotatedPath := filepath.Join(tempDir, "debug-2022-11-18T18-35-48.858.log.gz")
-	newDebugLogPath := filepath.Join(tempDir, "debug.json")
-	for _, f := range []string{legacyDebugLogPath, legacyDebugLogRotatedPath, newDebugLogPath} {
-		fh, err := os.Create(f)
-		require.NoError(t, err, "could not create log file for test")
-		fh.Close()
-	}
-
-	// Call cleanup
-	CleanUpRenamedDebugLogs(tempDir, log.NewJSONLogger(os.Stderr))
-
-	// Validate that we only cleaned up the files we meant to
-	_, err := os.Stat(legacyDebugLogPath)
-	require.True(t, os.IsNotExist(err))
-
-	_, err = os.Stat(legacyDebugLogRotatedPath)
-	require.True(t, os.IsNotExist(err))
-
-	_, err = os.Stat(newDebugLogPath)
-	require.NoError(t, err)
-
-	// Call cleanup again -- should be a no-op
-	CleanUpRenamedDebugLogs(tempDir, log.NewJSONLogger(os.Stderr))
-
-	_, err = os.Stat(newDebugLogPath)
-	require.NoError(t, err)
 }


### PR DESCRIPTION
In some subcommands (notably the Windows service subcommand), we create a system multislogger. However, we also have already created one in the main.go entrypoint. This PR updates all subcommands to accept the system multislogger created in main.go so that we only create/manage one of them.

I also pulled out `CleanUpRenamedDebugLogs` -- it's been long enough and I don't think we need it anymore.