### PR TITLE
Remove macos-12 runner since it will be deprecated soon

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
     - name: Check out code
@@ -130,9 +130,9 @@ jobs:
           # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
           - windows-2019
           - windows-2022
     needs: version_baseline
@@ -207,7 +207,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
     - uses: actions/checkout@v4

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -307,6 +307,11 @@ func (b *Builder) BuildCmd(src, appName string) func(context.Context) error {
 			ldFlags = append(ldFlags, "-H windowsgui")
 		}
 
+		if b.os == "darwin" {
+			// Suppress warnings like "ld: warning: ignoring duplicate libraries: '-lobjc'"
+			ldFlags = append(ldFlags, "-extldflags=-Wl,-no_warn_duplicate_libraries")
+		}
+
 		if b.stampVersion {
 			v, err := b.getVersion(ctx)
 			if err != nil {

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -309,6 +309,7 @@ func (b *Builder) BuildCmd(src, appName string) func(context.Context) error {
 
 		if b.os == "darwin" {
 			// Suppress warnings like "ld: warning: ignoring duplicate libraries: '-lobjc'"
+			// See: https://github.com/golang/go/issues/67799
 			ldFlags = append(ldFlags, "-extldflags=-Wl,-no_warn_duplicate_libraries")
 		}
 


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/10721, the macos-12 runner will be deprecated soon. I've replaced its usage with macos-13, the oldest version that will be supported come November. Since macos-15 is now available, I added that as well.

Added new flag to builder to address https://github.com/golang/go/issues/67799.