### PR TITLE
Get launcher.flags from correct directory in checkup

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -112,7 +112,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&servicesCheckup{}, doctorSupported | flareSupported},
 		{&powerCheckup{}, flareSupported},
 		{&osqueryCheckup{k: k}, doctorSupported | flareSupported},
-		{&launcherFlags{}, doctorSupported | flareSupported},
+		{&launcherFlags{k: k}, doctorSupported | flareSupported},
 		{&gnomeExtensions{}, doctorSupported | flareSupported},
 		{&quarantine{}, doctorSupported | flareSupported},
 		{&systemTime{}, doctorSupported | flareSupported},

--- a/ee/debug/checkups/launcher_flags.go
+++ b/ee/debug/checkups/launcher_flags.go
@@ -76,7 +76,7 @@ func (lf *launcherFlags) Data() any {
 }
 
 func (lf *launcherFlags) flagsFilePath() string {
-	identifier := "kolide-k2"
+	identifier := launcher.DefaultLauncherIdentifier
 	if lf.k.Identifier() != "" {
 		identifier = lf.k.Identifier()
 	}

--- a/ee/debug/checkups/launcher_flags.go
+++ b/ee/debug/checkups/launcher_flags.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/launcher"
 )
 
 type launcherFlags struct {
+	k       types.Knapsack
 	status  Status
 	summary string
 }
@@ -74,10 +76,14 @@ func (lf *launcherFlags) Data() any {
 }
 
 func (lf *launcherFlags) flagsFilePath() string {
+	identifier := "kolide-k2"
+	if lf.k.Identifier() != "" {
+		identifier = lf.k.Identifier()
+	}
 	if runtime.GOOS == "windows" {
-		return filepath.Join(`C:\Program Files\Kolide\Launcher-kolide-k2\conf`, "launcher.flags")
+		return filepath.Join(fmt.Sprintf(`C:\Program Files\Kolide\Launcher-%s\conf`, identifier), "launcher.flags")
 	}
 
 	// non-windows
-	return "/etc/kolide-k2/launcher.flags"
+	return fmt.Sprintf("/etc/%s/launcher.flags", identifier)
 }


### PR DESCRIPTION
In flare/doctor, we don't fetch the correct flag file if the identifier is not the default kolide-k2 -- this PR corrects that issue.