### PR TITLE
[KATC/IndexedDB] Adjust strict mode for opening leveldb-backed indexeddb

### DIFF
--- a/ee/indexeddb/indexeddb.go
+++ b/ee/indexeddb/indexeddb.go
@@ -43,8 +43,8 @@ func QueryIndexeddbObjectStore(dbLocation string, dbName string, objectStoreName
 
 	opts := &opt.Options{
 		Comparer:               indexeddbComparer,
-		DisableSeeksCompaction: true, // no need to perform compaction
-		Strict:                 opt.StrictAll,
+		DisableSeeksCompaction: true,               // no need to perform compaction
+		Strict:                 opt.StrictRecovery, // we prefer to drop corrupted data rather than fail to open the db altogether
 	}
 	db, err := leveldb.OpenFile(tempDbCopyLocation, opts)
 	if err != nil {


### PR DESCRIPTION
Previously, we were using strict mode `StrictAll`:

```go
const StrictAll = StrictManifest | StrictJournalChecksum | StrictJournal | StrictBlockChecksum | StrictCompaction | StrictReader | StrictRecovery
```

Several of these options prevent the database from being opened at all if corruption is present. It is more reasonable for our usecase to at least attempt to read the data out of the database. I have therefore opted to swap to `StrictRecovery` only (`If present then leveldb.Recover will drop corrupted 'sorted table'`).