### PR TITLE
use new version of context option for sloglint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters-settings:
         msg: do not use panic so that launcher can shut down gracefully
   sloglint:
     kv-only: true
-    context-only: true
+    context: "all"
     key-naming-case: snake
     static-msg: true
   revive:


### PR DESCRIPTION
this appears to be the new way to configure what we want, per the docs [here](https://golangci-lint.run/usage/linters/#sloglint)