### PR TITLE
pkg/osquery/runtime improvements, largely around improving test flakiness

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -596,8 +596,7 @@ func (o *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 		<-o.doneCtx.Done()
 
 		o.slogger.Log(context.TODO(), slog.LevelDebug,
-			"exiting errgroup",
-			"errgroup", "starting extension shutdown",
+			"starting extension shutdown",
 			"extension_name", name,
 		)
 

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -481,13 +481,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		span.AddEvent("extension_server_created")
 	}
 
-	if err := o.stats.Connected(o); err != nil {
-		r.slogger.Log(ctx, slog.LevelWarn,
-			"could not set connection time for osquery instance history",
-			"err", err,
-		)
-	}
-
 	// Now spawn an extension manager for the tables. We need to
 	// start this one in the background, because the runner.Start
 	// function needs to return promptly enough for osquery to use
@@ -516,6 +509,15 @@ func (r *Runner) launchOsqueryInstance() error {
 		}
 		return nil
 	})
+
+	// All done with osquery setup! Mark instance as connected, then proceed
+	// with setting up remaining errgroups.
+	if err := o.stats.Connected(o); err != nil {
+		r.slogger.Log(ctx, slog.LevelWarn,
+			"could not set connection time for osquery instance history",
+			"err", err,
+		)
+	}
 
 	// Health check on interval
 	o.errgroup.Go(func() error {

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -60,7 +60,7 @@ func SocketPath(rootDir string) string {
 	// launcher and osquery. We would like to be able to run multiple
 	// launchers.
 	//
-	// We could use something based on the laumcher root, but given the
+	// We could use something based on the launcher root, but given the
 	// context this runs in a ulid seems simpler.
 	return fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, ulid.New())
 }

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -82,7 +82,7 @@ func TestOsquerySlowStart(t *testing.T) {
 
 	// ensure that we actually had to wait on the socket
 	require.Contains(t, logBytes.String(), "osquery extension socket not created yet")
-	require.NoError(t, runner.Shutdown())
+	waitShutdown(t, runner, &logBytes)
 }
 
 // TestExtensionSocketPath tests that the launcher can start osqueryd with a custom extension socket path.
@@ -133,7 +133,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	assert.Equal(t, int32(0), resp.Status.Code)
 	assert.Equal(t, "OK", resp.Status.Message)
 
-	require.NoError(t, runner.Shutdown())
+	waitShutdown(t, runner, &logBytes)
 }
 
 // TestRestart tests that the launcher can restart the osqueryd process.

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -78,7 +78,7 @@ func TestOsquerySlowStart(t *testing.T) {
 		}),
 	)
 	go runner.Run()
-	waitHealthy(t, runner)
+	waitHealthy(t, runner, &logBytes)
 
 	// ensure that we actually had to wait on the socket
 	require.Contains(t, logBytes.String(), "osquery extension socket not created yet")
@@ -94,11 +94,17 @@ func TestExtensionSocketPath(t *testing.T) {
 	require.NoError(t, err)
 	defer rmRootDirectory()
 
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
@@ -113,7 +119,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	)
 	go runner.Run()
 
-	waitHealthy(t, runner)
+	waitHealthy(t, runner, &logBytes)
 
 	// wait for the launcher-provided extension to register
 	time.Sleep(2 * time.Second)
