### PR TITLE
Move key creation to runLauncher

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -345,7 +345,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		}
 	}
 
-	// make sure keys exist
+	// make sure keys exist -- we expect these keys to exist before rungroup starts
 	if err := osquery.SetupLauncherKeys(k.ConfigStore()); err != nil {
 		return fmt.Errorf("setting up initial launcher keys: %w", err)
 	}

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -345,6 +345,14 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		}
 	}
 
+	// make sure keys exist
+	if err := osquery.SetupLauncherKeys(k.ConfigStore()); err != nil {
+		return fmt.Errorf("setting up initial launcher keys: %w", err)
+	}
+	if err := agent.SetupKeys(ctx, k.Slogger(), k.ConfigStore(), false); err != nil {
+		return fmt.Errorf("setting up agent keys: %w", err)
+	}
+
 	// init osquery instance history
 	if err := osqueryInstanceHistory.InitHistory(k.OsqueryHistoryInstanceStore()); err != nil {
 		return fmt.Errorf("error initializing osquery instance history: %w", err)

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -91,9 +91,6 @@ type ExtensionOpts struct {
 	// RunDifferentialQueriesImmediately allows the client to execute a new query the first time it sees it,
 	// bypassing the scheduler.
 	RunDifferentialQueriesImmediately bool
-	// skipHardwareKeysSetup is a flag to indicate if we should skip setting up hardware keys.
-	// This is useful for testing environments where we don't have required hardware.
-	skipHardwareKeysSetup bool
 }
 
 type iterationTerminatedError struct{}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/startupsettings"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/uninstall"
@@ -129,14 +128,6 @@ func NewExtension(ctx context.Context, client service.KolideService, k types.Kna
 	}
 
 	configStore := k.ConfigStore()
-
-	if err := SetupLauncherKeys(configStore); err != nil {
-		return nil, fmt.Errorf("setting up initial launcher keys: %w", err)
-	}
-
-	if err := agent.SetupKeys(ctx, slogger, configStore, opts.skipHardwareKeysSetup); err != nil {
-		return nil, fmt.Errorf("setting up agent keys: %w", err)
-	}
 
 	nodekey, err := NodeKey(configStore)
 	if err != nil {

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -71,9 +71,7 @@ func TestNewExtensionEmptyEnrollSecret(t *testing.T) {
 	m.On("ReadEnrollSecret").Maybe().Return("", errors.New("test"))
 
 	// We should be able to make an extension despite an empty enroll secret
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{})
 	assert.Nil(t, err)
 	assert.NotNil(t, e)
 }
@@ -103,9 +101,7 @@ func TestNewExtensionDatabaseError(t *testing.T) {
 	m.On("ConfigStore").Return(agentbbolt.NewStore(multislogger.NewNopLogger(), db, storage.ConfigStore.String()))
 	m.On("Slogger").Return(multislogger.NewNopLogger()).Maybe()
 
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, m, ExtensionOpts{})
 	assert.NotNil(t, err)
 	assert.Nil(t, e)
 }
