### PR TITLE
added new store for uptime history and uptime tracking with knapsack

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -198,6 +198,11 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	flagController := flags.NewFlagController(slogger, stores[storage.AgentFlagsStore], fcOpts...)
 	k := knapsack.New(stores, flagController, db, multiSlogger, systemMultiSlogger)
 
+	// start counting uptime
+	processStartTime := time.Now()
+
+	k.UpTimeHistoryStore().Set([]byte("process_start_time"), []byte(processStartTime.Format(time.RFC3339)))
+
 	go runOsqueryVersionCheckAndAddToKnapsack(ctx, slogger, k, k.LatestOsquerydPath(ctx))
 	go timemachine.AddExclusions(ctx, k)
 

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -139,6 +139,10 @@ func (k *knapsack) TokenStore() types.KVStore {
 	return k.getKVStore(storage.TokenStore)
 }
 
+func (k *knapsack) UpTimeHistoryStore() types.KVStore {
+	return k.getKVStore(storage.UpTimeHistoryStore)
+}
+
 func (k *knapsack) SetLauncherWatchdogEnabled(enabled bool) error {
 	return k.flags.SetLauncherWatchdogEnabled(enabled)
 }

--- a/ee/agent/storage/bbolt/stores_bbolt.go
+++ b/ee/agent/storage/bbolt/stores_bbolt.go
@@ -33,6 +33,7 @@ func MakeStores(ctx context.Context, slogger *slog.Logger, db *bbolt.DB) (map[st
 		storage.ServerProvidedDataStore,
 		storage.TokenStore,
 		storage.ControlServerActionsStore,
+		storage.UpTimeHistoryStore,
 	}
 
 	for _, storeName := range storeNames {

--- a/ee/agent/storage/ci/stores_ci.go
+++ b/ee/agent/storage/ci/stores_ci.go
@@ -30,6 +30,7 @@ func MakeStores(t *testing.T, slogger *slog.Logger, db *bbolt.DB) (map[storage.S
 		storage.StatusLogsStore,
 		storage.ServerProvidedDataStore,
 		storage.TokenStore,
+		storage.UpTimeHistoryStore,
 	}
 
 	if os.Getenv("CI") == "true" {

--- a/ee/agent/storage/stores.go
+++ b/ee/agent/storage/stores.go
@@ -18,6 +18,7 @@ const (
 	ServerProvidedDataStore     Store = "server_provided_data"     // The store used for pushing values from server-backed tables.
 	TokenStore                  Store = "token_store"              // The store used for holding bearer auth tokens, e.g. the ones used to authenticate with the observability ingest server.
 	ControlServerActionsStore   Store = "action_store"             // The store used for storing actions sent by control server.
+	UpTimeHistoryStore          Store = "uptime_history"           // The store used for storing uptime history.
 )
 
 func (storeType Store) String() string {

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -912,96 +912,6 @@ func (_m *Knapsack) OsqueryHistoryInstanceStore() types.KVStore {
 	return r0
 }
 
-// OsqueryTlsConfigEndpoint provides a mock function with given fields:
-func (_m *Knapsack) OsqueryTlsConfigEndpoint() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for OsqueryTlsConfigEndpoint")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// OsqueryTlsDistributedReadEndpoint provides a mock function with given fields:
-func (_m *Knapsack) OsqueryTlsDistributedReadEndpoint() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for OsqueryTlsDistributedReadEndpoint")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// OsqueryTlsDistributedWriteEndpoint provides a mock function with given fields:
-func (_m *Knapsack) OsqueryTlsDistributedWriteEndpoint() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for OsqueryTlsDistributedWriteEndpoint")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// OsqueryTlsEnrollEndpoint provides a mock function with given fields:
-func (_m *Knapsack) OsqueryTlsEnrollEndpoint() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for OsqueryTlsEnrollEndpoint")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// OsqueryTlsLoggerEndpoint provides a mock function with given fields:
-func (_m *Knapsack) OsqueryTlsLoggerEndpoint() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for OsqueryTlsLoggerEndpoint")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
 // OsqueryVerbose provides a mock function with given fields:
 func (_m *Knapsack) OsqueryVerbose() bool {
 	ret := _m.Called()
@@ -2173,6 +2083,26 @@ func (_m *Knapsack) TufServerURL() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// UpTimeHistoryStore provides a mock function with given fields:
+func (_m *Knapsack) UpTimeHistoryStore() types.KVStore {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpTimeHistoryStore")
+	}
+
+	var r0 types.KVStore
+	if rf, ok := ret.Get(0).(func() types.KVStore); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.KVStore)
+		}
 	}
 
 	return r0

--- a/ee/agent/types/stores.go
+++ b/ee/agent/types/stores.go
@@ -17,4 +17,5 @@ type Stores interface {
 	StatusLogsStore() KVStore
 	ServerProvidedDataStore() KVStore
 	TokenStore() KVStore
+	UpTimeHistoryStore() KVStore
 }

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -31,7 +31,7 @@ func LauncherTables(k types.Knapsack) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		LauncherConfigTable(k.ConfigStore()),
 		LauncherDbInfo(k.BboltDB()),
-		LauncherInfoTable(k.ConfigStore()),
+		LauncherInfoTable(k.ConfigStore(), k.UpTimeHistoryStore()),
 		launcher_db.TablePlugin("kolide_server_data", k.ServerProvidedDataStore()),
 		launcher_db.TablePlugin("kolide_control_flags", k.AgentFlagsStore()),
 		LauncherAutoupdateConfigTable(k),


### PR DESCRIPTION
Resolves #1702 

- Added a start time entry at launcher that is available at the knapsack
- Added UpTimeHistoryStore to store start_time
- Modified kolide_launcher_info table to take in the UpTimeHistoryStore, calculate the delta and save the value in a new Column called uptime.

Preview:
![image](https://github.com/user-attachments/assets/32f7bc6f-fab1-44dc-af9a-d503fe70d554)
