### PR TITLE
optimize windows service startup

### DIFF
--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -170,7 +170,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	w.systemSlogger.Log(ctx, slog.LevelInfo,
 		"windows service starting",
 	)
-	// after this point windows service control manager will know that we've' successfully started,
+	// after this point windows service control manager will know that we've successfully started,
 	// it is safe to begin longer running operations
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -167,7 +167,6 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-
 	w.systemSlogger.Log(ctx, slog.LevelInfo,
 		"windows service starting",
 	)


### PR DESCRIPTION
See inline comments for additional technical context

We are seeing issues with windows devices timing out before launcher is able to start in certain environments. This typically coincides with significant resource contention/high activity during boot up. One bit of logic that stood out as possibly dragging things out is our registry and service manager interactions (to perform runtime service configuration). 

Moving these checks into the Execute function, after our Running status update should help to make startup faster, or at least more responsive to service control manager