### PR TITLE
Log when osquery instance has completed setup; improve interactive tests

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -472,10 +472,6 @@ func (r *Runner) launchOsqueryInstance() error {
 	o.extensionManagerClient, err = o.StartOsqueryClient(paths)
 	if err != nil {
 		traces.SetError(span, fmt.Errorf("could not create an extension client: %w", err))
-		r.slogger.Log(ctx, slog.LevelError,
-			"error creating extension client",
-			"err", err,
-		)
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -391,10 +391,6 @@ func (r *Runner) launchOsqueryInstance() error {
 			"could not create new osquery instance history",
 			"err", err,
 		)
-	} else {
-		r.slogger.Log(ctx, slog.LevelDebug,
-			"created osquery instance version history",
-		)
 	}
 	o.stats = stats
 
@@ -483,9 +479,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")
-	r.slogger.Log(ctx, slog.LevelDebug,
-		"osquery extension client created",
-	)
 
 	if len(o.opts.extensionPlugins) > 0 {
 		if err := o.StartOsqueryExtensionManagerServer("kolide_grpc", paths.extensionSocketPath, o.extensionManagerClient, o.opts.extensionPlugins); err != nil {
@@ -498,9 +491,6 @@ func (r *Runner) launchOsqueryInstance() error {
 		}
 		span.AddEvent("extension_server_created")
 	}
-	r.slogger.Log(ctx, slog.LevelDebug,
-		"osquery extension manager server created",
-	)
 
 	// Now spawn an extension manager for the tables. We need to
 	// start this one in the background, because the runner.Start
@@ -539,9 +529,6 @@ func (r *Runner) launchOsqueryInstance() error {
 			"err", err,
 		)
 	}
-	r.slogger.Log(ctx, slog.LevelDebug,
-		"osquery instance connected",
-	)
 
 	// Health check on interval
 	o.errgroup.Go(func() error {

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -468,6 +468,9 @@ func (r *Runner) launchOsqueryInstance() error {
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")
+	r.slogger.Log(ctx, slog.LevelDebug,
+		"osquery extension client created",
+	)
 
 	if len(o.opts.extensionPlugins) > 0 {
 		if err := o.StartOsqueryExtensionManagerServer("kolide_grpc", paths.extensionSocketPath, o.extensionManagerClient, o.opts.extensionPlugins); err != nil {
@@ -480,6 +483,9 @@ func (r *Runner) launchOsqueryInstance() error {
 		}
 		span.AddEvent("extension_server_created")
 	}
+	r.slogger.Log(ctx, slog.LevelDebug,
+		"osquery extension manager server created",
+	)
 
 	// Now spawn an extension manager for the tables. We need to
 	// start this one in the background, because the runner.Start

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -377,6 +377,9 @@ func (r *Runner) launchOsqueryInstance() error {
 	}
 
 	span.AddEvent("socket_created")
+	r.slogger.Log(ctx, slog.LevelDebug,
+		"osquery socket created",
+	)
 
 	stats, err := history.NewInstance()
 	if err != nil {

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -65,6 +65,10 @@ func (r *Runner) Run() error {
 	// Ensure we don't try to restart the instance before it's launched
 	r.instanceLock.Lock()
 	if err := r.launchOsqueryInstance(); err != nil {
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to launch osquery instance",
+			"err", err,
+		)
 		r.instanceLock.Unlock()
 		return fmt.Errorf("starting instance: %w", err)
 	}
@@ -387,6 +391,10 @@ func (r *Runner) launchOsqueryInstance() error {
 			"could not create new osquery instance history",
 			"err", err,
 		)
+	} else {
+		r.slogger.Log(ctx, slog.LevelDebug,
+			"created osquery instance version history",
+		)
 	}
 	o.stats = stats
 
@@ -468,6 +476,10 @@ func (r *Runner) launchOsqueryInstance() error {
 	o.extensionManagerClient, err = o.StartOsqueryClient(paths)
 	if err != nil {
 		traces.SetError(span, fmt.Errorf("could not create an extension client: %w", err))
+		r.slogger.Log(ctx, slog.LevelError,
+			"error creating extension client",
+			"err", err,
+		)
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -518,6 +518,9 @@ func (r *Runner) launchOsqueryInstance() error {
 			"err", err,
 		)
 	}
+	r.slogger.Log(ctx, slog.LevelDebug,
+		"osquery instance connected",
+	)
 
 	// Health check on interval
 	o.errgroup.Go(func() error {

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -487,7 +487,19 @@ func waitHealthy(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Thread
 			return fmt.Errorf("instance not healthy: %w", err)
 		}
 
-		// Confirms osquery instance setup is complete
+		// Make sure the socket exists
+		if runner.instance == nil {
+			return errors.New("instance does not exist yet")
+		}
+		extensionSocketPath := runner.instance.opts.extensionSocketPath
+		if extensionSocketPath == "" {
+			extensionSocketPath = SocketPath(runner.instance.opts.rootDirectory)
+		}
+		if _, err := os.Stat(extensionSocketPath); err != nil {
+			return fmt.Errorf("could not stat extension socket path %s: %w", extensionSocketPath, err)
+		}
+
+		// Confirm osquery instance setup is complete
 		if runner.instance != nil && runner.instance.stats.ConnectTime == "" {
 			return errors.New("no connect time set yet")
 		}

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -487,20 +487,11 @@ func waitHealthy(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Thread
 			return fmt.Errorf("instance not healthy: %w", err)
 		}
 
-		// Make sure the socket exists
+		// Confirm osquery instance setup is complete
 		if runner.instance == nil {
 			return errors.New("instance does not exist yet")
 		}
-		extensionSocketPath := runner.instance.opts.extensionSocketPath
-		if extensionSocketPath == "" {
-			extensionSocketPath = SocketPath(runner.instance.opts.rootDirectory)
-		}
-		if _, err := os.Stat(extensionSocketPath); err != nil {
-			return fmt.Errorf("could not stat extension socket path %s: %w", extensionSocketPath, err)
-		}
-
-		// Confirm osquery instance setup is complete
-		if runner.instance != nil && runner.instance.stats.ConnectTime == "" {
+		if runner.instance.stats.ConnectTime == "" {
 			return errors.New("no connect time set yet")
 		}
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -494,7 +494,7 @@ func waitHealthy(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Thread
 
 		// Good to go
 		return nil
-	}, 30*time.Second, 1*time.Second), fmt.Sprintf("runner logs: %s", logBytes.String()))
+	}, 30*time.Second, 1*time.Second), fmt.Sprintf("instance not healthy by %s: runner logs: %s", time.Now().String(), logBytes.String()))
 
 	// Give the instance just a little bit of buffer before we proceed
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
Continuing to look at flakiness in the Windows osquery runtime tests --

I've seen a decent number of test failures like [this one](https://github.com/kolide/launcher/actions/runs/10114504292/job/27973279477), where the instance is not marked as healthy in 30 seconds so the test fails. The logs help a little bit, but not as much as they could. This PR adds a couple debug-level logs to better document the osquery setup process, and adds a timestamp to the test failure message to better contextualize the runner logs.

Also updated interactive tests with similar changes as in previous PR: add timeouts so that we get test errors instead of test timeout panics; add logs to test failure messages.