### PR TITLE
Register the desktop app path with launch services

### DIFF
--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -67,6 +67,10 @@ func Lsof(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/sbin/lsof", arg...)
 }
 
+func Lsregister(ctx context.Context, arg ...string) (*exec.Cmd, error) {
+	return validatedCommand(ctx, "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister", arg...)
+}
+
 func Mdfind(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/mdfind", arg...)
 }

--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -67,10 +67,6 @@ func Lsof(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/sbin/lsof", arg...)
 }
 
-func Lsregister(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister", arg...)
-}
-
 func Mdfind(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/mdfind", arg...)
 }

--- a/ee/desktop/user/universallink/handler.m
+++ b/ee/desktop/user/universallink/handler.m
@@ -1,0 +1,19 @@
+//go:build darwin
+// +build darwin
+
+#import <Foundation/Foundation.h>
+
+BOOL registerAppBundle(char *cAppBundlePath) {
+    NSString *appBundlePath = [NSString stringWithUTF8String:cAppBundlePath];
+    CFURLRef url = (CFURLRef)[NSURL fileURLWithPath:appBundlePath];
+
+    // Set inUpdate to true to ensure app gets updated
+    OSStatus status = LSRegisterURL((CFURLRef)url, YES);
+
+    if (status != noErr) {
+        NSLog(@"could not register app bundle: LSRegisterURL returned error: %jd", (intmax_t)status);
+        return NO;
+    }
+
+    return YES;
+}

--- a/ee/desktop/user/universallink/handler_darwin.go
+++ b/ee/desktop/user/universallink/handler_darwin.go
@@ -142,7 +142,7 @@ func (u *universalLinkHandler) handleUniversalLinkRequest(requestUrl string) err
 					return
 				}
 				u.slogger.Log(ctx, slog.LevelWarn,
-					"could not make universal link request",
+					"could not forward universal link request",
 					"port", p,
 					"err", err,
 				)

--- a/ee/desktop/user/universallink/handler_darwin.go
+++ b/ee/desktop/user/universallink/handler_darwin.go
@@ -99,12 +99,6 @@ func register() error {
 		return fmt.Errorf("getting current executable: %w", err)
 	}
 
-	// If we're running the originally-installed version of launcher, no need to register;
-	// Launch Services should already know about this application from the install process.
-	if strings.HasPrefix(currentExecutable, "/usr/local") {
-		return nil
-	}
-
 	// Point to `Kolide.app`
 	currentExecutable = strings.TrimSuffix(currentExecutable, "/Contents/MacOS/launcher")
 

--- a/ee/desktop/user/universallink/handler_other_test.go
+++ b/ee/desktop/user/universallink/handler_other_test.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 package universallink
 
 import (


### PR DESCRIPTION
Ordinarily, it is not required to explicitly register an application with Launch Services -- this is done automatically on system boot, on new user login, and whenever Finder becomes aware of a new application. However, because our application autoupdates itself in a unique way, I think sometimes Launch Services doesn't learn about the new update quickly enough. This PR adds a call to [LSRegisterURL](https://developer.apple.com/documentation/coreservices/1446350-lsregisterurl?language=objc) to manually perform this registration.

It is acceptable to have multiple app bundle paths registered for the same app in Launch Services. Per the documentation, Launch Services should choose the registered application with the latest version. This is pretty good for our use case, at least for now. However, this doesn't appear to work with development versions the way we expect, and wouldn't necessarily cover the use case where we want to roll back to an earlier version -- so we will probably, at some point, want to unregister older app bundles too.

Useful sections in the [Launch Services](https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/LaunchServicesConcepts/LSCConcepts/LSCConcepts.html#//apple_ref/doc/uid/TP30000999-CH202-TP9) documentation:

* `Application Registration`
* `Preferred Application for a URL` 

This relates to previous universal link support work: https://github.com/kolide/launcher/pull/1727.