### PR TITLE
Do not echo debug logs to stderr on Windows

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -197,7 +197,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	go runOsqueryVersionCheck(ctx, slogger, k.LatestOsquerydPath(ctx))
 	go timemachine.AddExclusions(ctx, k)
 
-	if k.Debug() {
+	if k.Debug() && runtime.GOOS != "windows" {
 		// If we're in debug mode, then we assume we want to echo _all_ logs to stderr.
 		k.AddSlogHandler(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			AddSource: true,


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1791

This appears to be what prevents logs from shipping when the `debug` flag is set. We don't receive logs send to stderr on Windows anyway, so we can remove this.