### PR TITLE
Add `initial_version` to launcher info table, update a log line

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -49,6 +49,12 @@ func runMain() int {
 		"revision", version.Version().Revision,
 	)
 
+	// Set an os environmental variable that we can use to track launcher versions across
+	// various bits of updated binaries
+	if os.Getenv("KOLIDE_LAUNCHER_INITIAL_VERSION") == "" {
+		os.Setenv("KOLIDE_LAUNCHER_INITIAL_VERSION", version.Version().Version)
+	}
+
 	// create initial logger. As this is prior to options parsing,
 	// use the environment to determine verbosity.  It will be
 	// re-leveled during options parsing.

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -51,8 +51,10 @@ func runMain() int {
 
 	// Set an os environmental variable that we can use to track launcher versions across
 	// various bits of updated binaries
-	if os.Getenv("KOLIDE_LAUNCHER_INITIAL_VERSION") == "" {
-		os.Setenv("KOLIDE_LAUNCHER_INITIAL_VERSION", version.Version().Version)
+	if chain := os.Getenv("KOLIDE_LAUNCHER_VERSION_CHAIN"); chain == "" {
+		os.Setenv("KOLIDE_LAUNCHER_VERSION_CHAIN", version.Version().Version)
+	} else {
+		os.Setenv("KOLIDE_LAUNCHER_VERSION_CHAIN", fmt.Sprintf("%s:%s", chain, version.Version().Version))
 	}
 
 	// create initial logger. As this is prior to options parsing,

--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -60,7 +60,7 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 	hardwareUUIDChanged := false
 	munemoChanged := false
 
-	defer k.Slogger().Log(ctx, slog.LevelDebug, "checking to see if database should be reset...",
+	defer k.Slogger().Log(ctx, slog.LevelDebug, "finished check to see if database should be reset...",
 		"serial", serialChanged,
 		"hardware_uuid", hardwareUUIDChanged,
 		"munemo", munemoChanged,
@@ -82,16 +82,16 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 	}
 
 	if serialChanged || hardwareUUIDChanged || munemoChanged {
-		k.Slogger().Log(ctx, slog.LevelWarn, "detected new hardware or enrollment",
-			"serial_changed", serialChanged,
-			"hardware_uuid_changed", hardwareUUIDChanged,
-			"tenant_munemo_changed", munemoChanged,
-		)
-
 		// In the future, we can proceed with backing up and resetting the database.
 		// For now, we are only logging that we detected the change until we have a dependable
 		// hardware change detection method - see issue here https://github.com/kolide/launcher/issues/1346
 		/*
+			k.Slogger().Log(ctx, slog.LevelWarn, "resetting the database",
+				"serial_changed", serialChanged,
+				"hardware_uuid_changed", hardwareUUIDChanged,
+				"tenant_munemo_changed", munemoChanged,
+			)
+
 			if err := ResetDatabase(ctx, k, resetReasonNewHardwareOrEnrollmentDetected); err != nil {
 				k.Slogger().Log(ctx, slog.LevelError, "failed to reset database", "err", err)
 			}

--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -56,10 +56,16 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
 
-	k.Slogger().Log(ctx, slog.LevelDebug, "checking to see if database should be reset...")
-
 	serialChanged := false
 	hardwareUUIDChanged := false
+	munemoChanged := false
+
+	defer k.Slogger().Log(ctx, slog.LevelDebug, "checking to see if database should be reset...",
+		"serial", serialChanged,
+		"hardware_uuid", hardwareUUIDChanged,
+		"munemo", munemoChanged,
+	)
+
 	currentSerial, currentHardwareUUID, err := currentSerialAndHardwareUUID(ctx, k)
 	if err != nil {
 		k.Slogger().Log(ctx, slog.LevelWarn, "could not get current serial and hardware UUID", "err", err)
@@ -68,7 +74,6 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 		hardwareUUIDChanged = valueChanged(ctx, k, currentHardwareUUID, hostDataKeyHardwareUuid)
 	}
 
-	munemoChanged := false
 	currentTenantMunemo, err := currentMunemo(k)
 	if err != nil {
 		k.Slogger().Log(ctx, slog.LevelWarn, "could not get current munemo", "err", err)

--- a/pkg/osquery/table/launcher_info.go
+++ b/pkg/osquery/table/launcher_info.go
@@ -28,7 +28,7 @@ func LauncherInfoTable(store types.GetterSetter) *table.Plugin {
 		table.TextColumn("goos"),
 		table.TextColumn("revision"),
 		table.TextColumn("version"),
-		table.TextColumn("initial_version"),
+		table.TextColumn("version_chain"),
 		table.TextColumn("identifier"),
 		table.TextColumn("osquery_instance_id"),
 
@@ -77,7 +77,7 @@ func generateLauncherInfoTable(store types.GetterSetter) table.GenerateFunc {
 				"goos":                runtime.GOOS,
 				"revision":            version.Version().Revision,
 				"version":             version.Version().Version,
-				"initial_version":     os.Getenv("KOLIDE_LAUNCHER_INITIAL_VERSION"),
+				"version_chain":       os.Getenv("KOLIDE_LAUNCHER_VERSION_CHAIN"),
 				"identifier":          identifier,
 				"osquery_instance_id": osqueryInstance.InstanceId,
 				"fingerprint":         fingerprint,

--- a/pkg/osquery/table/launcher_info.go
+++ b/pkg/osquery/table/launcher_info.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/kolide/kit/version"
@@ -27,6 +28,7 @@ func LauncherInfoTable(store types.GetterSetter) *table.Plugin {
 		table.TextColumn("goos"),
 		table.TextColumn("revision"),
 		table.TextColumn("version"),
+		table.TextColumn("initial_version"),
 		table.TextColumn("identifier"),
 		table.TextColumn("osquery_instance_id"),
 
@@ -75,6 +77,7 @@ func generateLauncherInfoTable(store types.GetterSetter) table.GenerateFunc {
 				"goos":                runtime.GOOS,
 				"revision":            version.Version().Revision,
 				"version":             version.Version().Version,
+				"initial_version":     os.Getenv("KOLIDE_LAUNCHER_INITIAL_VERSION"),
 				"identifier":          identifier,
 				"osquery_instance_id": osqueryInstance.InstanceId,
 				"fingerprint":         fingerprint,


### PR DESCRIPTION
I've often wanted to know what the initial launcher version is. But, we don't expose that anywhere. This is a fairly simple addition that should help expose how launcher is running. Fixes #1740

Also tweak a log line about resetting the database. 