### PR TITLE
Take and use backups of the launcher database

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -260,8 +260,8 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// pickup
 	internal.RecordLauncherVersion(ctx, rootDirectory)
 
-	p := agentbbolt.NewDatabasePhotographer(k)
-	runGroup.Add("databasePhotographer", p.Execute, p.Interrupt)
+	dbBackupMaintainer := agentbbolt.NewDatabaseBackupMaintainer(k)
+	runGroup.Add("databaseBackupMaintainer", dbBackupMaintainer.Execute, dbBackupMaintainer.Interrupt)
 
 	// create the certificate pool
 	var rootPool *x509.CertPool

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -169,7 +169,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// unimplemented on windows, though empirically it seems to
 	// work.
 	boltOptions := &bbolt.Options{Timeout: time.Duration(30) * time.Second}
-	db, err := bbolt.Open(filepath.Join(rootDirectory, "launcher.db"), 0600, boltOptions)
+	db, err := bbolt.Open(agentbbolt.LauncherDbLocation(rootDirectory), 0600, boltOptions)
 	if err != nil {
 		return fmt.Errorf("open launcher db: %w", err)
 	}

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -259,6 +259,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// pickup
 	internal.RecordLauncherVersion(ctx, rootDirectory)
 
+	p := agentbbolt.NewDatabasePhotographer(k)
+	runGroup.Add("databasePhotographer", p.Execute, p.Interrupt)
+
 	// create the certificate pool
 	var rootPool *x509.CertPool
 	if k.RootPEM() != "" {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -168,6 +168,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// this. Note that the timeout is documented as failing
 	// unimplemented on windows, though empirically it seems to
 	// work.
+	agentbbolt.UseBackupDbIfNeeded(rootDirectory, slogger)
 	boltOptions := &bbolt.Options{Timeout: time.Duration(30) * time.Second}
 	db, err := bbolt.Open(agentbbolt.LauncherDbLocation(rootDirectory), 0600, boltOptions)
 	if err != nil {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -260,8 +260,8 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// pickup
 	internal.RecordLauncherVersion(ctx, rootDirectory)
 
-	dbBackupMaintainer := agentbbolt.NewDatabaseBackupMaintainer(k)
-	runGroup.Add("databaseBackupMaintainer", dbBackupMaintainer.Execute, dbBackupMaintainer.Interrupt)
+	dbBackupSaver := agentbbolt.NewDatabaseBackupSaver(k)
+	runGroup.Add("dbBackupSaver", dbBackupSaver.Execute, dbBackupSaver.Interrupt)
 
 	// create the certificate pool
 	var rootPool *x509.CertPool

--- a/ee/agent/storage/bbolt/backup.go
+++ b/ee/agent/storage/bbolt/backup.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/pkg/launcher"
 	"go.etcd.io/bbolt"
 )
 
@@ -89,15 +89,10 @@ func (p *photographer) backupDb() error {
 	}
 
 	// Confirm file exists and is nonempty
-	fileInfo, err := os.Stat(backupLocation)
-	if os.IsNotExist(err) {
-		return fmt.Errorf("backup succeeded, but no file at backup location %s", backupLocation)
-	}
-	if err != nil {
-		return fmt.Errorf("checking %s exists after taking backup: %w", backupLocation, err)
-	}
-	if fileInfo.Size() <= 0 {
-		return fmt.Errorf("backup succeeded, but backup database at %s is empty", backupLocation)
+	if exists, err := launcher.NonEmptyFileExists(backupLocation); !exists {
+		return fmt.Errorf("backup succeeded, but nonempty file does not exist at %s", backupLocation)
+	} else if err != nil {
+		return fmt.Errorf("backup succeeded, but error checking if file was created at %s: %w", backupLocation, err)
 	}
 
 	// Log success

--- a/ee/agent/storage/bbolt/backup.go
+++ b/ee/agent/storage/bbolt/backup.go
@@ -92,13 +92,13 @@ func (d *databaseBackupSaver) backupDb() error {
 		return fmt.Errorf("backup succeeded, but nonempty file does not exist at %s", backupLocation)
 	} else if err != nil {
 		return fmt.Errorf("backup succeeded, but error checking if file was created at %s: %w", backupLocation, err)
+	} else {
+		// Log success
+		d.slogger.Log(context.TODO(), slog.LevelDebug,
+			"took backup",
+			"backup_location", backupLocation,
+		)
 	}
-
-	// Log success
-	d.slogger.Log(context.TODO(), slog.LevelDebug,
-		"took backup",
-		"backup_location", backupLocation,
-	)
 
 	return nil
 }

--- a/ee/agent/storage/bbolt/backup.go
+++ b/ee/agent/storage/bbolt/backup.go
@@ -18,23 +18,23 @@ const (
 	backupInterval     = 1 * time.Hour
 )
 
-// databaseBackupMaintainer periodically takes backups of launcher.db.
-type databaseBackupMaintainer struct {
+// databaseBackupSaver periodically takes backups of launcher.db.
+type databaseBackupSaver struct {
 	knapsack    types.Knapsack
 	slogger     *slog.Logger
 	interrupt   chan struct{}
 	interrupted bool
 }
 
-func NewDatabaseBackupMaintainer(k types.Knapsack) *databaseBackupMaintainer {
-	return &databaseBackupMaintainer{
+func NewDatabaseBackupSaver(k types.Knapsack) *databaseBackupSaver {
+	return &databaseBackupSaver{
 		knapsack:  k,
-		slogger:   k.Slogger().With("component", "database_backup_maintainer"),
+		slogger:   k.Slogger().With("component", "database_backup_saver"),
 		interrupt: make(chan struct{}, 1),
 	}
 }
 
-func (d *databaseBackupMaintainer) Execute() error {
+func (d *databaseBackupSaver) Execute() error {
 	// Wait a little bit after startup before taking first backup, to allow for enrollment
 	select {
 	case <-d.interrupt:
@@ -69,7 +69,7 @@ func (d *databaseBackupMaintainer) Execute() error {
 	}
 }
 
-func (d *databaseBackupMaintainer) Interrupt(_ error) {
+func (d *databaseBackupSaver) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
 	if d.interrupted {
 		return
@@ -79,7 +79,7 @@ func (d *databaseBackupMaintainer) Interrupt(_ error) {
 	d.interrupt <- struct{}{}
 }
 
-func (d *databaseBackupMaintainer) backupDb() error {
+func (d *databaseBackupSaver) backupDb() error {
 	// Take backup -- it's fine to just overwrite previous backups
 	backupLocation := BackupLauncherDbLocation(d.knapsack.RootDirectory())
 	if err := d.knapsack.BboltDB().View(func(tx *bbolt.Tx) error {

--- a/ee/agent/storage/bbolt/backup.go
+++ b/ee/agent/storage/bbolt/backup.go
@@ -1,0 +1,118 @@
+package agentbbolt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kolide/launcher/ee/agent/types"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	snapshotInitialDelay = 10 * time.Minute
+	snapshotInterval     = 1 * time.Hour
+)
+
+// A photographer takes snapshots.
+// TODO RM - A better name.
+type photographer struct {
+	knapsack    types.Knapsack
+	slogger     *slog.Logger
+	interrupt   chan struct{}
+	interrupted bool
+}
+
+func NewDatabasePhotographer(k types.Knapsack) *photographer {
+	return &photographer{
+		knapsack:  k,
+		slogger:   k.Slogger().With("component", "database_photographer"),
+		interrupt: make(chan struct{}, 1),
+	}
+}
+
+func (p *photographer) Execute() error {
+	// Wait a little bit after startup before taking first snapshot, to allow for enrollment
+	select {
+	case <-p.interrupt:
+		p.slogger.Log(context.TODO(), slog.LevelDebug,
+			"received external interrupt during initial delay, stopping",
+		)
+		return nil
+	case <-time.After(snapshotInitialDelay):
+		break
+	}
+
+	// Take periodic snapshots
+	ticker := time.NewTicker(snapshotInterval)
+	defer ticker.Stop()
+	for {
+		if err := p.backupDb(); err != nil {
+			p.slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not perform periodic database backup",
+				"err", err,
+			)
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-p.interrupt:
+			p.slogger.Log(context.TODO(), slog.LevelDebug,
+				"interrupt received, exiting execute loop",
+			)
+			return nil
+		}
+	}
+}
+
+func (p *photographer) Interrupt(_ error) {
+	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
+	if p.interrupted {
+		return
+	}
+	p.interrupted = true
+
+	p.interrupt <- struct{}{}
+}
+
+func (p *photographer) backupDb() error {
+	// Take backup -- it's fine to just overwrite previous backups
+	backupLocation := BackupLauncherDbLocation(p.knapsack.RootDirectory())
+	if err := p.knapsack.BboltDB().View(func(tx *bbolt.Tx) error {
+		return tx.CopyFile(backupLocation, 0600)
+	}); err != nil {
+		return fmt.Errorf("backing up database: %w", err)
+	}
+
+	// Confirm file exists and is nonempty
+	fileInfo, err := os.Stat(backupLocation)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("backup succeeded, but no file at backup location %s", backupLocation)
+	}
+	if err != nil {
+		return fmt.Errorf("checking %s exists after taking backup: %w", backupLocation, err)
+	}
+	if fileInfo.Size() <= 0 {
+		return fmt.Errorf("backup succeeded, but backup database at %s is empty", backupLocation)
+	}
+
+	// Log success
+	p.slogger.Log(context.TODO(), slog.LevelDebug,
+		"took backup",
+		"backup_location", backupLocation,
+	)
+
+	return nil
+}
+
+func LauncherDbLocation(rootDir string) string {
+	return filepath.Join(rootDir, "launcher.db")
+}
+
+func BackupLauncherDbLocation(rootDir string) string {
+	return filepath.Join(rootDir, "launcher.db.bak")
+}

--- a/ee/agent/storage/bbolt/backup_test.go
+++ b/ee/agent/storage/bbolt/backup_test.go
@@ -147,6 +147,10 @@ func Test_rotate(t *testing.T) {
 			}
 		}
 	}
+
+	// Test rotation when backup db does not exist
+	_ = os.Remove(backupDbFileLocation)
+	require.NoError(t, d.rotate(), "must be able to rotate even when launcher.db.bak does not exist")
 }
 
 func TestInterrupt_Multiple(t *testing.T) {

--- a/ee/agent/storage/bbolt/backup_test.go
+++ b/ee/agent/storage/bbolt/backup_test.go
@@ -114,7 +114,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	testKnapsack := typesmocks.NewKnapsack(t)
 	testKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
-	p := NewDatabaseBackupMaintainer(testKnapsack)
+	p := NewDatabaseBackupSaver(testKnapsack)
 
 	// Start and then interrupt
 	go p.Execute()

--- a/ee/agent/storage/bbolt/backup_test.go
+++ b/ee/agent/storage/bbolt/backup_test.go
@@ -2,13 +2,111 @@ package agentbbolt
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
+
+func TestUseBackupDbIfNeeded(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name                string
+		originalDbExists    bool
+		backupDbExists      bool
+		shouldPerformRename bool
+	}{
+		{
+			name:                "original exists, backup exists, should use original",
+			originalDbExists:    true,
+			backupDbExists:      true,
+			shouldPerformRename: false,
+		},
+		{
+			name:                "original exists, backup does not exist, should use original",
+			originalDbExists:    true,
+			backupDbExists:      false,
+			shouldPerformRename: false,
+		},
+		{
+			name:                "original does not exist, backup exists, should use backup",
+			originalDbExists:    false,
+			backupDbExists:      true,
+			shouldPerformRename: true,
+		},
+		{
+			name:                "original does not exist, backup does not exist, should use (new) original",
+			originalDbExists:    false,
+			backupDbExists:      false,
+			shouldPerformRename: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Set up test databases
+			tempRootDir := t.TempDir()
+			originalDbFileLocation := LauncherDbLocation(tempRootDir)
+			backupDbFileLocation := BackupLauncherDbLocation(tempRootDir)
+			if tt.originalDbExists {
+				createNonEmptyBboltDb(t, originalDbFileLocation)
+			}
+			if tt.backupDbExists {
+				createNonEmptyBboltDb(t, backupDbFileLocation)
+			}
+
+			// Ask agentbbolt to use the backup database if the original one isn't present
+			UseBackupDbIfNeeded(tempRootDir, multislogger.NewNopLogger())
+
+			// Check to make sure appropriate action was taken
+			if tt.shouldPerformRename {
+				// The backup database should no longer exist
+				_, err := os.Stat(backupDbFileLocation)
+				require.Error(t, err, "should not be able to stat launcher.db.bak since it should have been renamed")
+				require.True(t, os.IsNotExist(err), "checking that launcher.db.bak does not exist, and error is not ErrNotExist")
+
+				// The original database should exist
+				_, err = os.Stat(originalDbFileLocation)
+				require.NoError(t, err, "checking if launcher.db exists")
+			} else {
+				// No rename, so we should be in the same state we started in
+				_, err := os.Stat(originalDbFileLocation)
+				if tt.originalDbExists {
+					require.NoError(t, err, "checking if launcher.db exists")
+				} else {
+					// launcher.db didn't exist before, it shouldn't exist now
+					require.True(t, os.IsNotExist(err), "checking that launcher.db does not exist, and error is not ErrNotExist")
+				}
+
+				_, err = os.Stat(backupDbFileLocation)
+				if tt.backupDbExists {
+					require.NoError(t, err, "checking if launcher.db.bak exists")
+				} else {
+					// launcher.db.bak didn't exist before, it shouldn't exist now
+					require.True(t, os.IsNotExist(err), "checking that launcher.db.bak does not exist, and error is not ErrNotExist")
+				}
+			}
+		})
+	}
+}
+
+func createNonEmptyBboltDb(t *testing.T, dbFileLocation string) time.Time {
+	boltOptions := &bbolt.Options{Timeout: time.Duration(5) * time.Second}
+	db, err := bbolt.Open(dbFileLocation, 0600, boltOptions)
+	require.NoError(t, err, "creating db")
+	require.NoError(t, db.Close(), "closing db")
+
+	fi, err := os.Stat(dbFileLocation)
+	require.NoError(t, err, "statting db")
+
+	return fi.ModTime()
+}
 
 func TestInterrupt_Multiple(t *testing.T) {
 	t.Parallel()

--- a/ee/agent/storage/bbolt/backup_test.go
+++ b/ee/agent/storage/bbolt/backup_test.go
@@ -114,7 +114,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	testKnapsack := typesmocks.NewKnapsack(t)
 	testKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
-	p := NewDatabasePhotographer(testKnapsack)
+	p := NewDatabaseBackupMaintainer(testKnapsack)
 
 	// Start and then interrupt
 	go p.Execute()

--- a/ee/agent/storage/bbolt/backup_test.go
+++ b/ee/agent/storage/bbolt/backup_test.go
@@ -1,0 +1,52 @@
+package agentbbolt
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterrupt_Multiple(t *testing.T) {
+	t.Parallel()
+
+	testKnapsack := typesmocks.NewKnapsack(t)
+	testKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+
+	p := NewDatabasePhotographer(testKnapsack)
+
+	// Start and then interrupt
+	go p.Execute()
+	p.Interrupt(errors.New("test error"))
+
+	// Confirm we can call Interrupt multiple times without blocking
+	interruptComplete := make(chan struct{})
+	expectedInterrupts := 3
+	for i := 0; i < expectedInterrupts; i += 1 {
+		go func() {
+			p.Interrupt(nil)
+			interruptComplete <- struct{}{}
+		}()
+	}
+
+	receivedInterrupts := 0
+	for {
+		if receivedInterrupts >= expectedInterrupts {
+			break
+		}
+
+		select {
+		case <-interruptComplete:
+			receivedInterrupts += 1
+			continue
+		case <-time.After(5 * time.Second):
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.FailNow()
+		}
+	}
+
+	require.Equal(t, expectedInterrupts, receivedInterrupts)
+}

--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/kolide/launcher/ee/agent"
+	agentbbolt "github.com/kolide/launcher/ee/agent/storage/bbolt"
 	"github.com/kolide/launcher/ee/agent/types"
 )
 
@@ -30,6 +31,14 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 	if err := agent.ResetDatabase(ctx, k, resetReasonUninstallRequested); err != nil {
 		slogger.Log(ctx, slog.LevelError,
 			"resetting database",
+			"err", err,
+		)
+	}
+
+	backupDbPath := agentbbolt.BackupLauncherDbLocation(k.RootDirectory())
+	if err := os.Remove(backupDbPath); err != nil {
+		slogger.Log(ctx, slog.LevelError,
+			"removing backup database",
 			"err", err,
 		)
 	}

--- a/ee/uninstall/uninstall_test.go
+++ b/ee/uninstall/uninstall_test.go
@@ -6,14 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/storage"
+	agentbbolt "github.com/kolide/launcher/ee/agent/storage/bbolt"
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
 
 func TestUninstall(t *testing.T) {
@@ -41,9 +44,17 @@ func TestUninstall(t *testing.T) {
 			_, err = os.Stat(enrollSecretPath)
 			require.NoError(t, err)
 
+			// create a backup database to delete
+			tempRootDir := t.TempDir()
+			backupDbLocation := agentbbolt.BackupLauncherDbLocation(tempRootDir)
+			db, err := bbolt.Open(backupDbLocation, 0600, &bbolt.Options{Timeout: time.Duration(5) * time.Second})
+			require.NoError(t, err, "creating db")
+			require.NoError(t, db.Close(), "closing db")
+
 			k := mocks.NewKnapsack(t)
 			k.On("EnrollSecretPath").Return(enrollSecretPath)
 			k.On("Slogger").Return(multislogger.NewNopLogger())
+			k.On("RootDirectory").Return(tempRootDir)
 			testConfigStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ConfigStore.String())
 			require.NoError(t, err, "could not create test config store")
 			k.On("ConfigStore").Return(testConfigStore)
@@ -102,6 +113,10 @@ func TestUninstall(t *testing.T) {
 			require.Equal(t, resetReasonUninstallRequested, resetRecord.ResetReason, "expected reset record to indicate the uninstall requested")
 			require.Equal(t, string(testSerial), resetRecord.Serial, "expected reset record to indicate the serial number from the original installation")
 			require.Equal(t, string(testHardwareUUID), resetRecord.HardwareUUID, "expected reset record to indicate the hardware UUID from the original installation")
+
+			// check that the backup database was removed
+			_, err = os.Stat(backupDbLocation)
+			require.True(t, os.IsNotExist(err), "checking that launcher.db.bak does not exist, and error is not ErrNotExist")
 		})
 	}
 }

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -98,7 +98,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 	}
 
 	optsDBLocation := filepath.Join(optsRootDirectory, "launcher.db")
-	dbExists, err := NonEmptyFileExists(optsDBLocation)
+	dbExists, err := nonEmptyFileExists(optsDBLocation)
 	// If we get an unknown error, back out from making any options changes. This is an
 	// unlikely path but doesn't feel right updating the rootDirectory without knowing what's going
 	// on here
@@ -120,7 +120,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 		}
 
 		testingLocation := filepath.Join(path, "launcher.db")
-		dbExists, err := NonEmptyFileExists(testingLocation)
+		dbExists, err := nonEmptyFileExists(testingLocation)
 		if err == nil && dbExists {
 			return path
 		}
@@ -136,7 +136,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 	return optsRootDirectory
 }
 
-func NonEmptyFileExists(path string) (bool, error) {
+func nonEmptyFileExists(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return false, nil

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -98,7 +98,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 	}
 
 	optsDBLocation := filepath.Join(optsRootDirectory, "launcher.db")
-	dbExists, err := nonEmptyFileExists(optsDBLocation)
+	dbExists, err := NonEmptyFileExists(optsDBLocation)
 	// If we get an unknown error, back out from making any options changes. This is an
 	// unlikely path but doesn't feel right updating the rootDirectory without knowing what's going
 	// on here
@@ -120,7 +120,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 		}
 
 		testingLocation := filepath.Join(path, "launcher.db")
-		dbExists, err := nonEmptyFileExists(testingLocation)
+		dbExists, err := NonEmptyFileExists(testingLocation)
 		if err == nil && dbExists {
 			return path
 		}
@@ -136,7 +136,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 	return optsRootDirectory
 }
 
-func nonEmptyFileExists(path string) (bool, error) {
+func NonEmptyFileExists(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return false, nil


### PR DESCRIPTION
- launcher takes periodic backups of its own database, beginning 10 mins after startup
- bbolt checkup includes stats about the backup database
- If its original database is unavailable but a backup is, launcher uses that backup db
- On remote uninstall, the backup database is deleted