### PR TITLE
[TUF] Prevent executable from being overwritten

### DIFF
--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -154,8 +154,10 @@ func (ulm *updateLibraryManager) stageAndVerifyUpdate(binary autoupdatableBinary
 		return stagedUpdatePath, fmt.Errorf("verification failed for target %s staged at %s: %w", targetFilename, stagedUpdatePath, err)
 	}
 
-	// Everything looks good: create the file and write it to disk
-	out, err := os.Create(stagedUpdatePath)
+	// Everything looks good: create the file and write it to disk.
+	// We create the file with 0655 permissions to prevent any other user from writing to this file
+	// before we can copy to it.
+	out, err := os.OpenFile(stagedUpdatePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0655)
 	if err != nil {
 		return "", fmt.Errorf("could not create file at %s: %w", stagedUpdatePath, err)
 	}

--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -162,7 +162,9 @@ func (ulm *updateLibraryManager) stageAndVerifyUpdate(binary autoupdatableBinary
 		return "", fmt.Errorf("could not create file at %s: %w", stagedUpdatePath, err)
 	}
 	if _, err := io.Copy(out, &fileBuffer); err != nil {
-		out.Close()
+		if err := out.Close(); err != nil {
+			return stagedUpdatePath, fmt.Errorf("could not write downloaded target %s to file %s and could not close file: %w", targetFilename, stagedUpdatePath, err)
+		}
 		return stagedUpdatePath, fmt.Errorf("could not write downloaded target %s to file %s: %w", targetFilename, stagedUpdatePath, err)
 	}
 	if err := out.Close(); err != nil {


### PR DESCRIPTION
Create executable with 0655 instead of default 0666.