### PR TITLE
ActionQueue retry on failure

### DIFF
--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -130,7 +130,7 @@ func (aq *ActionQueue) Update(data io.Reader) error {
 				"failed to do action with action, not marking action complete",
 				"err", err,
 			)
-			processError = fmt.Errorf("actor.Do failed: %w", err)
+			processError = fmt.Errorf("actor.Do, action type: %s, failed: %w", action.type, err)
 			continue
 		}
 

--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -100,6 +100,8 @@ func (aq *ActionQueue) Update(data io.Reader) error {
 		return fmt.Errorf("failed to decode actions data: %w", err)
 	}
 
+	var processError error = nil
+
 	for _, rawAction := range rawActionsToProcess {
 		var action action
 		if err := json.Unmarshal(rawAction, &action); err != nil {
@@ -128,6 +130,7 @@ func (aq *ActionQueue) Update(data io.Reader) error {
 				"failed to do action with action, not marking action complete",
 				"err", err,
 			)
+			processError = fmt.Errorf("actor.Do failed: %w", err)
 			continue
 		}
 
@@ -136,7 +139,7 @@ func (aq *ActionQueue) Update(data io.Reader) error {
 		aq.storeActionRecord(action)
 	}
 
-	return nil
+	return processError
 }
 
 func (aq *ActionQueue) RegisterActor(actorType string, actorToRegister actor) {

--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -130,7 +130,7 @@ func (aq *ActionQueue) Update(data io.Reader) error {
 				"failed to do action with action, not marking action complete",
 				"err", err,
 			)
-			processError = fmt.Errorf("actor.Do, action type: %s, failed: %w", action.type, err)
+			processError = fmt.Errorf("actor.Do, action type: %s, failed: %w", action.Type, err)
 			continue
 		}
 

--- a/ee/control/actionqueue/actionqueue_test.go
+++ b/ee/control/actionqueue/actionqueue_test.go
@@ -181,7 +181,6 @@ func TestActionQueue_HandlesDuplicatesWhenFirstActionCouldNotBeSent(t *testing.T
 	}
 	testActionsRaw, err := json.Marshal(actions)
 	require.NoError(t, err)
-	testActionsData := bytes.NewReader(testActionsRaw)
 
 	// Expect that the actor is called twice: once to unsuccessfully send the first action, and again to send the duplicate successfully
 	mockActor := mocks.NewActor(t)
