### PR TITLE
Only set arch on bin dir when we are building for Windows

### DIFF
--- a/pkg/packaging/detectLauncherVersion.go
+++ b/pkg/packaging/detectLauncherVersion.go
@@ -19,10 +19,7 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 	logger := log.With(ctxlog.FromContext(ctx), "library", "detectLauncherVersion")
 	level.Debug(logger).Log("msg", "Attempting launcher autodetection")
 
-	launcherPath := p.launcherLocation(filepath.Join(p.packageRoot, p.binDir))
-	if p.target.Platform == Windows {
-		launcherPath = p.launcherLocation(filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch)))
-	}
+	launcherPath := p.launcherLocation()
 
 	stdout, err := p.execOut(ctx, launcherPath, "-version")
 	if err != nil {
@@ -52,16 +49,20 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 // launcherLocation returns the location of the launcher binary within `binDir`. For darwin,
 // it may be in an app bundle -- we check to see if the binary exists there first, and then
 // fall back to the common location if it doesn't.
-func (p *PackageOptions) launcherLocation(binDir string) string {
+func (p *PackageOptions) launcherLocation() string {
 	if p.target.Platform == Darwin {
 		// We want /usr/local/Kolide.app, not /usr/local/bin/Kolide.app, so we use Dir to strip out `bin`
-		appBundleBinaryPath := filepath.Join(filepath.Dir(binDir), "Kolide.app", "Contents", "MacOS", "launcher")
+		appBundleBinaryPath := filepath.Join(p.packageRoot, filepath.Dir(p.binDir), "Kolide.app", "Contents", "MacOS", "launcher")
 		if info, err := os.Stat(appBundleBinaryPath); err == nil && !info.IsDir() {
 			return appBundleBinaryPath
 		}
 	}
 
-	return filepath.Join(binDir, p.target.PlatformBinaryName("launcher"))
+	if p.target.Platform == Windows {
+		return filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch), p.target.PlatformBinaryName("launcher"))
+	}
+
+	return filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName("launcher"))
 }
 
 // formatVersion formats the version according to the packaging requirements of the target platform

--- a/pkg/packaging/detectLauncherVersion.go
+++ b/pkg/packaging/detectLauncherVersion.go
@@ -19,7 +19,10 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 	logger := log.With(ctxlog.FromContext(ctx), "library", "detectLauncherVersion")
 	level.Debug(logger).Log("msg", "Attempting launcher autodetection")
 
