### PR TITLE
Separate osquery instance and runner further

### DIFF
--- a/docs/architecture/2024-10-23_osquery_refactor.md
+++ b/docs/architecture/2024-10-23_osquery_refactor.md
@@ -49,7 +49,7 @@ Therefore, we will want to refactor our current implementation with the followin
 
 To simplify the creation of multiple osquery instances, and to make it possible to increase the number of osquery instances running without performing a full launcher restart, we will move the osquery extension ownership to the osquery instance.
 
-This will also give us the opportunity to make the separation of responsibility between the runner and the instance clearer. The instance will create its own extension, extension server, etc. The runner will be responsible for the instances' state. This means the osquery instance stats should be owned by the runner, since the runner already has the responsibility of updating them.
+This will also give us the opportunity to make the separation of responsibility between the runner and the instance clearer. The instance will create its own extension, extension server, etc. The instance will be responsible for its own stats -- creating them during launch, and updating them during instance shutdown. The runner will be responsible for the instances' state.
 
 ```mermaid
 ---
@@ -63,7 +63,7 @@ erDiagram
     OSQUERYINSTANCE ||--|{ EXTENSIONSERVER : runs
     OSQUERYINSTANCE ||--|| EXTENSIONCLIENT : runs
     EXTENSIONSERVER ||--|| EXTENSION : forwards
-    OSQUERYRUNNER ||--|| STATS: updates
+    OSQUERYINSTANCE ||--|| STATS: updates
 ```
 
 The below diagram shows the desired future state -- it is identical to the above diagram except for the relationship cardinalities (e.g. `OSQUERYRUNNER` runs 0 or more of `OSQUERYINSTANCE`, rather than exactly 1 `OSQUERYINSTANCE`).
