### PR TITLE
Fix command exec's `WithUid` (RunAsUser) when running as self

### DIFF
--- a/ee/tables/tablehelpers/run_as_user_posix.go
+++ b/ee/tables/tablehelpers/run_as_user_posix.go
@@ -24,7 +24,10 @@ func WithUid(uid string) ExecOps {
 			return fmt.Errorf("looking up user with uid %s: %w", uid, err)
 		}
 
-		if currentUser.Uid != "0" && currentUser.Uid != runningUser.Uid {
+		// If the current user is the user to run as, then early return to avoid needing NoSetGroups.
+		if currentUser.Uid == runningUser.Uid {
+			return nil
+		} else if currentUser.Uid != "0" {
 			return fmt.Errorf("current user %s is not root and can't start process for other user %s", currentUser.Uid, uid)
 		}
 


### PR DESCRIPTION
I've been trying to test my new check that uses the `kolide_brew_upgradeable` table, when I kept hitting an issue in Live Query where all devices returned no results. I could easily get results locally, so I wasn't sure what was going on.

After more testing locally, I saw the error `fork/exec /opt/homebrew/bin/brew: operation not permitted`, and after some digging online I came to this [post](https://walac.github.io/golang-patch/).

Basically the syscall `SYS_SETGROUPS` requires elevated permissions, so a non-root user attempting to set the groups causes an `EPERM` error. There is a fix inside the `Credential` structure: `NoSetGroups`, but I figured since we are already running as the user, we can just early exit instead of adding that flag.

Outside of this issue, I had thought that the queries in Live Query go through a sudoed instance of launcher, but perhaps I was mistaken on that?