### PR TITLE
[KATC] Update config schema

### DIFF
--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -92,7 +92,7 @@ func (r *rowTransformStep) UnmarshalJSON(data []byte) error {
 type katcTableConfig struct {
 	SourceType        katcSourceType     `json:"source_type"`
 	SourcePaths       []string           `json:"source_paths"` // Describes how to connect to source (e.g. path to db) -- % and _ wildcards supported
-	Platform          string             `json:"platform"`
+	Filter            string             `json:"filter"`
 	Columns           []string           `json:"columns"`
 	SourceQuery       string             `json:"source_query"` // Query to run against each source path
 	RowTransformSteps []rowTransformStep `json:"row_transform_steps"`
@@ -113,7 +113,8 @@ func ConstructKATCTables(config map[string]string, slogger *slog.Logger) []osque
 			continue
 		}
 
-		if cfg.Platform != runtime.GOOS {
+		// For now, the filter is simply the OS
+		if cfg.Filter != runtime.GOOS {
 			continue
 		}
 

--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -16,7 +16,7 @@ import (
 // that performs the query against the source.
 type katcSourceType struct {
 	name     string
-	dataFunc func(ctx context.Context, slogger *slog.Logger, path string, query string, sourceConstraints *table.ConstraintList) ([]sourceData, error)
+	dataFunc func(ctx context.Context, slogger *slog.Logger, sourcePaths []string, query string, sourceConstraints *table.ConstraintList) ([]sourceData, error)
 }
 
 // sourceData holds the result of calling `katcSourceType.dataFunc`. It maps the
@@ -91,7 +91,7 @@ func (r *rowTransformStep) UnmarshalJSON(data []byte) error {
 // sends down these configurations.
 type katcTableConfig struct {
 	SourceType        katcSourceType     `json:"source_type"`
-	Source            string             `json:"source"` // Describes how to connect to source (e.g. path to db) -- % and _ wildcards supported
+	SourcePaths       []string           `json:"source_paths"` // Describes how to connect to source (e.g. path to db) -- % and _ wildcards supported
 	Platform          string             `json:"platform"`
 	Columns           []string           `json:"columns"`
 	Query             string             `json:"query"` // Query to run against `path`

--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -94,7 +94,7 @@ type katcTableConfig struct {
 	SourcePaths       []string           `json:"source_paths"` // Describes how to connect to source (e.g. path to db) -- % and _ wildcards supported
 	Platform          string             `json:"platform"`
 	Columns           []string           `json:"columns"`
-	Query             string             `json:"query"` // Query to run against `path`
+	SourceQuery       string             `json:"source_query"` // Query to run against each source path
 	RowTransformSteps []rowTransformStep `json:"row_transform_steps"`
 }
 

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -68,7 +68,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "unknown_source",
 					"platform": "%s",
 					"columns": ["data"],
-					"source_paths": []"/some/path/to/db.sqlite"],
+					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data;"
 				}`, runtime.GOOS),
 			},
@@ -81,7 +81,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "sqlite",
 					"platform": "%s",
 					"columns": ["data"],
-					"source_paths": []"/some/path/to/db.sqlite"],
+					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data;",
 					"row_transform_steps": ["unknown_step"]
 				}`, runtime.GOOS),

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -25,7 +25,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "sqlite",
 					"platform": "%s",
 					"columns": ["data"],
-					"source": "/some/path/to/db.sqlite",
+					"source_paths": ["/some/path/to/db.sqlite"],
 					"query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
 					"row_transform_steps": ["snappy"]
 				}`, runtime.GOOS),
@@ -39,7 +39,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "sqlite",
 					"platform": "%s",
 					"columns": ["data"],
-					"source": "/some/path/to/db.sqlite",
+					"source_paths": ["/some/path/to/db.sqlite"],
 					"query": "SELECT data FROM object_data;",
 					"row_transform_steps": ["snappy"]
 				}`, runtime.GOOS),
@@ -47,7 +47,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "sqlite",
 					"platform": "%s",
 					"columns": ["col1", "col2"],
