### PR TITLE
Ship a final batch of logs before shutdown

### DIFF
--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -149,7 +149,8 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 		case <-sb.sendTicker.C:
 			continue
 		case <-ctx.Done():
-			// Send one final batch, if possible, so that we can get logs related to shutdowns
+			// Send one final batch, if possible, so that we can get logs related to shutdowns.
+			// Sleep for one second first to allow any shutdown-related logs to be written.
 			time.Sleep(1 * time.Second)
 			if err := sb.sendAndPurge(); err != nil {
 				sb.logger.Log("msg", "failed to send final batch of logs on shutdown", "err", err)

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -149,6 +149,11 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 		case <-sb.sendTicker.C:
 			continue
 		case <-ctx.Done():
+			// Send one final batch, if possible, so that we can get logs related to shutdowns
+			time.Sleep(1 * time.Second)
+			if err := sb.sendAndPurge(); err != nil {
+				sb.logger.Log("msg", "failed to send final batch of logs on shutdown", "err", err)
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
Because the logshipper is in a rungroup, it stops shipping logs as soon as the rungroup is interrupted. This means we usually don't launcher logs around shutdown and have to rely on flares for shutdown information.

This PR adds a final call to ship one more batch before shutdown so that we can hopefully at least see the reason for launcher shutdown in the cloud logs.