### PR TITLE
Unique filename for osquery.sock

### DIFF
--- a/ee/tables/osquery_instance_history/osquery_instance_history.go
+++ b/ee/tables/osquery_instance_history/osquery_instance_history.go
@@ -9,6 +9,7 @@ import (
 
 func TablePlugin() *table.Plugin {
 	columns := []table.ColumnDefinition{
+		table.TextColumn("internal_id"),
 		table.TextColumn("start_time"),
 		table.TextColumn("connect_time"),
 		table.TextColumn("exit_time"),
@@ -32,6 +33,7 @@ func generate() table.GenerateFunc {
 		for _, instance := range history {
 
 			results = append(results, map[string]string{
+				"internal_id":  instance.InternalId,
 				"start_time":   instance.StartTime,
 				"connect_time": instance.ConnectTime,
 				"exit_time":    instance.ExitTime,

--- a/ee/tables/osquery_instance_history/osquery_instance_history.go
+++ b/ee/tables/osquery_instance_history/osquery_instance_history.go
@@ -9,7 +9,7 @@ import (
 
 func TablePlugin() *table.Plugin {
 	columns := []table.ColumnDefinition{
-		table.TextColumn("internal_id"),
+		table.TextColumn("instance_run_id"),
 		table.TextColumn("start_time"),
 		table.TextColumn("connect_time"),
 		table.TextColumn("exit_time"),
@@ -33,14 +33,14 @@ func generate() table.GenerateFunc {
 		for _, instance := range history {
 
 			results = append(results, map[string]string{
-				"internal_id":  instance.InternalId,
-				"start_time":   instance.StartTime,
-				"connect_time": instance.ConnectTime,
-				"exit_time":    instance.ExitTime,
-				"instance_id":  instance.InstanceId,
-				"version":      instance.Version,
-				"hostname":     instance.Hostname,
-				"errors":       instance.Error,
+				"instance_run_id": instance.RunId,
+				"start_time":      instance.StartTime,
+				"connect_time":    instance.ConnectTime,
+				"exit_time":       instance.ExitTime,
+				"instance_id":     instance.InstanceId,
+				"version":         instance.Version,
+				"hostname":        instance.Hostname,
+				"errors":          instance.Error,
 			})
 		}
 

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/startupsettings"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/augeas"
@@ -30,7 +31,7 @@ func StartProcess(knapsack types.Knapsack, interactiveRootDir string) (*os.Proce
 		return nil, nil, fmt.Errorf("creating root dir for interactive mode: %w", err)
 	}
 
-	socketPath := osqueryRuntime.SocketPath(interactiveRootDir)
+	socketPath := osqueryRuntime.SocketPath(interactiveRootDir, ulid.New())
 	augeasLensesPath := filepath.Join(interactiveRootDir, "augeas-lenses")
 
 	// only install augeas lenses on non-windows platforms

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -181,10 +181,6 @@ func downloadOsquery(dir string) error {
 // The default t.TempDir is too long of a path, creating too long of an osquery
 // extension socket, on posix systems.
 func testRootDirectory(t *testing.T) string {
-	if runtime.GOOS == "windows" {
-		return t.TempDir()
-	}
-
 	ulid := ulid.New()
 	rootDir := filepath.Join(os.TempDir(), ulid[len(ulid)-4:])
 	require.NoError(t, os.Mkdir(rootDir, 0700))

--- a/pkg/osquery/runtime/history/history.go
+++ b/pkg/osquery/runtime/history/history.go
@@ -88,7 +88,7 @@ func LatestInstanceUptimeMinutes() (int64, error) {
 }
 
 // NewInstance adds a new instance to the osquery instance history and returns it
-func NewInstance() (*Instance, error) {
+func NewInstance(internalId string) (*Instance, error) {
 	currentHistory.Lock()
 	defer currentHistory.Unlock()
 
@@ -98,8 +98,9 @@ func NewInstance() (*Instance, error) {
 	}
 
 	newInstance := &Instance{
-		StartTime: timeNow(),
-		Hostname:  hostname,
+		InternalId: internalId,
+		StartTime:  timeNow(),
+		Hostname:   hostname,
 	}
 
 	currentHistory.addInstanceToHistory(newInstance)

--- a/pkg/osquery/runtime/history/history.go
+++ b/pkg/osquery/runtime/history/history.go
@@ -88,7 +88,7 @@ func LatestInstanceUptimeMinutes() (int64, error) {
 }
 
 // NewInstance adds a new instance to the osquery instance history and returns it
-func NewInstance(internalId string) (*Instance, error) {
+func NewInstance(runId string) (*Instance, error) {
 	currentHistory.Lock()
 	defer currentHistory.Unlock()
 
@@ -98,9 +98,9 @@ func NewInstance(internalId string) (*Instance, error) {
 	}
 
 	newInstance := &Instance{
-		InternalId: internalId,
-		StartTime:  timeNow(),
-		Hostname:   hostname,
+		RunId:     runId,
+		StartTime: timeNow(),
+		Hostname:  hostname,
 	}
 
 	currentHistory.addInstanceToHistory(newInstance)

--- a/pkg/osquery/runtime/history/history_test.go
+++ b/pkg/osquery/runtime/history/history_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/storage"
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	"github.com/kolide/launcher/ee/agent/types"
@@ -58,7 +59,7 @@ func TestNewInstance(t *testing.T) { // nolint:paralleltest
 
 			require.NoError(t, InitHistory(setupStorage(t, tt.initialInstances...)))
 
-			_, err := NewInstance()
+			_, err := NewInstance(ulid.New())
 
 			assert.Equal(t, tt.wantNumInstances, len(currentHistory.instances), "expect history length to reflect new instance")
 

--- a/pkg/osquery/runtime/history/instance.go
+++ b/pkg/osquery/runtime/history/instance.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Instance struct {
+	InternalId  string // ID assigned by launcher
 	StartTime   string
 	ConnectTime string
 	ExitTime    string
 	Hostname    string
-	InstanceId  string
+	InstanceId  string // ID from osquery
 	Version     string
 	Error       string
 }

--- a/pkg/osquery/runtime/history/instance.go
+++ b/pkg/osquery/runtime/history/instance.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Instance struct {
-	InternalId  string // ID assigned by launcher
+	RunId       string // ID for instance, assigned by launcher
 	StartTime   string
 	ConnectTime string
 	ExitTime    string

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/pkg/backoff"
@@ -187,7 +188,8 @@ type osqueryOptions struct {
 	stdout              io.Writer
 }
 
-func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, instanceId string, opts ...OsqueryInstanceOption) *OsqueryInstance {
+func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *OsqueryInstance {
+	instanceId := ulid.New()
 	i := &OsqueryInstance{
 		knapsack:      knapsack,
 		slogger:       knapsack.Slogger().With("component", "osquery_instance", "instance_id", instanceId),

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -189,12 +189,12 @@ type osqueryOptions struct {
 }
 
 func newInstance(knapsack types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *OsqueryInstance {
-	instanceId := ulid.New()
+	id := ulid.New()
 	i := &OsqueryInstance{
 		knapsack:      knapsack,
-		slogger:       knapsack.Slogger().With("component", "osquery_instance", "instance_id", instanceId),
+		slogger:       knapsack.Slogger().With("component", "osquery_instance", "internal_id", id),
 		serviceClient: serviceClient,
-		id:            instanceId,
+		id:            id,
 	}
 
 	for _, opt := range opts {
@@ -360,7 +360,7 @@ func (i *OsqueryInstance) Launch() error {
 		"osquery socket created",
 	)
 
-	stats, err := history.NewInstance()
+	stats, err := history.NewInstance(i.id)
 	if err != nil {
 		i.slogger.Log(ctx, slog.LevelWarn,
 			"could not create new osquery instance history",

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -665,12 +665,12 @@ type osqueryFilePaths struct {
 // In return, a structure of paths is returned that can be used to launch an
 // osqueryd instance. An error may be returned if the supplied parameters are
 // unacceptable.
-func calculateOsqueryPaths(rootDirectory string, instanceId string, opts osqueryOptions) (*osqueryFilePaths, error) {
+func calculateOsqueryPaths(rootDirectory string, id string, opts osqueryOptions) (*osqueryFilePaths, error) {
 
 	// Determine the path to the extension socket
 	extensionSocketPath := opts.extensionSocketPath
 	if extensionSocketPath == "" {
-		extensionSocketPath = SocketPath(rootDirectory, instanceId)
+		extensionSocketPath = SocketPath(rootDirectory, id)
 	}
 
 	extensionAutoloadPath := filepath.Join(rootDirectory, "osquery.autoload")
@@ -678,7 +678,7 @@ func calculateOsqueryPaths(rootDirectory string, instanceId string, opts osquery
 	// We want to use a unique pidfile per launcher run to avoid file locking issues.
 	// See: https://github.com/kolide/launcher/issues/1599
 	osqueryFilePaths := &osqueryFilePaths{
-		pidfilePath:           filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.pid", instanceId)),
+		pidfilePath:           filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.pid", id)),
 		databasePath:          filepath.Join(rootDirectory, "osquery.db"),
 		augeasPath:            filepath.Join(rootDirectory, "augeas-lenses"),
 		extensionSocketPath:   extensionSocketPath,

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -40,6 +40,19 @@ const (
 	// is required for osquery startup. It is called kolide_grpc for mostly historic reasons;
 	// communication with Kolide SaaS happens over JSONRPC.
 	KolideSaasExtensionName = "kolide_grpc"
+
+	// How long to wait before erroring because we cannot open the osquery
+	// extension socket.
+	socketOpenTimeout = 10 * time.Second
+
+	// How often to try to open the osquery extension socket
+	socketOpenInterval = 200 * time.Millisecond
+
+	// How frequently we should healthcheck the client/server
+	healthCheckInterval = 60 * time.Second
+
+	// The maximum amount of time to wait for the osquery socket to be available -- overrides context deadline
+	maxSocketWaitTime = 30 * time.Second
 )
 
 // OsqueryInstanceOption is a functional option pattern for defining how an

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/service"
@@ -25,7 +24,7 @@ type Runner struct {
 
 func New(k types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *Runner {
 	runner := &Runner{
-		instance:      newInstance(k, serviceClient, ulid.New(), opts...),
+		instance:      newInstance(k, serviceClient, opts...),
 		slogger:       k.Slogger().With("component", "osquery_runner"),
 		knapsack:      k,
 		serviceClient: serviceClient,
@@ -92,7 +91,7 @@ func (r *Runner) Run() error {
 		}
 
 		r.instanceLock.Lock()
-		r.instance = newInstance(r.knapsack, r.serviceClient, ulid.New(), r.opts...)
+		r.instance = newInstance(r.knapsack, r.serviceClient, r.opts...)
 		if err := r.instance.launch(); err != nil {
 			r.slogger.Log(context.TODO(), slog.LevelWarn,
 				"fatal error restarting instance, shutting down",

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/service"
@@ -40,7 +41,7 @@ type Runner struct {
 
 func New(k types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *Runner {
 	runner := &Runner{
-		instance:      newInstance(k, serviceClient, opts...),
+		instance:      newInstance(k, serviceClient, ulid.New(), opts...),
 		slogger:       k.Slogger().With("component", "osquery_runner"),
 		knapsack:      k,
 		serviceClient: serviceClient,
@@ -107,7 +108,7 @@ func (r *Runner) Run() error {
 		}
 
 		r.instanceLock.Lock()
-		r.instance = newInstance(r.knapsack, r.serviceClient, r.opts...)
+		r.instance = newInstance(r.knapsack, r.serviceClient, ulid.New(), r.opts...)
 		if err := r.instance.launch(); err != nil {
 			r.slogger.Log(context.TODO(), slog.LevelWarn,
 				"fatal error restarting instance, shutting down",

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -5,27 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/service"
-)
-
-const (
-	// How long to wait before erroring because we cannot open the osquery
-	// extension socket.
-	socketOpenTimeout = 10 * time.Second
-
-	// How often to try to open the osquery extension socket
-	socketOpenInterval = 200 * time.Millisecond
-
-	// How frequently we should healthcheck the client/server
-	healthCheckInterval = 60 * time.Second
-
-	// The maximum amount of time to wait for the osquery socket to be available -- overrides context deadline
-	maxSocketWaitTime = 30 * time.Second
 )
 
 type Runner struct {

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -22,8 +22,8 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	return nil
 }
 
-func SocketPath(rootDir string, instanceId string) string {
-	return filepath.Join(rootDir, fmt.Sprintf("osquery-%s.sock", instanceId))
+func SocketPath(rootDir string, id string) string {
+	return filepath.Join(rootDir, fmt.Sprintf("osquery-%s.sock", id))
 }
 
 func platformArgs() []string {

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -22,8 +22,8 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	return nil
 }
 
-func SocketPath(rootDir string) string {
-	return filepath.Join(rootDir, "osquery.sock")
+func SocketPath(rootDir string, instanceId string) string {
+	return filepath.Join(rootDir, fmt.Sprintf("osquery-%s.sock", instanceId))
 }
 
 func platformArgs() []string {

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/pkg/errors"
 )
@@ -47,7 +46,7 @@ func killProcessGroup(origCmd *exec.Cmd) error {
 	return nil
 }
 
-func SocketPath(rootDir string) string {
+func SocketPath(rootDir string, instanceId string) string {
 	// On windows, local names pipes paths are all rooted in \\.\pipe\
 	// their names are limited to 256 characters, and can include any
 	// character other than backslash. They are case insensitive.
@@ -62,7 +61,7 @@ func SocketPath(rootDir string) string {
 	//
 	// We could use something based on the launcher root, but given the
 	// context this runs in a ulid seems simpler.
-	return fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, ulid.New())
+	return fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, instanceId)
 }
 
 func platformArgs() []string {

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -46,7 +46,7 @@ func killProcessGroup(origCmd *exec.Cmd) error {
 	return nil
 }
 
-func SocketPath(rootDir string, instanceId string) string {
+func SocketPath(rootDir string, id string) string {
 	// On windows, local names pipes paths are all rooted in \\.\pipe\
 	// their names are limited to 256 characters, and can include any
 	// character other than backslash. They are case insensitive.
@@ -61,7 +61,7 @@ func SocketPath(rootDir string, instanceId string) string {
 	//
 	// We could use something based on the launcher root, but given the
 	// context this runs in a ulid seems simpler.
-	return fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, instanceId)
+	return fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, id)
 }
 
 func platformArgs() []string {

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -36,7 +36,7 @@ func hasPermissionsToRunTest() bool {
 func TestOsquerySlowStart(t *testing.T) {
 	t.Parallel()
 
-	rootDirectory := t.TempDir()
+	rootDirectory := testRootDirectory(t)
 
 	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 
@@ -84,7 +84,7 @@ func TestOsquerySlowStart(t *testing.T) {
 func TestExtensionSocketPath(t *testing.T) {
 	t.Parallel()
 
-	rootDirectory := t.TempDir()
+	rootDirectory := testRootDirectory(t)
 
 	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -137,7 +137,7 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	k.On("OsqueryFlags").Return([]string{})
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 
-	i := newInstance(k, mockServiceClient(), ulid.New())
+	i := newInstance(k, mockServiceClient())
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -161,7 +161,7 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	k.On("OsqueryVerbose").Return(true)
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 
-	i := newInstance(k, mockServiceClient(), ulid.New())
+	i := newInstance(k, mockServiceClient())
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -197,7 +197,7 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
 
-	i := newInstance(k, mockServiceClient(), ulid.New())
+	i := newInstance(k, mockServiceClient())
 	i.opts = *osqOpts
 	i.knapsack = k
 
@@ -249,7 +249,7 @@ func TestCreateOsqueryCommand_SetsDisabledWatchdogSettingsAppropriately(t *testi
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
 
-	i := newInstance(k, mockServiceClient(), ulid.New())
+	i := newInstance(k, mockServiceClient())
 	i.opts = *osqOpts
 	i.knapsack = k
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827.

Relates to https://github.com/kolide/launcher/issues/1936.

The osquery socket file is named `osquery.sock` on posix systems, which would result in collisions when we run multiple osquery instances. This PR updates the socket file to use a unique run ID. We also add this run ID to the instance history and logs for greater visibility.