### PR TITLE
Check for systray error: unable to init instance: Unspecified error

### DIFF
--- a/ee/desktop/runner/runner_windows.go
+++ b/ee/desktop/runner/runner_windows.go
@@ -69,7 +69,10 @@ func osversion() (string, error) {
 
 // logIndicatesSystrayNeedsRestart checks to see if the log line contains
 // "tray not ready yet", which indicates that the systray had an irrecoverable
-// error during initialization and requires restart.
+// error during initialization and requires restart. Sometimes the tray may
+// also fail to initialize with "Unspecified error", so we check for the generic
+// initialization failed message as well.
 func logIndicatesSystrayNeedsRestart(logLine string) bool {
-	return strings.Contains(logLine, systray.ErrTrayNotReadyYet.Error())
+	return strings.Contains(logLine, systray.ErrTrayNotReadyYet.Error()) ||
+		strings.Contains(logLine, "systray error: unable to init instance")
 }


### PR DESCRIPTION
Adds on to https://github.com/kolide/launcher/pull/1835 by checking for a new error message that I've started seeing in the logs. There's no const for this error message.