### PR TITLE
[Tests] Capture osquery logs for troubleshooting flaky tests; use current stable osqueryd in tests

### DIFF
--- a/cmd/launcher/run_download_osquery.go
+++ b/cmd/launcher/run_download_osquery.go
@@ -34,6 +34,10 @@ func runDownloadOsquery(_ *multislogger.MultiSlogger, args []string) error {
 	if err := target.PlatformFromString(runtime.GOOS); err != nil {
 		return fmt.Errorf("error parsing platform: %w, %s", err, runtime.GOOS)
 	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
 
 	// We're reusing packaging code, which is based around having a persistent cache directory. It's not quite what
 	// we want but it'll do

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -42,6 +42,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("error parsing platform %s: %v", runtime.GOOS, err)
 		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
 	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -35,6 +35,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("error parsing platform: %s, %s", err, runtime.GOOS)
 		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit in tests
 	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
 
 	if err := os.MkdirAll(osquerydCacheDir, fsutil.DirMode); err != nil {
 		fmt.Printf("error creating cache dir: %s", err)

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -159,6 +159,10 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 	if err := target.PlatformFromString(runtime.GOOS); err != nil {
 		return fmt.Errorf("Error parsing platform: %s: %w", runtime.GOOS, err)
 	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
 
 	outputFile := filepath.Join(binDirectory, target.PlatformBinaryName("osqueryd"))
 	cacheDir := binDirectory

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -292,6 +292,10 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 	if err := target.PlatformFromString(runtime.GOOS); err != nil {
 		return fmt.Errorf("Error parsing platform: %s: %w", runtime.GOOS, err)
 	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
 
 	outputFile := filepath.Join(binDirectory, "osqueryd")
 	if runtime.GOOS == "windows" {
@@ -303,7 +307,7 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 		cacheDir = os.Getenv("TEMP")
 	}
 
-	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "5.14.1", target)
+	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "stable", target)
 	if err != nil {
 		return fmt.Errorf("An error occurred fetching the osqueryd binary: %w", err)
 	}

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -23,6 +23,7 @@ import (
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	"github.com/kolide/launcher/ee/agent/storage/inmemory"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
+	kolidelog "github.com/kolide/launcher/ee/log/osquerylogs"
 	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
@@ -302,7 +303,7 @@ func downloadOsqueryInBinDir(binDirectory string) error {
 		cacheDir = os.Getenv("TEMP")
 	}
 
-	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "stable", target)
+	path, err := packaging.FetchBinary(context.TODO(), cacheDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "5.14.1", target)
 	if err != nil {
 		return fmt.Errorf("An error occurred fetching the osqueryd binary: %w", err)
 	}
@@ -343,11 +344,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	t.Parallel()
 	rootDirectory := t.TempDir()
 
-	var logBytes threadsafebuffer.ThreadSafeBuffer
-	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -364,10 +361,10 @@ func TestWithOsqueryFlags(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient())
+	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
-	waitHealthy(t, runner, &logBytes)
-	waitShutdown(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
+	waitShutdown(t, runner, logBytes)
 }
 
 func TestFlagsChanged(t *testing.T) {
@@ -375,11 +372,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	rootDirectory := t.TempDir()
 
-	var logBytes threadsafebuffer.ThreadSafeBuffer
-	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -402,12 +395,12 @@ func TestFlagsChanged(t *testing.T) {
 	setUpMockStores(t, k)
 
 	// Start the runner
-	runner := New(k, mockServiceClient())
+	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
 
 	// Wait for the instance to start
 	time.Sleep(2 * time.Second)
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 
 	// Confirm watchdog is disabled
 	watchdogDisabled := false
@@ -425,7 +418,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	// Wait for the instance to restart
 	time.Sleep(2 * time.Second)
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 
 	// Now confirm that the instance is new
 	require.NotEqual(t, startingInstance, runner.instance, "instance not replaced")
@@ -462,7 +455,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	k.AssertExpectations(t)
 
-	waitShutdown(t, runner, &logBytes)
+	waitShutdown(t, runner, logBytes)
 }
 
 func waitShutdown(t *testing.T, runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer) {
@@ -514,11 +507,7 @@ func TestSimplePath(t *testing.T) {
 	t.Parallel()
 	rootDirectory := t.TempDir()
 
-	var logBytes threadsafebuffer.ThreadSafeBuffer
-	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -535,26 +524,22 @@ func TestSimplePath(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient())
+	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
 
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 
 	require.NotEmpty(t, runner.instance.stats.StartTime, "start time should be added to instance stats on start up")
 	require.NotEmpty(t, runner.instance.stats.ConnectTime, "connect time should be added to instance stats on start up")
 
-	waitShutdown(t, runner, &logBytes)
+	waitShutdown(t, runner, logBytes)
 }
 
 func TestMultipleShutdowns(t *testing.T) {
 	t.Parallel()
 	rootDirectory := t.TempDir()
 
-	var logBytes threadsafebuffer.ThreadSafeBuffer
-	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -571,13 +556,13 @@ func TestMultipleShutdowns(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient())
+	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
 
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 
 	for i := 0; i < 3; i += 1 {
-		waitShutdown(t, runner, &logBytes)
+		waitShutdown(t, runner, logBytes)
 	}
 }
 
@@ -585,11 +570,7 @@ func TestOsqueryDies(t *testing.T) {
 	t.Parallel()
 	rootDirectory := t.TempDir()
 
-	var logBytes threadsafebuffer.ThreadSafeBuffer
-	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -597,7 +578,7 @@ func TestOsqueryDies(t *testing.T) {
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinaryDirectory)
-	k.On("RootDirectory").Return(rootDirectory).Maybe()
+	k.On("RootDirectory").Return(rootDirectory)
 	k.On("OsqueryFlags").Return([]string{})
 	k.On("OsqueryVerbose").Return(true)
 	k.On("LoggingInterval").Return(5 * time.Minute).Maybe()
@@ -606,10 +587,10 @@ func TestOsqueryDies(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient())
+	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
 
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 
 	previousStats := runner.instance.stats
 
@@ -619,11 +600,11 @@ func TestOsqueryDies(t *testing.T) {
 	runner.instance.errgroup.Wait()
 	runner.instanceLock.Unlock()
 
-	waitHealthy(t, runner, &logBytes)
+	waitHealthy(t, runner, logBytes)
 	require.NotEmpty(t, previousStats.Error, "error should be added to stats when unexpected shutdown")
 	require.NotEmpty(t, previousStats.ExitTime, "exit time should be added to instance when unexpected shutdown")
 
-	waitShutdown(t, runner, &logBytes)
+	waitShutdown(t, runner, logBytes)
 }
 
 func TestNotStarted(t *testing.T) {
@@ -684,11 +665,7 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, teardown func()) {
 	rootDirectory := t.TempDir()
 
-	logBytes = &threadsafebuffer.ThreadSafeBuffer{}
-	slogger := slog.New(slog.NewTextHandler(logBytes, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
@@ -708,7 +685,7 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner = New(k, mockServiceClient())
+	runner = New(k, mockServiceClient(), opts...)
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 
@@ -758,4 +735,36 @@ func mockServiceClient() *servicemock.KolideService {
 			return 0, nil
 		},
 	}
+}
+
+// setUpTestSlogger sets up a logger that will log to a buffer.
+func setUpTestSlogger(rootDirectory string) (*threadsafebuffer.ThreadSafeBuffer, *slog.Logger, []OsqueryInstanceOption) {
+	logBytes := &threadsafebuffer.ThreadSafeBuffer{}
+
+	slogger := slog.New(slog.NewTextHandler(logBytes, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
+	// Capture osquery logs too
+	opts := []OsqueryInstanceOption{
+		WithStdout(kolidelog.NewOsqueryLogAdapter(
+			slogger.With(
+				"component", "osquery",
+				"osqlevel", "stdout",
+			),
+			rootDirectory,
+			kolidelog.WithLevel(slog.LevelDebug),
+		)),
+		WithStderr(kolidelog.NewOsqueryLogAdapter(
+			slogger.With(
+				"component", "osquery",
+				"osqlevel", "stderr",
+			),
+			rootDirectory,
+			kolidelog.WithLevel(slog.LevelDebug),
+		)),
+	}
+
+	return logBytes, slogger, opts
 }

--- a/pkg/packaging/fetch.go
+++ b/pkg/packaging/fetch.go
@@ -85,7 +85,7 @@ func FetchBinary(ctx context.Context, localCacheDir, name, binaryName, channelOr
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-		return "", fmt.Errorf("failed download %s, got http status %s", downloadReq.URL.String(), response.Status)
+		return "", fmt.Errorf("failed download, got http status %s", response.Status)
 	}
 
 	// Store it in cache

--- a/pkg/packaging/fetch.go
+++ b/pkg/packaging/fetch.go
@@ -85,7 +85,7 @@ func FetchBinary(ctx context.Context, localCacheDir, name, binaryName, channelOr
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-		return "", fmt.Errorf("failed download, got http status %s", response.Status)
+		return "", fmt.Errorf("failed download %s, got http status %s", downloadReq.URL.String(), response.Status)
 	}
 
 	// Store it in cache


### PR DESCRIPTION
We capture runner/instance logs when running tests for ease of troubleshooting -- I realized we can capture the osquery process logs too.

Also noticed we weren't setting the arch when downloading osquery for the test, so we were getting a super old version (5.8.2) -- fixed that.