### PR TITLE
Wrap main and remove os.Exit calls so all deferred functions will execute

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters-settings:
         msg: use ee/allowedcmd functions instead
       - p: ^os\.Exit.*$
         msg: do not use os.Exit so that launcher can shut down gracefully
+      - p: ^logutil\.Fatal.*$
+        msg: do not use logutil.Fatal so that launcher can shut down gracefully
   sloglint:
     kv-only: true
     context-only: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,8 @@ linters-settings:
     forbid:
       - p: ^exec\.Command.*$
         msg: use ee/allowedcmd functions instead
+      - p: ^os\.Exit.*$
+        msg: do not use os.Exit so that launcher can shut down gracefully
   sloglint:
     kv-only: true
     context-only: true

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -78,7 +78,7 @@ func runMain() error {
 	// handle that argument. Fall-back to running launcher
 	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], `-`) {
 		if err := runSubcommands(systemSlogger); err != nil {
-			systemSlogger.Log(ctx, slog.LevelInfo,
+			systemSlogger.Log(ctx, slog.LevelError,
 				"running with positional args",
 				"err", err,
 			)
@@ -92,7 +92,10 @@ func runMain() error {
 		if launcher.IsInfoCmd(err) {
 			return nil
 		}
-		level.Info(logger).Log("err", err)
+		systemSlogger.Log(ctx, slog.LevelError,
+			"could not parse options",
+			"err", err,
+		)
 		return fmt.Errorf("parsing options: %w", err)
 	}
 
@@ -203,6 +206,10 @@ func runNewerLauncherIfAvailable(ctx context.Context, slogger *slog.Logger) erro
 		// Fall back to legacy autoupdate library
 		newerBinary, err = autoupdate.FindNewestSelf(ctx)
 		if err != nil {
+			slogger.Log(ctx, slog.LevelError,
+				"could not check out latest launcher from legacy autoupdate library",
+				"err", err,
+			)
 			return nil
 		}
 	}

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -83,6 +83,9 @@ func runMain() error {
 
 	opts, err := launcher.ParseOptions("", os.Args[1:])
 	if err != nil {
+		if launcher.IsInfoCmd(err) {
+			return nil
+		}
 		level.Info(logger).Log("err", err)
 		return fmt.Errorf("parsing options: %w", err)
 	}

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -69,7 +69,9 @@ func runMain() error {
 	// fork-bombing itself. This is an ENV, because there's no
 	// good way to pass it through the flags.
 	if !env.Bool("LAUNCHER_SKIP_UPDATES", false) && !inBuildDir {
-		runNewerLauncherIfAvailable(ctx, systemSlogger.Logger)
+		if err := runNewerLauncherIfAvailable(ctx, systemSlogger.Logger); err != nil {
+			return fmt.Errorf("running newer version of launcher: %w", err)
+		}
 	}
 
 	// if the launcher is being ran with a positional argument,

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -79,7 +79,7 @@ func runMain() int {
 	}
 
 	// if the launcher is being ran with a positional argument,
-	// handle that argument. Fall-back to running launcher
+	// handle that argument.
 	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], `-`) {
 		if err := runSubcommands(systemSlogger); err != nil {
 			systemSlogger.Log(ctx, slog.LevelError,
@@ -91,6 +91,7 @@ func runMain() int {
 		return 0
 	}
 
+	// Fall back to running launcher
 	opts, err := launcher.ParseOptions("", os.Args[1:])
 	if err != nil {
 		if launcher.IsInfoCmd(err) {

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -76,7 +76,11 @@ func runMain() error {
 	// handle that argument. Fall-back to running launcher
 	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], `-`) {
 		if err := runSubcommands(systemSlogger); err != nil {
-			logutil.Fatal(logger, "err", fmt.Errorf("run with positional args: %w", err))
+			systemSlogger.Log(ctx, slog.LevelInfo,
+				"running with positional args",
+				"err", err,
+			)
+			return fmt.Errorf("running with positional args: %w", err)
 		}
 		return nil
 	}

--- a/cmd/launcher/svc.go
+++ b/cmd/launcher/svc.go
@@ -4,20 +4,15 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"errors"
 
 	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
 func runWindowsSvc(_ *multislogger.MultiSlogger, _ []string) error {
-	fmt.Println("This isn't windows")
-	os.Exit(1)
-	return nil
+	return errors.New("This isn't windows")
 }
 
 func runWindowsSvcForeground(_ *multislogger.MultiSlogger, _ []string) error {
-	fmt.Println("This isn't windows")
-	os.Exit(1)
-	return nil
+	return errors.New("This isn't windows")
 }

--- a/cmd/launcher/svc.go
+++ b/cmd/launcher/svc.go
@@ -10,9 +10,9 @@ import (
 )
 
 func runWindowsSvc(_ *multislogger.MultiSlogger, _ []string) error {
-	return errors.New("this isn't windows")
+	return errors.New("this is not windows")
 }
 
 func runWindowsSvcForeground(_ *multislogger.MultiSlogger, _ []string) error {
-	return errors.New("this isn't windows")
+	return errors.New("this is not windows")
 }

--- a/cmd/launcher/svc.go
+++ b/cmd/launcher/svc.go
@@ -10,9 +10,9 @@ import (
 )
 
 func runWindowsSvc(_ *multislogger.MultiSlogger, _ []string) error {
-	return errors.New("This isn't windows")
+	return errors.New("this isn't windows")
 }
 
 func runWindowsSvcForeground(_ *multislogger.MultiSlogger, _ []string) error {
-	return errors.New("This isn't windows")
+	return errors.New("this isn't windows")
 }

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -183,7 +183,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 
 	ctx = ctxlog.NewContext(ctx, w.logger)
 
-	runLauncherResults := make(chan struct{}, 0)
+	runLauncherResults := make(chan struct{})
 
 	go func() {
 		err := runLauncher(ctx, cancel, w.slogger, w.systemSlogger, w.opts)
@@ -231,7 +231,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 			w.systemSlogger.Log(ctx, slog.LevelInfo,
 				"shutting down service after runLauncher exited",
 			)
-			changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
+			// We don't want to tell the service manager that we've stopped on purpose,
+			// so that the service manager will restart launcher correctly.
 			return false, uint32(windows.ERROR_EXCEPTION_IN_SERVICE)
 		}
 	}

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -193,7 +193,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				"err", err,
 				"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 			)
-			changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
+
 			// Launcher is already shut down -- send signal to fully exit so that the service manager can restart the service
 			runLauncherResults <- struct{}{}
 		}
@@ -205,7 +205,6 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 		w.systemSlogger.Log(ctx, slog.LevelInfo,
 			"runLauncher exited cleanly",
 		)
-		changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
 		runLauncherResults <- struct{}{}
 	}()
 

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -43,7 +43,7 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 			"error parsing options",
 			"err", err,
 		)
-		os.Exit(1)
+		return fmt.Errorf("parsing options: %w", err)
 	}
 
 	localSlogger := multislogger.New()
@@ -152,7 +152,7 @@ func runWindowsSvcForeground(systemSlogger *multislogger.MultiSlogger, args []st
 	opts, err := launcher.ParseOptions("", os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
-		os.Exit(1)
+		return fmt.Errorf("parsing options: %w", err)
 	}
 
 	// set extra debug options
@@ -183,6 +183,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 
 	ctx = ctxlog.NewContext(ctx, w.logger)
 
+	runLauncherResults := make(chan struct{}, 0)
+
 	go func() {
 		err := runLauncher(ctx, cancel, w.slogger, w.systemSlogger, w.opts)
 		if err != nil {
@@ -192,8 +194,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 			)
 			changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
-			// Launcher is already shut down -- fully exit so that the service manager can restart the service
-			os.Exit(1)
+			// Launcher is already shut down -- send signal to fully exit so that the service manager can restart the service
+			runLauncherResults <- struct{}{}
 		}
 
 		// If we get here, it means runLauncher returned nil. If we do
@@ -204,7 +206,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 			"runLauncher exited cleanly",
 		)
 		changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
-		os.Exit(0)
+		runLauncherResults <- struct{}{}
 	}()
 
 	for {
@@ -231,6 +233,15 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 					"change_request", fmt.Sprintf("%+v", c),
 				)
 			}
