### PR TITLE
Upgrade actions to versions that run on node20

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: './go.mod'
           check-latest: true

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
+          cache: false
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0 # need a full checkout for `git describe`
 
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: './go.mod'
         check-latest: true
@@ -212,7 +212,7 @@ jobs:
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: './go.mod'
         check-latest: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,13 +44,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -82,7 +82,7 @@ jobs:
       run: make test
 
     - name: Cache build output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -106,7 +106,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -136,7 +136,7 @@ jobs:
     needs: version_baseline
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
@@ -183,7 +183,7 @@ jobs:
     needs: exec_testing
     steps:
     - name: cache restore build output
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ matrix.artifactos }}-${{ github.run_id }}
@@ -225,13 +225,13 @@ jobs:
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Go Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
     - name: Go Mod Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,7 +90,7 @@ jobs:
 
     # upload coverage here, because we don't cache it with the build
     - name: Upload coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}-coverage.out
         path: coverage.out
@@ -190,7 +190,7 @@ jobs:
         enableCrossOsArchive: true
 
     - name: Upload Build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifactos }}-build
         path: build/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         go-version-file: './go.mod'
         check-latest: true
+        cache: false
       id: go
 
     # use bash, because the powershell syntax is different and this is a cross platform workflow

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,7 +94,8 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}-coverage.out
-        path: coverage.out
+        path: ./coverage.out
+        if-no-files-found: error
 
   # this job captures the version of launcher on one of the runners then that version is
   # compared to the version of all other runners during exec testing. This is to ensure

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -216,6 +216,7 @@ jobs:
       with:
         go-version-file: './go.mod'
         check-latest: true
+        cache: false
       id: go
 
     - id: go-cache-paths

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Check out code
       id: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 
@@ -208,7 +208,7 @@ jobs:
           - macos-12
           - windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: './go.mod'
           check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,9 +29,7 @@ jobs:
       - run: make deps
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          skip-pkg-cache: true
+        uses: golangci/golangci-lint-action@v6
 
       # Run again as a workaround for https://github.com/golangci/golangci-lint-action/issues/362
       - name: golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -45,7 +45,7 @@ jobs:
     name: govulncheck
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
+          cache: false
 
       - run: make deps
 


### PR DESCRIPTION
I saw we were getting lots of [warnings](https://github.com/kolide/launcher/actions/runs/9783564126?pr=1770) in our CI jobs like:

> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v3, actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

This PR upgrades all actions to versions that run on node20, to make these warnings go away.

Upgrading `actions/upload-artifact` is additionally useful because `actions/upload-artifact@v3` is set to be deprecated toward the end of this year.

No more warnings:

* Actionlint: https://github.com/kolide/launcher/actions/runs/9844017555?pr=1771
* Lint: https://github.com/kolide/launcher/actions/runs/9844017560?pr=1771
* Go: https://github.com/kolide/launcher/actions/runs/9844017543?pr=1771