### PR TITLE
[LevelDB+IndexedDB] Add more information to log when we hit object property name with unexpected non-string type

### DIFF
--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -142,6 +142,7 @@ func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader *byt
 				objKeys[i] = k
 				i++
 			}
+			nextByte, err := srcReader.ReadByte() // peek ahead to see if next byte gives us useful information
 			slogger.Log(ctx, slog.LevelWarn,
 				"object property name has unexpected non-string type",
 				"tag", fmt.Sprintf("%02x", objPropertyStart),
@@ -149,6 +150,8 @@ func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader *byt
 				"current_obj_properties", strings.Join(objKeys, ","),
 				"unread_byte_count", srcReader.Len(),
 				"total_byte_count", srcReader.Size(),
+				"next_byte", fmt.Sprintf("%02x", nextByte),
+				"next_byte_read_err", err,
 			)
 			return obj, fmt.Errorf("object property name has unexpected non-string type %02x", objPropertyStart)
 		}

--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -70,7 +71,7 @@ func DeserializeChrome(ctx context.Context, slogger *slog.Logger, row map[string
 // readHeader reads through the header bytes at the start of `srcReader`.
 // It parses the version, if found. It stops as soon as it reaches the first
 // object reference.
-func readHeader(srcReader io.ByteReader) (uint64, error) {
+func readHeader(srcReader *bytes.Reader) (uint64, error) {
 	var version uint64
 	for {
 		nextByte, err := srcReader.ReadByte()
@@ -98,7 +99,7 @@ func readHeader(srcReader io.ByteReader) (uint64, error) {
 }
 
 // deserializeObject deserializes the next object from the srcReader.
-func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader io.ByteReader) (map[string][]byte, error) {
+func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) (map[string][]byte, error) {
 	obj := make(map[string][]byte)
 
 	for {
@@ -133,11 +134,21 @@ func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader io.B
 			currentPropertyName = string(objectPropertyNameBytes)
 		default:
 			// Handle unexpected tokens here. Likely, if we run into this issue, we've
-			// already committed an error when parsing.
+			// already committed an error when parsing. Collect as much information as
+			// we can, so that we can use logs to troubleshoot the issue.
+			i := 0
+			objKeys := make([]string, len(obj))
+			for k := range obj {
+				objKeys[i] = k
+				i++
+			}
 			slogger.Log(ctx, slog.LevelWarn,
 				"object property name has unexpected non-string type",
 				"tag", fmt.Sprintf("%02x", objPropertyStart),
 				"current_object_size", len(obj),
+				"current_obj_properties", strings.Join(objKeys, ","),
+				"unread_byte_count", srcReader.Len(),
+				"total_byte_count", srcReader.Size(),
 			)
 			return obj, fmt.Errorf("object property name has unexpected non-string type %02x", objPropertyStart)
 		}
@@ -211,7 +222,7 @@ func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader io.B
 
 // nextNonPaddingByte reads from srcReader and discards `tokenPadding` until
 // it reaches the next non-padded byte.
-func nextNonPaddingByte(srcReader io.ByteReader) (byte, error) {
+func nextNonPaddingByte(srcReader *bytes.Reader) (byte, error) {
 	for {
 		nextByte, err := srcReader.ReadByte()
 		if err != nil {
@@ -228,7 +239,7 @@ func nextNonPaddingByte(srcReader io.ByteReader) (byte, error) {
 }
 
 // deserializeSparseArray deserializes the next sparse array from the srcReader.
-func deserializeSparseArray(ctx context.Context, slogger *slog.Logger, srcReader io.ByteReader) ([]byte, error) {
+func deserializeSparseArray(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) ([]byte, error) {
 	// After an array start, the next byte will be the length of the array.
 	arrayLen, err := binary.ReadUvarint(srcReader)
 	if err != nil {
@@ -310,7 +321,7 @@ func deserializeSparseArray(ctx context.Context, slogger *slog.Logger, srcReader
 
 // deserializeDenseArray deserializes the next dense array from the srcReader.
 // Dense arrays are arrays of items that are NOT paired with indices, as in sparse arrays.
-func deserializeDenseArray(ctx context.Context, slogger *slog.Logger, srcReader io.ByteReader) ([]byte, error) {
+func deserializeDenseArray(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) ([]byte, error) {
 	// After an array start, the next byte will be the length of the array.
 	arrayLen, err := binary.ReadUvarint(srcReader)
 	if err != nil {
@@ -365,7 +376,7 @@ func deserializeDenseArray(ctx context.Context, slogger *slog.Logger, srcReader 
 	return arrBytes, nil
 }
 
-func deserializeNestedObject(ctx context.Context, slogger *slog.Logger, srcReader io.ByteReader) ([]byte, error) {
+func deserializeNestedObject(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) ([]byte, error) {
 	nestedObj, err := deserializeObject(ctx, slogger, srcReader)
 	if err != nil {
 		return nil, fmt.Errorf("deserializing nested object: %w", err)
@@ -386,7 +397,7 @@ func deserializeNestedObject(ctx context.Context, slogger *slog.Logger, srcReade
 }
 
 // deserializeAsciiStr handles the upcoming ascii string in srcReader.
-func deserializeAsciiStr(srcReader io.ByteReader) ([]byte, error) {
+func deserializeAsciiStr(srcReader *bytes.Reader) ([]byte, error) {
 	strLen, err := binary.ReadUvarint(srcReader)
 	if err != nil {
 		return nil, fmt.Errorf("reading uvarint: %w", err)
@@ -406,7 +417,7 @@ func deserializeAsciiStr(srcReader io.ByteReader) ([]byte, error) {
 }
 
 // deserializeUtf16Str handles the upcoming utf-16 string in srcReader.
-func deserializeUtf16Str(srcReader io.ByteReader) ([]byte, error) {
+func deserializeUtf16Str(srcReader *bytes.Reader) ([]byte, error) {
 	strLen, err := binary.ReadUvarint(srcReader)
 	if err != nil {
 		return nil, fmt.Errorf("reading uvarint: %w", err)

--- a/ee/indexeddb/values_test.go
+++ b/ee/indexeddb/values_test.go
@@ -37,3 +37,25 @@ func Test_deserializeIndexeddbValue(t *testing.T) {
 	// Confirm we got an id property for the object
 	require.Contains(t, obj, "id", "expected id property")
 }
+
+func Test_deserializeIndexeddbValue_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	testBytes := []byte{
+		// header
+		0x04, // padding, ignore
+		0xff, // version tag
+		0x01, // version
+		0x00, // padding, ignore
+		0x00, // padding, ignore
+		0x00, // padding, ignore
+		// object
+		0x6f, // object begin
+		0xff, // version tag -- invalid data!
+		0x7b, // object end
+		0x00, // properties_written
+	}
+
+	_, err := DeserializeChrome(context.TODO(), multislogger.NewNopLogger(), map[string][]byte{"data": testBytes})
+	require.Error(t, err, "should not have been able to deserialize malformed object")
+}


### PR DESCRIPTION
Also swapped from `io.ByteReader` interface to `*bytes.Reader` to be able to collect data about current position in data.