### PR TITLE
Moved run ID management to knapsack

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -195,9 +195,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	k := knapsack.New(stores, flagController, db, multiSlogger, systemMultiSlogger)
 
 	// Generate a new run ID
-	newRunID := ulid.New()
-	// Set the run ID in knapsack
-	k.SetRunID(newRunID)
+	newRunID := k.GetRunID()
 
 	// Apply the run ID to both logger and slogger
 	logger = log.With(logger, "run_id", newRunID)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -194,6 +194,15 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	flagController := flags.NewFlagController(slogger, stores[storage.AgentFlagsStore], fcOpts...)
 	k := knapsack.New(stores, flagController, db, multiSlogger, systemMultiSlogger)
 
+	// Generate a new run ID
+	newRunID := ulid.New()
+	// Set the run ID in knapsack
+	k.SetRunID(newRunID)
+
+	// Apply the run ID to both logger and slogger
+	logger = log.With(logger, "run_id", newRunID)
+	slogger = slogger.With("run_id", newRunID)
+
 	// start counting uptime
 	processStartTime := time.Now().UTC()
 

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -16,6 +16,9 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+// Package-level runID variable
+var runID string
+
 // type alias Flags, so that we can embed it inside knapsack, as `flags` and not `Flags`
 type flags types.Flags
 
@@ -57,6 +60,18 @@ func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB
 	}
 
 	return k
+}
+
+// SetRunID sets the run ID in the knapsack
+func (k *knapsack) SetRunID(id string) {
+	runID = id
+	k.slogger.With("run_id", id)
+	k.systemSlogger.With("run_id", id)
+}
+
+// GetRunID retrieves the run ID from the knapsack
+func (k *knapsack) GetRunID() string {
+	return runID
 }
 
 // Logging interface methods

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -9,6 +9,7 @@ import (
 
 	"log/slog"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/storage"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/tuf"
@@ -62,15 +63,13 @@ func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB
 	return k
 }
 
-// SetRunID sets the run ID in the knapsack
-func (k *knapsack) SetRunID(id string) {
-	runID = id
-	k.slogger.Logger = k.slogger.Logger.With("run_id", id)
-	k.systemSlogger.Logger = k.systemSlogger.Logger.With("run_id", id)
-}
-
-// GetRunID retrieves the run ID from the knapsack
+// NewRunID sets the run ID in the knapsack
 func (k *knapsack) GetRunID() string {
+	if runID == "" {
+		runID = ulid.New()
+		k.slogger.Logger = k.slogger.Logger.With("run_id", runID)
+		k.systemSlogger.Logger = k.systemSlogger.Logger.With("run_id", runID)
+	}
 	return runID
 }
 

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -65,8 +65,8 @@ func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB
 // SetRunID sets the run ID in the knapsack
 func (k *knapsack) SetRunID(id string) {
 	runID = id
-	k.slogger.With("run_id", id)
-	k.systemSlogger.With("run_id", id)
+	k.slogger.Logger = k.slogger.Logger.With("run_id", id)
+	k.systemSlogger.Logger = k.systemSlogger.Logger.With("run_id", id)
 }
 
 // GetRunID retrieves the run ID from the knapsack

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/kolide/kit/ulid"
 	slogmulti "github.com/samber/slog-multi"
 )
 
@@ -34,8 +33,7 @@ var ctxValueKeysToAdd = []contextKey{
 
 type MultiSlogger struct {
 	*slog.Logger
-	handlers      []slog.Handler
-	launcherRunId string
+	handlers []slog.Handler
 }
 
 // New creates a new multislogger if no handlers are passed in, it will
@@ -43,8 +41,7 @@ type MultiSlogger struct {
 func New(h ...slog.Handler) *MultiSlogger {
 	ms := &MultiSlogger{
 		// setting to fanout with no handlers is noop
-		Logger:        slog.New(slogmulti.Fanout()),
-		launcherRunId: ulid.New(),
+		Logger: slog.New(slogmulti.Fanout()),
 	}
 
 	ms.AddHandler(h...)
@@ -69,7 +66,7 @@ func (m *MultiSlogger) AddHandler(handler ...slog.Handler) {
 			Pipe(slogmulti.NewHandleInlineMiddleware(utcTimeMiddleware)).
 			Pipe(slogmulti.NewHandleInlineMiddleware(ctxValuesMiddleWare)).
 			Handler(slogmulti.Fanout(m.handlers...)),
-	).With("launcher_run_id", m.launcherRunId)
+	)
 }
 
 func utcTimeMiddleware(ctx context.Context, record slog.Record, next func(context.Context, slog.Record) error) error {


### PR DESCRIPTION
This pull request moves the run ID system to improve logging and tracking across the application. The changes include generating a unique run ID, setting it in the knapsack, and applying it to the logger and slogger for consistent tracking.

Resolves #1706 

### Run ID Implementation:

* [`cmd/launcher/launcher.go`](diffhunk://#diff-dd532c327d56a5d3623a61b7983e174e88bf93ba87f785ddfe9811a8029a9a63R197-R205): Added code to generate a new run ID and set it in the knapsack, logger, and slogger.
* [`ee/agent/knapsack/knapsack.go`](diffhunk://#diff-1fef7e482dbae76c26b95e73faa3353d09c1e04660f7156238bd991dd1ea004fR19-R21): Introduced a package-level `runID` variable and added `GetRunID` method to manage the run ID within the knapsack. [[1]](diffhunk://#diff-1fef7e482dbae76c26b95e73faa3353d09c1e04660f7156238bd991dd1ea004fR19-R21) [[2]](diffhunk://#diff-1fef7e482dbae76c26b95e73faa3353d09c1e04660f7156238bd991dd1ea004fR65-R76)

### Logger Updates:

* [`pkg/log/multislogger/multislogger.go`](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL8): Removed the `launcherRunId` variable from the `MultiSlogger` struct and its initialization, and updated the `AddHandler` method to no longer include the `launcher_run_id`. [[1]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL8) [[2]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL38) [[3]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL47) [[4]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL72-R69)