### PR TITLE
Standardize how we log and handle panics

### DIFF
--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -187,12 +187,12 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 		// Log panics from runLauncher
 		defer func() {
 			if r := recover(); r != nil {
-				w.systemSlogger.Log(context.TODO(), slog.LevelInfo,
+				w.systemSlogger.Log(ctx, slog.LevelInfo,
 					"panic occurred in runLauncher",
 					"err", r,
 				)
 				if err, ok := r.(error); ok {
-					w.systemSlogger.Log(context.TODO(), slog.LevelInfo,
+					w.systemSlogger.Log(ctx, slog.LevelInfo,
 						"panic stack trace",
 						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 					)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -185,7 +185,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	ctx = ctxlog.NewContext(ctx, w.logger)
 	runLauncherResults := make(chan struct{})
 
-	gowrapper.Go(w.systemSlogger.Logger, func() {
+	gowrapper.Go(ctx, w.systemSlogger.Logger, func() {
 		err := runLauncher(ctx, cancel, w.slogger, w.systemSlogger, w.opts)
 		if err != nil {
 			w.systemSlogger.Log(ctx, slog.LevelInfo,

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -184,6 +184,22 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	ctx = ctxlog.NewContext(ctx, w.logger)
 
 	go func() {
+		// Log panics from runLauncher
+		defer func() {
+			if r := recover(); r != nil {
+				w.systemSlogger.Log(context.TODO(), slog.LevelInfo,
+					"panic occurred in runLauncher",
+					"err", r,
+				)
+				if err, ok := r.(error); ok {
+					w.systemSlogger.Log(context.TODO(), slog.LevelInfo,
+						"panic stack trace",
+						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
+					)
+				}
+			}
+		}()
+
 		err := runLauncher(ctx, cancel, w.slogger, w.systemSlogger, w.opts)
 		if err != nil {
 			w.systemSlogger.Log(ctx, slog.LevelInfo,

--- a/ee/gowrapper/goroutine.go
+++ b/ee/gowrapper/goroutine.go
@@ -1,0 +1,35 @@
+package gowrapper
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/pkg/errors"
+)
+
+// Go is a thin wrapper around `go func()` that ensures we log panics
+// and then handle them appropriately. `onPanic` defines the behavior
+// that should happen after recovering from a panic.
+func Go(slogger *slog.Logger, goroutine func(), onPanic func(r any)) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slogger.Log(context.TODO(), slog.LevelError,
+					"panic occurred in goroutine",
+					"err", r,
+				)
+				if err, ok := r.(error); ok {
+					slogger.Log(context.TODO(), slog.LevelError,
+						"panic stack trace",
+						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
+					)
+				}
+
+				onPanic(r)
+			}
+		}()
+
+		goroutine()
+	}()
+}

--- a/ee/gowrapper/goroutine.go
+++ b/ee/gowrapper/goroutine.go
@@ -11,16 +11,16 @@ import (
 // Go is a thin wrapper around `go func()` that ensures we log panics
 // and then handle them appropriately. `onPanic` defines the behavior
 // that should happen after recovering from a panic.
-func Go(slogger *slog.Logger, goroutine func(), onPanic func(r any)) {
+func Go(ctx context.Context, slogger *slog.Logger, goroutine func(), onPanic func(r any)) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slogger.Log(context.TODO(), slog.LevelError,
+				slogger.Log(ctx, slog.LevelError,
 					"panic occurred in goroutine",
 					"err", r,
 				)
 				if err, ok := r.(error); ok {
-					slogger.Log(context.TODO(), slog.LevelError,
+					slogger.Log(ctx, slog.LevelError,
 						"panic stack trace",
 						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 					)

--- a/ee/gowrapper/goroutine_test.go
+++ b/ee/gowrapper/goroutine_test.go
@@ -1,0 +1,113 @@
+package gowrapper
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGo_WithPanic(t *testing.T) {
+	t.Parallel()
+
+	funcDelay := 200 * time.Millisecond
+
+	// Capture goroutine results so we know the goroutine executed
+	goroutineResults := make(chan struct{})
+	g := func() {
+		time.Sleep(funcDelay)
+		goroutineResults <- struct{}{}
+		panic("test panic")
+	}
+
+	// Capture onPanic results so we know that onPanic executed
+	onPanicResults := make(chan struct{})
+	p := func(_ any) {
+		time.Sleep(funcDelay)
+		onPanicResults <- struct{}{}
+	}
+
+	// Capture slogger output so we confirm we do some logging
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Kick off goroutine
+	Go(slogger, g, p)
+	timeoutGracePeriod := 200 * time.Millisecond
+
+	goroutineExecuted := false
+	onPanicExecuted := false
+
+	for {
+		// Goroutine all done
+		if goroutineExecuted && onPanicExecuted {
+			break
+		}
+
+		select {
+		case <-goroutineResults:
+			goroutineExecuted = true
+		case <-onPanicResults:
+			onPanicExecuted = true
+		case <-time.After(funcDelay + funcDelay + timeoutGracePeriod):
+			t.Error("goroutine did not exit within timeout: logs: ", logBytes.String())
+			t.FailNow()
+		}
+	}
+
+	require.True(t, goroutineExecuted, "goroutine did not execute")
+	require.True(t, onPanicExecuted, "onPanic did not execute")
+	require.Contains(t, logBytes.String(), "panic", "logs did not include panic information")
+}
+
+func TestGo_WithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	funcDelay := 200 * time.Millisecond
+
+	// Capture goroutine results so we know the goroutine executed
+	goroutineResults := make(chan struct{})
+	g := func() {
+		time.Sleep(funcDelay)
+		goroutineResults <- struct{}{}
+	}
+
+	// Capture onPanic results so we know that onPanic did not execute
+	onPanicResults := make(chan struct{})
+	p := func(_ any) {
+		time.Sleep(funcDelay)
+		onPanicResults <- struct{}{}
+	}
+
+	// Kick off goroutine
+	Go(multislogger.NewNopLogger(), g, p)
+	timeoutGracePeriod := 200 * time.Millisecond
+	goroutineEndTime := time.Now().Add(funcDelay + funcDelay + timeoutGracePeriod)
+
+	goroutineExecuted := false
+	onPanicExecuted := false
+
+	for {
+		// Wait until our timeout to make sure onPanic won't execute
+		if time.Now().After(goroutineEndTime) {
+			break
+		}
+
+		select {
+		case <-goroutineResults:
+			goroutineExecuted = true
+		case <-onPanicResults:
+			onPanicExecuted = true
+		case <-time.After(funcDelay + funcDelay + timeoutGracePeriod):
+			continue
+		}
+	}
+
+	require.True(t, goroutineExecuted, "goroutine did not execute")
+	require.False(t, onPanicExecuted, "onPanic should not have executed")
+}

--- a/ee/gowrapper/goroutine_test.go
+++ b/ee/gowrapper/goroutine_test.go
@@ -1,6 +1,7 @@
 package gowrapper
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func TestGo_WithPanic(t *testing.T) {
 	}))
 
 	// Kick off goroutine
-	Go(slogger, g, p)
+	Go(context.TODO(), slogger, g, p)
 	timeoutGracePeriod := 200 * time.Millisecond
 
 	goroutineExecuted := false
@@ -85,7 +86,7 @@ func TestGo_WithoutPanic(t *testing.T) {
 	}
 
 	// Kick off goroutine
-	Go(multislogger.NewNopLogger(), g, p)
+	Go(context.TODO(), multislogger.NewNopLogger(), g, p)
 	timeoutGracePeriod := 200 * time.Millisecond
 	goroutineEndTime := time.Now().Add(funcDelay + funcDelay + timeoutGracePeriod)
 

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -63,7 +63,7 @@ func (g *Group) Run() error {
 	actorErrors := make(chan actorError, len(g.actors))
 	for _, a := range g.actors {
 		a := a
-		gowrapper.Go(g.slogger, func() {
+		gowrapper.Go(context.TODO(), g.slogger, func() {
 			g.slogger.Log(context.TODO(), slog.LevelDebug,
 				"starting actor",
 				"actor", a.name,


### PR DESCRIPTION
Requires https://github.com/kolide/launcher/pull/1693

If one goroutine panics, all of launcher will terminate. Before termination, the panic will travel up to the top-level function in the executing goroutine. If we want to recover or log panics, we must do that in this top-level function.

This PR introduces `gowrapper` to wrap our goroutines, to make it easier to standardize recovering from and logging panics. It will always log the panic, and allows for providing an `onPanic` function that executes if gowrapper recovers from a panic.

This PR adds `gowrapper` usage to our windows service and to all of our rungroups.

References:
* https://forum.golangbridge.org/t/why-does-go-terminate-the-whole-process-if-one-goroutine-paincs/27122

<details>
<summary>Example logs from panic inside a rungroup</summary>

```
{
  "time":"2024-04-30T14:17:34.976926Z",
  "level":"ERROR",
  "source":{
    "function":"github.com/kolide/launcher/ee/gowrapper.Go.func1.1",
    "file":"/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go",
    "line":18
  },
  "msg":"panic occurred in goroutine",
  "launcher_run_id":"01HWQNTJJ3RET2810PM254GV7H",
  "component":"run_group",
  "err":"runtime error: index out of range [3] with length 0"
}
{
  "time":"2024-04-30T14:17:34.983632Z",
  "level":"ERROR",
  "source":{
    "function":"github.com/kolide/launcher/ee/gowrapper.Go.func1.1",
    "file":"/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go",
    "line":23
  },
  "msg":"panic stack trace",
  "launcher_run_id":"01HWQNTJJ3RET2810PM254GV7H",
  "component":"run_group",
  "stack_trace":"runtime error: index out of range [3] with length 0\ngithub.com/kolide/launcher/ee/gowrapper.Go.func1.1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:25\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:914\nruntime.goPanicIndex\n\t/usr/local/go/src/runtime/panic.go:114\ngithub.com/kolide/launcher/ee/tuf.(*TufAutoupdater).Execute\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/autoupdate.go:234\ngithub.com/kolide/launcher/pkg/rungroup.(*Group).Run.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/pkg/rungroup/rungroup.go:71\ngithub.com/kolide/launcher/ee/gowrapper.Go.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:33\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1197"
}
```

</details>

<details>
<summary>Example logs from panic inside Windows service</summary>

```
{
  "time":"2024-04-30T14:26:47.1429033Z",
  "level":"ERROR",
  "source":{
  "function":
    "github.com/kolide/launcher/ee/gowrapper.Go.func1.1",
    "file":"C:/Users/Becca/Repos/launcher/ee/gowrapper/goroutine.go",
    "line":18
  },
  "msg":"panic occurred in goroutine",
  "launcher_run_id":"01HWQPD75EQTGQFQ4BBZ1FNFGD",
  "err":"runtime error: index out of range [1] with length 0"
}
{
  "time":"2024-04-30T14:26:47.1434689Z",
  "level":"ERROR",
  "source":{
    "function":"github.com/kolide/launcher/ee/gowrapper.Go.func1.1",
    "file":"C:/Users/Becca/Repos/launcher/ee/gowrapper/goroutine.go",
    "line":23
  },
  "msg":"panic stack trace",
  "launcher_run_id":"01HWQPD75EQTGQFQ4BBZ1FNFGD",
  "stack_trace":"runtime error: index out of range [1] with length 0\ngithub.com/kolide/launcher/ee/gowrapper.Go.func1.1\n\tC:/Users/Becca/Repos/launcher/ee/gowrapper/goroutine.go:25\nruntime.gopanic\n\tC:/Program Files/Go/src/runtime/panic.go:914\nruntime.goPanicIndex\n\tC:/Program Files/Go/src/runtime/panic.go:114\nmain.runLauncher\n\tC:/Users/Becca/Repos/launcher/cmd/launcher/launcher.go:525\nmain.(*winSvc).Execute.func1\n\tC:/Users/Becca/Repos/launcher/cmd/launcher/svc_windows.go:189\ngithub.com/kolide/launcher/ee/gowrapper.Go.func1\n\tC:/Users/Becca/Repos/launcher/ee/gowrapper/goroutine.go:33\nruntime.goexit\n\tC:/Program Files/Go/src/runtime/asm_amd64.s:1650"
}
{
  "time":"2024-04-30T14:26:47.1434689Z",
  "level":"ERROR",
  "source":{
    "function":"main.(*winSvc).Execute.func2",
    "file":"C:/Users/Becca/Repos/launcher/cmd/launcher/svc_windows.go",
    "line":205
  },
  "msg":"exiting after runLauncher panic",
  "launcher_run_id":"01HWQPD75EQTGQFQ4BBZ1FNFGD",
  "err":"runtime error: index out of range [1] with length 0"
}
```

</details>