### PR TITLE
james/remove wmi unneeded releases

### DIFF
--- a/ee/wmi/wmi.go
+++ b/ee/wmi/wmi.go
@@ -153,8 +153,10 @@ func Query(ctx context.Context, slogger *slog.Logger, className string, properti
 	}
 	defer serviceRaw.Clear()
 
+	// the memory of result is released by `defer serviceRaw.Clear()` above,
+	// on windows arm64 machines, calling `service.Clear()` after `serviceRaw.Release()`
+	// would cause a panic
 	service := serviceRaw.ToIDispatch()
-	defer service.Release()
 
 	slogger.Log(ctx, slog.LevelDebug,
 		"running WMI query",
@@ -168,8 +170,10 @@ func Query(ctx context.Context, slogger *slog.Logger, className string, properti
 	}
 	defer resultRaw.Clear()
 
+	// the memory of result is released by `defer resultRaw.Clear()` above,
+	// on windows arm64 machines, calling `resultRaw.Clear()` after `result.Release()`
+	// would cause a panic
 	result := resultRaw.ToIDispatch()
-	defer result.Release()
 
 	if err := oleutil.ForEach(result, handler.HandleVariant); err != nil {
 		return nil, fmt.Errorf("ole foreach: %w", err)

--- a/ee/wmi/wmi.go
+++ b/ee/wmi/wmi.go
@@ -153,9 +153,16 @@ func Query(ctx context.Context, slogger *slog.Logger, className string, properti
 	}
 	defer serviceRaw.Clear()
 
-	// the memory of result is released by `defer serviceRaw.Clear()` above,
-	// on windows arm64 machines, calling `service.Clear()` after `serviceRaw.Release()`
-	// would cause a panic
+	// In testing, we find we do not need to `service.Release()`. The memory of result is released
+	// by `defer serviceRaw.Clear()` above, furthermore on windows arm64 machines, calling
+	// `service.Clear()` after `serviceRaw.Release()` causes a panic.
+	//
+	// Looking at the `serviceRaw.ToIDispatch()` implementation, it's just a cast that returns
+	// a pointer to the same memory. Which would explain why calling `serviceRaw.Release()` after
+	// `service.Clear()` causes a panic. It's unclear why this causes a panic on arm64 machines and
+	// not on amd64 machines.
+	//
+	// This also applies to the `resultRaw` and `results` variables below.
 	service := serviceRaw.ToIDispatch()
 
 	slogger.Log(ctx, slog.LevelDebug,
@@ -170,9 +177,7 @@ func Query(ctx context.Context, slogger *slog.Logger, className string, properti
 	}
 	defer resultRaw.Clear()
 
-	// the memory of result is released by `defer resultRaw.Clear()` above,
-	// on windows arm64 machines, calling `resultRaw.Clear()` after `result.Release()`
-	// would cause a panic
+	// see above comment about `service.Release()` to explain why `result.Release()` isn't called
 	result := resultRaw.ToIDispatch()
 
 	if err := oleutil.ForEach(result, handler.HandleVariant); err != nil {


### PR DESCRIPTION
I tested this by creating a small program that runs in a loop only clearing the `rawResult` and `rawService`. After 3K iterations, memory rose to around 9MB and remained stable. After 50K iterations memory was still at 9MB. This test was performed on both arm64 and amd64.
