### PR TITLE
Custom URL scheme for macOS

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/customprotocol"
 	runnerserver "github.com/kolide/launcher/ee/desktop/runner/server"
 	"github.com/kolide/launcher/ee/desktop/user/menu"
 	"github.com/kolide/launcher/ee/desktop/user/notify"
@@ -151,6 +152,9 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 			)
 		}
 	})
+
+	customProtocolHandler := customprotocol.NewCustomProtocolHandler(slogger)
+	runGroup.Add("customProtocolHandler", customProtocolHandler.Execute, customProtocolHandler.Interrupt)
 
 	// listen on shutdown channel
 	runGroup.Add("desktopServerShutdownListener", func() error {

--- a/ee/customprotocol/custom_protocol_handler.go
+++ b/ee/customprotocol/custom_protocol_handler.go
@@ -1,0 +1,66 @@
+package customprotocol
+
+/*
+#cgo darwin CFLAGS: -DDARWIN -x objective-c
+#cgo darwin LDFLAGS: -framework Foundation -framework AppKit
+#include "handler.h"
+*/
+import "C"
+import (
+	"context"
+	"log/slog"
+)
+
+var urlInput chan string
+
+type customProtocolHandler struct {
+	slogger     *slog.Logger
+	interrupted bool
+	interrupt   chan struct{}
+}
+
+func NewCustomProtocolHandler(slogger *slog.Logger) *customProtocolHandler {
+	return &customProtocolHandler{
+		slogger:   slogger.With("component", "custom_protocol_handler"),
+		interrupt: make(chan struct{}),
+	}
+}
+
+func (c *customProtocolHandler) Execute() error {
+	urlInput = make(chan string, 1) // the event handler blocks!, so buffer the channel at least once to get the first message
+	go C.StartURLHandler()
+
+	for {
+		select {
+		case i := <-urlInput:
+			c.slogger.Log(context.TODO(), slog.LevelInfo,
+				"got input from URL handler!",
+				"input", i,
+			)
+		case <-c.interrupt:
+			c.slogger.Log(context.TODO(), slog.LevelDebug,
+				"received external interrupt, stopping",
+			)
+			return nil
+		}
+	}
+}
+
+func (c *customProtocolHandler) Interrupt(_ error) {
+	c.slogger.Log(context.TODO(), slog.LevelInfo,
+		"received interrupt",
+	)
+
+	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
+	if c.interrupted {
+		return
+	}
+	c.interrupted = true
+
+	c.interrupt <- struct{}{}
+}
+
+//export HandleURL
+func HandleURL(u *C.char) {
+	urlInput <- C.GoString(u)
+}

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -23,6 +23,8 @@ type customProtocolHandler struct {
 }
 
 func NewCustomProtocolHandler(slogger *slog.Logger) *customProtocolHandler {
+	urlInput = make(chan string, 1)
+
 	return &customProtocolHandler{
 		slogger:   slogger.With("component", "custom_protocol_handler"),
 		interrupt: make(chan struct{}),
@@ -30,7 +32,6 @@ func NewCustomProtocolHandler(slogger *slog.Logger) *customProtocolHandler {
 }
 
 func (c *customProtocolHandler) Execute() error {
-	urlInput = make(chan string, 1)
 	C.StartURLHandler()
 
 	for {

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -37,8 +37,8 @@ func (c *customProtocolHandler) Execute() error {
 		select {
 		case i := <-urlInput:
 			c.slogger.Log(context.TODO(), slog.LevelInfo,
-				"got input from URL handler!",
-				"input", i,
+				"received custom protocol request",
+				"request", i,
 			)
 		case <-c.interrupt:
 			c.slogger.Log(context.TODO(), slog.LevelDebug,

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -30,7 +30,7 @@ func NewCustomProtocolHandler(slogger *slog.Logger) *customProtocolHandler {
 }
 
 func (c *customProtocolHandler) Execute() error {
-	urlInput = make(chan string, 1) // the event handler blocks!, so buffer the channel at least once to get the first message
+	urlInput = make(chan string, 1)
 	go C.StartURLHandler()
 
 	for {

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -31,7 +31,7 @@ func NewCustomProtocolHandler(slogger *slog.Logger) *customProtocolHandler {
 
 func (c *customProtocolHandler) Execute() error {
 	urlInput = make(chan string, 1)
-	go C.StartURLHandler()
+	C.StartURLHandler()
 
 	for {
 		select {

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -16,7 +16,7 @@ import (
 
 var urlInput chan string
 
-// customProtocolHandler receives requests from the browser that cannot be sent
+// customProtocolHandler receives requests `kolide://` from the browser that cannot be sent
 // directly to localserver; it processes and forwards them. Currently, this exists
 // only to ensure Safari support for device trust. Custom protocol handling requires
 // a running process for the given user, so this actor must run in launcher desktop.

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -63,7 +63,7 @@ func (c *customProtocolHandler) Interrupt(_ error) {
 	c.interrupt <- struct{}{}
 }
 
-//export HandleURL
-func HandleURL(u *C.char) {
+//export handleURL
+func handleURL(u *C.char) {
 	urlInput <- C.GoString(u)
 }

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -18,7 +18,8 @@ var urlInput chan string
 
 // customProtocolHandler receives requests from the browser that cannot be sent
 // directly to localserver; it processes and forwards them. Currently, this exists
-// only to ensure Safari support for device trust.
+// only to ensure Safari support for device trust. Custom protocol handling requires
+// a running process for the given user, so this actor must run in launcher desktop.
 type customProtocolHandler struct {
 	slogger     *slog.Logger
 	interrupted bool

--- a/ee/customprotocol/custom_protocol_handler_darwin.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin.go
@@ -1,3 +1,6 @@
+//go:build darwin
+// +build darwin
+
 package customprotocol
 
 /*

--- a/ee/customprotocol/custom_protocol_handler_other.go
+++ b/ee/customprotocol/custom_protocol_handler_other.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 )
 
+// Currently, we only require custom protocol handling on macOS (in order to
+// appropriately support Safari) -- so on other OSes, custom protocol handling
+// is a no-op.
 type noopCustomProtocolHandler struct {
 	interrupted bool
 	interrupt   chan struct{}

--- a/ee/customprotocol/custom_protocol_handler_other.go
+++ b/ee/customprotocol/custom_protocol_handler_other.go
@@ -24,5 +24,11 @@ func (n *noopCustomProtocolHandler) Execute() error {
 }
 
 func (n *noopCustomProtocolHandler) Interrupt(_ error) {
+	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
+	if n.interrupted {
+		return
+	}
+	n.interrupted = true
+
 	n.interrupt <- struct{}{}
 }

--- a/ee/customprotocol/custom_protocol_handler_other.go
+++ b/ee/customprotocol/custom_protocol_handler_other.go
@@ -1,0 +1,28 @@
+//go:build !darwin
+// +build !darwin
+
+package customprotocol
+
+import (
+	"log/slog"
+)
+
+type noopCustomProtocolHandler struct {
+	interrupted bool
+	interrupt   chan struct{}
+}
+
+func NewCustomProtocolHandler(_ *slog.Logger) *noopCustomProtocolHandler {
+	return &noopCustomProtocolHandler{
+		interrupt: make(chan struct{}),
+	}
+}
+
+func (n *noopCustomProtocolHandler) Execute() error {
+	<-n.interrupt
+	return nil
+}
+
+func (n *noopCustomProtocolHandler) Interrupt(_ error) {
+	n.interrupt <- struct{}{}
+}

--- a/ee/customprotocol/custom_protocol_handler_test.go
+++ b/ee/customprotocol/custom_protocol_handler_test.go
@@ -1,0 +1,49 @@
+package customprotocol
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterrupt_Multiple(t *testing.T) {
+	t.Parallel()
+
+	handler := NewCustomProtocolHandler(multislogger.NewNopLogger())
+
+	// Let the handler run for a bit
+	go handler.Execute()
+	time.Sleep(3 * time.Second)
+	handler.Interrupt(errors.New("test error"))
+
+	// Confirm we can call Interrupt multiple times without blocking
+	interruptComplete := make(chan struct{})
+	expectedInterrupts := 3
+	for i := 0; i < expectedInterrupts; i += 1 {
+		go func() {
+			handler.Interrupt(nil)
+			interruptComplete <- struct{}{}
+		}()
+	}
+
+	receivedInterrupts := 0
+	for {
+		if receivedInterrupts >= expectedInterrupts {
+			break
+		}
+
+		select {
+		case <-interruptComplete:
+			receivedInterrupts += 1
+			continue
+		case <-time.After(5 * time.Second):
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.FailNow()
+		}
+	}
+
+	require.Equal(t, expectedInterrupts, receivedInterrupts)
+}

--- a/ee/customprotocol/handler.h
+++ b/ee/customprotocol/handler.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+// Go callback
+extern void HandleURL(char*);
+
+@interface CustomProtocolConnector : NSObject
++ (void)handleGetURLEvent:(NSAppleEventDescriptor *)event;
+@end
+
+void StartURLHandler(void);

--- a/ee/customprotocol/handler.h
+++ b/ee/customprotocol/handler.h
@@ -2,7 +2,7 @@
 #import <AppKit/AppKit.h>
 
 // Go callback
-extern void HandleURL(char*);
+extern void handleURL(char*);
 
 @interface CustomProtocolConnector : NSObject
 + (void)handleGetURLEvent:(NSAppleEventDescriptor *)event;

--- a/ee/customprotocol/handler.m
+++ b/ee/customprotocol/handler.m
@@ -1,4 +1,7 @@
 
+//go:build darwin
+// +build darwin
+
 #include "handler.h"
 
 @implementation CustomProtocolConnector

--- a/ee/customprotocol/handler.m
+++ b/ee/customprotocol/handler.m
@@ -1,0 +1,16 @@
+
+#include "handler.h"
+
+@implementation CustomProtocolConnector
++ (void)handleGetURLEvent:(NSAppleEventDescriptor *)event
+{
+    HandleURL((char*)[[[event paramDescriptorForKeyword:keyDirectObject] stringValue] UTF8String]);
+}
+@end
+
+void StartURLHandler(void) {
+	  NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
+    [appleEventManager setEventHandler:[CustomProtocolConnector class]
+        andSelector:@selector(handleGetURLEvent:)
+        forEventClass:kInternetEventClass andEventID:kAEGetURL];
+}

--- a/ee/customprotocol/handler.m
+++ b/ee/customprotocol/handler.m
@@ -7,7 +7,7 @@
 @implementation CustomProtocolConnector
 + (void)handleGetURLEvent:(NSAppleEventDescriptor *)event
 {
-    HandleURL((char*)[[[event paramDescriptorForKeyword:keyDirectObject] stringValue] UTF8String]);
+    handleURL((char*)[[[event paramDescriptorForKeyword:keyDirectObject] stringValue] UTF8String]);
 }
 @end
 

--- a/ee/customprotocol/handler.m
+++ b/ee/customprotocol/handler.m
@@ -9,7 +9,7 @@
 @end
 
 void StartURLHandler(void) {
-	  NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
+    NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
     [appleEventManager setEventHandler:[CustomProtocolConnector class]
         andSelector:@selector(handleGetURLEvent:)
         forEventClass:kInternetEventClass andEventID:kAEGetURL];

--- a/tools/packaging/LauncherTemplate_Info.plist
+++ b/tools/packaging/LauncherTemplate_Info.plist
@@ -15,7 +15,7 @@
 				<string>com.kolide.agent</string>
 				<key>CFBundleURLSchemes</key>
 				<array>
-					<string>kolideagent</string>
+					<string>kolide</string>
 				</array>
 			</dict>
 		</array>

--- a/tools/packaging/LauncherTemplate_Info.plist
+++ b/tools/packaging/LauncherTemplate_Info.plist
@@ -6,6 +6,19 @@
 	<string>launcher</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.kolide.agent</string>
+	<key>CFBundleURLTypes</key>
+		<array>
+			<dict>
+				<key>CFBundleTypeRole</key>
+				<string>Viewer</string>
+				<key>CFBundleURLName</key>
+				<string>com.kolide.agent</string>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>kolideagent</string>
+				</array>
+			</dict>
+		</array>
 	<key>CFBundleName</key>
 	<string>Kolide</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Questions for code review:

* Do you like ~kolideagent~ `kolide` as the protocol name? Do you have another idea?

Notes:

* This does _not_ work if the actor runs in launcher root instead of launcher desktop.
* This required `/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -kill -seed` to force macOS to recognizing the custom binding. I think this was something weird with my test setup -- when others tested, they didn't need this command for the scheme to work. But it's possible that this is something we'll need to account for during launcher startup.

Excerpt from example log:

```
\"msg\":\"received custom protocol request\"
\"request_url\":\"kolide://wow\"
```

<details>
<summary>Screenshot of permission popup</summary>

<img width="466" alt="Screenshot 2024-05-03 at 3 43 36 PM" src="https://github.com/kolide/launcher/assets/8119675/854d6bc2-d2ec-47df-80b9-c9557feac1dc">

</details>

<details>

<summary>Useful links</summary>

* https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app
* https://stackoverflow.com/questions/77443348/javascript-invoke-custom-protocol

</details>