+		case <-runLauncherResults:
+			w.systemSlogger.Log(ctx, slog.LevelInfo,
+				"shutting down service after launcher shutdown",
+			)
+			changes <- svc.Status{State: svc.StopPending}
+			cancel()
+			time.Sleep(2 * time.Second) // give rungroups enough time to shut down
+			changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
+			return ssec, errno
 		}
 	}
 }

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -233,6 +233,9 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 			)
 			// We don't want to tell the service manager that we've stopped on purpose,
 			// so that the service manager will restart launcher correctly.
+			// We use this error code largely because the windows/svc code also uses it
+			// and it seems semantically correct enough; it doesn't appear to matter to us
+			// what the code is.
 			return false, uint32(windows.ERROR_EXCEPTION_IN_SERVICE)
 		}
 	}

--- a/cmd/make/make.go
+++ b/cmd/make/make.go
@@ -42,7 +42,7 @@ func main() {
 
 	if err := ff.Parse(fs, os.Args[1:], ffOpts...); err != nil {
 		logger := logutil.NewCLILogger(true)
-		logutil.Fatal(logger, "msg", "Error parsing flags", "err", err)
+		logutil.Fatal(logger, "msg", "Error parsing flags", "err", err) //nolint:forbidigo // Fine to use logutil.Fatal outside of launcher proper
 	}
 
 	logger := logutil.NewCLILogger(*flDebug)
@@ -98,10 +98,10 @@ func main() {
 			if fn, ok := targetSet[target]; ok {
 				level.Debug(logger).Log("msg", "calling target", "target", target)
 				if err := fn(ctx); err != nil {
-					logutil.Fatal(logger, "msg", "Target Failed", "err", err, "target", target)
+					logutil.Fatal(logger, "msg", "Target Failed", "err", err, "target", target) //nolint:forbidigo // Fine to use logutil.Fatal outside of launcher proper
 				}
 			} else {
-				logutil.Fatal(logger, "err", "target does not exist", "target", target)
+				logutil.Fatal(logger, "err", "target does not exist", "target", target) //nolint:forbidigo // Fine to use logutil.Fatal outside of launcher proper
 			}
 		}
 	}