-					"source": "/some/path/to/a/different/db.sqlite",
+					"source_paths": ["/some/path/to/a/different/db.sqlite"],
 					"query": "SELECT col1, col2 FROM some_table;",
 					"row_transform_steps": ["camel_to_snake"]
 				}`, runtime.GOOS),
@@ -68,7 +68,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "unknown_source",
 					"platform": "%s",
 					"columns": ["data"],
-					"source": "/some/path/to/db.sqlite",
+					"source_paths": []"/some/path/to/db.sqlite"],
 					"query": "SELECT data FROM object_data;"
 				}`, runtime.GOOS),
 			},
@@ -81,7 +81,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"source_type": "sqlite",
 					"platform": "%s",
 					"columns": ["data"],
-					"source": "/some/path/to/db.sqlite",
+					"source_paths": []"/some/path/to/db.sqlite"],
 					"query": "SELECT data FROM object_data;",
 					"row_transform_steps": ["unknown_step"]
 				}`, runtime.GOOS),

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -21,38 +21,71 @@ func TestConstructKATCTables(t *testing.T) {
 		{
 			testCaseName: "snappy_sqlite",
 			katcConfig: map[string]string{
-				"kolide_snappy_sqlite_test": fmt.Sprintf(`{
-					"source_type": "sqlite",
-					"filter": "%s",
-					"columns": ["data"],
-					"source_paths": ["/some/path/to/db.sqlite"],
-					"source_query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
-					"row_transform_steps": ["snappy"]
-				}`, runtime.GOOS),
+				"tables": fmt.Sprintf(`[
+					{
+						"name": "kolide_snappy_sqlite_test",
+						"source_type": "sqlite",
+						"filter": "%s",
+						"columns": ["data"],
+						"source_paths": ["/some/path/to/db.sqlite"],
+						"source_query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
+						"row_transform_steps": ["snappy"]
+					}
+				]`, runtime.GOOS),
 			},
 			expectedPluginCount: 1,
 		},
 		{
 			testCaseName: "multiple plugins",
 			katcConfig: map[string]string{
-				"test_1": fmt.Sprintf(`{
-					"source_type": "sqlite",
-					"filter": "%s",
-					"columns": ["data"],
-					"source_paths": ["/some/path/to/db.sqlite"],
-					"source_query": "SELECT data FROM object_data;",
-					"row_transform_steps": ["snappy"]
-				}`, runtime.GOOS),
-				"test_2": fmt.Sprintf(`{
-					"source_type": "sqlite",
-					"filter": "%s",
-					"columns": ["col1", "col2"],
-					"source_paths": ["/some/path/to/a/different/db.sqlite"],
-					"source_query": "SELECT col1, col2 FROM some_table;",
-					"row_transform_steps": ["camel_to_snake"]
-				}`, runtime.GOOS),
+				"tables": fmt.Sprintf(`[
+					{
+						"name": "test_1",
+						"source_type": "sqlite",
+						"filter": "%s",
+						"columns": ["data"],
+						"source_paths": ["/some/path/to/db.sqlite"],
+						"source_query": "SELECT data FROM object_data;",
+						"row_transform_steps": ["snappy"]
+					},
+					{
+						"name": "test_2",
+						"source_type": "sqlite",
+						"filter": "%s",
+						"columns": ["col1", "col2"],
+						"source_paths": ["/some/path/to/a/different/db.sqlite"],
+						"source_query": "SELECT col1, col2 FROM some_table;",
+						"row_transform_steps": ["camel_to_snake"]
+					}
+				]`, runtime.GOOS, runtime.GOOS),
 			},
 			expectedPluginCount: 2,
+		},
+		{
+			testCaseName: "skips invalid tables and returns valid tables",
+			katcConfig: map[string]string{
+				"tables": fmt.Sprintf(`[
+					{
+						"name": "not_a_valid_table",
+						"source_type": "not a real type",
+						"filter": "%s",
+						"columns": ["col1", "col2"],
+						"source_paths": ["/some/path/to/a/different/db.sqlite"],
+						"source_query": "SELECT col1, col2 FROM some_table;",
+						"row_transform_steps": ["not a real row transform step"]
+					},
+					{
+						"name": "valid_table",
+						"source_type": "sqlite",
+						"filter": "%s",
+						"columns": ["data"],
+						"source_paths": ["/some/path/to/db.sqlite"],
+						"source_query": "SELECT data FROM object_data;",
+						"row_transform_steps": ["snappy"]
+					}
+				]`, runtime.GOOS, runtime.GOOS),
+			},
+			expectedPluginCount: 1,
 		},
 		{
 			testCaseName: "malformed config",
@@ -62,29 +95,42 @@ func TestConstructKATCTables(t *testing.T) {
 			expectedPluginCount: 0,
 		},
 		{
+			testCaseName: "malformed table",
+			katcConfig: map[string]string{
+				"tables": "this is not a config",
+			},
+			expectedPluginCount: 0,
+		},
+		{
 			testCaseName: "invalid table source",
 			katcConfig: map[string]string{
-				"kolide_snappy_test": fmt.Sprintf(`{
-					"source_type": "unknown_source",
-					"filter": "%s",
-					"columns": ["data"],
-					"source_paths": ["/some/path/to/db.sqlite"],
-					"source_query": "SELECT data FROM object_data;"
-				}`, runtime.GOOS),
+				"tables": fmt.Sprintf(`[
+					{
+						"name": "kolide_snappy_test",
+						"source_type": "unknown_source",
+						"filter": "%s",
+						"columns": ["data"],
+						"source_paths": ["/some/path/to/db.sqlite"],
+						"source_query": "SELECT data FROM object_data;"
+					}
+				]`, runtime.GOOS),
 			},
 			expectedPluginCount: 0,
 		},
 		{
 			testCaseName: "invalid data processing step type",
 			katcConfig: map[string]string{
-				"kolide_snappy_test": fmt.Sprintf(`{
-					"source_type": "sqlite",
-					"filter": "%s",
-					"columns": ["data"],
-					"source_paths": ["/some/path/to/db.sqlite"],
-					"source_query": "SELECT data FROM object_data;",
-					"row_transform_steps": ["unknown_step"]
-				}`, runtime.GOOS),
+				"tables": fmt.Sprintf(`[
+					{
+						"name": "kolide_snappy_test",
+						"source_type": "sqlite",
+						"filter": "%s",
+						"columns": ["data"],
+						"source_paths": ["/some/path/to/db.sqlite"],
+						"source_query": "SELECT data FROM object_data;",
+						"row_transform_steps": ["unknown_step"]
+					}
+				]`, runtime.GOOS),
 			},
 			expectedPluginCount: 0,
 		},

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -26,7 +26,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"platform": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
-					"query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
+					"source_query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
 					"row_transform_steps": ["snappy"]
 				}`, runtime.GOOS),
 			},
