### PR TITLE
check for dbus channel open and fix initialActorError logging

### DIFF
--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -5,6 +5,7 @@ package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -77,7 +78,7 @@ func (d *dbusNotifier) Listen() error {
 		select {
 		case signal, open := <-d.signal:
 			if !open {
-				return fmt.Errorf("dbus signal channel closed, cannot proceed")
+				return errors.New("dbus signal channel closed, cannot proceed")
 			}
 
 			if signal == nil || signal.Name != signalActionInvoked {

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -75,7 +75,11 @@ func (d *dbusNotifier) Listen() error {
 
 	for {
 		select {
-		case signal := <-d.signal:
+		case signal, open := <-d.signal:
+			if !open {
+				return fmt.Errorf("dbus signal channel closed, cannot proceed")
+			}
+
 			if signal == nil || signal.Name != signalActionInvoked {
 				continue
 			}

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -93,7 +93,8 @@ func (g *Group) Run() error {
 
 	g.slogger.Log(context.TODO(), slog.LevelInfo,
 		"received interrupt error from first actor -- shutting down other actors",
-		"err", initialActorErr,
+		"err", initialActorErr.err,
+		"error_source", initialActorErr.errorSourceName,
 	)
 
 	defer g.slogger.Log(context.TODO(), slog.LevelDebug,


### PR DESCRIPTION
closes https://github.com/kolide/launcher/issues/1749

The linked issue is caused by the dbus signal channel closing on logout - we have a tight for/select loop that is spammed with nil values and continues immediately, consuming an entire CPU core. The fix here will trigger a restart on logout, preventing both the CPU consumption and MBA disappearing symptoms. But some additional context is worth reviewing before deciding if this is the way we want to go:

My first attempt at fixing was more complicated- it involved refactoring to support refreshing the dbus session connection when we detect this state. That fixes the CPU consumption issue and allows us to proceed without restarting, but the MBA still does not come back. As far as I can tell systray encounters the same issue, just separately within the desktop process. I think we can do something similar within systray, detecting the closed connection and refreshing, but wanted to get opinions about whether we thought that was worth the effort vs. a simple approach like this, which will guarantee a clean state for both after logout. 

I do not see this causing excessive restarts in testing so far (e.g. sleep/suspend states), this seems to specifically happen on explicit logout