### PR TITLE
Don't store hashes for unknown subsystems

### DIFF
--- a/ee/control/client_test.go
+++ b/ee/control/client_test.go
@@ -9,14 +9,16 @@ import (
 
 // TestClient is useful for clients in tests
 type TestClient struct {
-	subsystemMap map[string]string
-	hashData     map[string]any
+	subsystemMap      map[string]string
+	hashData          map[string]any
+	hashRequestCounts map[string]int
 }
 
 func NewControlTestClient(subsystemMap map[string]string, hashData map[string]any) (*TestClient, error) {
 	c := &TestClient{
-		subsystemMap: subsystemMap,
-		hashData:     hashData,
+		subsystemMap:      subsystemMap,
+		hashData:          hashData,
+		hashRequestCounts: make(map[string]int),
 	}
 	return c, nil
 }
@@ -31,6 +33,12 @@ func (c *TestClient) GetConfig() (data io.Reader, err error) {
 }
 
 func (c *TestClient) GetSubsystemData(hash string) (data io.Reader, err error) {
+	if _, ok := c.hashRequestCounts[hash]; !ok {
+		c.hashRequestCounts[hash] = 1
+	} else {
+		c.hashRequestCounts[hash] += 1
+	}
+
 	bodyBytes, err := json.Marshal(c.hashData[hash])
 	if err != nil {
 		return nil, fmt.Errorf("marshaling json: %w", err)

--- a/ee/control/control_test.go
+++ b/ee/control/control_test.go
@@ -236,7 +236,7 @@ func TestControlServiceFetch(t *testing.T) {
 			mockKnapsack.On("ForceControlSubsystems").Return(false)
 			mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
-			data := &TestClient{tt.subsystems, tt.hashData}
+			data, _ := NewControlTestClient(tt.subsystems, tt.hashData)
 			controlOpts := []Option{}
 			cs := New(mockKnapsack, data, controlOpts...)
 			err := cs.RegisterConsumer(tt.subsystem, tt.c)
@@ -260,6 +260,53 @@ func TestControlServiceFetch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestControlServiceFetch_IgnoresUnknownSubsystems(t *testing.T) {
+	t.Parallel()
+
+	mockKnapsack := typesMocks.NewKnapsack(t)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ControlRequestInterval)
+	mockKnapsack.On("ControlRequestInterval").Return(60 * time.Second)
+	mockKnapsack.On("ForceControlSubsystems").Return(false)
+	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+
+	unknownSubsystemHash := "602a42f1"
+	subsystems := map[string]string{"desktop": "502a42f0", "unknown": unknownSubsystemHash}
+	hashData := map[string]any{"502a42f0": "status"}
+
+	// The test client will panic if it receives a request for the `unknown` subsystem hash,
+	// validating that we don't process data for the `unknown` subsystem.
+	data, _ := NewControlTestClient(subsystems, hashData)
+	controlOpts := []Option{}
+	cs := New(mockKnapsack, data, controlOpts...)
+
+	// Register consumer/subscriber for `desktop` subsystem only
+	desktopConsumer := &mockConsumer{}
+	err := cs.RegisterConsumer("desktop", desktopConsumer)
+	require.NoError(t, err)
+	desktopSubscriber := &mockSubscriber{}
+	cs.RegisterSubscriber("desktop", desktopSubscriber)
+
+	// Run fetch for the first time
+	require.NoError(t, cs.Fetch())
+
+	// Expect desktop consumer to have gotten exactly one update
+	assert.Equal(t, 1, desktopConsumer.updates)
+
+	// Expect desktop subscriber to have gotten exactly one ping
+	assert.Equal(t, 1, desktopSubscriber.pings)
+
+	// Expect no requests to unknown hash
+	require.NotContains(t, data.hashRequestCounts, unknownSubsystemHash)
+
+	// Run fetch again. This time, data should be cached, so there should be no updates or pings.
+	require.NoError(t, cs.Fetch())
+	assert.Equal(t, 1, desktopConsumer.updates)
+	assert.Equal(t, 1, desktopSubscriber.pings)
+
+	// Expect no requests to unknown hash
+	require.NotContains(t, data.hashRequestCounts, unknownSubsystemHash)
 }
 
 func TestControlServiceFetch_WithControlRequestIntervalUpdate(t *testing.T) {
@@ -336,7 +383,7 @@ func TestControlServicePersistLastFetched(t *testing.T) {
 
 			// Make several instances of control service
 			for j := 0; j < tt.instances; j++ {
-				data := &TestClient{tt.subsystems, tt.hashData}
+				data, _ := NewControlTestClient(tt.subsystems, tt.hashData)
 				controlOpts := []Option{WithStore(store)}
 
 				mockKnapsack := typesMocks.NewKnapsack(t)


### PR DESCRIPTION
We've run into an issue a couple of times now:

1. We create a new subsystem on the server side, and write launcher code to handle this subsystem
2. We release the new subsystem first
3. Older versions of launcher store the hashes for the new subsystem's data, but they do not process that data because they don't know how to yet
4. launcher autoupdates to a new version, but does not know to fetch the data anew because the hashes are cached

The solution this PR proposes is to skip step 3: i.e., if a subsystem is unknown to launcher, do not store the hash of its data. That way, when launcher autoupdates and learns about this new subsystem, it will fetch that subsystem's data fresh for the first time.

I audited to check that I hadn't left off any subsystems. The only one this PR does not add is `desktop_notifier`, which is a legacy subsystem that has since moved under `actions`.