### PR TITLE
Update documentation for notifications and control server

### DIFF
--- a/docs/architecture/control_server.md
+++ b/docs/architecture/control_server.md
@@ -4,7 +4,7 @@
 
 The control server feature enables launcher to periodically query Kolide's SaaS app to receive
 data updates for various subsystems of launcher. Each subsystem is a named component and has a hash
-of it's data. When the launcher's control service finds a new
+of its data. When the launcher's control service finds a new
 update for a subsystem, it notifies a consumer registered to handle updates for the subsystem, then pings all subscribers for the subsystem.
 
 The latest update for each subsystem is cached so the control server can avoid re-sending updates

--- a/docs/architecture/flags.md
+++ b/docs/architecture/flags.md
@@ -1,6 +1,6 @@
 # Flags
 
-The `Flags` interface provides a simple API for storing and retrieving launcher flags at runtime. Currently, flags are of types `bool`, `int64` and `string`.
+The `Flags` interface provides a simple API for storing and retrieving launcher flags at runtime.
 
 Launcher flags are identified by a `FlagKey` and can be specified through various means:
 

--- a/docs/architecture/knapsack.md
+++ b/docs/architecture/knapsack.md
@@ -2,7 +2,7 @@
 
 `Knapsack` is an object instantiated very early on in the launcher startup process, and contains an inventory of useful services which are used throughout launcher. Its purpose is to provide a convenient API to access commonly used resources and functionality, while minimizing function argument list bloat.
 
-`Knapsack` is a superset of several interfaces, forming an API with a large surface area, resembling a Facade design pattern. `Knapsack` itself largely delegates operations and complexity to sub-components, as it's primary goal is to provide a simple API for any client within launcher to use easily and effectively.
+`Knapsack` is a superset of several interfaces, forming an API with a large surface area, resembling a Facade design pattern. `Knapsack` itself largely delegates operations and complexity to sub-components, as its primary goal is to provide a simple API for any client within launcher to use easily and effectively.
 
 ### Mocking Knapsack
 
@@ -10,7 +10,7 @@ Many times, tests can instantiate a mock `Knapsack` and provide mock method impl
 
 ```
 mockKnapsack := typesMocks.NewKnapsack(t)
-mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ControlRequestInterval
+mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ControlRequestInterval)
 mockKnapsack.On("ControlRequestInterval").Return(60 * time.Second)
 ```
 


### PR DESCRIPTION
I noticed our notification documentation was out-of-date -- this PR updates it to refer to the actionqueue refactor, and to note the approximate date we released notifications to stable.