### PR TITLE
Set slogger on rungroup after logshipping is set up, so that rungroup logs will be shipped

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -111,7 +111,8 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 		)
 	}
 
-	runGroup := rungroup.NewRunGroup(slogger)
+	runGroup := rungroup.NewRunGroup()
+	runGroup.SetSlogger(slogger)
 
 	// listen for signals
 	runGroup.Add("desktopSignalListener", func() error {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -206,7 +206,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	}
 
 	// create a rungroup for all the actors we create to allow for easy start/stop
-	runGroup := rungroup.NewRunGroup(slogger)
+	runGroup := rungroup.NewRunGroup()
 
 	// Need to set up the log shipper so that we can get the logger early
 	// and pass it to the various systems.
@@ -245,6 +245,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 		startupSpan.AddEvent("log_shipper_init_completed")
 	}
+
+	// Now that log shipping is set up, set the slogger on the rungroup so that rungroup logs
+	// will also be shipped.
+	runGroup.SetSlogger(k.Slogger())
 
 	startupSettingsWriter, err := startupsettings.OpenWriter(ctx, k)
 	if err != nil {

--- a/ee/watchdog/watchdog_service_windows.go
+++ b/ee/watchdog/watchdog_service_windows.go
@@ -227,7 +227,8 @@ func (w *winWatchdogSvc) checkLauncherStatus(ctx context.Context) error {
 
 func runLauncherWatchdogService(ctx context.Context, w *winWatchdogSvc) error {
 	// create a rungroup for all the actors we create to allow for easy start/stop
-	runGroup := rungroup.NewRunGroup(w.slogger.Logger)
+	runGroup := rungroup.NewRunGroup()
+	runGroup.SetSlogger(w.slogger.Logger)
 	powerEventWatcher, err := powereventwatcher.New(ctx, w.slogger.Logger, w.sleepStateUpdater)
 	if err != nil {
 		w.slogger.Log(ctx, slog.LevelDebug,

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kolide/launcher/ee/gowrapper"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -38,15 +39,19 @@ const (
 	executeReturnTimeout = 5 * time.Second  // After interrupted, how long for all actors to exit their `execute` functions
 )
 
-func NewRunGroup(slogger *slog.Logger) *Group {
+func NewRunGroup() *Group {
 	return &Group{
-		slogger: slogger.With("component", "run_group"),
+		slogger: multislogger.NewNopLogger(),
 		actors:  make([]rungroupActor, 0),
 	}
 }
 
 func (g *Group) Add(name string, execute func() error, interrupt func(error)) {
 	g.actors = append(g.actors, rungroupActor{name, execute, interrupt})
+}
+
+func (g *Group) SetSlogger(slogger *slog.Logger) {
+	g.slogger = slogger.With("component", "run_group")
 }
 
 func (g *Group) Run() error {

--- a/pkg/rungroup/rungroup_test.go
+++ b/pkg/rungroup/rungroup_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
 )
@@ -15,14 +14,14 @@ import (
 func TestRun_NoActors(t *testing.T) {
 	t.Parallel()
 
-	testRunGroup := NewRunGroup(multislogger.NewNopLogger())
+	testRunGroup := NewRunGroup()
 	require.NoError(t, testRunGroup.Run())
 }
 
 func TestRun_MultipleActors(t *testing.T) {
 	t.Parallel()
 
-	testRunGroup := NewRunGroup(multislogger.NewNopLogger())
+	testRunGroup := NewRunGroup()
 
 	groupReceivedInterrupts := make(chan struct{}, 3)
 
@@ -93,7 +92,7 @@ func TestRun_MultipleActors(t *testing.T) {
 func TestRun_MultipleActors_InterruptTimeout(t *testing.T) {
 	t.Parallel()
 
-	testRunGroup := NewRunGroup(multislogger.NewNopLogger())
+	testRunGroup := NewRunGroup()
 
 	groupReceivedInterrupts := make(chan struct{}, 3)
 
@@ -166,7 +165,7 @@ func TestRun_MultipleActors_InterruptTimeout(t *testing.T) {
 func TestRun_MultipleActors_ExecuteReturnTimeout(t *testing.T) {
 	t.Parallel()
 
-	testRunGroup := NewRunGroup(multislogger.NewNopLogger())
+	testRunGroup := NewRunGroup()
 
 	groupReceivedInterrupts := make(chan struct{}, 3)
 	// Keep track of when `execute`s return so we give testRunGroup.Run enough time to do its thing
@@ -250,7 +249,8 @@ func TestRun_RecoversAndLogsPanic(t *testing.T) {
 		Level: slog.LevelDebug,
 	}))
 
-	testRunGroup := NewRunGroup(slogger)
+	testRunGroup := NewRunGroup()
+	testRunGroup.SetSlogger(slogger)
 
 	// Actor that will panic in its execute function
 	testRunGroup.Add("panickingActor", func() error {


### PR DESCRIPTION
Despite the changes in https://github.com/kolide/launcher/pull/1822, I wasn't seeing rungroup shutdown logs being shipped. When looking through the shipped logs, I noticed that the only rungroup logs available were either from very old versions of launcher, or from the desktop process.

This PR updates when we set the slogger on the rungroup so that we set it after the shipping handler has been added.