### PR TITLE
[LevelDB IndexedDB] Discard padding bytes before reading object property start

### DIFF
--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -106,7 +106,7 @@ func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader io.B
 
 		// First, we'll want the object property name. Typically, we'll get " (denoting a string),
 		// then the length of the string, then the string itself.
-		objPropertyStart, err := srcReader.ReadByte()
+		objPropertyStart, err := nextNonPaddingByte(srcReader)
 		if err != nil {
 			return obj, fmt.Errorf("reading object property: %w", err)
 		}


### PR DESCRIPTION
Seeing errors `decoding obj for indexeddb version 15: object property name has unexpected non-string type 00`, indicating that we're using a padding byte as the next property type. Read through padding bytes and discard them.