### PR TITLE
Fix `autoupdate_managed` table value for MacOS 15

### DIFF
--- a/ee/tables/macos_software_update/SUSharedPrefs.h
+++ b/ee/tables/macos_software_update/SUSharedPrefs.h
@@ -62,6 +62,7 @@
 - (BOOL)bridgeOSUpdatesEnabled;
 - (BOOL)skipAPFSSnapshotting;
 - (BOOL)doesAllowBGStageWithoutInactivity;
+- (BOOL)isMacOSAutoUpdateManaged;
 - (BOOL)isAutomaticallyCheckForUpdatesManaged;
 - (BOOL)isAutomaticallyCheckForUpdatesEnabled;
 - (BOOL)adminDeferredInstallEnabled;
@@ -108,4 +109,3 @@
 - (void)reloadPreferences;
 
 @end
-

--- a/ee/tables/macos_software_update/software_update_table.go
+++ b/ee/tables/macos_software_update/software_update_table.go
@@ -50,6 +50,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 	var (
 		version                               = C.int(table.macOSBuildVersionPrefix)
 		isMacOSAutoUpdateManaged              = C.int(0)
+		isAutomaticallyCheckForUpdatesManaged = C.int(0)
 		isAutomaticallyCheckForUpdatesEnabled = C.int(0)
 		doesBackgroundDownload                = C.int(0)
 		doesAppStoreAutoUpdates               = C.int(0)
@@ -60,6 +61,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 	C.getSoftwareUpdateConfiguration(
 		version,
 		&isMacOSAutoUpdateManaged,
+		&isAutomaticallyCheckForUpdatesManaged,
 		&isAutomaticallyCheckForUpdatesEnabled,
 		&doesBackgroundDownload,
 		&doesAppStoreAutoUpdates,
@@ -70,7 +72,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 
 	resp := []map[string]string{
 		{
-			"autoupdate_managed":              fmt.Sprintf("%d", isMacOSAutoUpdateManaged),
+			"autoupdate_managed":              fmt.Sprintf("%d", max(isMacOSAutoUpdateManaged, isAutomaticallyCheckForUpdatesManaged)),
 			"autoupdate_enabled":              fmt.Sprintf("%d", isAutomaticallyCheckForUpdatesEnabled),
 			"download":                        fmt.Sprintf("%d", doesBackgroundDownload),
 			"app_updates":                     fmt.Sprintf("%d", doesAppStoreAutoUpdates),

--- a/ee/tables/macos_software_update/software_update_table.go
+++ b/ee/tables/macos_software_update/software_update_table.go
@@ -49,7 +49,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 	}
 	var (
 		version                               = C.int(table.macOSBuildVersionPrefix)
-		isAutomaticallyCheckForUpdatesManaged = C.int(0)
+		isMacOSAutoUpdateManaged              = C.int(0)
 		isAutomaticallyCheckForUpdatesEnabled = C.int(0)
 		doesBackgroundDownload                = C.int(0)
 		doesAppStoreAutoUpdates               = C.int(0)
@@ -59,7 +59,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 	)
 	C.getSoftwareUpdateConfiguration(
 		version,
-		&isAutomaticallyCheckForUpdatesManaged,
+		&isMacOSAutoUpdateManaged,
 		&isAutomaticallyCheckForUpdatesEnabled,
 		&doesBackgroundDownload,
 		&doesAppStoreAutoUpdates,
@@ -70,7 +70,7 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 
 	resp := []map[string]string{
 		{
-			"autoupdate_managed":              fmt.Sprintf("%d", isAutomaticallyCheckForUpdatesManaged),
+			"autoupdate_managed":              fmt.Sprintf("%d", isMacOSAutoUpdateManaged),
 			"autoupdate_enabled":              fmt.Sprintf("%d", isAutomaticallyCheckForUpdatesEnabled),
 			"download":                        fmt.Sprintf("%d", doesBackgroundDownload),
 			"app_updates":                     fmt.Sprintf("%d", doesAppStoreAutoUpdates),

--- a/ee/tables/macos_software_update/sus.h
+++ b/ee/tables/macos_software_update/sus.h
@@ -7,7 +7,7 @@ extern void productNestedKeyValueFound(unsigned int, char*, char*, char*);
 
 // Gets software update config flags from SUSharedPrefs API
 void getSoftwareUpdateConfiguration(int os_version,
-                                    int* isAutomaticallyCheckForUpdatesManaged,
+                                    int* isMacOSAutoUpdateManaged,
                                     int* isAutomaticallyCheckForUpdatesEnabled,
                                     int* doesBackgroundDownload,
                                     int* doesAppStoreAutoUpdates,

--- a/ee/tables/macos_software_update/sus.h
+++ b/ee/tables/macos_software_update/sus.h
@@ -8,6 +8,7 @@ extern void productNestedKeyValueFound(unsigned int, char*, char*, char*);
 // Gets software update config flags from SUSharedPrefs API
 void getSoftwareUpdateConfiguration(int os_version,
                                     int* isMacOSAutoUpdateManaged,
+                                    int* isAutomaticallyCheckForUpdatesManaged,
                                     int* isAutomaticallyCheckForUpdatesEnabled,
                                     int* doesBackgroundDownload,
                                     int* doesAppStoreAutoUpdates,

--- a/ee/tables/macos_software_update/sus.m
+++ b/ee/tables/macos_software_update/sus.m
@@ -6,7 +6,7 @@
 #import <SUUpdateProduct.h>
 
 void getSoftwareUpdateConfiguration(int os_version,
-                                    int* isAutomaticallyCheckForUpdatesManaged,
+                                    int* isMacOSAutoUpdateManaged,
                                     int* isAutomaticallyCheckForUpdatesEnabled,
                                     int* doesBackgroundDownload,
                                     int* doesAppStoreAutoUpdates,
@@ -22,9 +22,9 @@ void getSoftwareUpdateConfiguration(int os_version,
   Class SUSharedPrefs = [bundle classNamed:@"SUSharedPrefs"];
   id manager = [SUSharedPrefs sharedPrefManager];
 
-  BOOL val = [manager isAutomaticallyCheckForUpdatesManaged];
+  BOOL val = [manager isMacOSAutoUpdateManaged];
   if (val) {
-    *isAutomaticallyCheckForUpdatesManaged = 1;
+    *isMacOSAutoUpdateManaged = 1;
   }
 
   val = [manager isAutomaticallyCheckForUpdatesEnabled];

--- a/ee/tables/macos_software_update/sus.m
+++ b/ee/tables/macos_software_update/sus.m
@@ -7,6 +7,7 @@
 
 void getSoftwareUpdateConfiguration(int os_version,
                                     int* isMacOSAutoUpdateManaged,
+                                    int* isAutomaticallyCheckForUpdatesManaged,
                                     int* isAutomaticallyCheckForUpdatesEnabled,
                                     int* doesBackgroundDownload,
                                     int* doesAppStoreAutoUpdates,
@@ -25,6 +26,11 @@ void getSoftwareUpdateConfiguration(int os_version,
   BOOL val = [manager isMacOSAutoUpdateManaged];
   if (val) {
     *isMacOSAutoUpdateManaged = 1;
+  }
+
+  val = [manager isAutomaticallyCheckForUpdatesManaged];
+  if (val) {
+    *isAutomaticallyCheckForUpdatesManaged = 1;
   }
 
   val = [manager isAutomaticallyCheckForUpdatesEnabled];


### PR DESCRIPTION
In MacOS 15 Sequoia the SoftwareUpdate private framework has been updated and the `autoupdate_managed` value was no longer being detected for our `kolide_macos_software_update` table. After decompiling the framework it became clear what needed to change, but I was able to verify this change after we got a MDM profile on my laptop.

I've attached 4 photos of the decompiled framework (the first two are from MacOS 14 and the last two are from MacOS 15).
<img width="766" alt="Screenshot 2024-09-11 at 3 39 52 PM" src="https://github.com/user-attachments/assets/cd7049f9-1d28-4d87-ae47-a2377e87f183">
![Screenshot 2024-09-11 at 4 04 10 PM](https://github.com/user-attachments/assets/a9eacda4-4075-483f-a3f1-910ba62d9a5e)
<img width="736" alt="Screenshot 2024-09-11 at 3 41 48 PM" src="https://github.com/user-attachments/assets/b35509f4-9c47-4ac3-9cd9-9eb3f8b3ea85">
![Screenshot 2024-09-11 at 4 04 23 PM](https://github.com/user-attachments/assets/e1f2d9b4-7907-40df-8f8e-4e711b4d0d67)
In these images we can see that the `isMacOSAutoUpdateManaged` and `isAutomaticallyCheckForUpdatesManaged` performed the exact same operation in the older version of the framework, but in the newest version it seems that `isAutomaticallyCheckForUpdatesManaged` has been deprecated.

Here is the result after updating to use `isMacOSAutoUpdateManaged` with a managed device:
<img width="709" alt="Screenshot 2024-09-11 at 3 57 22 PM" src="https://github.com/user-attachments/assets/3adfc07f-d275-4bbf-a2c0-18de654c4d92">
Here is the result on my device without a profile to manage the autoupdates:
```
osquery> SELECT * FROM kolide_macos_software_update;
             autoupdate_managed = 0
             autoupdate_enabled = 1
                       download = 1
                    app_updates = 1
                     os_updates = 0
               critical_updates = 1
last_successful_check_timestamp = 1726030905
```
