### PR TITLE
allow update during initial delay when overridding initial delay

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -225,6 +225,11 @@ func (ta *TufAutoupdater) Execute() (err error) {
 			"received external interrupt during initial delay, stopping",
 		)
 		return nil
+	case signalRestartErr := <-ta.signalRestart:
+		ta.slogger.Log(context.TODO(), slog.LevelDebug,
+			"received interrupt to restart launcher after update during initial delay, stopping",
+		)
+		return signalRestartErr
 	case <-time.After(ta.knapsack.AutoupdateInitialDelay()):
 		break
 	}


### PR DESCRIPTION
When we get the `bypass_initial_delay` from server, were downloading the updated, but not restarting because we're not listing for restart signal during initial delay.