### PR TITLE
Trim osquery version correctly on Windows

### DIFF
--- a/pkg/packaging/helpers.go
+++ b/pkg/packaging/helpers.go
@@ -37,7 +37,9 @@ func (p *PackageOptions) setOsqueryVersionInCtx(ctx context.Context) {
 }
 
 func osqueryVersionFromVersionOutput(output string) string {
-	return strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(output), "osqueryd.exe version "), "osqueryd version ")
+	// Output looks like `osquery version x.y.z`, so split on `version` and return the last part of the string
+	parts := strings.SplitAfter(output, "version")
+	return strings.TrimSpace(parts[len(parts)-1])
 }
 
 // osqueryLocation returns the location of the osquery binary within `binDir`. For darwin,

--- a/pkg/packaging/helpers.go
+++ b/pkg/packaging/helpers.go
@@ -33,9 +33,11 @@ func (p *PackageOptions) setOsqueryVersionInCtx(ctx context.Context) {
 		return
 	}
 
-	osquerydVersionTrimmed := strings.TrimPrefix(strings.TrimSpace(stdout), "osqueryd version ")
+	packagekit.SetInContext(ctx, packagekit.ContextOsqueryVersionKey, osqueryVersionFromVersionOutput(stdout))
+}
 
-	packagekit.SetInContext(ctx, packagekit.ContextOsqueryVersionKey, osquerydVersionTrimmed)
+func osqueryVersionFromVersionOutput(output string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(output), "osqueryd.exe version "), "osqueryd version ")
 }
 
 // osqueryLocation returns the location of the osquery binary within `binDir`. For darwin,

--- a/pkg/packaging/helpers_test.go
+++ b/pkg/packaging/helpers_test.go
@@ -27,3 +27,37 @@ func TestSanitizeHostname(t *testing.T) {
 		require.Equal(t, tt.out, sanitizeHostname(tt.in))
 	}
 }
+
+func Test_osqueryVersionFromVersionOutput(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName    string
+		versionOutput   string
+		expectedVersion string
+	}{
+		{
+			testCaseName:    "windows",
+			versionOutput:   "osqueryd.exe version 5.14.1",
+			expectedVersion: "5.14.1",
+		},
+		{
+			testCaseName:    "non-windows",
+			versionOutput:   "osqueryd version 5.13.1",
+			expectedVersion: "5.13.1",
+		},
+		{
+			testCaseName: "extra spaces",
+			versionOutput: `
+osqueryd version 5.13.1
+`,
+			expectedVersion: "5.13.1",
+		},
+	} {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expectedVersion, osqueryVersionFromVersionOutput(tt.versionOutput))
+		})
+	}
+}


### PR DESCRIPTION
Missed this on https://github.com/kolide/launcher/pull/1901, added a test so it won't happen again