### PR TITLE
removed redundant slogger statement

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -197,9 +197,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// Generate a new run ID
 	newRunID := k.GetRunID()
 
-	// Apply the run ID to both logger and slogger
+	// Apply the run ID to logger which is later used in logshipper
+	// slogger run_id is set in the knapsack GetRunID()
 	logger = log.With(logger, "run_id", newRunID)
-	slogger = slogger.With("run_id", newRunID)
 
 	// start counting uptime
 	processStartTime := time.Now().UTC()


### PR DESCRIPTION
This pull request includes a minor update to the `cmd/launcher/launcher.go` file to clarify the handling of the `run_id` for logging purposes.

* [`cmd/launcher/launcher.go`](diffhunk://#diff-dd532c327d56a5d3623a61b7983e174e88bf93ba87f785ddfe9811a8029a9a63L200-L202): Updated comments to specify that the `run_id` is applied to the logger for use in the logshipper, and clarified that the `slogger` `run_id` is set in the knapsack `GetRunID()`.