### PR TITLE
add availablesleepstates output to windows flare power report

### DIFF
--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -61,7 +61,7 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 	hideWindow(powerCfgSleepStatesCmd)
 	availableSleepStatesOutput, err := powerCfgSleepStatesCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("running powercfg.exe for sleep states: error %w", err)
+		return fmt.Errorf("running powercfg.exe for sleep states: error %w, output %s", err, string(availableSleepStatesOutput))
 	}
 
 	zippedSleepStates, err := extraZip.Create("available_sleep_states.txt")

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -60,9 +60,8 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 
 	hideWindow(powerCfgSleepStatesCmd)
 	availableSleepStatesOutput, err := powerCfgSleepStatesCmd.CombinedOutput()
-
 	if err != nil {
-		return fmt.Errorf("running powercfg.exe: error %w, output %s", err, string(availableSleepStatesOutput))
+		return fmt.Errorf("running powercfg.exe for sleep states: error %w", err)
 	}
 
 	zippedSleepStates, err := extraZip.Create("available_sleep_states.txt")


### PR DESCRIPTION
updates the windows power report flare checkup to use a zip writer and adds an additional file with the output of `powercfg /a`

closes https://github.com/kolide/launcher/issues/1904