### PR TITLE
Move plugin ownership to osqueryinstance

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -57,7 +57,6 @@ import (
 	"github.com/kolide/launcher/pkg/osquery/runsimple"
 	osqueryruntime "github.com/kolide/launcher/pkg/osquery/runtime"
 	osqueryInstanceHistory "github.com/kolide/launcher/pkg/osquery/runtime/history"
-	"github.com/kolide/launcher/pkg/osquery/table"
 	"github.com/kolide/launcher/pkg/rungroup"
 	"github.com/kolide/launcher/pkg/service"
 	"github.com/kolide/launcher/pkg/traces"
@@ -372,7 +371,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// create the runner that will launch osquery
 	osqueryRunner := osqueryruntime.New(
 		k,
-		osqueryruntime.WithOsqueryExtensionPlugins(table.LauncherTables(k)...),
 		osqueryruntime.WithStdout(kolidelog.NewOsqueryLogAdapter(
 			k.Slogger().With(
 				"component", "osquery",
@@ -390,13 +388,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			kolidelog.WithLevel(slog.LevelInfo),
 		)),
 		osqueryruntime.WithAugeasLensFunction(augeas.InstallLenses),
-		osqueryruntime.WithConfigPluginFlag("kolide_grpc"),
-		osqueryruntime.WithLoggerPluginFlag("kolide_grpc"),
-		osqueryruntime.WithDistributedPluginFlag("kolide_grpc"),
 		osqueryruntime.WithOsqueryExtensionPlugins(
-			config.NewPlugin("kolide_grpc", extension.GenerateConfigs),
-			distributed.NewPlugin("kolide_grpc", extension.GetQueries, extension.WriteResults),
-			osquerylogger.NewPlugin("kolide_grpc", extension.LogString),
+			config.NewPlugin(osqueryruntime.KolideSaasExtensionName, extension.GenerateConfigs),
+			distributed.NewPlugin(osqueryruntime.KolideSaasExtensionName, extension.GetQueries, extension.WriteResults),
+			osquerylogger.NewPlugin(osqueryruntime.KolideSaasExtensionName, extension.LogString),
 		),
 	)
 	runGroup.Add("osqueryRunner", osqueryRunner.Run, osqueryRunner.Interrupt)

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kolide/launcher/ee/agent/storage"
-	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/threadsafebuffer"
@@ -55,9 +53,7 @@ func TestOsquerySlowStart(t *testing.T) {
 	slogger := multislogger.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	k.On("Slogger").Return(slogger.Logger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
-	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
-	require.NoError(t, err)
-	k.On("KatcConfigStore").Return(store)
+	setUpMockStores(t, k)
 
 	runner := New(
 		k,
@@ -106,9 +102,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	k.On("OsqueryVerbose").Return(true).Maybe()
 	k.On("OsqueryFlags").Return([]string{}).Maybe()
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
-	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.KatcConfigStore.String())
-	require.NoError(t, err)
-	k.On("KatcConfigStore").Return(store)
+	setUpMockStores(t, k)
 
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
 	runner := New(


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827

In preparation for moving the extension inside the osquery instance per [ADR](https://github.com/kolide/launcher/blob/main/docs/architecture/2024-10-23_osquery_refactor.md), this PR moves plugin ownership to OsqueryInstance. This simplifies setup -- the osquery instance knows what plugins it expects to have.

This PR also moves the launcher tables to the `kolide` extension with all the other tables, instead of keeping them in the `kolide_grpc` extension.

In the next PR (finally) I will move the extension over, and remove `WithOsqueryExtensionPlugins` / `i.opts.extensionPlugins` entirely.