### PR TITLE
Remove and consolidate osquery instance options

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -140,6 +140,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			"using default system root directory",
 			"path", rootDirectory,
 		)
+		// Make sure we have record of this new root directory in the opts, so it will be set
+		// correctly in the knapsack later.
+		opts.RootDirectory = rootDirectory
 	}
 
 	if err := os.MkdirAll(rootDirectory, fsutil.DirMode); err != nil {

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -356,12 +356,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// create the runner that will launch osquery
 	osqueryRunner := osqueryruntime.New(
 		k,
-		osqueryruntime.WithKnapsack(k),
-		osqueryruntime.WithRootDirectory(k.RootDirectory()),
 		osqueryruntime.WithOsqueryExtensionPlugins(table.LauncherTables(k)...),
-		osqueryruntime.WithSlogger(k.Slogger().With("component", "osquery_instance")),
-		osqueryruntime.WithOsqueryVerbose(k.OsqueryVerbose()),
-		osqueryruntime.WithOsqueryFlags(k.OsqueryFlags()),
 		osqueryruntime.WithStdout(kolidelog.NewOsqueryLogAdapter(
 			k.Slogger().With(
 				"component", "osquery",
@@ -379,8 +374,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			kolidelog.WithLevel(slog.LevelInfo),
 		)),
 		osqueryruntime.WithAugeasLensFunction(augeas.InstallLenses),
-		osqueryruntime.WithUpdateDirectory(k.UpdateDirectory()),
-		osqueryruntime.WithUpdateChannel(k.UpdateChannel()),
 		osqueryruntime.WithConfigPluginFlag("kolide_grpc"),
 		osqueryruntime.WithLoggerPluginFlag("kolide_grpc"),
 		osqueryruntime.WithDistributedPluginFlag("kolide_grpc"),

--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -404,22 +404,6 @@ func (fc *FlagController) OsqueryFlags() []string {
 	return fc.cmdLineOpts.OsqueryFlags
 }
 
-func (fc *FlagController) OsqueryTlsConfigEndpoint() string {
-	return fc.cmdLineOpts.OsqueryTlsConfigEndpoint
-}
-func (fc *FlagController) OsqueryTlsEnrollEndpoint() string {
-	return fc.cmdLineOpts.OsqueryTlsEnrollEndpoint
-}
-func (fc *FlagController) OsqueryTlsLoggerEndpoint() string {
-	return fc.cmdLineOpts.OsqueryTlsLoggerEndpoint
-}
-func (fc *FlagController) OsqueryTlsDistributedReadEndpoint() string {
-	return fc.cmdLineOpts.OsqueryTlsDistributedReadEndpoint
-}
-func (fc *FlagController) OsqueryTlsDistributedWriteEndpoint() string {
-	return fc.cmdLineOpts.OsqueryTlsDistributedWriteEndpoint
-}
-
 func (fc *FlagController) CurrentRunningOsqueryVersion() string {
 	return NewStringFlagValue(WithDefaultString("")).get(fc.getControlServerValue(keys.CurrentRunningOsqueryVersion))
 }

--- a/ee/agent/flags/flag_controller_test.go
+++ b/ee/agent/flags/flag_controller_test.go
@@ -128,16 +128,6 @@ func TestControllerStringFlags(t *testing.T) {
 				assert.Equal(t, expectedValue, value)
 				value = fc.Transport()
 				assert.Equal(t, expectedValue, value)
-				value = fc.OsqueryTlsConfigEndpoint()
-				assert.Equal(t, expectedValue, value)
-				value = fc.OsqueryTlsEnrollEndpoint()
-				assert.Equal(t, expectedValue, value)
-				value = fc.OsqueryTlsLoggerEndpoint()
-				assert.Equal(t, expectedValue, value)
-				value = fc.OsqueryTlsDistributedReadEndpoint()
-				assert.Equal(t, expectedValue, value)
-				value = fc.OsqueryTlsDistributedWriteEndpoint()
-				assert.Equal(t, expectedValue, value)
 			}
 
 			assertGettersValues("")

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -138,13 +138,6 @@ type Flags interface {
 	// overriding Launcher defaults)
 	OsqueryFlags() []string
 
-	// Osquery TLS options
-	OsqueryTlsConfigEndpoint() string
-	OsqueryTlsEnrollEndpoint() string
-	OsqueryTlsLoggerEndpoint() string
-	OsqueryTlsDistributedReadEndpoint() string
-	OsqueryTlsDistributedWriteEndpoint() string
-
 	// Osquery Version is the version of osquery that is being used.
 	SetCurrentRunningOsqueryVersion(version string) error
 	CurrentRunningOsqueryVersion() string

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -65,13 +65,6 @@ type Options struct {
 	// will check for updates from the control server.
 	ControlRequestInterval time.Duration
 
-	// Osquery TLS options
-	OsqueryTlsConfigEndpoint           string
-	OsqueryTlsEnrollEndpoint           string
-	OsqueryTlsLoggerEndpoint           string
-	OsqueryTlsDistributedReadEndpoint  string
-	OsqueryTlsDistributedWriteEndpoint string
-
 	// Autoupdate enables the autoupdate functionality.
 	Autoupdate bool
 	// TufServerURL is the URL for the tuf server.
@@ -234,13 +227,6 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		flTraceIngestServerURL            = flagset.String("trace_ingest_url", "", "Where to export traces")
 		flDisableIngestTLS                = flagset.Bool("disable_trace_ingest_tls", false, "Disable TLS for observability ingest server communication")
 
-		// osquery TLS endpoints
-		flOsqTlsConfig    = flagset.String("config_tls_endpoint", "", "Config endpoint for the osquery tls transport")
-		flOsqTlsEnroll    = flagset.String("enroll_tls_endpoint", "", "Enroll endpoint for the osquery tls transport")
-		flOsqTlsLogger    = flagset.String("logger_tls_endpoint", "", "Logger endpoint for the osquery tls transport")
-		flOsqTlsDistRead  = flagset.String("distributed_tls_read_endpoint", "", "Distributed read endpoint for the osquery tls transport")
-		flOsqTlsDistWrite = flagset.String("distributed_tls_write_endpoint", "", "Distributed write endpoint for the osquery tls transport")
-
 		// Autoupdate options
 		flAutoupdate             = flagset.Bool("autoupdate", DefaultAutoupdate, "Whether or not the osquery autoupdater is enabled (default: false)")
 		flTufServerURL           = flagset.String("tuf_url", DefaultTufServer, "TUF update server (default: https://tuf.kolide.com)")
@@ -268,6 +254,11 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		_ = flagset.Bool("disable_control_tls", false, "DEPRECATED")
 		_ = flagset.String("notary_url", "", "DEPRECATED")
 		_ = flagset.String("notary_prefix", "", "DEPRECATED")
+		_ = flagset.String("config_tls_endpoint", "", "DEPRECATED")
+		_ = flagset.String("enroll_tls_endpoint", "", "DEPRECATED")
+		_ = flagset.String("logger_tls_endpoint", "", "DEPRECATED")
+		_ = flagset.String("distributed_tls_read_endpoint", "", "DEPRECATED")
+		_ = flagset.String("distributed_tls_write_endpoint", "", "DEPRECATED")
 	)
 
 	flagset.Var(&flOsqueryFlags, "osquery_flag", "Flags to pass to osquery (possibly overriding Launcher defaults)")
@@ -382,56 +373,51 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 	}
 
 	opts := &Options{
-		Autoupdate:                         *flAutoupdate,
-		AutoupdateInterval:                 *flAutoupdateInterval,
-		AutoupdateInitialDelay:             *flAutoupdateInitialDelay,
-		CertPins:                           certPins,
-		CompactDbMaxTx:                     *flCompactDbMaxTx,
-		ConfigFilePath:                     *flConfigFilePath,
-		Control:                            false,
-		ControlServerURL:                   controlServerURL,
-		ControlRequestInterval:             *flControlRequestInterval,
-		Debug:                              *flDebug,
-		DelayStart:                         *flDelayStart,
-		DisableControlTLS:                  disableControlTLS,
-		Identifier:                         *flPackageIdentifier,
-		InsecureControlTLS:                 insecureControlTLS,
-		EnableInitialRunner:                *flInitialRunner,
-		WatchdogEnabled:                    *flWatchdogEnabled,
-		EnrollSecret:                       *flEnrollSecret,
-		EnrollSecretPath:                   *flEnrollSecretPath,
-		ExportTraces:                       *flExportTraces,
-		LogIngestServerURL:                 *flLogIngestServerURL,
-		LocalDevelopmentPath:               *flLocalDevelopmentPath,
-		TraceIngestServerURL:               *flTraceIngestServerURL,
-		DisableTraceIngestTLS:              *flDisableIngestTLS,
-		IAmBreakingEELicense:               *flIAmBreakingEELicense,
-		InsecureTLS:                        *flInsecureTLS,
-		InsecureTransport:                  *flInsecureTransport,
-		KolideHosted:                       *flKolideHosted,
-		KolideServerURL:                    *flKolideServerURL,
-		LogMaxBytesPerBatch:                *flLogMaxBytesPerBatch,
-		LoggingInterval:                    *flLoggingInterval,
-		MirrorServerURL:                    *flMirrorURL,
-		TufServerURL:                       *flTufServerURL,
-		OsqueryFlags:                       flOsqueryFlags,
-		OsqueryTlsConfigEndpoint:           *flOsqTlsConfig,
-		OsqueryTlsDistributedReadEndpoint:  *flOsqTlsDistRead,
-		OsqueryTlsDistributedWriteEndpoint: *flOsqTlsDistWrite,
-		OsqueryTlsEnrollEndpoint:           *flOsqTlsEnroll,
-		OsqueryTlsLoggerEndpoint:           *flOsqTlsLogger,
-		OsqueryVerbose:                     *flOsqueryVerbose,
-		OsquerydPath:                       osquerydPath,
-		OsqueryHealthcheckStartupDelay:     *flOsqueryHealthcheckStartupDelay,
-		RootDirectory:                      *flRootDirectory,
-		RootPEM:                            *flRootPEM,
-		TraceSamplingRate:                  *flTraceSamplingRate,
-		Transport:                          *flTransport,
-		UpdateChannel:                      updateChannel,
-		UpdateDirectory:                    *flUpdateDirectory,
-		WatchdogDelaySec:                   *flWatchdogDelaySec,
-		WatchdogMemoryLimitMB:              *flWatchdogMemoryLimitMB,
-		WatchdogUtilizationLimitPercent:    *flWatchdogUtilizationLimitPercent,
+		Autoupdate:                      *flAutoupdate,
+		AutoupdateInterval:              *flAutoupdateInterval,
+		AutoupdateInitialDelay:          *flAutoupdateInitialDelay,
+		CertPins:                        certPins,
+		CompactDbMaxTx:                  *flCompactDbMaxTx,
+		ConfigFilePath:                  *flConfigFilePath,
+		Control:                         false,
+		ControlServerURL:                controlServerURL,
+		ControlRequestInterval:          *flControlRequestInterval,
+		Debug:                           *flDebug,
+		DelayStart:                      *flDelayStart,
+		DisableControlTLS:               disableControlTLS,
+		Identifier:                      *flPackageIdentifier,
+		InsecureControlTLS:              insecureControlTLS,
+		EnableInitialRunner:             *flInitialRunner,
+		WatchdogEnabled:                 *flWatchdogEnabled,
+		EnrollSecret:                    *flEnrollSecret,
+		EnrollSecretPath:                *flEnrollSecretPath,
+		ExportTraces:                    *flExportTraces,
+		LogIngestServerURL:              *flLogIngestServerURL,
+		LocalDevelopmentPath:            *flLocalDevelopmentPath,
+		TraceIngestServerURL:            *flTraceIngestServerURL,
+		DisableTraceIngestTLS:           *flDisableIngestTLS,
+		IAmBreakingEELicense:            *flIAmBreakingEELicense,
+		InsecureTLS:                     *flInsecureTLS,
+		InsecureTransport:               *flInsecureTransport,
+		KolideHosted:                    *flKolideHosted,
+		KolideServerURL:                 *flKolideServerURL,
+		LogMaxBytesPerBatch:             *flLogMaxBytesPerBatch,
+		LoggingInterval:                 *flLoggingInterval,
+		MirrorServerURL:                 *flMirrorURL,
+		TufServerURL:                    *flTufServerURL,
+		OsqueryFlags:                    flOsqueryFlags,
+		OsqueryVerbose:                  *flOsqueryVerbose,
+		OsquerydPath:                    osquerydPath,
+		OsqueryHealthcheckStartupDelay:  *flOsqueryHealthcheckStartupDelay,
+		RootDirectory:                   *flRootDirectory,
+		RootPEM:                         *flRootPEM,
+		TraceSamplingRate:               *flTraceSamplingRate,
+		Transport:                       *flTransport,
+		UpdateChannel:                   updateChannel,
+		UpdateDirectory:                 *flUpdateDirectory,
+		WatchdogDelaySec:                *flWatchdogDelaySec,
+		WatchdogMemoryLimitMB:           *flWatchdogMemoryLimitMB,
+		WatchdogUtilizationLimitPercent: *flWatchdogUtilizationLimitPercent,
 	}
 
 	return opts, nil

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/storage"
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
@@ -41,12 +42,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	binDirectory, rmBinDirectory, err := osqueryTempDir()
+	binDirectory, err := agent.MkdirTemp("")
 	if err != nil {
 		fmt.Println("Failed to make temp dir for test binaries")
 		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
-	defer rmBinDirectory()
+	defer os.Remove(binDirectory)
 
 	s, err := storageci.NewStore(nil, multislogger.NewNopLogger(), storage.OsqueryHistoryInstanceStore.String())
 	if err != nil {
@@ -88,9 +89,7 @@ func TestCalculateOsqueryPaths(t *testing.T) {
 	binDir, err := getBinDir()
 	require.NoError(t, err)
 
-	paths, err := calculateOsqueryPaths(osqueryOptions{
-		rootDirectory: binDir,
-	})
+	paths, err := calculateOsqueryPaths(binDir, osqueryOptions{})
 
 	require.NoError(t, err)
 
@@ -130,8 +129,11 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)
 	k.On("WatchdogDelaySec").Return(120)
+	k.On("OsqueryVerbose").Return(true)
+	k.On("OsqueryFlags").Return([]string{})
+	k.On("Slogger").Return(multislogger.NewNopLogger())
 
-	i := newInstance()
+	i := newInstance(k)
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -145,16 +147,17 @@ func TestCreateOsqueryCommand(t *testing.T) {
 
 func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	t.Parallel()
-	osqOpts := &osqueryOptions{
-		osqueryFlags: []string{"verbose=false", "windows_event_channels=foo,bar"},
-	}
+	osqOpts := &osqueryOptions{}
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(true)
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)
 	k.On("WatchdogDelaySec").Return(120)
+	k.On("OsqueryFlags").Return([]string{"verbose=false", "windows_event_channels=foo,bar"})
+	k.On("OsqueryVerbose").Return(true)
+	k.On("Slogger").Return(multislogger.NewNopLogger())
 
-	i := newInstance()
+	i := newInstance(k)
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -186,8 +189,11 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)
 	k.On("WatchdogDelaySec").Return(120)
+	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("OsqueryVerbose").Return(true)
+	k.On("OsqueryFlags").Return([]string{})
 
-	i := newInstance()
+	i := newInstance(k)
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -235,8 +241,11 @@ func TestCreateOsqueryCommand_SetsDisabledWatchdogSettingsAppropriately(t *testi
 	osqOpts := &osqueryOptions{}
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(false)
+	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("OsqueryVerbose").Return(true)
+	k.On("OsqueryFlags").Return([]string{})
 
-	i := newInstance()
+	i := newInstance(k)
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -305,9 +314,7 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 
 func TestBadBinaryPath(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -315,12 +322,11 @@ func TestBadBinaryPath(t *testing.T) {
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("LatestOsquerydPath", mock.Anything).Return("")
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryVerbose").Return(true)
+	k.On("OsqueryFlags").Return([]string{})
 
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-	)
+	runner := New(k)
 	assert.Error(t, runner.Run())
 
 	k.AssertExpectations(t)
@@ -328,9 +334,7 @@ func TestBadBinaryPath(t *testing.T) {
 
 func TestWithOsqueryFlags(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -344,29 +348,23 @@ func TestWithOsqueryFlags(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{"verbose=false"})
+	k.On("OsqueryVerbose").Return(false)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store).Maybe() // attempt to make this test less flaky
 
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-		WithOsqueryFlags([]string{"verbose=false"}),
-	)
+	runner := New(k)
 	go runner.Run()
 	waitHealthy(t, runner, &logBytes)
-	assert.Equal(t, []string{"verbose=false"}, runner.instance.opts.osqueryFlags)
-
 	waitShutdown(t, runner, &logBytes)
 }
 
 func TestFlagsChanged(t *testing.T) {
 	t.Parallel()
 
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -385,17 +383,15 @@ func TestFlagsChanged(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{"verbose=false"})
+	k.On("OsqueryVerbose").Return(false)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store).Maybe() // attempt to make this test less flaky
 
 	// Start the runner
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-		WithOsqueryFlags([]string{"verbose=false"}),
-	)
+	runner := New(k)
 	go runner.Run()
 
 	// Wait for the instance to start
@@ -505,9 +501,7 @@ func waitHealthy(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Thread
 
 func TestSimplePath(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -521,15 +515,14 @@ func TestSimplePath(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{})
+	k.On("OsqueryVerbose").Return(true)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store).Maybe() // attempt to make this test less flaky
 
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-	)
+	runner := New(k)
 	go runner.Run()
 
 	waitHealthy(t, runner, &logBytes)
@@ -542,9 +535,7 @@ func TestSimplePath(t *testing.T) {
 
 func TestMultipleShutdowns(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -558,15 +549,14 @@ func TestMultipleShutdowns(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{})
+	k.On("OsqueryVerbose").Return(true)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store).Maybe() // attempt to make this test less flaky
 
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-	)
+	runner := New(k)
 	go runner.Run()
 
 	waitHealthy(t, runner, &logBytes)
@@ -578,9 +568,7 @@ func TestMultipleShutdowns(t *testing.T) {
 
 func TestOsqueryDies(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -594,15 +582,14 @@ func TestOsqueryDies(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{})
+	k.On("OsqueryVerbose").Return(true)
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store).Maybe() // attempt to make this test less flaky
 
-	runner := New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-	)
+	runner := New(k)
 	go runner.Run()
 	require.NoError(t, err)
 
@@ -625,14 +612,13 @@ func TestOsqueryDies(t *testing.T) {
 
 func TestNotStarted(t *testing.T) {
 	t.Parallel()
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
-	defer rmRootDirectory()
+	rootDirectory := t.TempDir()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
-	runner := newRunner(WithKnapsack(k), WithRootDirectory(rootDirectory))
-	require.NoError(t, err)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("Slogger").Return(multislogger.NewNopLogger())
+	runner := newRunner(k)
 
 	assert.Error(t, runner.Healthy())
 	assert.NoError(t, runner.Shutdown())
@@ -679,8 +665,7 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 
 // sets up an osquery instance with a running extension to be used in tests.
 func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, teardown func()) {
-	rootDirectory, rmRootDirectory, err := osqueryTempDir()
-	require.NoError(t, err)
+	rootDirectory := t.TempDir()
 
 	logBytes = &threadsafebuffer.ThreadSafeBuffer{}
 	slogger := slog.New(slog.NewTextHandler(logBytes, &slog.HandlerOptions{
@@ -697,22 +682,20 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
+	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("OsqueryFlags").Return([]string{}).Maybe()
+	k.On("OsqueryVerbose").Return(true).Maybe()
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
 	require.NoError(t, err)
 	k.On("KatcConfigStore").Return(store)
 
-	runner = New(
-		k,
-		WithKnapsack(k),
-		WithRootDirectory(rootDirectory),
-	)
+	runner = New(k)
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 
 	requirePgidMatch(t, runner.instance.cmd.Process.Pid)
 
 	teardown = func() {
-		defer rmRootDirectory()
 		waitShutdown(t, runner, logBytes)
 	}
 	return runner, logBytes, teardown


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827 -- getting some tidying out of the way before making more substantial changes.

This PR updates our osquery instance options:

1. Remove unused options
2. Remove options that are redundant with knapsack flags, opting to pull these values from the knapsack instead

While I was validating that the root directory will always be set by the time that we make it to the osquery runner, I noticed that in `runLauncher` if the root directory wasn't set in the launcher options and we fell back to making a temp directory, we wouldn't save that temp directory in the knapsack flags. I updated to save it in the launcher options, so that it would later be available via the knapsack. I imagine we don't run into this issue much/at all, but wanted to address it just in case.