### PR TITLE
Log table_type correctly in KATC logs

### DIFF
--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -54,6 +54,13 @@ func (kst *katcSourceType) UnmarshalJSON(data []byte) error {
 	}
 }
 
+func (kst *katcSourceType) String() string {
+	if kst == nil {
+		return ""
+	}
+	return kst.name
+}
+
 // rowTransformStep defines an operation performed against a row of data
 // returned from a source. The `name` is the identifier parsed from the
 // JSON KATC config.

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -86,9 +86,13 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 	}
 
 	// Add extra fields to slogger
+	var tableType string
+	if cfg.SourceType != nil {
+		tableType = cfg.SourceType.name
+	}
 	k.slogger = slogger.With(
 		"table_name", tableName,
-		"table_type", cfg.SourceType,
+		"table_type", tableType,
 	)
 
 	return &k, columns

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -86,13 +86,9 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 	}
 
 	// Add extra fields to slogger
-	var tableType string
-	if cfg.SourceType != nil {
-		tableType = cfg.SourceType.name
-	}
 	k.slogger = slogger.With(
 		"table_name", tableName,
-		"table_type", tableType,
+		"table_type", cfg.SourceType.String(),
 	)
 
 	return &k, columns


### PR DESCRIPTION
Fixes `table_type` being set to `{}` in logs.