### PR TITLE
windows root directory fallback

### DIFF
--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -57,7 +57,7 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 	// Create a local logger. This logs to a known path, and aims to help diagnostics
 	if opts.RootDirectory != "" {
 		// check for old root directories before creating DB in case we've stomped over with windows MSI install
-		updatedRootDirectory := determineRootDirectory(opts.RootDirectory, systemSlogger.Logger)
+		updatedRootDirectory := determineRootDirectory(opts, systemSlogger.Logger)
 		if updatedRootDirectory != opts.RootDirectory {
 			systemSlogger.Log(context.TODO(), slog.LevelInfo,
 				"old root directory contents detected, overriding opts.RootDirectory",
@@ -252,7 +252,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 
 // determineRootDirectory is used specifically for windows deployments to override the
 // configured root directory if another one containing a launcher DB already exists
-func determineRootDirectory(optsRootDirectory string, slogger *slog.Logger, opts *launcher.Options) string {
+func determineRootDirectory(opts *launcher.Options, slogger *slog.Logger) string {
+	optsRootDirectory := opts.RootDirectory
 	// don't mess with the path if this installation isn't pointing to a kolide server URL
 	if opts.ControlServerURL != "k2device.kolide.com" && opts.ControlServerURL != "k2device-preprod.kolide.com" {
 		return optsRootDirectory

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -54,10 +54,9 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 	localSlogger := multislogger.New()
 	logger := log.NewNopLogger()
 
-	// Create a local logger. This logs to a known path, and aims to help diagnostics
 	if opts.RootDirectory != "" {
 		// check for old root directories before creating DB in case we've stomped over with windows MSI install
-		updatedRootDirectory := determineRootDirectory(opts, systemSlogger.Logger)
+		updatedRootDirectory := determineRootDirectory(systemSlogger.Logger, opts)
 		if updatedRootDirectory != opts.RootDirectory {
 			systemSlogger.Log(context.TODO(), slog.LevelInfo,
 				"old root directory contents detected, overriding opts.RootDirectory",
@@ -68,6 +67,7 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 			opts.RootDirectory = updatedRootDirectory
 		}
 
+		// Create a local logger. This logs to a known path, and aims to help diagnostics
 		ll := locallogger.NewKitLogger(filepath.Join(opts.RootDirectory, "debug.json"))
 		logger = ll
 
@@ -252,7 +252,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 
 // determineRootDirectory is used specifically for windows deployments to override the
 // configured root directory if another one containing a launcher DB already exists
-func determineRootDirectory(opts *launcher.Options, slogger *slog.Logger) string {
+func determineRootDirectory(slogger *slog.Logger, opts *launcher.Options) string {
 	optsRootDirectory := opts.RootDirectory
 	// don't mess with the path if this installation isn't pointing to a kolide server URL
 	if opts.KolideServerURL != "k2device.kolide.com" && opts.KolideServerURL != "k2device-preprod.kolide.com" {

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -255,7 +255,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 func determineRootDirectory(opts *launcher.Options, slogger *slog.Logger) string {
 	optsRootDirectory := opts.RootDirectory
 	// don't mess with the path if this installation isn't pointing to a kolide server URL
-	if opts.ControlServerURL != "k2device.kolide.com" && opts.ControlServerURL != "k2device-preprod.kolide.com" {
+	if opts.KolideServerURL != "k2device.kolide.com" && opts.KolideServerURL != "k2device-preprod.kolide.com" {
 		return optsRootDirectory
 	}
 


### PR DESCRIPTION
These changes are to allow a windows device to fallback to a historical (or current) root directory location. When an MSI with a different root directory is freshly installed over another, launcher cannot see the existing DB and triggers a new enrollment.
To avoid this, svc_windows will override the root_directory set by the MSI if a populated database exists in another known root directory location