-	launcherPath := p.launcherLocation(filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch)))
+	launcherPath := p.launcherLocation(filepath.Join(p.packageRoot, p.binDir))
+	if p.target.Platform == Windows {
+		launcherPath = p.launcherLocation(filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch)))
+	}
 
 	stdout, err := p.execOut(ctx, launcherPath, "-version")
 	if err != nil {
@@ -51,9 +54,8 @@ func (p *PackageOptions) detectLauncherVersion(ctx context.Context) error {
 // fall back to the common location if it doesn't.
 func (p *PackageOptions) launcherLocation(binDir string) string {
 	if p.target.Platform == Darwin {
-		// We want /usr/local/Kolide.app, not /usr/local/bin/universal/Kolide.app, so we use Dir to strip out `bin`
-		// and universal
-		appBundleBinaryPath := filepath.Join(filepath.Dir(filepath.Dir(binDir)), "Kolide.app", "Contents", "MacOS", "launcher")
+		// We want /usr/local/Kolide.app, not /usr/local/bin/Kolide.app, so we use Dir to strip out `bin`
+		appBundleBinaryPath := filepath.Join(filepath.Dir(binDir), "Kolide.app", "Contents", "MacOS", "launcher")
 		if info, err := os.Stat(appBundleBinaryPath); err == nil && !info.IsDir() {
 			return appBundleBinaryPath
 		}

--- a/pkg/packaging/detectLauncherVersion_test.go
+++ b/pkg/packaging/detectLauncherVersion_test.go
@@ -95,7 +95,7 @@ func TestLauncherLocation(t *testing.T) {
 
 	// Create a temp directory with an app bundle in it
 	tmpDir := t.TempDir()
-	binDir := filepath.Join(tmpDir, "bin", "universal")
+	binDir := filepath.Join(tmpDir, "bin")
 	require.NoError(t, os.MkdirAll(binDir, 0755))
 	baseDir := filepath.Join(tmpDir, "Kolide.app", "Contents", "MacOS")
 	require.NoError(t, os.MkdirAll(baseDir, 0755))

--- a/pkg/packaging/detectLauncherVersion_test.go
+++ b/pkg/packaging/detectLauncherVersion_test.go
@@ -85,19 +85,25 @@ func TestFormatVersion(t *testing.T) {
 	}
 }
 
-func TestLauncherLocation(t *testing.T) {
+func TestLauncherLocation_Darwin(t *testing.T) {
 	t.Parallel()
 
-	pDarwin := &PackageOptions{target: Target{Platform: Darwin}}
+	pDarwin := &PackageOptions{
+		target: Target{
+			Platform: Darwin,
+		},
+		packageRoot: t.TempDir(),
+		binDir:      "bin",
+	}
 
 	// First, test that if the app bundle doesn't exist, we fall back to the top-level binary
-	require.Equal(t, filepath.Join("some", "dir", "launcher"), pDarwin.launcherLocation(filepath.Join("some", "dir")))
+	expectedFallbackLauncherLocation := filepath.Join(pDarwin.packageRoot, pDarwin.binDir, "launcher")
+	require.Equal(t, expectedFallbackLauncherLocation, pDarwin.launcherLocation())
 
 	// Create a temp directory with an app bundle in it
-	tmpDir := t.TempDir()
-	binDir := filepath.Join(tmpDir, "bin")
+	binDir := filepath.Join(pDarwin.packageRoot, pDarwin.binDir)
 	require.NoError(t, os.MkdirAll(binDir, 0755))
-	baseDir := filepath.Join(tmpDir, "Kolide.app", "Contents", "MacOS")
+	baseDir := filepath.Join(pDarwin.packageRoot, "Kolide.app", "Contents", "MacOS")
 	require.NoError(t, os.MkdirAll(baseDir, 0755))
 	expectedLauncherBinaryPath := filepath.Join(baseDir, "launcher")
 	f, err := os.Create(expectedLauncherBinaryPath)
@@ -106,13 +112,38 @@ func TestLauncherLocation(t *testing.T) {
 	defer os.Remove(expectedLauncherBinaryPath)
 
 	// Now, confirm that we find the binary inside the app bundle
-	require.Equal(t, expectedLauncherBinaryPath, pDarwin.launcherLocation(binDir))
+	require.Equal(t, expectedLauncherBinaryPath, pDarwin.launcherLocation())
+}
+
+func TestLauncherLocation_Windows(t *testing.T) {
+	t.Parallel()
+
+	pWindows := &PackageOptions{
+		target: Target{
+			Platform: Windows,
+			Arch:     Amd64,
+		},
+		packageRoot: t.TempDir(),
+		binDir:      "bin",
+	}
 
 	// No file check for windows, just expect the binary in the given location
-	pWindows := &PackageOptions{target: Target{Platform: Windows}}
-	require.Equal(t, filepath.Join("some", "dir", "launcher.exe"), pWindows.launcherLocation(filepath.Join("some", "dir")))
+	expectedLauncherLocation := filepath.Join(pWindows.packageRoot, pWindows.binDir, string(pWindows.target.Arch), "launcher.exe")
+	require.Equal(t, expectedLauncherLocation, pWindows.launcherLocation())
+}
 
-	// Same as for windows: no file check, just expect the binary in the given location
-	pLinux := &PackageOptions{target: Target{Platform: Linux}}
-	require.Equal(t, filepath.Join("some", "dir", "launcher"), pLinux.launcherLocation(filepath.Join("some", "dir")))
+func TestLauncherLocation_Linux(t *testing.T) {
+	t.Parallel()
+
+	pLinux := &PackageOptions{
+		target: Target{
+			Platform: Linux,
+		},
+		packageRoot: t.TempDir(),
+		binDir:      "bin",
+	}
+
+	// No file check for Linux, just expect the binary in the given location
+	expectedLauncherLocation := filepath.Join(pLinux.packageRoot, pLinux.binDir, "launcher")
+	require.Equal(t, expectedLauncherLocation, pLinux.launcherLocation())
 }

--- a/pkg/packaging/fetch.go
+++ b/pkg/packaging/fetch.go
@@ -40,7 +40,9 @@ func FetchBinary(ctx context.Context, localCacheDir, name, binaryName, channelOr
 
 	// put binaries in arch specific directory to avoid naming collisions in wix msi building
 	// where a single destination will have multiple, mutally exclusive sources
-	localCacheDir = filepath.Join(localCacheDir, string(target.Arch))
+	if target.Platform == Windows {
+		localCacheDir = filepath.Join(localCacheDir, string(target.Arch))
+	}
 
 	if err := os.MkdirAll(localCacheDir, fsutil.DirMode); err != nil {
 		return "", fmt.Errorf("could not create cache directory: %w", err)
@@ -140,7 +142,11 @@ func dlTarPath(name, channelOrVersion, platform, arch string) (string, error) {
 }
 
 func dlTarPathFromVersion(name, version, platform, arch string) string {
-	return path.Join("kolide", name, platform, arch, fmt.Sprintf("%s-%s.tar.gz", name, version))
+	// Include arch for Windows
+	if platform == string(Windows) {
+		return path.Join("kolide", name, platform, arch, fmt.Sprintf("%s-%s.tar.gz", name, version))
+	}
+	return path.Join("kolide", name, platform, fmt.Sprintf("%s-%s.tar.gz", name, version))
 }
 
 //go:embed assets/tuf/root.json

--- a/pkg/packaging/fetch.go
+++ b/pkg/packaging/fetch.go
@@ -38,7 +38,7 @@ func FetchBinary(ctx context.Context, localCacheDir, name, binaryName, channelOr
 		return "", errors.New("empty cache dir argument")
 	}
 
-	// put binaries in arch specific directory to avoid naming collisions in wix msi building
+	// put binaries in arch specific directory for Windows to avoid naming collisions in wix msi building
 	// where a single destination will have multiple, mutally exclusive sources
 	if target.Platform == Windows {
 		localCacheDir = filepath.Join(localCacheDir, string(target.Arch))
@@ -142,11 +142,7 @@ func dlTarPath(name, channelOrVersion, platform, arch string) (string, error) {
 }
 
 func dlTarPathFromVersion(name, version, platform, arch string) string {
-	// Include arch for Windows
-	if platform == string(Windows) {
-		return path.Join("kolide", name, platform, arch, fmt.Sprintf("%s-%s.tar.gz", name, version))
-	}
-	return path.Join("kolide", name, platform, fmt.Sprintf("%s-%s.tar.gz", name, version))
+	return path.Join("kolide", name, platform, arch, fmt.Sprintf("%s-%s.tar.gz", name, version))
 }
 
 //go:embed assets/tuf/root.json

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -387,7 +387,10 @@ func (p *PackageOptions) getBinary(ctx context.Context, symbolicName, binaryName
 		return nil
 	}
 
-	binPath := filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch), binaryName)
+	binPath := filepath.Join(p.packageRoot, p.binDir, binaryName)
+	if p.target.Platform == Windows {
+		binPath = filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch), binaryName)
+	}
 	if err := os.MkdirAll(filepath.Dir(binPath), fsutil.DirMode); err != nil {
 		return fmt.Errorf("could not create directory for binary %s: %w", binaryName, err)
 	}

--- a/pkg/packaging/packaging_test.go
+++ b/pkg/packaging/packaging_test.go
@@ -277,3 +277,65 @@ func testedTargets() []Target {
 		},
 	}
 }
+
+func Test_fullPathToBareBinary(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName string
+		binaryName   string
+		identifier   string
+		packageRoot  string
+		binDir       string
+		target       Target
+		expectedPath string
+	}{
+		{
+			testCaseName: "darwin",
+			binaryName:   "launcher",
+			packageRoot:  filepath.Join("test", "root"),
+			binDir:       filepath.Join("usr", "local", "test-identifier", "bin"),
+			target: Target{
+				Platform: Darwin,
+				Arch:     Arm64,
+			},
+			expectedPath: filepath.Join("test", "root", "usr", "local", "test-identifier", "bin", "launcher"),
+		},
+		{
+			testCaseName: "linux",
+			binaryName:   "launcher",
+			packageRoot:  filepath.Join("test", "root"),
+			binDir:       filepath.Join("usr", "local", "test-identifier", "bin"),
+			target: Target{
+				Platform: Linux,
+				Arch:     Amd64,
+			},
+			expectedPath: filepath.Join("test", "root", "usr", "local", "test-identifier", "bin", "launcher"),
+		},
+		{
+			testCaseName: "windows",
+			binaryName:   "launcher.exe",
+			packageRoot:  filepath.Join("test", "root"),
+			binDir:       filepath.Join("Launcher-test-identifier", "bin"),
+			target: Target{
+				Platform: Windows,
+				Arch:     Amd64,
+			},
+			expectedPath: filepath.Join("test", "root", "Launcher-test-identifier", "bin", "amd64", "launcher.exe"),
+		},
+	} {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			p := &PackageOptions{
+				packageRoot: tt.packageRoot,
+				binDir:      tt.binDir,
+				target:      tt.target,
+			}
+
+			actualPath := p.fullPathToBareBinary(tt.binaryName)
+			require.Equal(t, tt.expectedPath, actualPath)
+		})
+	}
+}


### PR DESCRIPTION
We are currently setting the bin dir to `/usr/local/kolide-k2/bin/amd64` on Linux, which we don't want to do yet. This PR makes sure we only add the arch to the bin dir if we're building for Windows.