### PR TITLE
make sqlite migrations allow launcher downgrades

### DIFF
--- a/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
+++ b/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
@@ -263,6 +263,7 @@ func Test_MissingMigrations(t *testing.T) {
 
 	// now re-open and re-attempt migrations, this will only work if we correctly ignore the missing
 	// migration file error
-	_, migrationError := OpenRW(context.TODO(), tempRootDir, StartupSettingsStore)
+	s, migrationError := OpenRW(context.TODO(), tempRootDir, StartupSettingsStore)
 	require.NoError(t, migrationError, "database error running missing migration")
+	require.NoError(t, s.Close(), "error closing sqliteStore conn")
 }

--- a/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
+++ b/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
@@ -234,3 +234,35 @@ func Test_Migrations(t *testing.T) {
 	require.NoError(t, srcErr, "source error closing migration")
 	require.NoError(t, dbErr, "database error closing migration")
 }
+
+func Test_MissingMigrations(t *testing.T) {
+	t.Parallel()
+
+	tempRootDir := t.TempDir()
+
+	conn, err := validatedDbConn(context.TODO(), tempRootDir)
+	require.NoError(t, err, "setting up db connection")
+	require.NoError(t, conn.Close(), "closing test db")
+
+	d, err := iofs.New(migrations, "migrations")
+	require.NoError(t, err, "loading migration files")
+
+	m, err := migrate.NewWithSourceInstance("iofs", d, fmt.Sprintf("sqlite://%s?query", dbLocation(tempRootDir)))
+	require.NoError(t, err, "creating migrate instance")
+	require.NoError(t, m.Up(), "expected no error running all migrations")
+	currentVersion, dirty, err := m.Version()
+	require.NoError(t, err, "error looking for current version")
+	require.False(t, dirty, "did not expect dirty migration state")
+	missingMigrationVersion := int(currentVersion) + 1
+	forceVersionErr := m.Force(missingMigrationVersion)
+	require.NoError(t, forceVersionErr, "error forcing version")
+
+	srcErr, dbErr := m.Close()
+	require.NoError(t, srcErr, "source error closing migration")
+	require.NoError(t, dbErr, "database error closing migration")
+
+	// now re-open and re-attempt migrations, this will only work if we correctly ignore the missing
+	// migration file error
+	_, migrationError := OpenRW(context.TODO(), tempRootDir, StartupSettingsStore)
+	require.NoError(t, migrationError, "database error running missing migration")
+}

--- a/ee/agent/storage/sqlite/migrations.md
+++ b/ee/agent/storage/sqlite/migrations.md
@@ -15,3 +15,6 @@ Add your SQL to these files. Adhere to best practices, including:
 1. All migrations should be able to run multiple times without error (e.g. use `CREATE TABLE IF NOT EXISTS` instead of `CREATE TABLE`)
 
 The database will automatically apply new migrations on startup.
+
+Note that because we currently package our migration files with launcher, it is possible for us to run a migration and then downgrade to a version of launcher which cannot find the corresponding migration file.
+To avoid this issue, we ignore missing migration file errors when migrating up on startup. This is enough for now, because all migrations can be run multiple times without error (see best practices note above). If these migrations become more complex, (e.g. table altercations that will break prior launcher versions, instead of completely new tables), we will need to explore another path forward here (likely hosting migrations with rollbacks outside of launcher, so that older versions can rollback newer migrations).


### PR DESCRIPTION
Quick fix so that future schema migrations included in launcher releases can still work with launcher downgrades (at least to our next release version which includes these changes). I wanted to get something in as quickly as possible to support the incoming sqlite changes for the watchdog effort. 
There are some additional notes added to ee/agent/storage/sqlite/migrations.md for reference