### PR TITLE
[Chrome IndexedDB] Fix header processing

### DIFF
--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -99,7 +99,7 @@ func readHeader(srcReader *bytes.Reader) (uint64, error) {
 			}
 
 			if peekByte == tokenObjectBegin {
-				// Our last two bytes are 0xff 0x6f -- we have completed reading the header.
+				// We read the version followed by 0x6f -- we have completed reading the header.
 				return version, nil
 			}
 		default:

--- a/ee/indexeddb/values_test.go
+++ b/ee/indexeddb/values_test.go
@@ -19,6 +19,8 @@ func Test_deserializeIndexeddbValue(t *testing.T) {
 		0x00, // padding, ignore
 		0x00, // padding, ignore
 		0x00, // padding, ignore
+		0xff, // version tag (indicates end of header)
+		0x0f, // version
 		// object
 		0x6f, // object begin
 		0x22, // string tag
@@ -49,9 +51,11 @@ func Test_deserializeIndexeddbValue_InvalidType(t *testing.T) {
 		0x00, // padding, ignore
 		0x00, // padding, ignore
 		0x00, // padding, ignore
+		0xff, // version tag (indicates end of header)
+		0x0f, // version
 		// object
 		0x6f, // object begin
-		0xff, // version tag -- invalid data!
+		0x54, // boolean true tag -- invalid data!
 		0x7b, // object end
 		0x00, // properties_written
 	}


### PR DESCRIPTION
I wasn't adequately accounting for the header structure before. This appears to be correct now -- needed to add a constraint that the header ENDS with `<version tag, version, object tag>`, instead of terminating processing the header as soon as we see `<object tag>` (because that may occur before the end of the header and should just be ignored).