### PR TITLE
remove watchdog service on remote uninstall

### DIFF
--- a/ee/uninstall/uninstall_windows.go
+++ b/ee/uninstall/uninstall_windows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kolide/launcher/ee/watchdog"
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
@@ -28,6 +29,11 @@ func disableAutoStart(ctx context.Context) error {
 	cfg.StartType = mgr.StartManual
 	if err := launcherSvc.UpdateConfig(cfg); err != nil {
 		return fmt.Errorf("updating launcher service config: %w", err)
+	}
+
+	// attempt to remove watchdog service in case it is installed to prevent startups later on
+	if err := watchdog.RemoveService(svcMgr); err != nil {
+		return fmt.Errorf("removing watchdog service, error may be expected if not enabled: %w", err)
 	}
 
 	return nil

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -353,6 +353,11 @@ func RemoveService(serviceManager *mgr.Mgr) error {
 
 	defer existingService.Close()
 
+	// attempt to stop the service first, we don't care if this fails because we are going to
+	// remove the service next anyway (the removal happens faster if stopped first, but will
+	// happen eventually regardless)
+	existingService.Control(svc.Stop)
+
 	if err := backoff.WaitFor(func() error {
 		if err = existingService.Delete(); err != nil {
 			return err

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -202,7 +202,7 @@ func (wc *WatchdogController) ServiceEnabledChanged(enabled bool) {
 	defer serviceManager.Disconnect()
 
 	if !enabled {
-		err := removeService(serviceManager, launcherWatchdogServiceName)
+		err := RemoveService(serviceManager)
 		if err != nil {
 			if err.Error() == serviceDoesNotExistError {
 				wc.slogger.Log(ctx, slog.LevelDebug, "watchdog service was not previously installed")
@@ -344,10 +344,9 @@ func (wc *WatchdogController) installService(serviceManager *mgr.Mgr) error {
 	return nil
 }
 
-// removeService utilizes the passed serviceManager to remove the existing service
-// after looking up the handle from serviceName
-func removeService(serviceManager *mgr.Mgr, serviceName string) error {
-	existingService, err := serviceManager.OpenService(serviceName)
+// RemoveService utilizes the passed serviceManager to remove any existing watchdog service if it exists
+func RemoveService(serviceManager *mgr.Mgr) error {
+	existingService, err := serviceManager.OpenService(launcherWatchdogServiceName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds removal of the watchdog service to the remote uninstall/disable path, to prevent any unwanted restarts of the main launcher service after being set to manual start mode on uninstall