### PR TITLE
disable arm64 builds for non kolide

### DIFF
--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -17,6 +17,11 @@ import (
 	"github.com/kolide/launcher/pkg/contexts/ctxlog"
 )
 
+const (
+	// Internal kolide identifier
+	nababeIdentifier = "kolide-nababe-k2"
+)
+
 type wixTool struct {
 	wixPath         string     // Where is wix installed
 	packageRoot     string     // What's the root of the packaging files?
@@ -303,7 +308,10 @@ func (wo *wixTool) addServices(ctx context.Context) error {
 
 				// create a condition based on architecture
 				// have to format in the "%P" in "%PROCESSOR_ARCHITECTURE"
-				heatWrite.WriteString(fmt.Sprintf(`<Condition> %sROCESSOR_ARCHITECTURE="%s" </Condition>`, "%P", strings.ToUpper(string(currentArchSpecificBinDir))))
+				// feature flag only for nababe
+				if wo.identifier == nababeIdentifier {
+					heatWrite.WriteString(fmt.Sprintf(`<Condition> %sROCESSOR_ARCHITECTURE="%s" </Condition>`, "%P", strings.ToUpper(string(currentArchSpecificBinDir))))
+				}
 				heatWrite.WriteString("\n")
 
 				if err := service.Xml(heatWrite); err != nil {
@@ -319,7 +327,10 @@ func (wo *wixTool) addServices(ctx context.Context) error {
 				}
 
 				// create a condition based on architecture
-				heatWrite.WriteString(fmt.Sprintf(`<Condition> %sROCESSOR_ARCHITECTURE="%s" </Condition>`, "%P", strings.ToUpper(string(currentArchSpecificBinDir))))
+				// feature flag only for nababe
+				if wo.identifier == nababeIdentifier {
+					heatWrite.WriteString(fmt.Sprintf(`<Condition> %sROCESSOR_ARCHITECTURE="%s" </Condition>`, "%P", strings.ToUpper(string(currentArchSpecificBinDir))))
+				}
 				heatWrite.WriteString("\n")
 			}
 		}

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -28,6 +28,8 @@ var assets embed.FS
 const (
 	// Enroll secret should be readable only by root
 	secretPerms = 0600
+	// Internal kolide identifier
+	nababeIdentifier = "kolide-nababe-k2"
 )
 
 // PackageOptions encapsulates the launcher build options. It's
@@ -235,24 +237,25 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 	// Disabling the addition of arm64 binaries until arm64 is stable
 
 	// for windows, make a separate target for arm64
-	// if p.target.Platform == Windows {
-	// 	// make a copy of P
-	// 	packageOptsCopy := *p
-	// 	packageOptsCopy.target.Arch = Arm64
+	// feature flag only for nababe
+	if p.target.Platform == Windows && p.Identifier == nababeIdentifier {
+		// make a copy of P
+		packageOptsCopy := *p
+		packageOptsCopy.target.Arch = Arm64
 
-	// 	if err := packageOptsCopy.getBinary(ctx, "osqueryd", packageOptsCopy.target.PlatformBinaryName("osqueryd"), packageOptsCopy.OsqueryVersion); err != nil {
-	// 		return fmt.Errorf("fetching binary osqueryd: %w", err)
-	// 	}
+		if err := packageOptsCopy.getBinary(ctx, "osqueryd", packageOptsCopy.target.PlatformBinaryName("osqueryd"), packageOptsCopy.OsqueryVersion); err != nil {
+			return fmt.Errorf("fetching binary osqueryd: %w", err)
+		}
 
-	// 	launcherVersion := packageOptsCopy.LauncherVersion
-	// 	if packageOptsCopy.LauncherArmPath != "" {
-	// 		launcherVersion = packageOptsCopy.LauncherArmPath
-	// 	}
+		launcherVersion := packageOptsCopy.LauncherVersion
+		if packageOptsCopy.LauncherArmPath != "" {
+			launcherVersion = packageOptsCopy.LauncherArmPath
+		}
 
-	// 	if err := packageOptsCopy.getBinary(ctx, "launcher", packageOptsCopy.target.PlatformBinaryName("launcher"), launcherVersion); err != nil {
-	// 		return fmt.Errorf("fetching binary launcher: %w", err)
-	// 	}
-	// }
+		if err := packageOptsCopy.getBinary(ctx, "launcher", packageOptsCopy.target.PlatformBinaryName("launcher"), launcherVersion); err != nil {
+			return fmt.Errorf("fetching binary launcher: %w", err)
+		}
+	}
 
 	// Some darwin specific bits
 	if p.target.Platform == Darwin {

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -232,25 +232,27 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 		return fmt.Errorf("fetching binary launcher: %w", err)
 	}
 
+	// Disabling the addition of arm64 binaries until arm64 is stable
+
 	// for windows, make a separate target for arm64
-	if p.target.Platform == Windows {
-		// make a copy of P
-		packageOptsCopy := *p
-		packageOptsCopy.target.Arch = Arm64
+	// if p.target.Platform == Windows {
+	// 	// make a copy of P
+	// 	packageOptsCopy := *p
+	// 	packageOptsCopy.target.Arch = Arm64
 
-		if err := packageOptsCopy.getBinary(ctx, "osqueryd", packageOptsCopy.target.PlatformBinaryName("osqueryd"), packageOptsCopy.OsqueryVersion); err != nil {
-			return fmt.Errorf("fetching binary osqueryd: %w", err)
-		}
+	// 	if err := packageOptsCopy.getBinary(ctx, "osqueryd", packageOptsCopy.target.PlatformBinaryName("osqueryd"), packageOptsCopy.OsqueryVersion); err != nil {
+	// 		return fmt.Errorf("fetching binary osqueryd: %w", err)
+	// 	}
 
-		launcherVersion := packageOptsCopy.LauncherVersion
-		if packageOptsCopy.LauncherArmPath != "" {
-			launcherVersion = packageOptsCopy.LauncherArmPath
-		}
+	// 	launcherVersion := packageOptsCopy.LauncherVersion
+	// 	if packageOptsCopy.LauncherArmPath != "" {
+	// 		launcherVersion = packageOptsCopy.LauncherArmPath
+	// 	}
 
-		if err := packageOptsCopy.getBinary(ctx, "launcher", packageOptsCopy.target.PlatformBinaryName("launcher"), launcherVersion); err != nil {
-			return fmt.Errorf("fetching binary launcher: %w", err)
-		}
-	}
+	// 	if err := packageOptsCopy.getBinary(ctx, "launcher", packageOptsCopy.target.PlatformBinaryName("launcher"), launcherVersion); err != nil {
+	// 		return fmt.Errorf("fetching binary launcher: %w", err)
+	// 	}
+	// }
 
 	// Some darwin specific bits
 	if p.target.Platform == Darwin {


### PR DESCRIPTION
This disables arm64 builds in packaging to allow arm64 machines to emulate amd64. Internal builds will still have arm64.