### PR TITLE
Custom error for homebrew table not found

### DIFF
--- a/ee/allowedcmd/cmd.go
+++ b/ee/allowedcmd/cmd.go
@@ -8,11 +8,11 @@ package allowedcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"errors"
 )
 
 type AllowedCommand func(ctx context.Context, arg ...string) (*exec.Cmd, error)

--- a/ee/allowedcmd/cmd.go
+++ b/ee/allowedcmd/cmd.go
@@ -34,7 +34,7 @@ func validatedCommand(ctx context.Context, knownPath string, arg ...string) (*ex
 	// We expect to know the exact location for allowlisted commands on all
 	// OSes except for a few Linux distros.
 	if !allowSearchPath() {
-		return nil, fmt.Errorf("%w: %s",ErrCommandNotFound, knownPath)
+		return nil, fmt.Errorf("%w: %s", ErrCommandNotFound, knownPath)
 	}
 
 	cmdName := filepath.Base(knownPath)
@@ -42,7 +42,7 @@ func validatedCommand(ctx context.Context, knownPath string, arg ...string) (*ex
 		return newCmd(ctx, foundPath, arg...), nil
 	}
 
-	return nil, fmt.Errorf("%w: %s and could not be located elsewhere", ErrCommandNotFound, knownPath)
+	return nil, fmt.Errorf("%w: not found at %s and could not be located elsewhere", ErrCommandNotFound, knownPath)
 }
 
 func allowSearchPath() bool {

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -13,12 +13,10 @@ func Apt(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/apt", arg...)
 }
 
-var ErrHomebrewNotFound = errors.New("homebrew not found")
-
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	validatedCmd, err := validatedCommand(ctx, "/home/linuxbrew/.linuxbrew/bin/brew", arg...)
 	if err != nil {
-		return nil, ErrHomebrewNotFound
+		return nil, nil
 	}
 
 	validatedCmd.Env = append(validatedCmd.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1")

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -13,10 +13,12 @@ func Apt(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return validatedCommand(ctx, "/usr/bin/apt", arg...)
 }
 
+var ErrHomebrewNotFound = errors.New("homebrew not found")
+
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	validatedCmd, err := validatedCommand(ctx, "/home/linuxbrew/.linuxbrew/bin/brew", arg...)
 	if err != nil {
-		return nil, err
+		return nil, ErrHomebrewNotFound
 	}
 
 	validatedCmd.Env = append(validatedCmd.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1")

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -16,7 +16,7 @@ func Apt(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 func Brew(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	validatedCmd, err := validatedCommand(ctx, "/home/linuxbrew/.linuxbrew/bin/brew", arg...)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	validatedCmd.Env = append(validatedCmd.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1")

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"errors"
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
@@ -43,7 +44,12 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	// that user. To reduce duplicating the WithUid table helper, we can find the owner of the binary,
 	// and pass the said owner to the WIthUid method to handle setting the appropriate env vars.
 	cmd, err := allowedcmd.Brew(ctx)
+		
 	if err != nil {
+		if errors.Is(err, allowedcmd.ErrHomebrewNotFound) {
+			// No data, no error
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failure allocating allowedcmd.Brew: %w", err)
 	}
 

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -46,7 +46,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	cmd, err := allowedcmd.Brew(ctx)
 		
 	if err != nil {
-		if errors.Is(err, allowedcmd.ErrHomebrewNotFound) {
+		if errors.Is(err, allowedcmd.ErrCommandNotFound) {
 			// No data, no error
 			return nil, nil
 		}

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -48,7 +48,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	if err != nil {
 		if errors.Is(err, allowedcmd.ErrCommandNotFound) {
 			// No data, no error
-			return nil, err
+			return nil, nil
 		}
 		return nil, fmt.Errorf("failure allocating allowedcmd.Brew: %w", err)
 	}

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -48,7 +48,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	if err != nil {
 		if errors.Is(err, allowedcmd.ErrCommandNotFound) {
 			// No data, no error
-			return nil, nil
+			return nil, err
 		}
 		return nil, fmt.Errorf("failure allocating allowedcmd.Brew: %w", err)
 	}

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -44,7 +44,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 	// that user. To reduce duplicating the WithUid table helper, we can find the owner of the binary,
 	// and pass the said owner to the WIthUid method to handle setting the appropriate env vars.
 	cmd, err := allowedcmd.Brew(ctx)
-		
+
 	if err != nil {
 		if errors.Is(err, allowedcmd.ErrCommandNotFound) {
 			// No data, no error

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -6,13 +6,13 @@ package brew_upgradeable
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
-	"errors"
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"


### PR DESCRIPTION
Which issue(s) this PR fixes:
#1864 

Description:
In the given solution, an error is returned every time an issue occurs during the `validatedCommand` call, regardless of the cause. For instance, if the binary file does not exist, should we use a specific error to handle this scenario?