### PR TITLE
Continue in kolide_jwt when rawData is empty

### DIFF
--- a/ee/tables/jwt/jwt.go
+++ b/ee/tables/jwt/jwt.go
@@ -72,7 +72,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 			for _, includeRawJWT := range tablehelpers.GetConstraints(queryContext, "include_raw_jwt", tablehelpers.WithAllowedValues(allowedIncludeValues), tablehelpers.WithDefaults("false")) {
 				for _, dataQuery := range tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*")) {
 					rawData, err := os.ReadFile(path)
-					if err != nil {
+					if len(rawData) == 0 || err != nil {
 						t.slogger.Log(ctx, slog.LevelInfo, "error reading JWT data file", "err", err)
 						continue
 					}

--- a/ee/tables/jwt/jwt_test.go
+++ b/ee/tables/jwt/jwt_test.go
@@ -34,6 +34,10 @@ func TestTransformOutput(t *testing.T) {
 		res  map[string]string
 	}{
 		{
+			name: "empty token",
+			path: "testdata/empty",
+		},
+		{
 			name: "rsa256 JWT valid",
 			path: "testdata/rsa256.raw",
 			keys: map[string]string{
@@ -149,7 +153,12 @@ func TestTransformOutput(t *testing.T) {
 			rows, err := jwtTable.generate(context.TODO(), mockQC)
 
 			require.NoError(t, err)
-			require.Contains(t, rows, tt.res, "generated rows should contain the expected result")
+
+			if tt.name == "empty token" {
+				require.Nil(t, rows, "the result should be nil for an empty token")
+			} else {
+				require.Contains(t, rows, tt.res, "generated rows should contain the expected result")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Attempting to pass an empty or null token to the jwt parser will cause a fatal error (`ErrTokenMalformed`) and panic (`panic: runtime error: invalid memory address or nil pointer dereference`). I'm simply checking that the `rawData` is not of length `0`, otherwise throw the same error (`error reading JWT data file`) before trying to hand it off to the jwt parser.

Something I should've caught previously, but I did not have a test for it. I do now.