### PR TITLE
add invoking user permissions metadata for flares

### DIFF
--- a/ee/debug/checkups/flare-environment-platform-specifics.go
+++ b/ee/debug/checkups/flare-environment-platform-specifics.go
@@ -3,6 +3,9 @@
 
 package checkups
 
+import "os"
+
 func flareEnvironmentPlatformSpecifics(flareEnv map[string]any) {
 	flareEnv["seph"] = "Sdf"
+	flareEnv["invoked_as_root"] = os.Geteuid() == 0
 }

--- a/ee/debug/checkups/flare-environment-platform-specifics_windows.go
+++ b/ee/debug/checkups/flare-environment-platform-specifics_windows.go
@@ -3,6 +3,8 @@
 
 package checkups
 
+import "golang.org/x/sys/windows"
+
 func flareEnvironmentPlatformSpecifics(flareEnv map[string]any) {
-	return
+	flareEnv["invoked_with_elevated_permissions"] = windows.GetCurrentProcessToken().IsElevated()
 }


### PR DESCRIPTION
it is sometimes confusing to me whether something failed due to a permissions issue with the flare invocation, this sticks an explicit check into the metadata for quick reference