@@ -80,7 +80,7 @@ erDiagram
     OSQUERYINSTANCE ||--|{ EXTENSIONSERVER : runs
     OSQUERYINSTANCE ||--|| EXTENSIONCLIENT : runs
     EXTENSIONSERVER ||--|| EXTENSION : forwards
-    OSQUERYRUNNER ||--o{ STATS: updates
+    OSQUERYINSTANCE ||--|| STATS: updates
 ```
 
 ## Consequences
@@ -94,3 +94,4 @@ This decision does preserve a shared JSONRPC client to talk to Kolide SaaS. If w
 ## Changelog
 
 2024-10-23: Initial draft of ADR.
+2024-11-04: Updated ADR so that instance, rather than runner, manages instance stats.

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -196,6 +196,13 @@ func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, o
 	return i
 }
 
+// WaitShutdown waits for the instance's errgroup routines to exit, then returns the
+// initial error. It should be called after either `Exited` has returned, or after
+// the instance has been asked to shut down.
+func (i *OsqueryInstance) WaitShutdown() error {
+	return i.errgroup.Wait()
+}
+
 // Exited returns a channel to monitor for signal that instance has shut itself down
 func (i *OsqueryInstance) Exited() <-chan struct{} {
 	return i.doneCtx.Done()

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -196,9 +196,17 @@ func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, o
 	return i
 }
 
+// BeginShutdown cancels the context associated with the errgroup.
+func (i *OsqueryInstance) BeginShutdown() {
+	i.slogger.Log(context.TODO(), slog.LevelInfo,
+		"instance shutdown requested",
+	)
+	i.cancel()
+}
+
 // WaitShutdown waits for the instance's errgroup routines to exit, then returns the
 // initial error. It should be called after either `Exited` has returned, or after
-// the instance has been asked to shut down.
+// the instance has been asked to shut down via call to `BeginShutdown`.
 func (i *OsqueryInstance) WaitShutdown() error {
 	return i.errgroup.Wait()
 }

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -196,6 +196,11 @@ func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, o
 	return i
 }
 
+// Exited returns a channel to monitor for signal that instance has shut itself down
+func (i *OsqueryInstance) Exited() <-chan struct{} {
+	return i.doneCtx.Done()
+}
+
 func (i *OsqueryInstance) launch() error {
 	ctx, span := traces.StartSpan(context.Background())
 	defer span.End()

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -216,7 +216,9 @@ func (i *OsqueryInstance) Exited() <-chan struct{} {
 	return i.doneCtx.Done()
 }
 
-func (i *OsqueryInstance) launch() error {
+// Launch starts the osquery instance and its components. It will run until one of its
+// components becomes unhealthy, or until it is asked to shutdown via `BeginShutdown`.
+func (i *OsqueryInstance) Launch() error {
 	ctx, span := traces.StartSpan(context.Background())
 	defer span.End()
 

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -73,7 +73,7 @@ func (r *Runner) Run() error {
 	// called), or stops (if Shutdown was called).
 	for {
 		// Wait for async processes to exit
-		<-r.instance.doneCtx.Done()
+		<-r.instance.Exited()
 		r.slogger.Log(context.TODO(), slog.LevelInfo,
 			"osquery instance exited",
 		)

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -93,7 +93,7 @@ func (r *Runner) Run() error {
 		}
 
 		// Error case -- osquery instance shut down and needs to be restarted
-		err := r.instance.errgroup.Wait()
+		err := r.instance.WaitShutdown()
 		r.slogger.Log(context.TODO(), slog.LevelInfo,
 			"unexpected restart of instance",
 			"err", err,
@@ -157,7 +157,7 @@ func (r *Runner) Shutdown() error {
 	r.instanceLock.Lock()
 	defer r.instanceLock.Unlock()
 	r.instance.cancel()
-	if err := r.instance.errgroup.Wait(); err != context.Canceled && err != nil {
+	if err := r.instance.WaitShutdown(); err != context.Canceled && err != nil {
 		return fmt.Errorf("while shutting down instance: %w", err)
 	}
 	return nil
@@ -206,7 +206,7 @@ func (r *Runner) Restart() error {
 	// Cancelling will cause all of the cleanup routines to execute, and a
 	// new instance will start.
 	r.instance.cancel()
-	r.instance.errgroup.Wait()
+	r.instance.WaitShutdown()
 
 	return nil
 }

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -58,7 +58,7 @@ func New(k types.Knapsack, serviceClient service.KolideService, opts ...OsqueryI
 func (r *Runner) Run() error {
 	// Ensure we don't try to restart the instance before it's launched
 	r.instanceLock.Lock()
-	if err := r.instance.launch(); err != nil {
+	if err := r.instance.Launch(); err != nil {
 		r.slogger.Log(context.TODO(), slog.LevelWarn,
 			"failed to launch osquery instance",
 			"err", err,
@@ -108,7 +108,7 @@ func (r *Runner) Run() error {
 
 		r.instanceLock.Lock()
 		r.instance = newInstance(r.knapsack, r.serviceClient, r.opts...)
-		if err := r.instance.launch(); err != nil {
+		if err := r.instance.Launch(); err != nil {
 			r.slogger.Log(context.TODO(), slog.LevelWarn,
 				"fatal error restarting instance, shutting down",
 				"err", err,

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -156,7 +156,7 @@ func (r *Runner) Shutdown() error {
 	close(r.shutdown)
 	r.instanceLock.Lock()
 	defer r.instanceLock.Unlock()
-	r.instance.cancel()
+	r.instance.BeginShutdown()
 	if err := r.instance.WaitShutdown(); err != context.Canceled && err != nil {
 		return fmt.Errorf("while shutting down instance: %w", err)
 	}
@@ -205,7 +205,7 @@ func (r *Runner) Restart() error {
 	defer r.instanceLock.Unlock()
 	// Cancelling will cause all of the cleanup routines to execute, and a
 	// new instance will start.
-	r.instance.cancel()
+	r.instance.BeginShutdown()
 	r.instance.WaitShutdown()
 
 	return nil


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827

Per [ADR](https://github.com/kolide/launcher/blob/main/docs/architecture/2024-10-23_osquery_refactor.md), this PR solidifies the separation between the instance and the runner. The runner does not manage fields inside the instance's struct; the instance updates its own.

I did depart from the ADR slightly -- I determined the instance should manage its own stats.