### PR TITLE
Prevent osquery instance restarts while instance is still launching

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -62,9 +62,13 @@ func New(k types.Knapsack, opts ...OsqueryInstanceOption) *Runner {
 }
 
 func (r *Runner) Run() error {
+	// Ensure we don't try to restart the instance before it's launched
+	r.instanceLock.Lock()
 	if err := r.launchOsqueryInstance(); err != nil {
+		r.instanceLock.Unlock()
 		return fmt.Errorf("starting instance: %w", err)
 	}
+	r.instanceLock.Unlock()
 
 	// This loop waits for the completion of the async routines,
 	// and either restarts the instance (if Shutdown was not


### PR DESCRIPTION
It is possible for e.g. control server flags to change while the osquery instance is still launching, which would prompt a call to `runner.Restart`. Through testing, this can sometimes put the osquery runner in a bad state, where the instance isn't running and it doesn't attempt to launch a new one.

To prevent this, we use the preexisting instance lock during initial instance launch, which will pause the `runner.Restart` call until the lock is free again.