@@ -194,7 +193,13 @@ func TestActionQueue_HandlesDuplicatesWhenFirstActionCouldNotBeSent(t *testing.T
 	// Call Do and assert our expectations about completed actions
 	actionqueue := New(mockKnapsack)
 	actionqueue.RegisterActor(testActorType, mockActor)
-	require.NoError(t, actionqueue.Update(testActionsData))
+	// First attempt fails
+	err = actionqueue.Update(bytes.NewReader(testActionsRaw))
+	require.Error(t, err)
+
+	// Second attempt succeeds
+	err = actionqueue.Update(bytes.NewReader(testActionsRaw))
+	require.NoError(t, err)
 }
 
 func TestCleanup(t *testing.T) {

--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -336,13 +336,12 @@ func (cs *ControlService) fetchAndUpdate(subsystem, hash string) error {
 
 	// Consumer and subscriber(s) notified now
 	if err := cs.update(subsystem, data); err != nil {
-		// Although we failed to update, the payload may be bad and there's no
-		// sense in repeatedly attempting to apply a bad update.
-		// A new update will have a new hash, so continue and remember this hash.
+		// Returning the error so we don't store the hash and we can try again next time
 		slogger.Log(context.TODO(), slog.LevelError,
 			"failed to update consumers and subscribers",
 			"err", err,
 		)
+		return err
 	}
 
 	// Remember the hash of the last fetched version of this subsystem's data

--- a/ee/control/control_test.go
+++ b/ee/control/control_test.go
@@ -231,10 +231,10 @@ func TestControlServiceUpdateErr(t *testing.T) {
 	// Verify error consumer was called
 	assert.Equal(t, 1, errConsumer.updates)
 
-	// Verify hash was still recorded despite error
+	// Verify hash was not recorded due to error
 	val, err := store.Get([]byte("actions"))
 	require.NoError(t, err)
-	assert.Equal(t, "abc123", string(val))
+	assert.Empty(t, string(val))
 }
 
 func TestControlServiceRetryAfterUpdateErr(t *testing.T) {
@@ -261,7 +261,7 @@ func TestControlServiceRetryAfterUpdateErr(t *testing.T) {
 	err := cs.RegisterConsumer("actions", errConsumer)
 	require.NoError(t, err)
 
-	// First fetch - should fail but store hash
+	// First fetch - should fail and not store hash
 	err = cs.Fetch()
 	require.NoError(t, err)
 	assert.Equal(t, 1, errConsumer.updates)


### PR DESCRIPTION
Resolves #1708 

We are implementing a retry pattern by returning an error from func (aq *ActionQueue) Update(data io.Reader) error if any action fails to process. Then the updated data for that subsystem shouldn't be stored, so Update would be called again in 1 minute by the control system, effectively handling the retry for us.

This pull request introduces error handling improvements and additional test cases for the `ActionQueue` and `ControlService` components. The main changes include adding error handling for action processing failures, updating test cases to handle these errors, and adding new test cases for retry logic in the `ControlService`.

Error handling improvements:

* [`ee/control/actionqueue/actionqueue.go`](diffhunk://#diff-cca5130d6e3079d2547d3a07ba5e38697d8c53b479fae5a3331e493f16bbdfc6R103-R104): Introduced `processError` to capture errors during action processing and return it at the end of the `Update` method. [[1]](diffhunk://#diff-cca5130d6e3079d2547d3a07ba5e38697d8c53b479fae5a3331e493f16bbdfc6R103-R104) [[2]](diffhunk://#diff-cca5130d6e3079d2547d3a07ba5e38697d8c53b479fae5a3331e493f16bbdfc6R133) [[3]](diffhunk://#diff-cca5130d6e3079d2547d3a07ba5e38697d8c53b479fae5a3331e493f16bbdfc6L139-R142)

Updates to existing tests:

* [`ee/control/actionqueue/actionqueue_test.go`](diffhunk://#diff-fdb0ac79b39f0f53a044a97ac956da7f0aacd9afc8bfc20d9882e25d8f2daa76L184): Modified the `TestActionQueue_HandlesDuplicatesWhenFirstActionCouldNotBeSent` test to check for errors on the first attempt and ensure success on the second attempt. [[1]](diffhunk://#diff-fdb0ac79b39f0f53a044a97ac956da7f0aacd9afc8bfc20d9882e25d8f2daa76L184) [[2]](diffhunk://#diff-fdb0ac79b39f0f53a044a97ac956da7f0aacd9afc8bfc20d9882e25d8f2daa76L197-R202)

New test cases:

* [`ee/control/control_test.go`](diffhunk://#diff-e617fc1085458f7b44b67e0310a766ecd3a50347f35400ecb88340499737ddc2R202-R286): Added `TestControlServiceUpdateErr` to verify that the `ControlService` handles update errors correctly and records the hash despite the error.
* [`ee/control/control_test.go`](diffhunk://#diff-e617fc1085458f7b44b67e0310a766ecd3a50347f35400ecb88340499737ddc2R202-R286): Added `TestControlServiceRetryAfterUpdateErr` to test the retry logic after an update error, ensuring that subsequent updates succeed and the final hash is recorded.

Mock updates:

* [`ee/control/control_test.go`](diffhunk://#diff-e617fc1085458f7b44b67e0310a766ecd3a50347f35400ecb88340499737ddc2R27): Modified the `mockConsumer` to support returning an error in the `Update` method. [[1]](diffhunk://#diff-e617fc1085458f7b44b67e0310a766ecd3a50347f35400ecb88340499737ddc2R27) [[2]](diffhunk://#diff-e617fc1085458f7b44b67e0310a766ecd3a50347f35400ecb88340499737ddc2L38-R39)