### PR TITLE
package-builder: add `--bin_root_dir` flag

### DIFF
--- a/cmd/package-builder/package-builder.go
+++ b/cmd/package-builder/package-builder.go
@@ -64,6 +64,11 @@ func runMake(args []string) error {
 			env.String("PACKAGE_VERSION", ""),
 			"the resultant package version. If left blank, auto detection will be attempted",
 		)
+		flBinRootDir = flagset.String(
+			"bin_root_dir",
+			"/usr/local",
+			"the root directory path for the launcher on macOS and Linux",
+		)
 		flOsqueryVersion = flagset.String(
 			"osquery_version",
 			env.String("OSQUERY_VERSION", "stable"),
@@ -242,6 +247,7 @@ func runMake(args []string) error {
 		OmitSecret:        *flOmitSecret,
 		CertPins:          *flCertPins,
 		RootPEM:           *flRootPEM,
+		BinRootDir:        *flBinRootDir,
 		CacheDir:          cacheDir,
 		TufServerURL:      *flTufURL,
 		MirrorURL:         *flMirrorURL,

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -49,6 +49,7 @@ type PackageOptions struct {
 	OmitSecret        bool
 	CertPins          string
 	RootPEM           string
+	BinRootDir        string
 	CacheDir          string
 	TufServerURL      string
 	MirrorURL         string
@@ -721,7 +722,7 @@ fi`
 func (p *PackageOptions) setupDirectories() error {
 	switch p.target.Platform {
 	case Linux, Darwin:
-		p.binDir = filepath.Join("/usr/local", p.Identifier, "bin")
+		p.binDir = filepath.Join(p.BinRootDir, p.Identifier, "bin")
 		p.confDir = filepath.Join("/etc", p.Identifier)
 		p.rootDir = filepath.Join("/var", p.Identifier, sanitizeHostname(p.Hostname))
 	case Windows:


### PR DESCRIPTION
This PR allows the Kolide Launcher to be deployed to Fedora SilverBlue, where /usr is read-only. To build for this platform, pass `--bin_root_dir=/opt` to `./build/package-builder`.

Without this flag, Kolide fails to install on Silverblue with:

```
sudo rpm-ostree install zxkx_thomas-stromberg-0ac07b_kolide-launcher.rpm                                                         
...
Resolving dependencies... done
Relabeling... done
Checking out packages... done
error: Checkout launcher-kolide-k2-1.6.2-1.x86_64: opendir(local): No such file or directory
```

It turns out that on Silverblue, `/usr/local` is a symlink to `../var/usrlocal/`, which makes `rpm-ostree` upset with life.
