### PR TITLE
added download info to flare

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -125,6 +125,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&uninstallHistoryCheckup{k: k}, flareSupported},
 		{&desktopMenu{k: k}, flareSupported},
 		{&coredumpCheckup{}, doctorSupported | flareSupported},
+		{&DownloadDirectory{}, flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -125,7 +125,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&uninstallHistoryCheckup{k: k}, flareSupported},
 		{&desktopMenu{k: k}, flareSupported},
 		{&coredumpCheckup{}, doctorSupported | flareSupported},
-		{&DownloadDirectory{}, flareSupported},
+		{&downloadDirectory{}, flareSupported},
 	}
 
 	checkupsToRun := make([]checkupInt, 0)

--- a/ee/debug/checkups/download_directory.go
+++ b/ee/debug/checkups/download_directory.go
@@ -95,8 +95,10 @@ func getDownloadDirs() []string {
 
 	if runtime.GOOS == "windows" {
 		baseDir = "C:\\Users"
-	} else {
+	} else if runtime.GOOS == "darwin" {
 		baseDir = "/Users"
+	} else {
+		baseDir = "/home"
 	}
 
 	entries, err := os.ReadDir(baseDir)

--- a/ee/debug/checkups/download_directory.go
+++ b/ee/debug/checkups/download_directory.go
@@ -1,0 +1,117 @@
+package checkups
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type DownloadDirectory struct {
+	status  Status
+	summary string
+	files   []string
+}
+
+func (c *DownloadDirectory) Name() string {
+	return "Download directory contents"
+}
+
+func (c *DownloadDirectory) Run(_ context.Context, extraFH io.Writer) error {
+	downloadDir := getDownloadDir()
+	if downloadDir == "" {
+		return fmt.Errorf("no default download directory")
+	}
+
+	err := filepath.Walk(downloadDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && isKolideInstaller(info.Name()) {
+			c.files = append(c.files, path)
+		}
+		return nil
+	})
+
+	switch {
+	case os.IsNotExist(err):
+		c.status = Warning
+		c.summary = fmt.Sprintf("download directory (%s) not present", downloadDir)
+	case err != nil:
+		c.status = Erroring
+		c.summary = fmt.Sprintf("error listing files in directory (%s): %s", downloadDir, err)
+	case len(c.files) == 0:
+		c.status = Warning
+		c.summary = fmt.Sprintf("no Kolide installers found in directory (%s)", downloadDir)
+	default:
+		c.status = Passing
+		fileNames := make([]string, len(c.files))
+		for i, file := range c.files {
+			fileNames[i] = filepath.Base(file)
+		}
+		installerList := strings.Join(fileNames, ", ")
+		c.summary = fmt.Sprintf("Found Kolide installer(s) in directory (%s): %s", downloadDir, installerList)
+
+	}
+
+	if len(c.files) > 0 {
+		fmt.Fprintln(extraFH, "Kolide installers found:")
+		for _, file := range c.files {
+			fmt.Fprintln(extraFH, file)
+		}
+	}
+
+	return nil
+}
+
+func (c *DownloadDirectory) ExtraFileName() string {
+	return "kolide-installers"
+}
+
+func (c *DownloadDirectory) Status() Status {
+	return c.status
+}
+
+func (c *DownloadDirectory) Summary() string {
+	return c.summary
+}
+
+func (c *DownloadDirectory) Data() any {
+	return c.files
+}
+
+func getDownloadDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(homeDir, "Downloads")
+	case "linux":
+		return filepath.Join(homeDir, "Downloads")
+	case "windows":
+		return filepath.Join(homeDir, "Downloads")
+	}
+
+	return ""
+}
+
+func isKolideInstaller(filename string) bool {
+	lowerFilename := strings.ToLower(filename)
+	switch runtime.GOOS {
+	case "darwin":
+		return strings.HasSuffix(lowerFilename, "kolide-launcher.pkg")
+	case "linux":
+		return strings.HasSuffix(lowerFilename, "kolide-launcher.rpm") ||
+			strings.HasSuffix(lowerFilename, "kolide-launcher.deb") ||
+			strings.HasSuffix(lowerFilename, "kolide-launcher.pacman")
+	case "windows":
+		return strings.HasSuffix(lowerFilename, "kolide-launcher.msi")
+	}
+	return false
+}

--- a/ee/debug/checkups/download_directory.go
+++ b/ee/debug/checkups/download_directory.go
@@ -17,7 +17,7 @@ type downloadDirectory struct {
 }
 
 func (c *downloadDirectory) Name() string {
-	return "Download directory contents for all users"
+	return "Kolide Downloads"
 }
 
 func (c *downloadDirectory) Run(_ context.Context, extraFH io.Writer) error {
@@ -107,11 +107,12 @@ func getDownloadDirs() []string {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() {
-			userDir := filepath.Join(baseDir, entry.Name(), "Downloads")
-			if _, err := os.Stat(userDir); err == nil {
-				userDirs = append(userDirs, userDir)
-			}
+		if !entry.IsDir() {
+			continue
+		}
+		userDir := filepath.Join(baseDir, entry.Name(), "Downloads")
+		if _, err := os.Stat(userDir); err == nil {
+			userDirs = append(userDirs, userDir)
 		}
 	}
 

--- a/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
+++ b/ee/tables/execparsers/flatpak/remote_ls/upgradeable/parser.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 )
 
-// The app id conforms to: [dbus specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names)
-var flatpakAppIdRegexp = regexp.MustCompile(`(([a-zA-Z0-9_]+\.){1,}([a-zA-Z0-9_]+))`)
+// The app id conforms to: [dbus bus name specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names)
+var flatpakAppIdRegexp = regexp.MustCompile(`((?:[a-zA-Z_-]+[a-zA-Z0-9_-]*\.){1,}[a-zA-Z_-]+[a-zA-Z0-9_-]*)`)
 
 // Wow this has been a head-pounding bugger of a thing.
 //


### PR DESCRIPTION
- The download checkup should run only for flares 

- The download checkup should write out a list of all Kolide installers found in the downloads directory; installers will have the filename or filename suffix kolide-launcher.msi on Windows, kolide-launcher.pkg on MacOS, and kolide-launcher.rpm, kolide-launcher.deb, or kolide-launcher.pacman on Linux

Local example:
![image](https://github.com/user-attachments/assets/77ebd614-731c-4803-bd82-7ea435256f37)


Closes #1753 
