### PR TITLE
Add brew no auto update to brew execs

### DIFF
--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -21,7 +21,14 @@ func Bputil(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 }
 
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "HOMEBREW_NO_AUTO_UPDATE=1 /opt/homebrew/bin/brew", arg...)
+	cmd, err := validatedCommand(ctx, "/opt/homebrew/bin/brew", arg...)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Env = append(cmd.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1")
+
+	return cmd, nil
 }
 
 func Diskutil(ctx context.Context, arg ...string) (*exec.Cmd, error) {

--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -21,7 +21,7 @@ func Bputil(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 }
 
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "/opt/homebrew/bin/brew", arg...)
+	return validatedCommand(ctx, "HOMEBREW_NO_AUTO_UPDATE=1 /opt/homebrew/bin/brew", arg...)
 }
 
 func Diskutil(ctx context.Context, arg ...string) (*exec.Cmd, error) {

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -14,7 +14,7 @@ func Apt(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 }
 
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "/home/linuxbrew/.linuxbrew/bin/brew", arg...)
+	return validatedCommand(ctx, "HOMEBREW_NO_AUTO_UPDATE=1 /home/linuxbrew/.linuxbrew/bin/brew", arg...)
 }
 
 func Cryptsetup(ctx context.Context, arg ...string) (*exec.Cmd, error) {

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -14,7 +14,14 @@ func Apt(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 }
 
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "HOMEBREW_NO_AUTO_UPDATE=1 /home/linuxbrew/.linuxbrew/bin/brew", arg...)
+	cmd, err := validatedCommand(ctx, "/home/linuxbrew/.linuxbrew/bin/brew", arg...)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Env = append(cmd.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1")
+
+	return cmd, nil
 }
 
 func Cryptsetup(ctx context.Context, arg ...string) (*exec.Cmd, error) {

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -45,7 +45,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	for _, uid := range uids {
 		for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 			// Brew can take a while to load the first time the command is ran, so leaving 60 seconds for the timeout here.
-			output, err := tablehelpers.Exec(ctx, t.slogger, 60, allowedcmd.Brew, []string{"outdated", "--json"}, true, tablehelpers.WithUid(uid))
+			output, err := tablehelpers.Exec(ctx, t.slogger, 60, allowedcmd.Brew, []string{"outdated", "--json"}, false, tablehelpers.WithUid(uid))
 			if err != nil {
 				t.slogger.Log(ctx, slog.LevelInfo, "failure querying user brew installed packages", "err", err, "target_uid", uid)
 				continue

--- a/ee/tables/tablehelpers/run_as_user_posix.go
+++ b/ee/tables/tablehelpers/run_as_user_posix.go
@@ -49,7 +49,7 @@ func WithUid(uid string) ExecOps {
 		}
 
 		// Set PWD and HOME to the running user's home directory for supporting executes that use them as the prefix to create temp files.
-		cmd.Env = append(cmd.Environ(), "PWD=" + runningUser.HomeDir, "HOME=" + runningUser.HomeDir)
+		cmd.Env = append(cmd.Environ(), "PWD="+runningUser.HomeDir, "HOME="+runningUser.HomeDir)
 
 		return nil
 	}

--- a/ee/tables/tablehelpers/run_as_user_posix.go
+++ b/ee/tables/tablehelpers/run_as_user_posix.go
@@ -48,6 +48,9 @@ func WithUid(uid string) ExecOps {
 			},
 		}
 
+		// Set PWD and HOME to the running user's home directory for supporting executes that use them as the prefix to create temp files.
+		cmd.Env = append(cmd.Environ(), "PWD=" + runningUser.HomeDir, "HOME=" + runningUser.HomeDir)
+
 		return nil
 	}
 }


### PR DESCRIPTION
Multiple homebrew commands will invoke `brew update` before running the command that's called. This can cause unpredictable data being returned. Adding `HOMEBREW_NO_AUTO_UPDATE=1` to the exec will ensure this doesn't happen.