--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -318,7 +318,7 @@ func usage() {
 func main() {
 	if len(os.Args) < 2 {
 		usage()
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher
 	}
 
 	var run func([]string) error
@@ -331,12 +331,12 @@ func main() {
 		run = runListTargets
 	default:
 		usage()
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher
 	}
 
 	if err := run(os.Args[2:]); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher
 	}
 }
 

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -33,14 +33,14 @@ func TestMain(m *testing.M) {
 	downloadDir, err := os.MkdirTemp("", "osquery-runsimple")
 	if err != nil {
 		fmt.Printf("failed to make temp dir for test osquery binary: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
 	defer os.RemoveAll(downloadDir)
 
 	target := packaging.Target{}
 	if err := target.PlatformFromString(runtime.GOOS); err != nil {
 		fmt.Printf("error parsing platform %s: %v", runtime.GOOS, err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	dlPath, err := packaging.FetchBinary(ctx, downloadDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "nightly", target)
 	if err != nil {
 		fmt.Printf("error fetching binary osqueryd binary: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
 
 	testOsqueryBinary = filepath.Join(downloadDir, filepath.Base(dlPath))
@@ -59,12 +59,12 @@ func TestMain(m *testing.M) {
 
 	if err := fsutil.CopyFile(dlPath, testOsqueryBinary); err != nil {
 		fmt.Printf("error copying osqueryd binary: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
 
 	// Run the tests
 	retCode := m.Run()
-	os.Exit(retCode)
+	os.Exit(retCode) //nolint:forbidigo // Fine to use os.Exit inside tests
 }
 
 func TestDetectAndRemediateHardwareChange(t *testing.T) {

--- a/ee/agent/storage/ci/keyvalue_store_ci.go
+++ b/ee/agent/storage/ci/keyvalue_store_ci.go
@@ -37,7 +37,7 @@ func SetupDB(t *testing.T) *bbolt.DB {
 		dbDir, err = os.MkdirTemp(os.TempDir(), "storage-bbolt")
 		if err != nil {
 			fmt.Println("Failed to create temp dir for bbolt test")
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 		}
 	}
 
@@ -52,7 +52,7 @@ func SetupDB(t *testing.T) *bbolt.DB {
 	} else {
 		if err != nil {
 			fmt.Println("Falied to create bolt db")
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 		}
 	}
 

--- a/ee/dataflatten/examples/flatten/main.go
+++ b/ee/dataflatten/examples/flatten/main.go
@@ -15,7 +15,7 @@ import (
 func checkError(err error) {
 	if err != nil {
 		fmt.Printf("Got Error: %v\nStack:\n%+v\n", err, err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 }
 

--- a/ee/tuf/util_test.go
+++ b/ee/tuf/util_test.go
@@ -175,11 +175,11 @@ func TestHelperProcess(t *testing.T) {
 	case "sleep":
 		time.Sleep(10 * time.Second)
 	case "exit0":
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // Fine to use os.Exit inside tests
 	case "exit1":
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	case "exit2":
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
 
 	// default behavior nothing

--- a/ee/ui/assets/generator/generator.go
+++ b/ee/ui/assets/generator/generator.go
@@ -44,7 +44,7 @@ func main() {
 	)
 	if err := flagset.Parse(os.Args[1:]); err != nil {
 		level.Error(logger).Log("msg", "error parsing flags", "err", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 	// relevel with the debug flag
@@ -61,7 +61,7 @@ func main() {
 		}
 	}
 	if missingOpt {
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 	inDir = *flIndir
@@ -72,7 +72,7 @@ func main() {
 	files, err := filepath.Glob(inDir + "/*.png")
 	if err != nil {
 		level.Error(logger).Log("msg", "error globbing input files", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 	for _, file := range files {
 		file = filepath.Base(file)
@@ -82,7 +82,7 @@ func main() {
 
 	if dir, err := os.MkdirTemp("", "icon-generator"); err != nil {
 		level.Error(logger).Log("msg", "error making tmpdir", "err", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	} else {
 		tmpDir = dir
 	}
@@ -95,7 +95,7 @@ func main() {
 				"msg", "error generating ico",
 				"name", name,
 				"err", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 		}
 
 		if err := generatePng(ctx, logger, name); err != nil {
@@ -103,13 +103,13 @@ func main() {
 				"msg", "error generating png",
 				"name", name,
 				"err", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 		}
 	}
 
 	if err := generateAssetGo(ctx, logger); err != nil {
 		level.Error(logger).Log("msg", "error expanding template", "error", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 }

--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -45,7 +45,7 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 		)
 	}
 
-	os.Exit(0)
+	os.Exit(0) //nolint:forbidigo // Since we're disabling launcher, it is probably fine to call os.Exit here and skip a graceful shutdown
 }
 
 func removeEnrollSecretFile(knapsack types.Knapsack) error {

--- a/pkg/autoupdate/findnew_test.go
+++ b/pkg/autoupdate/findnew_test.go
@@ -460,11 +460,11 @@ func TestHelperProcess(t *testing.T) {
 	case "sleep":
 		time.Sleep(10 * time.Second)
 	case "exit0":
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // Fine to use os.Exit in tests
 	case "exit1":
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	case "exit2":
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	// default behavior nothing

--- a/pkg/execwrapper/exec_windows.go
+++ b/pkg/execwrapper/exec_windows.go
@@ -5,7 +5,6 @@ package execwrapper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,7 +48,5 @@ func Exec(ctx context.Context, argv0 string, argv []string, envv []string) error
 			"err", err,
 		)
 	}
-	os.Exit(cmd.ProcessState.ExitCode())
-	return errors.New("Exec shouldn't have gotten here.")
-
+	return fmt.Errorf("exec completed with exit code %d", cmd.ProcessState.ExitCode())
 }

--- a/pkg/launcher/errors.go
+++ b/pkg/launcher/errors.go
@@ -1,0 +1,34 @@
+package launcher
+
+import (
+	"errors"
+	"fmt"
+)
+
+// InfoCmd is a launcher parsing error indicating that launcher was called with an informational command
+// as a flag (for example, --version or --dev_help), and that launcher execution should not proceed.
+// This allows us to print the information and exit gracefully.
+type InfoCmd struct {
+	msg string
+}
+
+func NewInfoCmdError(cmd string) InfoCmd {
+	return InfoCmd{
+		msg: fmt.Sprintf("launcher called with info cmd %s", cmd),
+	}
+}
+
+func (e InfoCmd) Error() string {
+	return e.msg
+}
+
+func (e InfoCmd) Is(target error) bool {
+	if _, ok := target.(InfoCmd); ok {
+		return true
+	}
+	return false
+}
+
+func IsInfoCmd(err error) bool {
+	return errors.Is(err, InfoCmd{})
+}

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -289,13 +289,13 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 	// handle --version
 	if *flVersion {
 		version.PrintFull()
-		os.Exit(0)
+		return nil, nil
 	}
 
 	// handle --usage
 	if *flDeveloperUsage {
 		developerUsage(flagset)
-		os.Exit(0)
+		return nil, nil
 	}
 
 	// if an osqueryd path was not set, it's likely that we want to use the bundled

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -289,13 +289,13 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 	// handle --version
 	if *flVersion {
 		version.PrintFull()
-		return nil, nil
+		return nil, NewInfoCmdError("--version")
 	}
 
-	// handle --usage
+	// handle --dev_help
 	if *flDeveloperUsage {
 		developerUsage(flagset)
-		return nil, nil
+		return nil, NewInfoCmdError("--dev_help")
 	}
 
 	// if an osqueryd path was not set, it's likely that we want to use the bundled

--- a/pkg/log/eventlog/writer_windows.go
+++ b/pkg/log/eventlog/writer_windows.go
@@ -49,6 +49,10 @@ type Writer struct {
 }
 
 func (w *Writer) Close() error {
+	// TODO RM why does only CI hit this issue
+	if w == nil {
+		return nil
+	}
 	return windows.DeregisterEventSource(w.handle)
 }
 

--- a/pkg/log/eventlog/writer_windows.go
+++ b/pkg/log/eventlog/writer_windows.go
@@ -49,10 +49,6 @@ type Writer struct {
 }
 
 func (w *Writer) Close() error {
-	// TODO RM why does only CI hit this issue
-	if w == nil {
-		return nil
-	}
 	return windows.DeregisterEventSource(w.handle)
 }
 

--- a/pkg/log/multislogger/syslogger_windows.go
+++ b/pkg/log/multislogger/syslogger_windows.go
@@ -18,7 +18,7 @@ func SystemSlogger() (*MultiSlogger, io.Closer, error) {
 	if !windows.GetCurrentProcessToken().IsElevated() {
 		syslogger := defaultSystemSlogger()
 
-		syslogger.Log(context.TODO(), slog.LevelDebug,
+		syslogger.Log(context.TODO(), slog.LevelInfo,
 			"launcher running on windows without elevated permissions, using default stderr instead of eventlog",
 		)
 
@@ -26,7 +26,7 @@ func SystemSlogger() (*MultiSlogger, io.Closer, error) {
 	}
 
 	eventLogWriter, err := eventlog.NewWriter(serviceName)
-	if err != nil {
+	if err != nil || eventLogWriter == nil {
 		syslogger := defaultSystemSlogger()
 
 		syslogger.Log(context.TODO(), slog.LevelError,

--- a/pkg/make/builder_test.go
+++ b/pkg/make/builder_test.go
@@ -221,10 +221,10 @@ func TestHelperProcess(t *testing.T) { //nolint:paralleltest
 	}
 
 	if os.Getenv("GO_WANT_HELPER_PROCESS_FORCE_ERROR") == "1" {
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
-	defer os.Exit(0)
+	defer os.Exit(0) //nolint:forbidigo // Fine to use os.Exit in tests
 
 	args := os.Args
 	for len(args) > 0 {
@@ -236,7 +236,7 @@ func TestHelperProcess(t *testing.T) { //nolint:paralleltest
 	}
 	if len(args) == 0 {
 		fmt.Fprintf(os.Stderr, "No command\n")
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	cmd, args := args[0], args[1:]
@@ -249,7 +249,7 @@ func TestHelperProcess(t *testing.T) { //nolint:paralleltest
 		fmt.Println(iargs...)
 	case cmd == "exit":
 		n, _ := strconv.Atoi(args[0])
-		os.Exit(n)
+		os.Exit(n) //nolint:forbidigo // Fine to use os.Exit in tests
 	case cmd == "go" && args[0] == "mod" && args[1] == "download":
 		return
 	case cmd == "git" && args[0] == "describe":
@@ -257,6 +257,6 @@ func TestHelperProcess(t *testing.T) { //nolint:paralleltest
 		return
 	default:
 		fmt.Fprintf(os.Stderr, "Can't mock, unknown command(%q) args(%q) -- Fix TestHelperProcess", cmd, args)
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 }

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -175,6 +175,9 @@ func (e *Extension) Execute() error {
 		// select to either exit or write another batch of logs
 		select {
 		case <-e.done:
+			e.slogger.Log(context.TODO(), slog.LevelInfo,
+				"osquery extension received shutdown request",
+			)
 			return nil
 		case <-ticker.Chan():
 			// Resume loop

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -27,23 +27,23 @@ func TestMain(m *testing.M) {
 	target := packaging.Target{}
 	if err := target.PlatformFromString(runtime.GOOS); err != nil {
 		fmt.Printf("error parsing platform: %s, %s", err, runtime.GOOS)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	if err := os.MkdirAll(osquerydCacheDir, fsutil.DirMode); err != nil {
 		fmt.Printf("error creating cache dir: %s", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	_, err := packaging.FetchBinary(context.TODO(), osquerydCacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "stable", target)
 	if err != nil {
 		fmt.Printf("error fetching binary osqueryd binary: %s", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	// Run the tests!
 	retCode := m.Run()
-	os.Exit(retCode)
+	os.Exit(retCode) //nolint:forbidigo // Fine to use os.Exit in tests
 }
 
 // TestProc tests the start process function, it's named weird because path of the temp dir has to be short enough

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -24,13 +24,13 @@ func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "osquery-runsimple")
 	if err != nil {
 		fmt.Println("Failed to make temp dir for test binaries")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 	defer os.RemoveAll(dir)
 
 	if err := downloadOsqueryInBinDir(dir); err != nil {
 		fmt.Printf("Failed to download osquery: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	testOsqueryBinary = filepath.Join(dir, "osqueryd")
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 
 	// Run the tests!
 	retCode := m.Run()
-	os.Exit(retCode)
+	os.Exit(retCode) //nolint:forbidigo // Fine to use os.Exit in tests
 }
 
 func Test_OsqueryRunSqlNoIO(t *testing.T) {

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -42,18 +42,18 @@ func TestMain(m *testing.M) {
 	binDirectory, rmBinDirectory, err := osqueryTempDir()
 	if err != nil {
 		fmt.Println("Failed to make temp dir for test binaries")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 	defer rmBinDirectory()
 
 	s, err := storageci.NewStore(nil, multislogger.NewNopLogger(), storage.OsqueryHistoryInstanceStore.String())
 	if err != nil {
 		fmt.Println("Failed to make new store")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 	if err := history.InitHistory(s); err != nil {
 		fmt.Println("Failed to init history")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	testOsqueryBinaryDirectory = filepath.Join(binDirectory, "osqueryd")
@@ -62,12 +62,12 @@ func TestMain(m *testing.M) {
 
 	if err := downloadOsqueryInBinDir(binDirectory); err != nil {
 		fmt.Printf("Failed to download osquery: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	// Run the tests!
 	retCode := m.Run()
-	os.Exit(retCode)
+	os.Exit(retCode) //nolint:forbidigo // Fine to use os.Exit in tests
 }
 
 // getBinDir finds the directory of the currently running binary (where we will

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -96,10 +96,10 @@ func TestHelperProcess(t *testing.T) {
 	}
 
 	if os.Getenv("GO_WANT_HELPER_PROCESS_FORCE_ERROR") == "1" {
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
-	defer os.Exit(0)
+	defer os.Exit(0) //nolint:forbidigo // Fine to use os.Exit in tests
 
 	args := os.Args
 	for len(args) > 0 {
@@ -111,7 +111,7 @@ func TestHelperProcess(t *testing.T) {
 	}
 	if len(args) == 0 {
 		fmt.Fprintf(os.Stderr, "No command\n")
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 	cmd, args := args[0], args[1:]
@@ -124,7 +124,7 @@ func TestHelperProcess(t *testing.T) {
 		fmt.Println(iargs...)
 	case cmd == "exit":
 		n, _ := strconv.Atoi(args[0])
-		os.Exit(n)
+		os.Exit(n) //nolint:forbidigo // Fine to use os.Exit in tests
 	case strings.HasSuffix(cmd, "launcher") && args[0] == "-version":
 		fmt.Println(`launcher - version 0.5.6-19-g17c8589
   branch: 	master
@@ -134,7 +134,7 @@ func TestHelperProcess(t *testing.T) {
   go version: 	go1.11`)
 	default:
 		fmt.Fprintf(os.Stderr, "Can't mock, unknown command(%q) args(%q) -- Fix TestHelperProcess", cmd, args)
-		os.Exit(2)
+		os.Exit(2) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
 
 }

--- a/tools/download-osquery.go
+++ b/tools/download-osquery.go
@@ -22,13 +22,13 @@ func main() {
 
 	if *flPlatform == "" {
 		fmt.Println("The --platform option must be defined")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 	target := packaging.Target{}
 	if err := target.PlatformFromString(*flPlatform); err != nil {
 		fmt.Printf("Error parsing platform: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 	// If we have a cacheDir, use it. Otherwise. set something random.
@@ -38,7 +38,7 @@ func main() {
 		cacheDir, err = os.MkdirTemp("", "download_cache")
 		if err != nil {
 			fmt.Printf("Could not create temp dir for caching files %v", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 		}
 		defer os.RemoveAll(cacheDir)
 	}
@@ -48,14 +48,14 @@ func main() {
 	path, err := packaging.FetchBinary(ctx, cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), *flVersion, target)
 	if err != nil {
 		fmt.Println("An error occurred fetching the osqueryd binary: ", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 	}
 
 	if *flOutput != "" {
 		platformOutput := target.PlatformBinaryName(*flOutput)
 		if err := fsutil.CopyFile(path, platformOutput); err != nil {
 			fmt.Printf("Couldn't copy file to %s: %s", platformOutput, err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo // Fine to use os.Exit outside of launcher proper
 		}
 		fmt.Println(*flOutput)
 	} else {


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/pull/1692

When we call os.Exit, deferred functions will not execute, which means e.g. the event log writer on windows won't get closed. For a more graceful shutdown, we wrap main as `runMain` and disallow `os.Exit` calls outside of the new `main`.