### PR TITLE
Fix panic in 1.6.4

### DIFF
--- a/pkg/service/publish_results_test.go
+++ b/pkg/service/publish_results_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TrivialTruncate(t *testing.T) {
+	t.Parallel()
+
+	const maxLen = 5
+	var tests = []struct {
+		in       string
+		expected string
+	}{
+		{
+			in:       "",
+			expected: "",
+		},
+		{
+			in:       "1",
+			expected: "1",
+		},
+		{
+			in:       "short",
+			expected: "short",
+		},
+		{
+			in:       "and this is a long string",
+			expected: "and t...",
+		},
+		{
+			in:       "我喜歡吃辣的食物",
+			expected: "我\xe5\x96...",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+		})
+
+		actual := trivialTruncate(tt.in, maxLen)
+		spew.Dump(actual)
+		require.Equal(t, tt.expected, actual)
+	}
+
+}

--- a/pkg/service/publish_results_test.go
+++ b/pkg/service/publish_results_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +43,6 @@ func Test_TrivialTruncate(t *testing.T) {
 		})
 
 		actual := trivialTruncate(tt.in, maxLen)
-		spew.Dump(actual)
 		require.Equal(t, tt.expected, actual)
 	}
 


### PR DESCRIPTION
Oops. :facepalm: I introduced a panic in #1667

```
panic: runtime error: slice bounds out of range [:200] with capacity 176

goroutine 24249 [running]:
github.com/kolide/launcher/pkg/service.logmw.PublishResults.func1({0x1400042bbe0?, 0x1400042bc00?, 0x102047300?})
	/Users/runner/work/launcher/launcher/pkg/service/publish_results.go:187 +0x400
github.com/kolide/launcher/pkg/service.logmw.PublishResults({{0x1018a05d0?, 0x140001e9410?}, {0x1018946b8?, 0x14000611680?}}, {0x101891d30?, 0x14000780f60}, {0x1400027e000, 0xb9}, {0x14000ae9400, 0x1, ...})
	/Users/runner/work/launcher/launcher/pkg/service/publish_results.go:216 +0x174
github.com/kolide/launcher/pkg/service.uuidmw.PublishResults({{0x101894628?, 0x14000604600?}}, {0x101891d30, 0x14000780f30}, {0x1400027e000, 0xb9}, {0x14000ae9400, 0x1, 0x1})
	/Users/runner/work/launcher/launcher/pkg/service/publish_results.go:221 +0xac
github.com/kolide/launcher/pkg/osquery.(*Extension).writeResultsWithReenroll(0x14000112b40, {0x101891d30?, 0x14000780e70?}, {0x14000ae9400, 0x1, 0x1}, 0x1)
	/Users/runner/work/launcher/launcher/pkg/osquery/extension.go:924 +0xd0
github.com/kolide/launcher/pkg/osquery.(*Extension).WriteResults(0x140006bd8a8?, {0x101891d30?, 0x14000780c30?}, {0x14000ae9400, 0x1, 0x1})
	/Users/runner/work/launcher/launcher/pkg/osquery/extension.go:916 +0xac
github.com/osquery/osquery-go/plugin/distributed.(*Plugin).Call(0x1400060e840, {0x101891d30, 0x14000780c00}, 0xb?)
	/Users/runner/go/pkg/mod/github.com/osquery/osquery-go@v0.0.0-20231006172600-d6f325f636a9/plugin/distributed/distributed.go:297 +0x7f4
github.com/osquery/osquery-go.(*ExtensionManagerServer).Call(0x140004312c0, {0x101891d68?, 0x14000ae9360?}, {0x140009a7cf0, 0xb}, {0x140009a7d00, 0xb}, 0x1011af708?)
	/Users/runner/go/pkg/mod/github.com/osquery/osquery-go@v0.0.0-20231006172600-d6f325f636a9/server.go:317 +0x174
github.com/osquery/osquery-go/gen/osquery.(*extensionProcessorCall).Process(0x14000627f30, {0x101891d30, 0x14000780b10}, 0x4?, {0x10189e410?, 0x1400026a150}, {0x10189e410, 0x1400026a1c0})
	/Users/runner/go/pkg/mod/github.com/osquery/osquery-go@v0.0.0-20231006172600-d6f325f636a9/gen/osquery/osquery.go:1455 +0x258
github.com/osquery/osquery-go/gen/osquery.(*ExtensionProcessor).Process(0x140005334e8, {0x101891d30, 0x14000780b10}, {0x10189e410, 0x1400026a150}, {0x10189e410?, 0x1400026a1c0?})
	/Users/runner/go/pkg/mod/github.com/osquery/osquery-go@v0.0.0-20231006172600-d6f325f636a9/gen/osquery/osquery.go:1317 +0x1e4
github.com/apache/thrift/lib/go/thrift.(*TSimpleServer).processRequests(0x140004315e0, {0x1018968e0, 0x14000437280})
	/Users/runner/go/pkg/mod/github.com/apache/thrift@v0.16.0/lib/go/thrift/simple_server.go:320 +0x430
github.com/apache/thrift/lib/go/thrift.(*TSimpleServer).innerAccept.func1()
	/Users/runner/go/pkg/mod/github.com/apache/thrift@v0.16.0/lib/go/thrift/simple_server.go:198 +0x60
created by github.com/apache/thrift/lib/go/thrift.(*TSimpleServer).innerAccept in goroutine 228
	/Users/runner/go/pkg/mod/github.com/apache/thrift@v0.16.0/lib/go/thrift/simple_server.go:196 +0x178
```