### PR TITLE
do not pre-create data files in wix for uninstall cleanup

### DIFF
--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -263,19 +263,6 @@ func (wo *wixTool) setupDataDir(ctx context.Context) error {
 		return fmt.Errorf("create base data dir error for wix harvest: %w", err)
 	}
 
-	// touch these known file names before harvest to ensure they're cleaned up on uninstall
-	dataFilenames := []string{"launcher.db", "metadata.json", "kv.sqlite"}
-
-	for _, fname := range dataFilenames {
-		newPath := filepath.Join(dataFilesPath, fname)
-		newFile, err := os.Create(newPath)
-		if err != nil {
-			return err
-		}
-
-		newFile.Close()
-	}
-
 	_, err = wo.execOut(ctx,
 		filepath.Join(wo.wixPath, "heat.exe"),
 		"dir", wo.packageDataRoot,


### PR DESCRIPTION
Certain data directory files are pre-created as empty files during wix packaging, to ensure that these are cleaned up on uninstall.

However some deployments forcibly re-install a new MSI outside of the autoupdate flow. This will trigger the uninstall first, which is now able to remove those files, leaving the device in an unenrolled state