### PR TITLE
refactor power_event_watcher for configurable subscriber behavior

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -293,7 +293,8 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// For now, remediation is not performed -- we only log the hardware change.
 	agent.DetectAndRemediateHardwareChange(ctx, k)
 
-	powerEventWatcher, err := powereventwatcher.New(ctx, k, slogger)
+	powerEventSubscriber := powereventwatcher.NewKnapsackSubscriber(slogger, k)
+	powerEventWatcher, err := powereventwatcher.New(ctx, slogger, powerEventSubscriber)
 	if err != nil {
 		slogger.Log(ctx, slog.LevelDebug,
 			"could not init power event watcher",

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -293,7 +293,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// For now, remediation is not performed -- we only log the hardware change.
 	agent.DetectAndRemediateHardwareChange(ctx, k)
 
-	powerEventSubscriber := powereventwatcher.NewKnapsackSubscriber(slogger, k)
+	powerEventSubscriber := powereventwatcher.NewKnapsackSleepStateUpdater(slogger, k)
 	powerEventWatcher, err := powereventwatcher.New(ctx, slogger, powerEventSubscriber)
 	if err != nil {
 		slogger.Log(ctx, slog.LevelDebug,

--- a/ee/powereventwatcher/power_event_watcher_other.go
+++ b/ee/powereventwatcher/power_event_watcher_other.go
@@ -16,21 +16,13 @@ type noOpPowerEventWatcher struct {
 	interrupted bool
 }
 
-type knapsackSubscriber struct{}
+type noOpKnapsackSubscriber struct{}
 
-func NewKnapsackSubscriber(_ *slog.Logger, _ types.Knapsack) *knapsackSubscriber {
-	return &knapsackSubscriber{}
+func NewKnapsackSubscriber(_ *slog.Logger, _ types.Knapsack) *noOpKnapsackSubscriber {
+	return &noOpKnapsackSubscriber{}
 }
 
-func (ks *knapsackSubscriber) OnPowerEvent(_ int) error {
-	return nil
-}
-
-func (ks *knapsackSubscriber) OnStartup() error {
-	return nil
-}
-
-func New(ctx context.Context, _ types.Knapsack, _ *slog.Logger) (*noOpPowerEventWatcher, error) {
+func New(ctx context.Context, _ *slog.Logger, _ *noOpKnapsackSubscriber) (*noOpPowerEventWatcher, error) {
 	_, span := traces.StartSpan(ctx)
 	defer span.End()
 

--- a/ee/powereventwatcher/power_event_watcher_other.go
+++ b/ee/powereventwatcher/power_event_watcher_other.go
@@ -16,6 +16,20 @@ type noOpPowerEventWatcher struct {
 	interrupted bool
 }
 
+type knapsackSubscriber struct{}
+
+func NewKnapsackSubscriber(_ *slog.Logger, _ types.Knapsack) *knapsackSubscriber {
+	return &knapsackSubscriber{}
+}
+
+func (ks *knapsackSubscriber) OnPowerEvent(_ int) error {
+	return nil
+}
+
+func (ks *knapsackSubscriber) OnStartup() error {
+	return nil
+}
+
 func New(ctx context.Context, _ types.Knapsack, _ *slog.Logger) (*noOpPowerEventWatcher, error) {
 	_, span := traces.StartSpan(ctx)
 	defer span.End()

--- a/ee/powereventwatcher/power_event_watcher_other.go
+++ b/ee/powereventwatcher/power_event_watcher_other.go
@@ -16,13 +16,13 @@ type noOpPowerEventWatcher struct {
 	interrupted bool
 }
 
-type noOpKnapsackSubscriber struct{}
+type noOpKnapsackSleepStateUpdater struct{}
 
-func NewKnapsackSubscriber(_ *slog.Logger, _ types.Knapsack) *noOpKnapsackSubscriber {
-	return &noOpKnapsackSubscriber{}
+func NewKnapsackSleepStateUpdater(_ *slog.Logger, _ types.Knapsack) *noOpKnapsackSleepStateUpdater {
+	return &noOpKnapsackSleepStateUpdater{}
 }
 
-func New(ctx context.Context, _ *slog.Logger, _ *noOpKnapsackSubscriber) (*noOpPowerEventWatcher, error) {
+func New(ctx context.Context, _ *slog.Logger, _ *noOpKnapsackSleepStateUpdater) (*noOpPowerEventWatcher, error) {
 	_, span := traces.StartSpan(ctx)
 	defer span.End()
 

--- a/ee/powereventwatcher/power_event_watcher_other_test.go
+++ b/ee/powereventwatcher/power_event_watcher_other_test.go
@@ -17,7 +17,8 @@ import (
 func TestInterrupt_Multiple(t *testing.T) {
 	t.Parallel()
 
-	p, err := New(context.TODO(), typesmocks.NewKnapsack(t), multislogger.NewNopLogger())
+	ksubscriber := NewKnapsackSubscriber(multislogger.NewNopLogger(), typesmocks.NewKnapsack(t))
+	p, err := New(context.TODO(), multislogger.NewNopLogger(), ksubscriber)
 	require.NoError(t, err)
 
 	// Start and then interrupt

--- a/ee/powereventwatcher/power_event_watcher_other_test.go
+++ b/ee/powereventwatcher/power_event_watcher_other_test.go
@@ -17,7 +17,7 @@ import (
 func TestInterrupt_Multiple(t *testing.T) {
 	t.Parallel()
 
-	ksubscriber := NewKnapsackSubscriber(multislogger.NewNopLogger(), typesmocks.NewKnapsack(t))
+	ksubscriber := NewKnapsackSleepStateUpdater(multislogger.NewNopLogger(), typesmocks.NewKnapsack(t))
 	p, err := New(context.TODO(), multislogger.NewNopLogger(), ksubscriber)
 	require.NoError(t, err)
 

--- a/ee/powereventwatcher/power_event_watcher_windows.go
+++ b/ee/powereventwatcher/power_event_watcher_windows.go
@@ -47,9 +47,9 @@ type (
 		OnStartup() error
 	}
 
-	// knapsackSubscriber implements the powerEventSubscriber interface and
+	// knapsackSleepStateUpdater implements the powerEventSubscriber interface and
 	// updates the knapsack.InModernStandby state based on the power events observed
-	knapsackSubscriber struct {
+	knapsackSleepStateUpdater struct {
 		knapsack types.Knapsack
 		slogger  *slog.Logger
 	}
@@ -63,14 +63,14 @@ const (
 	operationSuccessfulMsg = "The operation completed successfully."
 )
 
-func NewKnapsackSubscriber(slogger *slog.Logger, k types.Knapsack) *knapsackSubscriber {
-	return &knapsackSubscriber{
+func NewKnapsackSleepStateUpdater(slogger *slog.Logger, k types.Knapsack) *knapsackSleepStateUpdater {
+	return &knapsackSleepStateUpdater{
 		knapsack: k,
 		slogger:  slogger,
 	}
 }
 
-func (ks *knapsackSubscriber) OnPowerEvent(eventID int) error {
+func (ks *knapsackSleepStateUpdater) OnPowerEvent(eventID int) error {
 	switch eventID {
 	case eventIdEnteringModernStandby, eventIdEnteringSleep:
 		ks.slogger.Log(context.TODO(), slog.LevelDebug,
@@ -106,7 +106,7 @@ func (ks *knapsackSubscriber) OnPowerEvent(eventID int) error {
 	return nil
 }
 
-func (ks *knapsackSubscriber) OnStartup() error {
+func (ks *knapsackSleepStateUpdater) OnStartup() error {
 	// Clear InModernStandby flag, in case it's cached. We may have missed wake/sleep events
 	// while launcher was not running, and we want to err on the side of assuming the device
 	// is awake.

--- a/ee/powereventwatcher/power_event_watcher_windows.go
+++ b/ee/powereventwatcher/power_event_watcher_windows.go
@@ -28,13 +28,30 @@ type (
 
 	powerEventWatcher struct {
 		slogger                 *slog.Logger
-		knapsack                types.Knapsack
+		powerEventSubscriber    powerEventSubscriber
 		subscriptionHandle      uintptr
 		subscribeProcedure      *syscall.LazyProc
 		unsubscribeProcedure    *syscall.LazyProc
 		renderEventLogProcedure *syscall.LazyProc
 		interrupt               chan struct{}
 		interrupted             bool
+	}
+
+	// powerEventSubscriber is an interface to be implemented by anything utilizing the power event updates.
+	// implementers are provided to New, and the interface methods below are called as described during relevant updates
+	powerEventSubscriber interface {
+		// OnPowerEvent will be called for the provided subscriber whenever any watched event is observed
+		OnPowerEvent(eventID int) error
+		// OnStartup will be called when the powerEventWatcher is initially set up, allowing subscribers
+		// to perform any setup behavior (e.g. cache clearing, state resetting)
+		OnStartup() error
+	}
+
+	// knapsackSubscriber implements the powerEventSubscriber interface and
+	// updates the knapsack.InModernStandby state based on the power events observed
+	knapsackSubscriber struct {
+		knapsack types.Knapsack
+		slogger  *slog.Logger
 	}
 )
 
@@ -46,8 +63,58 @@ const (
 	operationSuccessfulMsg = "The operation completed successfully."
 )
 
+func NewKnapsackSubscriber(slogger *slog.Logger, k types.Knapsack) *knapsackSubscriber {
+	return &knapsackSubscriber{
+		knapsack: k,
+		slogger:  slogger,
+	}
+}
+
+func (ks *knapsackSubscriber) OnPowerEvent(eventID int) error {
+	switch eventID {
+	case eventIdEnteringModernStandby, eventIdEnteringSleep:
+		ks.slogger.Log(context.TODO(), slog.LevelDebug,
+			"system is sleeping",
+			"event_id", eventID,
+		)
+		if err := ks.knapsack.SetInModernStandby(true); err != nil {
+			ks.slogger.Log(context.TODO(), slog.LevelWarn,
+				"encountered error setting modern standby value",
+				"in_modern_standby", true,
+				"err", err,
+			)
+		}
+	case eventIdExitingModernStandby:
+		ks.slogger.Log(context.TODO(), slog.LevelDebug,
+			"system is waking",
+			"event_id", eventID,
+		)
+		if err := ks.knapsack.SetInModernStandby(false); err != nil {
+			ks.slogger.Log(context.TODO(), slog.LevelWarn,
+				"encountered error setting modern standby value",
+				"in_modern_standby", false,
+				"err", err,
+			)
+		}
+	default:
+		ks.slogger.Log(context.TODO(), slog.LevelWarn,
+			"received unexpected event ID in log",
+			"event_id", eventID,
+		)
+	}
+
+	return nil
+}
+
+func (ks *knapsackSubscriber) OnStartup() error {
+	// Clear InModernStandby flag, in case it's cached. We may have missed wake/sleep events
+	// while launcher was not running, and we want to err on the side of assuming the device
+	// is awake.
+	return ks.knapsack.SetInModernStandby(false)
+}
+
 // New sets up a subscription to relevant power events with a callback to `onPowerEvent`.
-func New(ctx context.Context, k types.Knapsack, slogger *slog.Logger) (*powerEventWatcher, error) {
+func New(ctx context.Context, slogger *slog.Logger, pes powerEventSubscriber) (*powerEventWatcher, error) {
 	_, span := traces.StartSpan(ctx)
 	defer span.End()
 
@@ -55,7 +122,7 @@ func New(ctx context.Context, k types.Knapsack, slogger *slog.Logger) (*powerEve
 
 	p := &powerEventWatcher{
 		slogger:                 slogger.With("component", "power_event_watcher"),
-		knapsack:                k,
+		powerEventSubscriber:    pes,
 		subscribeProcedure:      evtApi.NewProc("EvtSubscribe"),
 		unsubscribeProcedure:    evtApi.NewProc("EvtClose"),
 		renderEventLogProcedure: evtApi.NewProc("EvtRender"),
@@ -97,10 +164,13 @@ func New(ctx context.Context, k types.Knapsack, slogger *slog.Logger) (*powerEve
 	// Save the handle so that we can close it later
 	p.subscriptionHandle = subscriptionHandle
 
-	// Clear InModernStandby flag, in case it's cached. We may have missed wake/sleep events
-	// while launcher was not running, and we want to err on the side of assuming the device
-	// is awake.
-	k.SetInModernStandby(false)
+	if err := p.powerEventSubscriber.OnStartup(); err != nil {
+		// log any issues here but don't prevent creation of the watcher
+		slogger.Log(ctx, slog.LevelError,
+			"encountered error issuing subscriber OnStartup",
+			"err", err,
+		)
+	}
 
 	return p, nil
 }
@@ -195,34 +265,10 @@ func (p *powerEventWatcher) onPowerEvent(action uint32, _ uintptr, eventHandle u
 		return ret
 	}
 
-	switch e.System.EventID {
-	case eventIdEnteringModernStandby, eventIdEnteringSleep:
-		p.slogger.Log(context.TODO(), slog.LevelDebug,
-			"system is sleeping",
-			"event_id", e.System.EventID,
-		)
-		if err := p.knapsack.SetInModernStandby(true); err != nil {
-			p.slogger.Log(context.TODO(), slog.LevelWarn,
-				"could not enable osquery healthchecks on system sleep",
-				"err", err,
-			)
-		}
-	case eventIdExitingModernStandby:
-		p.slogger.Log(context.TODO(), slog.LevelDebug,
-			"system is waking",
-			"event_id", e.System.EventID,
-		)
-		if err := p.knapsack.SetInModernStandby(false); err != nil {
-			p.slogger.Log(context.TODO(), slog.LevelWarn,
-				"could not enable osquery healthchecks on system wake",
-				"err", err,
-			)
-		}
-	default:
+	if err := p.powerEventSubscriber.OnPowerEvent(e.System.EventID); err != nil {
 		p.slogger.Log(context.TODO(), slog.LevelWarn,
-			"received unexpected event ID in log",
-			"event_id", e.System.EventID,
-			"raw_event", string(utf8bytes),
+			"subscriber encountered error OnPowerEvent update",
+			"err", err,
 		)
 	}
 


### PR DESCRIPTION
To support the windows watchdog efforts, we will be re-using the `power_event_watcher` code from the watchdog service. Currently the power_event_watcher component takes a knapsack reference and directly manipulates the `InModernStandby` value as a result of the observed events. These are also persisted to bbolt, making this a little tricky for sharing with a separate service as is.

We can't simply read the values from bbolt within watchdog because if launcher proper stops functioning (and requires watchdog intervention) we shouldn't trust the latest stored value.

We also likely won't want two versions of the same logs always being added from both watchdog and launcher, and I didn't want to just duplicate all of this code. This was the cleanest approach I could come up with, and should allow watchdog to simply define a new `powerEventSubscriber` (and avoid knapsack/stores setup). happy to hear any alternative suggestions!
