### PR TITLE
include arch and os in local server headers

### DIFF
--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -170,7 +170,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 					}
 
 					return fmt.Errorf("expected no processes, found %d", len(r.uidProcs))
-				}, 10*time.Second, 1*time.Second))
+				}, 30*time.Second, 1*time.Second))
 			} else {
 				if runtime.GOOS == "windows" {
 					assert.Contains(t, r.uidProcs, user.Username)

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/desktop/user/notify"
+	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/assert"
@@ -163,7 +164,13 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			// does not have a console user, so we don't expect any processes
 			// to be started.
 			if tt.cleanShutdown || (os.Getenv("CI") == "true" && runtime.GOOS == "linux") {
-				assert.Len(t, r.uidProcs, 0, "unexpected process: logs: %s", logBytes.String())
+				require.NoError(t, backoff.WaitFor(func() error {
+					if len(r.uidProcs) == 0 {
+						return nil
+					}
+
+					return fmt.Errorf("expected no processes, found %d", len(r.uidProcs))
+				}, 10*time.Second, 1*time.Second))
 			} else {
 				if runtime.GOOS == "windows" {
 					assert.Contains(t, r.uidProcs, user.Username)

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -25,13 +25,15 @@ import (
 )
 
 const (
-	timestampValidityRange                   = 150
-	kolideKryptoEccHeader20230130Value       = "2023-01-30"
-	kolideKryptoHeaderKey                    = "X-Kolide-Krypto"
-	kolideSessionIdHeaderKey                 = "X-Kolide-Session"
-	kolidePresenceDetectionInterval          = "X-Kolide-Presence-Detection-Interval"
-	kolidePresenceDetectionReason            = "X-Kolide-Presence-Detection-Reason"
-	kolideDurationSinceLastPresenceDetection = "X-Kolide-Duration-Since-Last-Presence-Detection"
+	timestampValidityRange                            = 150
+	kolideKryptoEccHeader20230130Value                = "2023-01-30"
+	kolideKryptoHeaderKey                             = "X-Kolide-Krypto"
+	kolideSessionIdHeaderKey                          = "X-Kolide-Session"
+	kolidePresenceDetectionIntervalHeaderKey          = "X-Kolide-Presence-Detection-Interval"
+	kolidePresenceDetectionReasonHeaderKey            = "X-Kolide-Presence-Detection-Reason"
+	kolideDurationSinceLastPresenceDetectionHeaderKey = "X-Kolide-Duration-Since-Last-Presence-Detection"
+	kolideOsHeaderKey                                 = "X-Kolide-Os"
+	kolideArchHeaderKey                               = "X-Kolide-Arch"
 )
 
 type v2CmdRequestType struct {
@@ -315,6 +317,9 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 		// bhr contains the data returned by the request defined above
 		bhr := &bufferedHttpResponse{}
 		next.ServeHTTP(bhr, newReq)
+
+		bhr.Header().Add(kolideOsHeaderKey, runtime.GOOS)
+		bhr.Header().Add(kolideArchHeaderKey, runtime.GOARCH)
 
 		// add headers to the response map
 		// this assumes that the response to `bhr` was a json encoded blob.

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kolide/krypto/pkg/echelper"
 	"github.com/kolide/launcher/ee/agent/keys"
 	"github.com/kolide/launcher/ee/localserver/mocks"
+	"github.com/kolide/launcher/ee/presencedetection"
 
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
@@ -245,7 +246,11 @@ func TestKryptoEcMiddleware(t *testing.T) {
 					// check that the presence detection interval is present
 					if runtime.GOOS == "darwin" {
 						require.Equal(t, (0 * time.Second).String(), responseHeaders[kolideDurationSinceLastPresenceDetectionHeaderKey][0])
+						return
 					}
+
+					// not darwin
+					require.Equal(t, presencedetection.DetectionFailedDurationValue.String(), responseHeaders[kolideDurationSinceLastPresenceDetectionHeaderKey][0])
 				})
 			}
 		})

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -42,7 +42,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 
 	koldieSessionId := ulid.New()
 	cmdRequestHeaders := map[string][]string{
-		kolidePresenceDetectionInterval: {"0s"},
+		kolidePresenceDetectionIntervalHeaderKey: {"0s"},
 	}
 
 	cmdReqCallBackHeaders := map[string][]string{
@@ -240,9 +240,11 @@ func TestKryptoEcMiddleware(t *testing.T) {
 					responseHeaders, err := extractJsonProperty[map[string][]string](opened.ResponseData, "headers")
 					require.NoError(t, err)
 
+					require.Equal(t, runtime.GOOS, responseHeaders[kolideOsHeaderKey][0])
+
 					// check that the presence detection interval is present
 					if runtime.GOOS == "darwin" {
-						require.Equal(t, (0 * time.Second).String(), responseHeaders[kolideDurationSinceLastPresenceDetection][0])
+						require.Equal(t, (0 * time.Second).String(), responseHeaders[kolideDurationSinceLastPresenceDetectionHeaderKey][0])
 					}
 				})
 			}

