### PR TITLE
Use new timestamp server

### DIFF
--- a/pkg/packagekit/authenticode/authenticode_windows.go
+++ b/pkg/packagekit/authenticode/authenticode_windows.go
@@ -45,7 +45,7 @@ func Sign(ctx context.Context, file string, opts ...SigntoolOpt) error {
 	so := &signtoolOptions{
 		signtoolPath:    "signtool.exe",
 		timestampServer: "http://timestamp.verisign.com/scripts/timstamp.dll",
-		rfc3161Server:   "http://sha256timestamp.ws.symantec.com/sha256/timestamp",
+		rfc3161Server:   "http://timestamp.digicert.com",
 		execCC:          exec.CommandContext, //nolint:forbidigo // Fine to use exec.CommandContext outside of launcher proper
 	}
 


### PR DESCRIPTION
The symantec timestamp server we've been using has had two significant outages this week. https://stackoverflow.com/a/78766595 seems to indicate it's EOL.

In the future we should make this a configurable packaging option, but for now I just want to quickly swap to a server that works.