### PR TITLE
Add additional global state return value to socketfilterfw parser

### DIFF
--- a/ee/tables/execparsers/socketfilterfw/parser.go
+++ b/ee/tables/execparsers/socketfilterfw/parser.go
@@ -114,7 +114,7 @@ func sanitizeState(state string) string {
 	// include a state like string, which is why we match on
 	// the string value of "connections" for that mode.
 	//
-	// When both the Firewall and Stealth mode is enabled,
+	// When both the Firewall and Stealth Mode are enabled,
 	// the global firewall state value is `2` instead of `1`.
 	case "1", "2", "on", "enabled", "connections":
 		return "1"

--- a/ee/tables/execparsers/socketfilterfw/parser.go
+++ b/ee/tables/execparsers/socketfilterfw/parser.go
@@ -113,7 +113,10 @@ func sanitizeState(state string) string {
 	// When the "block all" firewall option is enabled, it doesn't
 	// include a state like string, which is why we match on
 	// the string value of "connections" for that mode.
-	case "1", "on", "enabled", "connections":
+	//
+	// When both the Firewall and Stealth mode is enabled,
+	// the global firewall state value is `2` instead of `1`.
+	case "1", "2", "on", "enabled", "connections":
 		return "1"
 	case "throttled", "brief", "detail":
 		// The "logging option" value differs from the booleans.

--- a/ee/tables/execparsers/socketfilterfw/parser_test.go
+++ b/ee/tables/execparsers/socketfilterfw/parser_test.go
@@ -67,7 +67,7 @@ func TestParse(t *testing.T) {
 					"block_all_enabled":               "0",
 					"allow_built-in_signed_enabled":   "1",
 					"allow_downloaded_signed_enabled": "1",
-					"stealth_enabled":                 "0",
+					"stealth_enabled":                 "1",
 					"logging_enabled":                 "1",
 					"logging_option":                  "throttled",
 				},

--- a/ee/tables/execparsers/socketfilterfw/test-data/data.txt
+++ b/ee/tables/execparsers/socketfilterfw/test-data/data.txt
@@ -1,7 +1,7 @@
-Firewall is enabled. (State = 1)
+Firewall is enabled. (State = 2)
 Firewall has block all state set to disabled.
 Automatically allow built-in signed software ENABLED.
 Automatically allow downloaded signed software ENABLED.
-Firewall stealth mode is off
+Stealth mode enabled
 Log mode is on 
 Log Option is throttled 


### PR DESCRIPTION
I missed a possible return value for the global state in the initial `socketfilterfw` table PR. This value of `2` is only returned when both the Firewall and Stealth Mode are enabled.