### PR TITLE
Add new changelog categories, reorder categories so general is at the bottom

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,15 @@ changelog:
     - title: Table Changes
       labels:
         - "component:table"
-    - title: General
-      labels:
-        - "*"
     - title: Build and Package
       labels:
         - "component:build&packaging"
+    - title: Features and Improvements
+      labels:
+        - "features-improvements"
+    - title: Bug Fixes
+      labels:
+        - "bug-fixes"
+    - title: General # Non-code changes like tests, CI, documentation
+      labels:
+        - "*"


### PR DESCRIPTION
Though I very much want to create 20 specific categories and labels for the most organized possible changelog, this is not actually a sustainable approach. I have added a mere (extremely restrained) two new categories that I think would be useful for anyone skimming a changelog -- improvements and features, and bugfixes. I also have moved "general" to the bottom because I think the wildcard being higher affects whether lower labels will be processed correctly.

I have not yet created the labels for the two new categories -- will do that after this PR has merged. Happy to add/change anything here.

I see we have a `type:security` label that is not referenced in these categories. Do we want to add that here too?