### PR TITLE
[Chrome IndexedDB] Fix EOF while reading header

### DIFF
--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -54,53 +54,60 @@ func DeserializeChrome(ctx context.Context, slogger *slog.Logger, row map[string
 	srcReader := bytes.NewReader(data)
 
 	// First, read through the header to extract top-level data
-	version, err := readHeader(srcReader)
+	indexeddbVersion, serializerVersion, err := readHeader(srcReader)
 	if err != nil {
-		return nil, fmt.Errorf("reading header: %w", err)
+		return nil, fmt.Errorf("reading header with indexeddb version %d and serializer version %d: %w", indexeddbVersion, serializerVersion, err)
 	}
 
 	// Now, parse the actual data in this row
 	objData, err := deserializeObject(ctx, slogger, srcReader)
 	if err != nil {
-		return nil, fmt.Errorf("decoding obj for indexeddb version %d: %w", version, err)
+		return nil, fmt.Errorf("decoding obj for indexeddb version %d and serializer version %d: %w", indexeddbVersion, serializerVersion, err)
 	}
 
 	return objData, nil
 }
 
 // readHeader reads through the header bytes at the start of `srcReader`.
-// It parses the version, if found. The header always ends with the byte
+// First is the version for the LevelDB-backed IndexedDB. Next is the header
+// attached to the serialized object. The header always ends with the byte
 // 0xff (tokenVersion), followed by the version (a varint), followed by 0x6f (tokenObjectBegin)
 // -- we stop reading the header at this point.
-func readHeader(srcReader *bytes.Reader) (uint64, error) {
-	var version uint64
+func readHeader(srcReader *bytes.Reader) (uint64, uint64, error) {
+	// See: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/docs/leveldb_coding_scheme.md#object-store-data
+	indexeddbVersion, err := binary.ReadUvarint(srcReader)
+	if err != nil {
+		return 0, 0, fmt.Errorf("reading uvarint as indexeddb version: %w", err)
+	}
+
+	var serializerVersion uint64
 	for {
 		nextByte, err := srcReader.ReadByte()
 		if err != nil {
 			if err == io.EOF {
-				return 0, fmt.Errorf("unexpected EOF reading header: version: %d", version)
+				return indexeddbVersion, serializerVersion, errors.New("unexpected EOF reading header")
 			}
-			return 0, fmt.Errorf("reading next byte in header with version %d: %w", version, err)
+			return indexeddbVersion, serializerVersion, fmt.Errorf("reading next byte in header: %w", err)
 		}
 
 		switch nextByte {
 		case tokenVersion:
 			// Read the version first. It is fine to overwrite version if we saw the version token
 			// before -- the last instance of the version token is the correct one.
-			version, err = binary.ReadUvarint(srcReader)
+			serializerVersion, err = binary.ReadUvarint(srcReader)
 			if err != nil {
-				return 0, fmt.Errorf("decoding uint32 for version in header: %w", err)
+				return indexeddbVersion, serializerVersion, fmt.Errorf("decoding uint32 for version in header: %w", err)
 			}
 
 			// Next, determine whether this is the 0xff token at the end of the header
 			peekByte, err := srcReader.ReadByte()
 			if err != nil {
-				return 0, fmt.Errorf("peeking at next byte after version tag and version %d: %w", version, err)
+				return indexeddbVersion, serializerVersion, fmt.Errorf("peeking at next byte after version tag and version: %w", err)
 			}
 
 			if peekByte == tokenObjectBegin {
 				// We read the version followed by 0x6f -- we have completed reading the header.
-				return version, nil
+				return indexeddbVersion, serializerVersion, nil
 			}
 		default:
 			// Padding -- ignore

--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -78,9 +78,9 @@ func readHeader(srcReader *bytes.Reader) (uint64, error) {
 		nextByte, err := srcReader.ReadByte()
 		if err != nil {
 			if err == io.EOF {
-				return 0, fmt.Errorf("unexpected EOF reading header")
+				return 0, fmt.Errorf("unexpected EOF reading header: version: %d", version)
 			}
-			return 0, fmt.Errorf("reading next byte: %w", err)
+			return 0, fmt.Errorf("reading next byte in header with version %d: %w", version, err)
 		}
 
 		switch nextByte {
@@ -89,13 +89,13 @@ func readHeader(srcReader *bytes.Reader) (uint64, error) {
 			// before -- the last instance of the version token is the correct one.
 			version, err = binary.ReadUvarint(srcReader)
 			if err != nil {
-				return 0, fmt.Errorf("decoding uint32: %w", err)
+				return 0, fmt.Errorf("decoding uint32 for version in header: %w", err)
 			}
 
 			// Next, determine whether this is the 0xff token at the end of the header
 			peekByte, err := srcReader.ReadByte()
 			if err != nil {
-				return 0, fmt.Errorf("peeking at next byte after version tag: %w", err)
+				return 0, fmt.Errorf("peeking at next byte after version tag and version %d: %w", version, err)
 			}
 
 			if peekByte == tokenObjectBegin {


### PR DESCRIPTION
Figured out the issue, which is that the indexeddb values start with a varint indicating indexeddb version _before_ the serialized value begins. So, now we read that and _then_ proceed to read the serialized value, beginning with its header.

I validated this fix against the same data I used to test https://github.com/kolide/launcher/pull/1814.