--- a/ee/localserver/presence-detection-middleware_test.go
+++ b/ee/localserver/presence-detection-middleware_test.go
@@ -109,7 +109,7 @@ func TestPresenceDetectionHandler(t *testing.T) {
 			handlerToTest.ServeHTTP(rr, req)
 
 			if tt.shouldHavePresenceDetectionDurationResponseHeader {
-				require.NotEmpty(t, rr.Header().Get(kolideDurationSinceLastPresenceDetection))
+				require.NotEmpty(t, rr.Header().Get(kolideDurationSinceLastPresenceDetectionHeaderKey))
 			}
 			require.Equal(t, tt.expectedStatusCode, rr.Code)
 		})

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -421,7 +421,7 @@ func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler 
 
 		// can test this by adding an unauthed endpoint to the mux and running, for example:
 		// curl -i -H "X-Kolide-Presence-Detection-Interval: 10s" -H "X-Kolide-Presence-Detection-Reason: my reason" localhost:12519/id
-		detectionIntervalStr := r.Header.Get(kolidePresenceDetectionInterval)
+		detectionIntervalStr := r.Header.Get(kolidePresenceDetectionIntervalHeaderKey)
 
 		// no presence detection requested
 		if detectionIntervalStr == "" {
@@ -439,7 +439,7 @@ func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler 
 
 		// set a default reason, on macos the popup will look like "Kolide is trying to authenticate."
 		reason := "authenticate"
-		reasonHeader := r.Header.Get(kolidePresenceDetectionReason)
+		reasonHeader := r.Header.Get(kolidePresenceDetectionReasonHeaderKey)
 		if reasonHeader != "" {
 			reason = reasonHeader
 		}
@@ -460,7 +460,7 @@ func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler 
 		// and send the request through
 		// allow the server to decide what to do based on last detection duration
 
-		w.Header().Add(kolideDurationSinceLastPresenceDetection, durationSinceLastDetection.String())
+		w.Header().Add(kolideDurationSinceLastPresenceDetectionHeaderKey, durationSinceLastDetection.String())
 		next.ServeHTTP(w, r)
 	})
 }

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kolide/krypto/pkg/echelper"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/presencedetection"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/kolide/launcher/pkg/traces"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -415,6 +416,7 @@ func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler 
 
 		// presence detection is only supported on macos currently
 		if runtime.GOOS != "darwin" {
+			w.Header().Add(kolideDurationSinceLastPresenceDetectionHeaderKey, presencedetection.DetectionFailedDurationValue.String())
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -414,19 +414,19 @@ func (ls *localServer) rateLimitHandler(next http.Handler) http.Handler {
 func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		// presence detection is only supported on macos currently
-		if runtime.GOOS != "darwin" {
-			w.Header().Add(kolideDurationSinceLastPresenceDetectionHeaderKey, presencedetection.DetectionFailedDurationValue.String())
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		// can test this by adding an unauthed endpoint to the mux and running, for example:
 		// curl -i -H "X-Kolide-Presence-Detection-Interval: 10s" -H "X-Kolide-Presence-Detection-Reason: my reason" localhost:12519/id
 		detectionIntervalStr := r.Header.Get(kolidePresenceDetectionIntervalHeaderKey)
 
 		// no presence detection requested
 		if detectionIntervalStr == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// presence detection is only supported on macos currently
+		if runtime.GOOS != "darwin" {
+			w.Header().Add(kolideDurationSinceLastPresenceDetectionHeaderKey, presencedetection.DetectionFailedDurationValue.String())
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
In the event that presence detection is requested for a non-supported OS, return default failure duration `-1s`. Always include OS and Arch in headers.