@@ -135,13 +141,13 @@ func TestExtensionSocketPath(t *testing.T) {
 // Should investigate why this is the case.
 func TestRestart(t *testing.T) {
 	t.Parallel()
-	runner, teardown := setupOsqueryInstanceForTests(t)
+	runner, logBytes, teardown := setupOsqueryInstanceForTests(t)
 	defer teardown()
 
 	previousStats := runner.instance.stats
 
 	require.NoError(t, runner.Restart())
-	waitHealthy(t, runner)
+	waitHealthy(t, runner, logBytes)
 
 	require.NotEmpty(t, runner.instance.stats.StartTime, "start time should be set on latest instance stats after restart")
 	require.NotEmpty(t, runner.instance.stats.ConnectTime, "connect time should be set on latest instance stats after restart")
@@ -152,7 +158,7 @@ func TestRestart(t *testing.T) {
 	previousStats = runner.instance.stats
 
 	require.NoError(t, runner.Restart())
-	waitHealthy(t, runner)
+	waitHealthy(t, runner, logBytes)
 
 	require.NotEmpty(t, runner.instance.stats.StartTime, "start time should be added to latest instance stats after restart")
 	require.NotEmpty(t, runner.instance.stats.ConnectTime, "connect time should be added to latest instance stats after restart")

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -448,10 +448,11 @@ func TestFlagsChanged(t *testing.T) {
 // fatals the test
 func waitHealthy(t *testing.T, runner *Runner) {
 	require.NoError(t, backoff.WaitFor(func() error {
-		if runner.Healthy() == nil {
-			return nil
+		err := runner.Healthy()
+		if err != nil {
+			return fmt.Errorf("instance not healthy: %w", err)
 		}
-		return fmt.Errorf("instance not healthy")
+		return nil
 	}, 30*time.Second, 1*time.Second))
 }
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -4,7 +4,6 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -358,7 +357,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	waitHealthy(t, runner, &logBytes)
 	assert.Equal(t, []string{"verbose=false"}, runner.instance.opts.osqueryFlags)
 
-	runner.Interrupt(errors.New("test error"))
+	require.NoError(t, runner.Shutdown())
 }
 
 func TestFlagsChanged(t *testing.T) {
@@ -455,7 +454,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	k.AssertExpectations(t)
 
-	runner.Interrupt(errors.New("test error"))
+	require.NoError(t, runner.Shutdown())
 }
 
 // waitHealthy expects the instance to be healthy within 30 seconds, or else

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -461,7 +461,7 @@ func waitShutdown(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Threa
 	// We don't want to retry shutdowns because subsequent shutdown calls don't do anything --
 	// they return nil immediately, which would give `backoff` the impression that shutdown has
 	// completed when it hasn't.
-	// Instead, call `Shutdown` once, wait for our timeout (2 minutes), and report failure if
+	// Instead, call `Shutdown` once, wait for our timeout (1 minute), and report failure if
 	// `Shutdown` has not returned.
 	shutdownErr := make(chan error)
 	go func() {
@@ -471,7 +471,7 @@ func waitShutdown(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Threa
 	select {
 	case err := <-shutdownErr:
 		require.NoError(t, err, fmt.Sprintf("runner logs: %s", logBytes.String()))
-	case <-time.After(2 * time.Minute):
+	case <-time.After(1 * time.Minute):
 		t.Error("runner did not shut down within timeout", fmt.Sprintf("runner logs: %s", logBytes.String()))
 		t.FailNow()
 	}


### PR DESCRIPTION
I've noticed that the runtime tests have been particularly flaky on Windows lately and it's been holding up CI significantly because we often have to wait for the 10-min test timeout to hit before test failure. See e.g. https://github.com/kolide/launcher/actions/runs/10094889355/job/27918355827.

## Issues found

* `runner.Shutdown` was getting stuck; tests would panic after 10 minutes due to timeout. (This really holds up CI, plus the panic means we don't really get any useful information about what part of the test got stuck.)
* `waitHealthy` reported that the osquery instance was healthy before we'd actually finished launching the instance. I believe that this was what caused `runner.Shutdown` to get stuck.
* I saw in the logs that sometimes the PID file wasn't getting removed. Not really a big deal, but I fixed it anyway.

## Fixes in this PR

### Test improvements

* Tests fail faster: add a one-minute timeout to calling `runner.Shutdown`, so that we can quickly fail and get useful troubleshooting information when `Shutdown` is stuck -- instead of waiting 10 minutes to hit test timeout + panic, which gives us no useful information about the issue
* Confirm osquery instance is fully set up: instead of only validating that `runner.Healthy()` returns no error, also confirm that the launch function has finished all critical work, and add a little bit of a sleep buffer before proceeding
* Test failures include more useful troubleshooting information: include error message from calling `runner.Healthy` when that fails; include runner logs in failure messages

### Code improvements

* Retry PID file removal
* A log message was erroneously tagged as an errgroup exiting when it was not -- updated appropriately
* Mark instance as connected after all extension manager servers are set up, not just `kolide_grpc`