### PR TITLE
Ensure Flatpak parser regex follows dbus bus name spec

### DIFF
--- a/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
+++ b/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 )
 
-// The app id conforms to: [dbus specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names)
-var flatpakAppIdRegexp = regexp.MustCompile(`((?:[a-zA-Z]+[a-zA-Z0-9_]*\.){1,}[a-zA-Z]+[a-zA-Z0-9_]*)`)
+// The app id conforms to: [dbus bus name specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names)
+var flatpakAppIdRegexp = regexp.MustCompile(`((?:[a-zA-Z_-]+[a-zA-Z0-9_-]*\.){1,}[a-zA-Z_-]+[a-zA-Z0-9_-]*)`)
 
 // Wow this has been a head-pounding bugger of a thing.
 //

--- a/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
+++ b/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The app id conforms to: [dbus specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names)
-var flatpakAppIdRegexp = regexp.MustCompile(`(([a-zA-Z0-9_]+\.){1,}([a-zA-Z0-9_]+))`)
+var flatpakAppIdRegexp = regexp.MustCompile(`((?:[a-zA-Z]+[a-zA-Z0-9_]*\.){1,}[a-zA-Z]+[a-zA-Z0-9_]*)`)
 
 // Wow this has been a head-pounding bugger of a thing.
 //


### PR DESCRIPTION
The previous regex was prone to matching version strings as it was not ensuring the pattern didn't start with a digit. While the [dbus bus name spec](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names) does allow for this, it only applies to unique connection names, while the package names are "_well-known bus names_", which can't start with a digit.

I've updated the regex to reflect this difference, as well I noticed the `-` was missing from the pattern so I've added that.