### PR TITLE
Add snap installed table

### DIFF
--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -67,6 +67,7 @@ func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath stri
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_pacman_version_info", pacman_info.Parser, allowedcmd.Pacman, []string{"-Qi"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_pacman_upgradeable", pacman_upgradeable.Parser, allowedcmd.Pacman, []string{"-Qu"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_rpm_version_info", rpm.Parser, allowedcmd.Rpm, []string{"-qai"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(slogger, "kolide_snap_installed", data_table.NewParser(), allowedcmd.Snap, []string{"list"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_snap_upgradeable", data_table.NewParser(), allowedcmd.Snap, []string{"refresh", "--list"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.TablePluginExec(slogger, "kolide_zypper_upgradeable_packages", dataflattentable.XmlType, allowedcmd.Zypper, []string{"-x", "lu"}),


### PR DESCRIPTION
Adding a `kolide_snap_installed` table so we can query all packages installed not just what is currently out-of-date.

```
osquery> SELECT * FROM kolide_snap_installed;
+-------------+--------+-----------+--------------------+-------+
| fullkey     | parent | key       | value              | query |
+-------------+--------+-----------+--------------------+-------+
| 0/Rev       | 0      | Rev       | 2318               | *     |
| 0/Tracking  | 0      | Tracking  | latest/stable      | *     |
| 0/Version   | 0      | Version   | 20240416           | *     |
| 0/Name      | 0      | Name      | core20             | *     |
| 0/Notes     | 0      | Notes     | base               | *     |
| 0/Publisher | 0      | Publisher | canonical**        | *     |
| 1/Name      | 1      | Name      | core22             | *     |
| 1/Notes     | 1      | Notes     | base               | *     |
| 1/Publisher | 1      | Publisher | canonical**        | *     |
| 1/Rev       | 1      | Rev       | 1380               | *     |
| 1/Tracking  | 1      | Tracking  | latest/stable      | *     |
| 1/Version   | 1      | Version   | 20240408           | *     |
| 2/Publisher | 2      | Publisher | google-cloud-sdk** | *     |
| 2/Rev       | 2      | Rev       | 247                | *     |
| 2/Tracking  | 2      | Tracking  | latest/stable/…    | *     |
| 2/Version   | 2      | Version   | 480.0.0            | *     |
| 2/Name      | 2      | Name      | google-cloud-cli   | *     |
| 2/Notes     | 2      | Notes     | classic            | *     |
| 3/Name      | 3      | Name      | lxd                | *     |
| 3/Notes     | 3      | Notes     | -                  | *     |
| 3/Publisher | 3      | Publisher | canonical**        | *     |
| 3/Rev       | 3      | Rev       | 29351              | *     |
| 3/Tracking  | 3      | Tracking  | 5.0/stable/…       | *     |
| 3/Version   | 3      | Version   | 5.0.3-80aeff7      | *     |
| 4/Notes     | 4      | Notes     | snapd              | *     |
| 4/Publisher | 4      | Publisher | canonical**        | *     |
| 4/Rev       | 4      | Rev       | 21759              | *     |
| 4/Tracking  | 4      | Tracking  | latest/stable      | *     |
| 4/Version   | 4      | Version   | 2.63               | *     |
| 4/Name      | 4      | Name      | snapd              | *     |
+-------------+--------+-----------+--------------------+-------+
```