### PR TITLE
fix host checkup panic

### DIFF
--- a/ee/secureenclavesigner/secureenclavesigner_darwin.go
+++ b/ee/secureenclavesigner/secureenclavesigner_darwin.go
@@ -114,6 +114,16 @@ func (ses *secureEnclaveSigner) Public() crypto.PublicKey {
 		return nil
 	}
 
+	// currentConsoleUserKey may return no error and a nil pointer where the inability
+	// to get the key is expected (see logic around calling firstConsoleUser). In this case,
+	// k will be a "typed" nil, as an uninitialized pointer to a ecdsa.PublicKey. We're returning
+	// this typed nil assigned as the crypto.PublicKey interface. This means that the interface's value
+	// will be nil, but it's underlying type will not be - so it will pass nil checks but panic
+	// when typecasted later. Explicitly return an untyped nil in this case to prevent confusion and panics later
+	if k == nil {
+		return nil
+	}
+
 	return k
 }
 


### PR DESCRIPTION
Fixes the panics coming out of the host checkup. See comment for additional explanation, for more context there is a better explanation of what's happening here: https://go.dev/doc/faq#nil_error