### PR TITLE
batch tmutil call args to prevent argument list too long errors

### DIFF
--- a/ee/agent/timemachine/timemachine_darwin.go
+++ b/ee/agent/timemachine/timemachine_darwin.go
@@ -33,10 +33,17 @@ func AddExclusions(ctx context.Context, k types.Knapsack) {
 		launcher.pid
 	*/
 
-	exclusionPatterns := []string{
+	exclusionPatternsFirstBatch := []string{
 		"*.json",
 		"*.json.gz",
 		"*.db",
+	}
+
+	addExclusionsFromPathPatterns(ctx, k, exclusionPatternsFirstBatch)
+
+	// Attempting to run this with a single tmutil call we see a lot of tmutil failures logged with error "argument list too long".
+	// To avoid this we run in two separate batches, attempting to cut the post-glob argument list roughly in half
+	exclusionPatternsSecondBatch := []string{
 		"*.sqlite",
 		"desktop_*",
 		"*.pid",
@@ -45,6 +52,10 @@ func AddExclusions(ctx context.Context, k types.Knapsack) {
 		"osquery*",
 	}
 
+	addExclusionsFromPathPatterns(ctx, k, exclusionPatternsSecondBatch)
+}
+
+func addExclusionsFromPathPatterns(ctx context.Context, k types.Knapsack, exclusionPatterns []string) {
 	var exclusionPaths []string
 	for _, pattern := range exclusionPatterns {
 		matches, err := filepath.Glob(filepath.Join(k.RootDirectory(), pattern))


### PR DESCRIPTION
We're seeing 18k errors logged in the last two days for `fork/exec /usr/bin/tmutil: argument list too long` - I am unable to reproduce this error on my machine but some brief research indicates that this is determined by the `ARG_MAX` set per machine.

We generate the filepaths for exclusion based on the output of `filepath.Glob` on our predefined patterns. This can also vary slightly per machine (mostly by the count of debug logs at the time this runs). To keep this simple I've approximated two equal (ish) batches of patterns, moved the exclusion logic into a helper, and run it twice. This should cut the args per call roughly in half and reduce the likelihood of hitting this error