### PR TITLE
prevent watchdog installation for dev environments

### DIFF
--- a/cmd/launcher/svc_config_windows.go
+++ b/cmd/launcher/svc_config_windows.go
@@ -30,7 +30,7 @@ const (
 
 func checkServiceConfiguration(logger *slog.Logger, opts *launcher.Options) {
 	// If this isn't a Kolide installation, do not update the configuration
-	if opts.KolideServerURL != "k2device.kolide.com" && opts.KolideServerURL != "k2device-preprod.kolide.com" {
+	if !launcher.IsKolideHostedServerURL(opts.KolideServerURL) {
 		return
 	}
 

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -156,7 +156,8 @@ func (wc *WatchdogController) ServiceEnabledChanged(enabled bool) {
 	// we don't alter watchdog installation (install or remove) if this is a non-prod deployment
 	if !launcher.IsKolideHostedServerURL(wc.knapsack.KolideServerURL()) {
 		wc.slogger.Log(ctx, slog.LevelDebug,
-			"skipping ServiceEnabledChanged for launcher watchdog",
+			"skipping ServiceEnabledChanged for launcher watchdog in non-prod environment",
+			"server_url", wc.knapsack.KolideServerURL(),
 			"enabled", enabled,
 		)
 

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -153,6 +153,16 @@ func (wc *WatchdogController) Interrupt(_ error) {
 
 func (wc *WatchdogController) ServiceEnabledChanged(enabled bool) {
 	ctx := context.TODO()
+	// we don't alter watchdog installation (install or remove) if this is a non-prod deployment
+	if !launcher.IsKolideHostedServerURL(wc.knapsack.KolideServerURL()) {
+		wc.slogger.Log(ctx, slog.LevelDebug,
+			"skipping ServiceEnabledChanged for launcher watchdog",
+			"enabled", enabled,
+		)
+
+		return
+	}
+
 	var serviceManager *mgr.Mgr
 	var err error
 

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/launcher"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -163,6 +164,16 @@ func (wc *WatchdogController) ServiceEnabledChanged(enabled bool) {
 		wc.slogger.Log(ctx, slog.LevelDebug,
 			"skipping ServiceEnabledChanged for launcher watchdog in non-prod environment",
 			"server_url", wc.knapsack.KolideServerURL(),
+			"enabled", enabled,
+		)
+
+		return
+	}
+
+	// we also don't alter watchdog installation if we're running without elevated permissions
+	if !windows.GetCurrentProcessToken().IsElevated() {
+		wc.slogger.Log(ctx, slog.LevelDebug,
+			"skipping ServiceEnabledChanged for launcher watchdog running without elevated permissions",
 			"enabled", enabled,
 		)
 

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -96,6 +96,11 @@ func (wc *WatchdogController) publishLogs(ctx context.Context) {
 		return
 	}
 
+	// we don't install watchdog for non-prod deployments, so we should also skip log publication
+	if !launcher.IsKolideHostedServerURL(wc.knapsack.KolideServerURL()) {
+		return
+	}
+
 	logsToDelete := make([]any, 0)
 
 	if err := wc.logPublisher.ForEach(func(rowid, timestamp int64, v []byte) error {

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -627,3 +627,9 @@ func commandUsage(fs *flag.FlagSet, short string) func() {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 }
+
+// IsKolideHostedServerURL is a convenience function to enable gating functionality for
+// developer (or other non-production) deployments
+func IsKolideHostedServerURL(serverURL string) bool {
+	return serverURL == "k2device.kolide.com" || serverURL == "k2device-preprod.kolide.com"
+}

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -93,7 +93,7 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL string) s
 	}
 
 	// don't mess with the path if this installation isn't pointing to a kolide server URL
-	if kolideServerURL != "k2device.kolide.com" && kolideServerURL != "k2device-preprod.kolide.com" {
+	if !IsKolideHostedServerURL(kolideServerURL) {
 		return optsRootDirectory
 	}
 


### PR DESCRIPTION
There were a few places already where we gate behavior on the KolideServerURL with the same checks. This adds a helper function to check a serverURL against our match criteria, and adds this check to the watchdog installation and log publication routines
