### PR TITLE
Disable sloglint until golangci-lint bumps to version with fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - nakedret
     - paralleltest
     - revive
-    - sloglint
+    # - sloglint # TODO -- re-enable once golangci-lint bumps to sloglint v0.7.1
     - sqlclosecheck
     - staticcheck
     - unconvert


### PR DESCRIPTION
The lint pipeline is currently failing due to this issue: https://github.com/go-simpler/sloglint/issues/46. See e.g.: https://github.com/kolide/launcher/actions/runs/9270963073/job/25505241155

This issue is already fixed in sloglint v0.7.1, but golangci-lint hasn't picked up the updated version yet. This PR disables the sloglint linter; I will re-enable it once dependabot bumps the sloglint version for golangci-lint.