@@ -115,9 +111,7 @@ func TestGetHostIdentifier(t *testing.T) {
 	defer cleanup()
 
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	ident, err := e.getHostIdentifier()
@@ -132,9 +126,7 @@ func TestGetHostIdentifier(t *testing.T) {
 	db, cleanup = makeTempDB(t)
 	defer cleanup()
 	k = makeKnapsack(t, db)
-	e, err = NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err = NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	ident, err = e.getHostIdentifier()
@@ -149,9 +141,7 @@ func TestGetHostIdentifierCorruptedData(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), &mock.KolideService{}, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	// Put garbage UUID in DB
@@ -180,9 +170,7 @@ func TestExtensionEnrollTransportError(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -202,9 +190,7 @@ func TestExtensionEnrollSecretInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	k := makeKnapsack(t, db)
 	defer cleanup()
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -233,9 +219,7 @@ func TestExtensionEnroll(t *testing.T) {
 	expectedEnrollSecret := "foo_secret"
 	k.On("ReadEnrollSecret").Maybe().Return(expectedEnrollSecret, nil)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	key, invalid, err := e.Enroll(context.Background())
@@ -254,9 +238,7 @@ func TestExtensionEnroll(t *testing.T) {
 	assert.Equal(t, expectedNodeKey, key)
 	assert.Equal(t, expectedEnrollSecret, gotEnrollSecret)
 
-	e, err = NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err = NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	// Still should not re-enroll (because node key stored in DB)
 	key, invalid, err = e.Enroll(context.Background())
@@ -290,9 +272,7 @@ func TestExtensionGenerateConfigsTransportError(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 	k.ConfigStore().Set([]byte(nodeKeyKey), []byte("some_node_key"))
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -313,9 +293,7 @@ func TestExtensionGenerateConfigsCaching(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -352,9 +330,7 @@ func TestExtensionGenerateConfigsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -381,9 +357,7 @@ func TestGenerateConfigs_CannotEnrollYet(t *testing.T) {
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("ReadEnrollSecret").Maybe().Return("", errors.New("test"))
 
-	e, err := NewExtension(context.TODO(), s, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), s, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -412,9 +386,7 @@ func TestExtensionGenerateConfigs(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	configs, err := e.GenerateConfigs(context.Background())
@@ -433,9 +405,7 @@ func TestExtensionWriteLogsTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	err = e.writeLogsWithReenroll(context.Background(), logger.LogTypeSnapshot, []string{"foobar"}, true)
@@ -459,9 +429,7 @@ func TestExtensionWriteLogsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -490,9 +458,7 @@ func TestExtensionWriteLogs(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = expectedNodeKey
 
@@ -567,9 +533,7 @@ func TestExtensionWriteBufferedLogsEmpty(t *testing.T) {
 	k.On("StatusLogsStore").Return(statusLogsStore)
 	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	// No buffered logs should result in success and no remote action being
@@ -609,9 +573,7 @@ func TestExtensionWriteBufferedLogs(t *testing.T) {
 	k.On("ResultLogsStore").Return(resultLogsStore)
 	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	e.LogString(context.Background(), logger.LogTypeStatus, "status foo")
@@ -680,9 +642,7 @@ func TestExtensionWriteBufferedLogsEnrollmentInvalid(t *testing.T) {
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("ReadEnrollSecret").Maybe().Return("enroll_secret", nil)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	e.LogString(context.Background(), logger.LogTypeStatus, "status foo")
@@ -728,8 +688,7 @@ func TestExtensionWriteBufferedLogsLimit(t *testing.T) {
 	k.On("ResultLogsStore").Return(resultLogsStore)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      100,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: 100,
 	})
 	require.Nil(t, err)
 
@@ -799,8 +758,7 @@ func TestExtensionWriteBufferedLogsDropsBigLog(t *testing.T) {
 	k.On("ResultLogsStore").Return(resultLogsStore)
 
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      15,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: 15,
 	})
 	require.Nil(t, err)
 
@@ -885,10 +843,9 @@ func TestExtensionWriteLogsLoop(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	expectedLoggingInterval := 10 * time.Second
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      200,
-		Clock:                 mockClock,
-		LoggingInterval:       expectedLoggingInterval,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: 200,
+		Clock:            mockClock,
+		LoggingInterval:  expectedLoggingInterval,
 	})
 	require.Nil(t, err)
 
@@ -1016,8 +973,7 @@ func TestExtensionPurgeBufferedLogs(t *testing.T) {
 
 	max := 10
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBufferedLogs:       max,
-		skipHardwareKeysSetup: true,
+		MaxBufferedLogs: max,
 	})
 	require.Nil(t, err)
 
@@ -1055,9 +1011,7 @@ func TestExtensionGetQueriesTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	queries, err := e.GetQueries(context.Background())
@@ -1087,9 +1041,7 @@ func TestExtensionGetQueriesEnrollmentInvalid(t *testing.T) {
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
 
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -1117,9 +1069,7 @@ func TestExtensionGetQueries(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	queries, err := e.GetQueries(context.Background())
@@ -1138,9 +1088,7 @@ func TestExtensionWriteResultsTransportError(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	err = e.WriteResults(context.Background(), []distributed.Result{})
@@ -1164,9 +1112,7 @@ func TestExtensionWriteResultsEnrollmentInvalid(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 	e.NodeKey = "bad_node_key"
 
@@ -1189,9 +1135,7 @@ func TestExtensionWriteResults(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
+	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{})
 	require.Nil(t, err)
 
 	expectedResults := []distributed.Result{

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1208,21 +1208,12 @@ func TestExtensionWriteResults(t *testing.T) {
 	assert.Equal(t, expectedResults, gotResults)
 }
 
-func TestLauncherRsaKeys(t *testing.T) {
-	m := &mock.KolideService{}
-
+func TestSetupLauncherKeys(t *testing.T) {
 	configStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ConfigStore.String())
 	require.NoError(t, err)
 	require.NoError(t, err)
 
-	k := mocks.NewKnapsack(t)
-	k.On("ConfigStore").Return(configStore)
-	k.On("Slogger").Return(multislogger.NewNopLogger())
-
-	_, err = NewExtension(context.TODO(), m, k, ExtensionOpts{
-		skipHardwareKeysSetup: true,
-	})
-	require.NoError(t, err)
+	require.NoError(t, SetupLauncherKeys(configStore))
 
 	key, err := PrivateRSAKeyFromDB(configStore)
 	require.NoError(t, err)

--- a/pkg/osquery/log_publication_state_test.go
+++ b/pkg/osquery/log_publication_state_test.go
@@ -24,8 +24,7 @@ func TestExtensionLogPublicationHappyPath(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      startingBatchLimitBytes,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)
 
@@ -61,8 +60,7 @@ func TestExtensionLogPublicationRespondsToNetworkTimeouts(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      startingBatchLimitBytes,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)
 
@@ -113,8 +111,7 @@ func TestExtensionLogPublicationIgnoresNonTimeoutErrors(t *testing.T) {
 	defer cleanup()
 	k := makeKnapsack(t, db)
 	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
-		MaxBytesPerBatch:      startingBatchLimitBytes,
-		skipHardwareKeysSetup: true,
+		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827

In preparation for moving the extension inside the osquery instance per [ADR](https://github.com/kolide/launcher/blob/main/docs/architecture/2024-10-23_osquery_refactor.md), this PR moves launcher key creation _out_ of the extension.

We expect that the launcher keys are available as soon as the rungroup starts. Since extension start will happen after rungroup start in the future, we need to move the launcher key creation to `runLauncher`, before the rungroup starts.