### PR TITLE
Take all backup dbs into account for checkup + remote uninstall

### DIFF
--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -35,12 +35,14 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 		)
 	}
 
-	backupDbPath := agentbbolt.BackupLauncherDbLocation(k.RootDirectory())
-	if err := os.Remove(backupDbPath); err != nil {
-		slogger.Log(ctx, slog.LevelError,
-			"removing backup database",
-			"err", err,
-		)
+	backupDbPaths := agentbbolt.BackupLauncherDbLocations(k.RootDirectory())
+	for _, db := range backupDbPaths {
+		if err := os.Remove(db); err != nil {
+			slogger.Log(ctx, slog.LevelError,
+				"removing backup database",
+				"err", err,
+			)
+		}
 	}
 
 	if !exitOnCompletion {


### PR DESCRIPTION
Small update to https://github.com/kolide/launcher/pull/1755 -- I added db rotation in that PR, but neglected to account for those rotated dbs in the checkup and remote uninstall. This PR corrects that oversight.