### PR TITLE
collect power events for windows flares

### DIFF
--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -79,15 +79,18 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 		return fmt.Errorf("creating powershell get-winevent command: %w", err)
 	}
 
-	outFile, err := extraZip.Create("windows_power_events.json")
+	powerEventFile, err := extraZip.Create("windows_power_events.json")
 	if err != nil {
 		return fmt.Errorf("creating windows_power_events.json: %w", err)
 	}
 
-	getWinEventCmd.Stderr = outFile
-	getWinEventCmd.Stdout = outFile
-	if err = getWinEventCmd.Run(); err != nil {
-		return fmt.Errorf("running get-winevent command: %w", err)
+	powerEventsOut, err := getWinEventCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running get-winevent command: %w, output %s", err, string(powerEventsOut))
+	}
+
+	if _, err := powerEventFile.Write(powerEventsOut); err != nil {
+		return fmt.Errorf("writing power events to output file: %w", err)
 	}
 
 	return nil

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -73,7 +73,7 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 		return fmt.Errorf("writing available sleep states output file: %w", err)
 	}
 
-	eventFilter := `Get-Winevent -FilterHashtable @{LogName='System'; ProviderName='Microsoft-Windows-Power-Troubleshooter','Microsoft-Windows-Kernel-Power'} -MaxEvents 500 | Select-Object -Property 'Id','LogName','ProviderName','Message','TimeCreated' | ConvertTo-Json`
+	eventFilter := `Get-Winevent -FilterHashtable @{LogName='System'; ProviderName='Microsoft-Windows-Power-Troubleshooter','Microsoft-Windows-Kernel-Power'} -MaxEvents 500 | Select-Object @{name='Time'; expression={$_.TimeCreated.ToString("O")}},Id,LogName,ProviderName,Message,TimeCreated | ConvertTo-Json`
 	getWinEventCmd, err := allowedcmd.Powershell(ctx, eventFilter)
 	if err != nil {
 		return fmt.Errorf("creating powershell get-winevent command: %w", err)


### PR DESCRIPTION
adds collection of windows kernel-power and power-troubleshooter provider events to cross reference with our internal sleep transition logging and the system power report we generate