### PR TITLE
[LevelDB IndexedDB] Return empty rows instead of error when db or object store doesn't exist

### DIFF
--- a/ee/indexeddb/indexeddb.go
+++ b/ee/indexeddb/indexeddb.go
@@ -71,7 +71,7 @@ func QueryIndexeddbObjectStore(dbLocation string, dbName string, objectStoreName
 		if errors.Is(err, leveldberrors.ErrNotFound) {
 			return objs, nil
 		}
-		return nil, fmt.Errorf("querying for database id: %w", err) // TODO if leveldb: not found, return no rows?
+		return nil, fmt.Errorf("querying for database id: %w", err)
 	}
 	databaseId, _ := binary.Uvarint(databaseIdRaw)
 

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -156,6 +156,7 @@ func TestQueryChromeIndexedDB(t *testing.T) {
 	// indexeddb_leveldb.go and the ee/indexeddb package.
 
 	for _, tt := range []struct {
+		testName     string
 		fileName     string
 		dbName       string
 		objStoreName string
@@ -163,15 +164,32 @@ func TestQueryChromeIndexedDB(t *testing.T) {
 		zipBytes     []byte
 	}{
 		{
+			testName:     "file__0.indexeddb.leveldb.zip",
 			fileName:     "file__0.indexeddb.leveldb.zip",
 			dbName:       "launchertestdb",
 			objStoreName: "launchertestobjstore",
 			expectedRows: 2,
 			zipBytes:     basicChromeIndexeddb,
 		},
+		{
+			testName:     "file__0.indexeddb.leveldb.zip -- db does not exist",
+			fileName:     "file__0.indexeddb.leveldb.zip",
+			dbName:       "not-the-correct-db-name",
+			objStoreName: "launchertestobjstore",
+			expectedRows: 0,
+			zipBytes:     basicChromeIndexeddb,
+		},
+		{
+			testName:     "file__0.indexeddb.leveldb.zip -- object store does not exist",
+			fileName:     "file__0.indexeddb.leveldb.zip",
+			dbName:       "launchertestdb",
+			objStoreName: "not-the-correct-obj-store-name",
+			expectedRows: 0,
+			zipBytes:     basicChromeIndexeddb,
+		},
 	} {
 		tt := tt
-		t.Run(tt.fileName, func(t *testing.T) {
+		t.Run(tt.testName, func(t *testing.T) {
 			t.Parallel()
 
 			// Write zip bytes to file


### PR DESCRIPTION
I think this is more consistent behavior -- we already ignore filepaths that don't exist. If the filepath to the indexeddb exists, but the indexeddb hasn't been initialized (db doesn't exist yet, object store doesn't exist yet), we should also return no data instead of an error.