### PR TITLE
pin go 1.22.7 to test desktop crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22
+go 1.22.7
 
 toolchain go1.22.2
 


### PR DESCRIPTION
Launcher Desktop is crashing with cgo errors in the latest nightly build. The latest nightly bumped go from 1.22.7 -> 1.22.8. Looking at the [minor releases of 1.22](https://go.dev/doc/devel/release#go1.22.minor), I can see that there were changes to cgo, so seeing if the effected launcher somehow.