### PR TITLE
Set osquery version in packaging context

### DIFF
--- a/pkg/packagekit/context.go
+++ b/pkg/packagekit/context.go
@@ -32,7 +32,7 @@ func InitContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-func setInContext(ctx context.Context, key contextKey, val string) {
+func SetInContext(ctx context.Context, key contextKey, val string) {
 	// If there's no pointer, then there's no point in setting
 	// this. It won't get back to the caller.
 	ptr, ok := ctx.Value(key).(*string)

--- a/pkg/packagekit/context_test.go
+++ b/pkg/packagekit/context_test.go
@@ -54,7 +54,7 @@ func TestContext(t *testing.T) {
 	}
 
 	for _, pair := range contextPairs {
-		setInContext(ctx, pair.key, pair.val)
+		SetInContext(ctx, pair.key, pair.val)
 	}
 
 	for _, pair := range contextPairs {

--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -178,7 +178,7 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 		return fmt.Errorf("copying output: %w", err)
 	}
 
-	setInContext(ctx, ContextLauncherVersionKey, po.Version)
+	SetInContext(ctx, ContextLauncherVersionKey, po.Version)
 
 	return nil
 }

--- a/pkg/packagekit/package_pkg.go
+++ b/pkg/packagekit/package_pkg.go
@@ -61,7 +61,7 @@ func PackagePkg(ctx context.Context, w io.Writer, po *PackageOptions, arch strin
 		return fmt.Errorf("copying output: %w", err)
 	}
 
-	setInContext(ctx, ContextLauncherVersionKey, po.Version)
+	SetInContext(ctx, ContextLauncherVersionKey, po.Version)
 
 	return nil
 }
@@ -89,7 +89,7 @@ func runNotarize(ctx context.Context, file string, po *PackageOptions) error {
 		"uuid", uuid,
 	)
 
-	setInContext(ctx, ContextNotarizationUuidKey, uuid)
+	SetInContext(ctx, ContextNotarizationUuidKey, uuid)
 
 	return nil
 }

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -175,7 +175,7 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 		return fmt.Errorf("copying output: %w", err)
 	}
 
-	setInContext(ctx, ContextLauncherVersionKey, po.Version)
+	SetInContext(ctx, ContextLauncherVersionKey, po.Version)
 
 	return nil
 }

--- a/pkg/packaging/helpers.go
+++ b/pkg/packaging/helpers.go
@@ -1,11 +1,58 @@
 package packaging
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/kolide/launcher/pkg/contexts/ctxlog"
+	"github.com/kolide/launcher/pkg/packagekit"
 )
 
 // sanitizeHostname will replace any ":" characters in a given hostname with "-"
 // This is useful because ":" is not a valid character for file paths.
 func sanitizeHostname(hostname string) string {
 	return strings.Replace(hostname, ":", "-", -1)
+}
+
+// setOsqueryVersionInCtx retrieves the osquery version (by running the binary) and
+// sets it in the context.
+func (p *PackageOptions) setOsqueryVersionInCtx(ctx context.Context) {
+	logger := log.With(ctxlog.FromContext(ctx), "library", "setOsqueryVersionInCtx")
+
+	osqueryPath := p.osqueryLocation()
+	stdout, err := p.execOut(ctx, osqueryPath, "-version")
+	if err != nil {
+		level.Warn(logger).Log(
+			"msg", "could not run osqueryd -version",
+			"err", err,
+		)
+		return
+	}
+
+	osquerydVersionTrimmed := strings.TrimPrefix(strings.TrimSpace(stdout), "osqueryd version ")
+
+	packagekit.SetInContext(ctx, packagekit.ContextOsqueryVersionKey, osquerydVersionTrimmed)
+}
+
+// osqueryLocation returns the location of the osquery binary within `binDir`. For darwin,
+// it may be in an app bundle -- we check to see if the binary exists there first, and then
+// fall back to the common location if it doesn't.
+func (p *PackageOptions) osqueryLocation() string {
+	if p.target.Platform == Darwin {
+		// We want /usr/local/osquery.app, not /usr/local/bin/Kolide.app, so we use Dir to strip out `bin`
+		appBundleBinaryPath := filepath.Join(p.packageRoot, filepath.Dir(p.binDir), "osquery.app", "Contents", "MacOS", "launcher")
+		if info, err := os.Stat(appBundleBinaryPath); err == nil && !info.IsDir() {
+			return appBundleBinaryPath
+		}
+	}
+
+	if p.target.Platform == Windows {
+		return filepath.Join(p.packageRoot, p.binDir, string(p.target.Arch), p.target.PlatformBinaryName("osqueryd"))
+	}
+
+	return filepath.Join(p.packageRoot, p.binDir, p.target.PlatformBinaryName("osqueryd"))
 }

--- a/pkg/packaging/packaging.go
+++ b/pkg/packaging/packaging.go
@@ -93,7 +93,6 @@ func NewPackager() *PackageOptions {
 }
 
 func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, target Target) error {
-
 	p.target = target
 	p.packageWriter = packageWriter
 
@@ -283,6 +282,9 @@ func (p *PackageOptions) Build(ctx context.Context, packageWriter io.Writer, tar
 			return fmt.Errorf("version detection: %w", err)
 		}
 	}
+
+	// Record the osquery version, now that we've downloaded it
+	p.setOsqueryVersionInCtx(ctx)
 
 	p.initOptions = &packagekit.InitOptions{
 		Name:        "launcher",


### PR DESCRIPTION
This change will allow us to record the osquery version when building packages. (We already do this for launcher version, using the same method.)