@@ -40,7 +40,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"platform": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
-					"query": "SELECT data FROM object_data;",
+					"source_query": "SELECT data FROM object_data;",
 					"row_transform_steps": ["snappy"]
 				}`, runtime.GOOS),
 				"test_2": fmt.Sprintf(`{
@@ -48,7 +48,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"platform": "%s",
 					"columns": ["col1", "col2"],
 					"source_paths": ["/some/path/to/a/different/db.sqlite"],
-					"query": "SELECT col1, col2 FROM some_table;",
+					"source_query": "SELECT col1, col2 FROM some_table;",
 					"row_transform_steps": ["camel_to_snake"]
 				}`, runtime.GOOS),
 			},
@@ -69,7 +69,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"platform": "%s",
 					"columns": ["data"],
 					"source_paths": []"/some/path/to/db.sqlite"],
-					"query": "SELECT data FROM object_data;"
+					"source_query": "SELECT data FROM object_data;"
 				}`, runtime.GOOS),
 			},
 			expectedPluginCount: 0,
@@ -82,7 +82,7 @@ func TestConstructKATCTables(t *testing.T) {
 					"platform": "%s",
 					"columns": ["data"],
 					"source_paths": []"/some/path/to/db.sqlite"],
-					"query": "SELECT data FROM object_data;",
+					"source_query": "SELECT data FROM object_data;",
 					"row_transform_steps": ["unknown_step"]
 				}`, runtime.GOOS),
 			},

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -23,7 +23,7 @@ func TestConstructKATCTables(t *testing.T) {
 			katcConfig: map[string]string{
 				"kolide_snappy_sqlite_test": fmt.Sprintf(`{
 					"source_type": "sqlite",
-					"platform": "%s",
+					"filter": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data JOIN object_store ON (object_data.object_store_id = object_store.id) WHERE object_store.name=\"testtable\";",
@@ -37,7 +37,7 @@ func TestConstructKATCTables(t *testing.T) {
 			katcConfig: map[string]string{
 				"test_1": fmt.Sprintf(`{
 					"source_type": "sqlite",
-					"platform": "%s",
+					"filter": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data;",
@@ -45,7 +45,7 @@ func TestConstructKATCTables(t *testing.T) {
 				}`, runtime.GOOS),
 				"test_2": fmt.Sprintf(`{
 					"source_type": "sqlite",
-					"platform": "%s",
+					"filter": "%s",
 					"columns": ["col1", "col2"],
 					"source_paths": ["/some/path/to/a/different/db.sqlite"],
 					"source_query": "SELECT col1, col2 FROM some_table;",
@@ -66,7 +66,7 @@ func TestConstructKATCTables(t *testing.T) {
 			katcConfig: map[string]string{
 				"kolide_snappy_test": fmt.Sprintf(`{
 					"source_type": "unknown_source",
-					"platform": "%s",
+					"filter": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data;"
@@ -79,7 +79,7 @@ func TestConstructKATCTables(t *testing.T) {
 			katcConfig: map[string]string{
 				"kolide_snappy_test": fmt.Sprintf(`{
 					"source_type": "sqlite",
-					"platform": "%s",
+					"filter": "%s",
 					"columns": ["data"],
 					"source_paths": ["/some/path/to/db.sqlite"],
 					"source_query": "SELECT data FROM object_data;",

--- a/ee/katc/sqlite.go
+++ b/ee/katc/sqlite.go
@@ -13,32 +13,34 @@ import (
 )
 
 // sqliteData is the dataFunc for sqlite KATC tables
-func sqliteData(ctx context.Context, slogger *slog.Logger, sourcePattern string, query string, sourceConstraints *table.ConstraintList) ([]sourceData, error) {
-	pathPattern := sourcePatternToGlobbablePattern(sourcePattern)
-	sqliteDbs, err := filepath.Glob(pathPattern)
-	if err != nil {
-		return nil, fmt.Errorf("globbing for files with pattern %s: %w", pathPattern, err)
-	}
-
+func sqliteData(ctx context.Context, slogger *slog.Logger, sourcePaths []string, query string, sourceConstraints *table.ConstraintList) ([]sourceData, error) {
 	results := make([]sourceData, 0)
-	for _, sqliteDb := range sqliteDbs {
-		// Check to make sure `sqliteDb` adheres to sourceConstraints
-		valid, err := checkPathConstraints(sqliteDb, sourceConstraints)
+	for _, sourcePath := range sourcePaths {
+		pathPattern := sourcePatternToGlobbablePattern(sourcePath)
+		sqliteDbs, err := filepath.Glob(pathPattern)
 		if err != nil {
-			return nil, fmt.Errorf("checking source path constraints: %w", err)
-		}
-		if !valid {
-			continue
+			return nil, fmt.Errorf("globbing for files with pattern %s: %w", pathPattern, err)
 		}
 
-		rowsFromDb, err := querySqliteDb(ctx, slogger, sqliteDb, query)
-		if err != nil {
-			return nil, fmt.Errorf("querying %s: %w", sqliteDb, err)
+		for _, sqliteDb := range sqliteDbs {
+			// Check to make sure `sqliteDb` adheres to sourceConstraints
+			valid, err := checkPathConstraints(sqliteDb, sourceConstraints)
+			if err != nil {
+				return nil, fmt.Errorf("checking source path constraints: %w", err)
+			}
+			if !valid {
+				continue
+			}
+
+			rowsFromDb, err := querySqliteDb(ctx, slogger, sqliteDb, query)
+			if err != nil {
+				return nil, fmt.Errorf("querying %s: %w", sqliteDb, err)
+			}
+			results = append(results, sourceData{
+				path: sqliteDb,
+				rows: rowsFromDb,
+			})
 		}
-		results = append(results, sourceData{
-			path: sqliteDb,
-			rows: rowsFromDb,
-		})
 	}
 
 	return results, nil

--- a/ee/katc/sqlite.go
+++ b/ee/katc/sqlite.go
@@ -23,7 +23,7 @@ func sqliteData(ctx context.Context, slogger *slog.Logger, sourcePattern string,
 	results := make([]sourceData, 0)
 	for _, sqliteDb := range sqliteDbs {
 		// Check to make sure `sqliteDb` adheres to sourceConstraints
-		valid, err := checkSourceConstraints(sqliteDb, sourceConstraints)
+		valid, err := checkPathConstraints(sqliteDb, sourceConstraints)
 		if err != nil {
 			return nil, fmt.Errorf("checking source path constraints: %w", err)
 		}

--- a/ee/katc/sqlite_test.go
+++ b/ee/katc/sqlite_test.go
@@ -59,7 +59,7 @@ func Test_sqliteData(t *testing.T) {
 	}
 
 	// Query data
-	results, err := sqliteData(context.TODO(), multislogger.NewNopLogger(), filepath.Join(sqliteDir, "*.sqlite"), "SELECT uuid, value FROM test_data;", nil)
+	results, err := sqliteData(context.TODO(), multislogger.NewNopLogger(), []string{filepath.Join(sqliteDir, "*.sqlite")}, "SELECT uuid, value FROM test_data;", nil)
 	require.NoError(t, err)
 
 	// Confirm we have the correct number of `sourceData` returned (one per db)
@@ -89,7 +89,7 @@ func Test_sqliteData_noSourcesFound(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	results, err := sqliteData(context.TODO(), multislogger.NewNopLogger(), filepath.Join(tmpDir, "db.sqlite"), "SELECT * FROM data;", nil)
+	results, err := sqliteData(context.TODO(), multislogger.NewNopLogger(), []string{filepath.Join(tmpDir, "db.sqlite")}, "SELECT * FROM data;", nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(results))
 }

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-const sourceColumnName = "source"
+const pathColumnName = "path"
 
 // katcTable is a Kolide ATC table. It queries the source and transforms the response data
 // per the configuration in its `cfg`.
@@ -24,12 +24,12 @@ type katcTable struct {
 func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (*katcTable, []table.ColumnDefinition) {
 	columns := []table.ColumnDefinition{
 		{
-			Name: sourceColumnName,
+			Name: pathColumnName,
 			Type: table.ColumnTypeText,
 		},
 	}
 	columnLookup := map[string]struct{}{
-		sourceColumnName: {},
+		pathColumnName: {},
 	}
 	for i := 0; i < len(cfg.Columns); i += 1 {
 		columns = append(columns, table.ColumnDefinition{
@@ -62,9 +62,9 @@ func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContex
 	transformedResults := make([]map[string]string, 0)
 	for _, s := range dataRaw {
 		for _, dataRawRow := range s.rows {
-			// Make sure source is included in row data
+			// Make sure source's path is included in row data
 			rowData := map[string]string{
-				sourceColumnName: s.path,
+				pathColumnName: s.path,
 			}
 
 			// Run any needed transformations on the row data
@@ -103,30 +103,30 @@ func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContex
 	return filteredResults, nil
 }
 
-// getSourceConstraint retrieves any constraints against the `source` column
+// getSourceConstraint retrieves any constraints against the `path` column
 func getSourceConstraint(queryContext table.QueryContext) *table.ConstraintList {
-	sourceConstraint, sourceConstraintExists := queryContext.Constraints[sourceColumnName]
+	sourceConstraint, sourceConstraintExists := queryContext.Constraints[pathColumnName]
 	if sourceConstraintExists {
 		return &sourceConstraint
 	}
 	return nil
 }
 
-// checkSourceConstraints validates whether a given `source` matches the given constraints.
-func checkSourceConstraints(source string, sourceConstraints *table.ConstraintList) (bool, error) {
-	if sourceConstraints == nil {
+// checkPathConstraints validates whether a given `path` matches the given constraints.
+func checkPathConstraints(path string, pathConstraints *table.ConstraintList) (bool, error) {
+	if pathConstraints == nil {
 		return true, nil
 	}
 
-	for _, sourceConstraint := range sourceConstraints.Constraints {
-		switch sourceConstraint.Operator {
+	for _, pathConstraint := range pathConstraints.Constraints {
+		switch pathConstraint.Operator {
 		case table.OperatorEquals:
-			if source != sourceConstraint.Expression {
+			if path != pathConstraint.Expression {
 				return false, nil
 			}
 		case table.OperatorLike:
 			// Transform the expression into a regex to test if we have a match.
-			likeRegexpStr := regexp.QuoteMeta(sourceConstraint.Expression)
+			likeRegexpStr := regexp.QuoteMeta(pathConstraint.Expression)
 			// % matches zero or more characters
 			likeRegexpStr = strings.Replace(likeRegexpStr, "%", `.*`, -1)
 			// _ matches a single character
@@ -137,13 +137,13 @@ func checkSourceConstraints(source string, sourceConstraints *table.ConstraintLi
 			if err != nil {
 				return false, fmt.Errorf("invalid LIKE statement: %w", err)
 			}
-			if !r.MatchString(source) {
+			if !r.MatchString(path) {
 				return false, nil
 			}
 		case table.OperatorGlob:
 			// Transform the expression into a regex to test if we have a match.
 			// Unlike LIKE, GLOB is case-sensitive.
-			globRegexpStr := regexp.QuoteMeta(sourceConstraint.Expression)
+			globRegexpStr := regexp.QuoteMeta(pathConstraint.Expression)
 			// * matches zero or more characters
 			globRegexpStr = strings.Replace(globRegexpStr, `\*`, `.*`, -1)
 			// ? matches a single character
@@ -152,19 +152,19 @@ func checkSourceConstraints(source string, sourceConstraints *table.ConstraintLi
 			if err != nil {
 				return false, fmt.Errorf("invalid GLOB statement: %w", err)
 			}
-			if !r.MatchString(source) {
+			if !r.MatchString(path) {
 				return false, nil
 			}
 		case table.OperatorRegexp:
-			r, err := regexp.Compile(sourceConstraint.Expression)
+			r, err := regexp.Compile(pathConstraint.Expression)
 			if err != nil {
 				return false, fmt.Errorf("invalid regex: %w", err)
 			}
-			if !r.MatchString(source) {
+			if !r.MatchString(path) {
 				return false, nil
 			}
 		default:
-			return false, fmt.Errorf("operator %v not valid source constraint", sourceConstraint.Operator)
+			return false, fmt.Errorf("operator %v not valid path constraint", pathConstraint.Operator)
 		}
 	}
 

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -53,7 +53,7 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 // generate handles queries against a KATC table.
 func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	// Fetch data from our table source
-	dataRaw, err := k.cfg.SourceType.dataFunc(ctx, k.slogger, k.cfg.SourcePaths, k.cfg.Query, getSourceConstraint(queryContext))
+	dataRaw, err := k.cfg.SourceType.dataFunc(ctx, k.slogger, k.cfg.SourcePaths, k.cfg.SourceQuery, getSourceConstraint(queryContext))
 	if err != nil {
 		return nil, fmt.Errorf("fetching data: %w", err)
 	}

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -21,7 +21,7 @@ type katcTable struct {
 }
 
 // newKatcTable returns a new table with the given `cfg`, as well as the osquery columns for that table.
-func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (*katcTable, []table.ColumnDefinition) {
+func newKatcTable(cfg katcTableConfig, slogger *slog.Logger) (*katcTable, []table.ColumnDefinition) {
 	columns := []table.ColumnDefinition{
 		{
 			Name: pathColumnName,
@@ -43,7 +43,7 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 		cfg:          cfg,
 		columnLookup: columnLookup,
 		slogger: slogger.With(
-			"table_name", tableName,
+			"table_name", cfg.Name,
 			"table_type", cfg.SourceType,
 			"table_source_paths", cfg.SourcePaths,
 		),

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -45,7 +45,7 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 		slogger: slogger.With(
 			"table_name", tableName,
 			"table_type", cfg.SourceType,
-			"table_source", cfg.Source,
+			"table_source_paths", cfg.SourcePaths,
 		),
 	}, columns
 }
@@ -53,7 +53,7 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 // generate handles queries against a KATC table.
 func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
 	// Fetch data from our table source
-	dataRaw, err := k.cfg.SourceType.dataFunc(ctx, k.slogger, k.cfg.Source, k.cfg.Query, getSourceConstraint(queryContext))
+	dataRaw, err := k.cfg.SourceType.dataFunc(ctx, k.slogger, k.cfg.SourcePaths, k.cfg.Query, getSourceConstraint(queryContext))
 	if err != nil {
 		return nil, fmt.Errorf("fetching data: %w", err)
 	}

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -82,6 +82,7 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 	// At long last, our source is adequately configured.
 	// Move on to constructing our KATC table.
 	cfg := katcTableConfig{
+		Name: "test_katc_table",
 		SourceType: katcSourceType{
 			name:     sqliteSourceType,
 			dataFunc: sqliteData,
@@ -101,7 +102,7 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 			},
 		},
 	}
-	testTable, _ := newKatcTable("test_katc_table", cfg, multislogger.NewNopLogger())
+	testTable, _ := newKatcTable(cfg, multislogger.NewNopLogger())
 
 	// Make a query context restricting the source to our exact source sqlite database
 	queryContext := table.QueryContext{

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -89,7 +89,7 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 		Platform:    runtime.GOOS,
 		Columns:     []string{expectedColumn},
 		SourcePaths: []string{filepath.Join(databaseDir, "%.sqlite")}, // All sqlite files in the test directory
-		Query:       "SELECT data FROM object_data;",
+		SourceQuery: "SELECT data FROM object_data;",
 		RowTransformSteps: []rowTransformStep{
 			{
 				name:          snappyDecodeTransformStep,

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -106,7 +106,7 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 	// Make a query context restricting the source to our exact source sqlite database
 	queryContext := table.QueryContext{
 		Constraints: map[string]table.ConstraintList{
-			sourceColumnName: {
+			pathColumnName: {
 				Constraints: []table.Constraint{
 					{
 						Operator:   table.OperatorEquals,
@@ -123,8 +123,8 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 
 	// Validate results
 	require.Equal(t, 1, len(results), "exactly one row expected")
-	require.Contains(t, results[0], sourceColumnName, "missing source column")
-	require.Equal(t, sourceFilepath, results[0][sourceColumnName])
+	require.Contains(t, results[0], pathColumnName, "missing source column")
+	require.Equal(t, sourceFilepath, results[0][pathColumnName])
 	require.Contains(t, results[0], expectedColumn, "expected column missing")
 	require.Equal(t, expectedColumnValue, results[0][expectedColumn], "data mismatch")
 }
@@ -134,14 +134,14 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 
 	for _, tt := range []struct {
 		testCaseName  string
-		source        string
+		path          string
 		constraints   table.ConstraintList
 		valid         bool
 		errorExpected bool
 	}{
 		{
 			testCaseName: "equals",
-			source:       filepath.Join("some", "path", "to", "a", "source"),
+			path:         filepath.Join("some", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -155,7 +155,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "not equals",
-			source:       filepath.Join("some", "path", "to", "a", "source"),
+			path:         filepath.Join("some", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -169,7 +169,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "LIKE with % wildcard",
-			source:       filepath.Join("a", "path", "to", "db.sqlite"),
+			path:         filepath.Join("a", "path", "to", "db.sqlite"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -183,7 +183,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "LIKE with underscore wildcard",
-			source:       filepath.Join("a", "path", "to", "db.sqlite"),
+			path:         filepath.Join("a", "path", "to", "db.sqlite"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -197,7 +197,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "LIKE is case-insensitive",
-			source:       filepath.Join("a", "path", "to", "db.sqlite"),
+			path:         filepath.Join("a", "path", "to", "db.sqlite"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -210,7 +210,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "GLOB with * wildcard",
-			source:       filepath.Join("another", "path", "to", "a", "source"),
+			path:         filepath.Join("another", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -224,7 +224,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "GLOB with ? wildcard",
-			source:       filepath.Join("another", "path", "to", "a", "source"),
+			path:         filepath.Join("another", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -238,7 +238,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "regexp",
-			source:       filepath.Join("test", "path", "to", "a", "source"),
+			path:         filepath.Join("test", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -252,7 +252,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "invalid regexp",
-			source:       filepath.Join("test", "path", "to", "a", "source"),
+			path:         filepath.Join("test", "path", "to", "a", "source"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -266,7 +266,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "unsupported",
-			source:       filepath.Join("test", "path", "to", "a", "source", "2"),
+			path:         filepath.Join("test", "path", "to", "a", "source", "2"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -280,7 +280,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "multiple constraints where one does not match",
-			source:       filepath.Join("test", "path", "to", "a", "source", "3"),
+			path:         filepath.Join("test", "path", "to", "a", "source", "3"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -298,7 +298,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		},
 		{
 			testCaseName: "multiple constraints where all match",
-			source:       filepath.Join("test", "path", "to", "a", "source", "3"),
+			path:         filepath.Join("test", "path", "to", "a", "source", "3"),
 			constraints: table.ConstraintList{
 				Constraints: []table.Constraint{
 					{
@@ -319,7 +319,7 @@ func Test_checkSourcePathConstraints(t *testing.T) {
 		t.Run(tt.testCaseName, func(t *testing.T) {
 			t.Parallel()
 
-			valid, err := checkSourceConstraints(tt.source, &tt.constraints)
+			valid, err := checkPathConstraints(tt.path, &tt.constraints)
 			if tt.errorExpected {
 				require.Error(t, err, "expected error on checking constraints")
 			} else {

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -86,10 +86,10 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 			name:     sqliteSourceType,
 			dataFunc: sqliteData,
 		},
-		Platform: runtime.GOOS,
-		Columns:  []string{expectedColumn},
-		Source:   filepath.Join(databaseDir, "%.sqlite"), // All sqlite files in the test directory
-		Query:    "SELECT data FROM object_data;",
+		Platform:    runtime.GOOS,
+		Columns:     []string{expectedColumn},
+		SourcePaths: []string{filepath.Join(databaseDir, "%.sqlite")}, // All sqlite files in the test directory
+		Query:       "SELECT data FROM object_data;",
 		RowTransformSteps: []rowTransformStep{
 			{
 				name:          snappyDecodeTransformStep,

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -86,7 +86,7 @@ func Test_generate_SqliteBackedIndexedDB(t *testing.T) {
 			name:     sqliteSourceType,
 			dataFunc: sqliteData,
 		},
-		Platform:    runtime.GOOS,
+		Filter:      runtime.GOOS,
 		Columns:     []string{expectedColumn},
 		SourcePaths: []string{filepath.Join(databaseDir, "%.sqlite")}, // All sqlite files in the test directory
 		SourceQuery: "SELECT data FROM object_data;",


### PR DESCRIPTION
This PR makes the following config updates:

* Rename `source` column to `path` to be more consistent with our e.g. dataflatten tables, which also return a `path` column
* Rename `source` to `source_paths` for clarity; additionally, make it an array rather than a single string to allow for matching against multiple patterns
* Rename `query` to `source_query` to disambiguate from the `query` column we use elsewhere
* Rename `platform` to `filter` to clarify that we may have other types of filters in the future
* Update config structure to be a list of tables instead of a map, so that K2 is able to send down config definitions for all tables instead of filtering by platform; launcher handles the filtering instead
* To support the above, move the table name inside the table config

These changes were made in roughly this order; it is possible to review commit-by-commit if that's easier.