### PR TITLE
Fix potential nil panics in ee/desktop/runner detected by nilaway

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -588,6 +588,11 @@ func (r *DesktopUsersProcessesRunner) spawnForUser(ctx context.Context, uid stri
 		traces.SetError(span, fmt.Errorf("running desktop command as user: %w", err))
 		return fmt.Errorf("running desktop command as user: %w", err)
 	}
+	// Extra nil check to ensure we can access cmd.Process.Pid safely later
+	if cmd.Process == nil {
+		traces.SetError(span, fmt.Errorf("starting desktop command: %w", err))
+		return fmt.Errorf("starting desktop command: %w", err)
+	}
 
 	span.AddEvent("command_started")
 

--- a/ee/desktop/runner/runner_darwin.go
+++ b/ee/desktop/runner/runner_darwin.go
@@ -25,7 +25,7 @@ func (r *DesktopUsersProcessesRunner) runAsUser(ctx context.Context, uid string,
 	}
 
 	runningUser, err := user.LookupId(uid)
-	if err != nil {
+	if err != nil || runningUser == nil {
 		return fmt.Errorf("looking up user with uid %s: %w", uid, err)
 	}
 

--- a/ee/desktop/runner/runner_linux.go
+++ b/ee/desktop/runner/runner_linux.go
@@ -42,7 +42,7 @@ func (r *DesktopUsersProcessesRunner) runAsUser(ctx context.Context, uid string,
 	}
 
 	runningUser, err := user.LookupId(uid)
-	if err != nil {
+	if err != nil || runningUser == nil {
 		return fmt.Errorf("looking up user with uid %s: %w", uid, err)
 	}
 

--- a/ee/desktop/runner/runner_windows.go
+++ b/ee/desktop/runner/runner_windows.go
@@ -19,7 +19,7 @@ func (r *DesktopUsersProcessesRunner) runAsUser(ctx context.Context, uid string,
 	defer span.End()
 
 	explorerProc, err := consoleuser.ExplorerProcess(ctx, uid)
-	if err != nil {
+	if err != nil || explorerProc == nil {
 		return fmt.Errorf("getting user explorer process: %w", err)
 	}
 


### PR DESCRIPTION
Per suggestion from @directionless, used [nilaway](https://github.com/uber-go/nilaway) to detect potential nil panics in the desktop runner.