### PR TITLE
watchdog installation path updates

### DIFF
--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -246,7 +246,7 @@ func (wc *WatchdogController) getExecutablePath() (string, error) {
 
 func (wc *WatchdogController) installService(serviceManager *mgr.Mgr) error {
 	ctx := context.TODO()
-	currentExe, err := wc.getExecutablePath()
+	installedExePath, err := wc.getExecutablePath()
 	if err != nil {
 		return fmt.Errorf("determining watchdog executable path: %w", err)
 	}
@@ -269,7 +269,7 @@ func (wc *WatchdogController) installService(serviceManager *mgr.Mgr) error {
 
 	restartService, err := serviceManager.CreateService(
 		launcherWatchdogServiceName,
-		currentExe,
+		installedExePath,
 		svcMgrConf,
 		serviceArgs...,
 	)

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"slices"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	agentsqlite "github.com/kolide/launcher/ee/agent/storage/sqlite"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/backoff"
+	"github.com/kolide/launcher/pkg/launcher"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -230,11 +232,23 @@ func (wc *WatchdogController) ServiceEnabledChanged(enabled bool) {
 	}
 }
 
+func (wc *WatchdogController) getExecutablePath() (string, error) {
+	defaultBinDir := launcher.DefaultPath(launcher.BinDirectory)
+	defaultLauncherLocation := filepath.Join(defaultBinDir, "launcher.exe")
+	// do some basic sanity checking to prevent installation from a bad path
+	_, err := os.Stat(defaultLauncherLocation)
+	if err != nil {
+		return "", err
+	}
+
+	return defaultLauncherLocation, nil
+}
+
 func (wc *WatchdogController) installService(serviceManager *mgr.Mgr) error {
 	ctx := context.TODO()
-	currentExe, err := os.Executable()
+	currentExe, err := wc.getExecutablePath()
 	if err != nil {
-		return fmt.Errorf("collecting current executable path: %w", err)
+		return fmt.Errorf("determining watchdog executable path: %w", err)
 	}
 
 	svcMgrConf := mgr.Config{


### PR DESCRIPTION
we install the watchdog service at runtime by gathering the current executable via `os.Executable()`. If this occurs from an autoupdated version, it will hold up autoupdate's `TidyLibrary` functionality later (or break watchdog if watchdog is stopped while tidy runs).

To avoid this we can just install the service with the originally installed launcher.exe path, instead of the currently running autoupdate version. That path is left alone, but the find latest logic should still allow the correct launcher version to run the watchdog code 