### PR TITLE
Log error when we can't initialize a read-only TUF metadata client

### DIFF
--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -2,7 +2,6 @@ package tuf
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -243,7 +242,7 @@ func findExecutable(ctx context.Context, binary autoupdatableBinary, tufReposito
 	// Initialize a read-only TUF metadata client to parse the data we already have downloaded about releases.
 	metadataClient, err := readOnlyTufMetadataClient(tufRepositoryLocation)
 	if err != nil {
-		return nil, errors.New("could not initialize TUF client, cannot find release")
+		return nil, fmt.Errorf("could not initialize TUF client, cannot find release: %w", err)
 	}
 
 	// From already-downloaded metadata, look for the release version


### PR DESCRIPTION
I think we only see this error on brand-new installs that haven't pulled any metadata down yet, but it would be nice to know for sure.