### PR TITLE
If we don't have any TUF metadata locally, return friendlier error message

### DIFF
--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -2,6 +2,7 @@ package tuf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -248,7 +249,10 @@ func findExecutable(ctx context.Context, binary autoupdatableBinary, tufReposito
 	// From already-downloaded metadata, look for the release version
 	targets, err := metadataClient.Targets()
 	if err != nil {
-		return nil, fmt.Errorf("could not get target: %w", err)
+		return nil, fmt.Errorf("could not get targets: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("no local TUF metadata available -- likely new install")
 	}
 
 	targetName, _, err := findTarget(ctx, binary, targets, pinnedVersion, channel, slogger)


### PR DESCRIPTION
From this:

```json
{
"time":"2024-10-23T17:05:21.508261Z",
"level":"INFO",
"msg":"could not find executable matching current release",
"component":"tuf_library_lookup",
"binary":"launcher",
"err":"could not find release: expected release file launcher/darwin/universal/nightly/release.json for binary launcher to be in targets but it was not"
}
```

to this:

```json
{
"time":"2024-10-23T17:34:47.45264Z",
"level":"INFO",
"msg":"could not find executable matching current release",
"component":"tuf_library_lookup",
"binary":"launcher",
"err":"no local TUF metadata available -- likely new install"
}
```