### PR TITLE
Make jsonrpc the default for transport

### DIFF
--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -213,7 +213,7 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		flInitialRunner                   = flagset.Bool("with_initial_runner", false, "Run differential queries from config ahead of scheduled interval.")
 		flKolideServerURL                 = flagset.String("hostname", "", "The hostname of the gRPC server")
 		flKolideHosted                    = flagset.Bool("kolide_hosted", false, "Use Kolide SaaS settings for defaults")
-		flTransport                       = flagset.String("transport", "grpc", "The transport protocol that should be used to communicate with remote (default: grpc)")
+		flTransport                       = flagset.String("transport", "jsonrpc", "The transport protocol that should be used to communicate with remote (default: jsonrpc)")
 		flLoggingInterval                 = flagset.Duration("logging_interval", 60*time.Second, "The interval at which logs should be flushed to the server")
 		flOsquerydPath                    = flagset.String("osqueryd_path", "", "Path to the osqueryd binary to use (Default: find osqueryd in $PATH)")
 		flOsqueryHealthcheckStartupDelay  = flagset.Duration("osquery_healthcheck_startup_delay", 10*time.Minute, "time to wait before beginning osquery healthchecks")

--- a/pkg/launcher/options_test.go
+++ b/pkg/launcher/options_test.go
@@ -238,7 +238,6 @@ func getArgsAndResponse() (map[string]string, *Options) {
 		"-autoupdate_interval": "48h",
 		"-logging_interval":    fmt.Sprintf("%ds", randomInt),
 		"-osqueryd_path":       windowsAddExe("/dev/null"),
-		"-transport":           "grpc",
 	}
 
 	opts := &Options{
@@ -258,7 +257,7 @@ func getArgsAndResponse() (map[string]string, *Options) {
 		TufServerURL:                    "https://tuf.kolide.com",
 		OsquerydPath:                    windowsAddExe("/dev/null"),
 		OsqueryHealthcheckStartupDelay:  10 * time.Minute,
-		Transport:                       "grpc",
+		Transport:                       "jsonrpc",
 		UpdateChannel:                   "stable",
 		DelayStart:                      0 * time.Second,
 		WatchdogEnabled:                 false,


### PR DESCRIPTION
The expected value for the `transport` flag has de facto been `jsonrpc` for a significant amount of time now, but that hasn't been reflected in the default value in the options. This PR updates the default.