### PR TITLE
Refactor log file handling to standardize zip creation and improve er…

### DIFF
--- a/ee/debug/checkups/download_directory.go
+++ b/ee/debug/checkups/download_directory.go
@@ -1,6 +1,7 @@
 package checkups
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
 	"io"
@@ -28,21 +29,27 @@ func (c *downloadDirectory) Run(_ context.Context, extraFH io.Writer) error {
 		return nil
 	}
 
-	for _, downloadDir := range downloadDirs {
-		pattern := filepath.Join(downloadDir, "kolide-launcher*")
-		matches, err := filepath.Glob(pattern)
+	if extraFH != io.Discard {
+		zipWriter := zip.NewWriter(extraFH)
+		defer zipWriter.Close()
 
-		if err != nil {
-			fmt.Fprintf(extraFH, "Error listing files in directory (%s): %s\n", downloadDir, err)
-			continue
-		}
+		for _, downloadDir := range downloadDirs {
+			pattern := filepath.Join(downloadDir, "kolide-launcher*")
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				continue
+			}
 
-		for _, match := range matches {
-			if info, err := os.Stat(match); err == nil {
-				c.files = append(c.files, fileInfo{
-					Name:    match,
-					ModTime: info.ModTime(),
-				})
+			for _, match := range matches {
+				if info, err := os.Stat(match); err == nil {
+					c.files = append(c.files, fileInfo{
+						Name:    match,
+						ModTime: info.ModTime(),
+					})
+					if err := addFileToZip(zipWriter, match); err != nil {
+						fmt.Fprintf(extraFH, "Error adding file to zip %s: %v\n", match, err)
+					}
+				}
 			}
 		}
 	}
@@ -63,18 +70,11 @@ func (c *downloadDirectory) Run(_ context.Context, extraFH io.Writer) error {
 		c.summary = fmt.Sprintf("Found Kolide installer(s) across user download directories: %s", installerList)
 	}
 
-	if len(c.files) > 0 {
-		fmt.Fprintln(extraFH, "Kolide installers found:")
-		for _, file := range c.files {
-			fmt.Fprintln(extraFH, file)
-		}
-	}
-
 	return nil
 }
 
 func (c *downloadDirectory) ExtraFileName() string {
-	return "kolide-installers-all-users.txt"
+	return "kolide-installers-all-users.zip"
 }
 
 func (c *downloadDirectory) Status() Status {

--- a/ee/debug/checkups/init_logs_darwin.go
+++ b/ee/debug/checkups/init_logs_darwin.go
@@ -4,8 +4,6 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 )
 
@@ -17,20 +15,9 @@ func writeInitLogs(_ context.Context, logZip *zip.Writer) error {
 
 	var lastErr error
 	for _, f := range stdMatches {
-		out, err := logZip.Create(filepath.Base(f))
-		if err != nil {
+		if err := addFileToZip(logZip, f); err != nil {
 			lastErr = err
-			continue
 		}
-
-		in, err := os.Open(f)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		defer in.Close()
-
-		io.Copy(out, in)
 	}
 
 	return lastErr

--- a/ee/debug/checkups/init_logs_linux.go
+++ b/ee/debug/checkups/init_logs_linux.go
@@ -2,8 +2,10 @@ package checkups
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 )
@@ -14,13 +16,10 @@ func writeInitLogs(ctx context.Context, logZip *zip.Writer) error {
 		return fmt.Errorf("creating journalctl command: %w", err)
 	}
 
-	outFile, err := logZip.Create("linux_journalctl_launcher_logs.json")
+	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("creating linux_journalctl_launcher_logs.json: %w", err)
 	}
 
-	cmd.Stderr = outFile
-	cmd.Stdout = outFile
-
-	return cmd.Run()
+	return addStreamToZip(logZip, "linux_journalctl_launcher_logs.json", time.Now(), bytes.NewReader(output))
 }

--- a/ee/debug/checkups/init_logs_windows.go
+++ b/ee/debug/checkups/init_logs_windows.go
@@ -2,8 +2,10 @@ package checkups
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 )
@@ -15,13 +17,11 @@ func writeInitLogs(ctx context.Context, logZip *zip.Writer) error {
 		return fmt.Errorf("creating powershell command: %w", err)
 	}
 
-	outFile, err := logZip.Create("windows_launcher_events.json")
+	// Capture command output
+	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("creating windows_launcher_events.json: %w", err)
 	}
 
-	cmd.Stderr = outFile
-	cmd.Stdout = outFile
-
-	return cmd.Run()
+	return addStreamToZip(logZip, "windows_launcher_events.json", time.Now(), bytes.NewReader(output))
 }

--- a/ee/debug/checkups/launchd_darwin.go
+++ b/ee/debug/checkups/launchd_darwin.go
@@ -80,6 +80,7 @@ func (c *launchdCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 	c.summary = "state is running"
 	return nil
 }
+
 func (c *launchdCheckup) ExtraFileName() string {
 	return "launchd.zip"
 }

--- a/ee/debug/checkups/launchd_darwin.go
+++ b/ee/debug/checkups/launchd_darwin.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 )
@@ -31,38 +31,24 @@ func (c *launchdCheckup) Name() string {
 }
 
 func (c *launchdCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
-	// Check that the plist exists (this uses open not stat, because we also want to copy it)
-	launchdPlist, err := os.Open(launchdPlistPath)
-	if os.IsNotExist(err) {
+	// Check that the plist exists
+	if _, err := os.Stat(launchdPlistPath); os.IsNotExist(err) {
 		c.status = Failing
 		c.summary = "plist does not exist"
 		return nil
-	} else if err != nil {
-		c.status = Failing
-		c.summary = fmt.Sprintf("error reading %s: %s", launchdPlistPath, err)
-		return nil
 	}
-	defer launchdPlist.Close()
 
 	extraZip := zip.NewWriter(extraWriter)
 	defer extraZip.Close()
 
-	zippedPlist, err := extraZip.Create(filepath.Base(launchdPlistPath))
-	if err != nil {
+	// Add plist file using our utility
+	if err := addFileToZip(extraZip, launchdPlistPath); err != nil {
 		c.status = Erroring
-		c.summary = fmt.Sprintf("unable to create extra information: %s", err)
+		c.summary = fmt.Sprintf("unable to add plist file: %s", err)
 		return nil
 	}
 
-	if _, err := io.Copy(zippedPlist, launchdPlist); err != nil {
-		c.status = Erroring
-		c.summary = fmt.Sprintf("unable to write extra information: %s", err)
-		return nil
-	}
-
-	// run launchctl to check status
-	var printOut bytes.Buffer
-
+	// Run launchctl to check status
 	cmd, err := allowedcmd.Launchctl(ctx, "print", launchdServiceName)
 	if err != nil {
 		c.status = Erroring
@@ -70,28 +56,21 @@ func (c *launchdCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 		return nil
 	}
 
-	cmd.Stdout = &printOut
-	cmd.Stderr = &printOut
-	if err := cmd.Run(); err != nil {
+	output, err := cmd.Output()
+	if err != nil {
 		c.status = Failing
 		c.summary = fmt.Sprintf("error running launchctl print: %s", err)
 		return nil
 	}
 
-	zippedOut, err := extraZip.Create("launchctl-print.txt")
-	if err != nil {
+	// Add command output using our streaming utility
+	if err := addStreamToZip(extraZip, "launchctl-print.txt", time.Now(), bytes.NewReader(output)); err != nil {
 		c.status = Erroring
-		c.summary = fmt.Sprintf("unable to create launchctl-print.txt: %s", err)
+		c.summary = fmt.Sprintf("unable to add launchctl-print.txt output: %s", err)
 		return nil
 	}
-	if _, err := zippedOut.Write(printOut.Bytes()); err != nil {
-		c.status = Erroring
-		c.summary = fmt.Sprintf("unable to write launchctl-print.txt: %s", err)
-		return nil
 
-	}
-
-	if !strings.Contains(printOut.String(), "state = running") {
+	if !strings.Contains(string(output), "state = running") {
 		c.status = Failing
 		c.summary = "state not active"
 		return nil
@@ -101,7 +80,6 @@ func (c *launchdCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 	c.summary = "state is running"
 	return nil
 }
-
 func (c *launchdCheckup) ExtraFileName() string {
 	return "launchd.zip"
 }

--- a/ee/debug/checkups/logs.go
+++ b/ee/debug/checkups/logs.go
@@ -48,22 +48,13 @@ func (c *Logs) Run(_ context.Context, fullFH io.Writer) error {
 	matches, _ := filepath.Glob(filepath.Join(c.k.RootDirectory(), "debug*"))
 
 	for _, f := range matches {
-		out, err := logZip.Create(filepath.Base(f))
-		if err != nil {
-			continue
+		if err := addFileToZip(logZip, f); err != nil {
+			return fmt.Errorf("adding %s to zip: %w", f, err)
 		}
-
-		in, err := os.Open(f)
-		if err != nil {
-			fmt.Fprintf(out, "error reading file:\n%s", err)
-			continue
-		}
-		defer in.Close()
-
-		io.Copy(out, in)
 	}
 
 	return nil
+
 }
 
 func (c *Logs) Status() Status {

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -52,13 +52,13 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 	}
 
 	hideWindow(powerCfgSleepStatesCmd)
-	sleepStatesOutput, err := powerCfgSleepStatesCmd.Output()
+	availableSleepStatesOutput, err := powerCfgSleepStatesCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("running powercfg.exe for sleep states: error %w", err)
 	}
 
 	// Add sleep states using addStreamToZip
-	if err := addStreamToZip(extraZip, "available_sleep_states.txt", time.Now(), bytes.NewReader(sleepStatesOutput)); err != nil {
+	if err := addStreamToZip(extraZip, "available_sleep_states.txt", time.Now(), bytes.NewReader(availableSleepStatesOutput)); err != nil {
 		return fmt.Errorf("adding sleep states to zip: %w", err)
 	}
 

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -59,7 +59,7 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 
 	// Add sleep states using addStreamToZip
 	if err := addStreamToZip(extraZip, "available_sleep_states.txt", time.Now(), bytes.NewReader(availableSleepStatesOutput)); err != nil {
-		return fmt.Errorf("adding sleep states to zip: %w", err)
+		return fmt.Errorf("running powercfg.exe for sleep states: error %w, output %s", err, string(availableSleepStatesOutput))
 	}
 
 	// Get power events

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -71,7 +71,7 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 
 	powerEventsOutput, err := getWinEventCmd.Output()
 	if err != nil {
-		return fmt.Errorf("running get-winevent command: %w", err)
+		return fmt.Errorf("running get-winevent command: %w, output %s", err, string(powerEventsOutput))
 	}
 
 	// Add power events using addStreamToZip

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -81,6 +81,7 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 
 	return nil
 }
+
 func (p *powerCheckup) ExtraFileName() string {
 	return "power.zip"
 }

--- a/ee/debug/checkups/power_windows.go
+++ b/ee/debug/checkups/power_windows.go
@@ -5,10 +5,12 @@ package checkups
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
@@ -35,67 +37,50 @@ func (p *powerCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 		return fmt.Errorf("running powercfg.exe: error %w, output %s", err, string(out))
 	}
 
-	sprHandle, err := os.Open(tmpFilePath)
-	if err != nil {
-		return fmt.Errorf("opening system power report: %w", err)
-	}
-	defer sprHandle.Close()
-
 	extraZip := zip.NewWriter(extraWriter)
 	defer extraZip.Close()
 
-	zippedPowerReport, err := extraZip.Create("power.html")
-	if err != nil {
-		return fmt.Errorf("creating power report zip file: %w", err)
+	// Add the power report using addFileToZip
+	if err := addFileToZip(extraZip, tmpFilePath); err != nil {
+		return fmt.Errorf("adding power report to zip: %w", err)
 	}
 
-	if _, err := io.Copy(zippedPowerReport, sprHandle); err != nil {
-		return fmt.Errorf("copying system power report: %w", err)
-	}
-
+	// Get available sleep states
 	powerCfgSleepStatesCmd, err := allowedcmd.Powercfg(ctx, "/availablesleepstates")
 	if err != nil {
 		return fmt.Errorf("creating powercfg sleep states command: %w", err)
 	}
 
 	hideWindow(powerCfgSleepStatesCmd)
-	availableSleepStatesOutput, err := powerCfgSleepStatesCmd.CombinedOutput()
+	sleepStatesOutput, err := powerCfgSleepStatesCmd.Output()
 	if err != nil {
-		return fmt.Errorf("running powercfg.exe for sleep states: error %w, output %s", err, string(availableSleepStatesOutput))
+		return fmt.Errorf("running powercfg.exe for sleep states: error %w", err)
 	}
 
-	zippedSleepStates, err := extraZip.Create("available_sleep_states.txt")
-	if err != nil {
-		return fmt.Errorf("creating available sleep states output file: %w", err)
+	// Add sleep states using addStreamToZip
+	if err := addStreamToZip(extraZip, "available_sleep_states.txt", time.Now(), bytes.NewReader(sleepStatesOutput)); err != nil {
+		return fmt.Errorf("adding sleep states to zip: %w", err)
 	}
 
-	if _, err := zippedSleepStates.Write(availableSleepStatesOutput); err != nil {
-		return fmt.Errorf("writing available sleep states output file: %w", err)
-	}
-
+	// Get power events
 	eventFilter := `Get-Winevent -FilterHashtable @{LogName='System'; ProviderName='Microsoft-Windows-Power-Troubleshooter','Microsoft-Windows-Kernel-Power'} -MaxEvents 500 | Select-Object @{name='Time'; expression={$_.TimeCreated.ToString("O")}},Id,LogName,ProviderName,Message,TimeCreated | ConvertTo-Json`
 	getWinEventCmd, err := allowedcmd.Powershell(ctx, eventFilter)
 	if err != nil {
 		return fmt.Errorf("creating powershell get-winevent command: %w", err)
 	}
 
-	powerEventFile, err := extraZip.Create("windows_power_events.json")
+	powerEventsOutput, err := getWinEventCmd.Output()
 	if err != nil {
-		return fmt.Errorf("creating windows_power_events.json: %w", err)
+		return fmt.Errorf("running get-winevent command: %w", err)
 	}
 
-	powerEventsOut, err := getWinEventCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("running get-winevent command: %w, output %s", err, string(powerEventsOut))
-	}
-
-	if _, err := powerEventFile.Write(powerEventsOut); err != nil {
-		return fmt.Errorf("writing power events to output file: %w", err)
+	// Add power events using addStreamToZip
+	if err := addStreamToZip(extraZip, "windows_power_events.json", time.Now(), bytes.NewReader(powerEventsOutput)); err != nil {
+		return fmt.Errorf("adding power events to zip: %w", err)
 	}
 
 	return nil
 }
-
 func (p *powerCheckup) ExtraFileName() string {
 	return "power.zip"
 }

--- a/ee/debug/checkups/util.go
+++ b/ee/debug/checkups/util.go
@@ -52,18 +52,20 @@ type fileInfo struct {
 
 // addFileToZip takes a file path, and a zip writer, and adds the file and some metadata.
 func addFileToZip(z *zip.Writer, location string) error {
+	// Create metadata file first, keeping existing pattern
 	metaout, err := z.Create(filepath.Join(".", location+".flaremeta"))
 	if err != nil {
 		return fmt.Errorf("creating %s in zip: %w", location+".flaremeta", err)
 	}
 
-	// Not totally clear if we should use Lstat or Stat here.
+	// Get file info first as we do in original
 	fi, err := os.Stat(location)
 	if os.IsNotExist(err) || os.IsPermission(err) {
 		fmt.Fprintf(metaout, `{ "error stating file": "%s" }`, err)
 		return nil
 	}
 
+	// Marshal metadata
 	b, err := json.Marshal(fileInfo{
 		Name:    fi.Name(),
 		Size:    fi.Size(),
@@ -80,7 +82,6 @@ func addFileToZip(z *zip.Writer, location string) error {
 	if err := json.Indent(&buf, b, "", "  "); err != nil {
 		// Structural error. Abort
 		return fmt.Errorf("indenting json: %w", err)
-
 	}
 	metaout.Write(buf.Bytes())
 
@@ -95,13 +96,62 @@ func addFileToZip(z *zip.Writer, location string) error {
 	}
 	defer fh.Close()
 
-	dataout, err := z.Create(filepath.Join(".", location))
+	// Create zip header with metadata
+	header, err := zip.FileInfoHeader(fi)
+	if err != nil {
+		return fmt.Errorf("creating file header: %w", err)
+	}
+	header.Name = filepath.Join(".", location)
+
+	// Create file in zip with metadata
+	dataout, err := z.CreateHeader(header)
 	if err != nil {
 		return fmt.Errorf("creating %s in zip: %w", location, err)
 	}
 
 	if _, err := io.Copy(dataout, fh); err != nil {
 		return fmt.Errorf("copy data into zip file %s: %w", location, err)
+	}
+
+	return nil
+}
+
+func addStreamToZip(z *zip.Writer, name string, modTime time.Time, reader io.Reader) error {
+	// Create metadata file first
+	metaout, err := z.Create(name + ".flaremeta")
+	if err != nil {
+		return fmt.Errorf("creating %s in zip: %w", name+".flaremeta", err)
+	}
+
+	// Marshal metadata
+	b, err := json.Marshal(fileInfo{
+		Name:    filepath.Base(name),
+		ModTime: modTime,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling json: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, b, "", "  "); err != nil {
+		return fmt.Errorf("indenting json: %w", err)
+	}
+	metaout.Write(buf.Bytes())
+
+	// Create the main file in zip
+	header := &zip.FileHeader{
+		Name:     name,
+		Method:   zip.Deflate,
+		Modified: modTime,
+	}
+
+	out, err := z.CreateHeader(header)
+	if err != nil {
+		return fmt.Errorf("creating %s in zip: %w", name, err)
+	}
+
+	if _, err := io.Copy(out, reader); err != nil {
+		return fmt.Errorf("copying data to zip: %w", err)
 	}
 
 	return nil

--- a/ee/debug/checkups/util.go
+++ b/ee/debug/checkups/util.go
@@ -58,7 +58,7 @@ func addFileToZip(z *zip.Writer, location string) error {
 		return fmt.Errorf("creating %s in zip: %w", location+".flaremeta", err)
 	}
 
-	// Get file info first as we do in original
+	// Get file info
 	fi, err := os.Stat(location)
 	if os.IsNotExist(err) || os.IsPermission(err) {
 		fmt.Fprintf(metaout, `{ "error stating file": "%s" }`, err)
@@ -83,7 +83,10 @@ func addFileToZip(z *zip.Writer, location string) error {
 		// Structural error. Abort
 		return fmt.Errorf("indenting json: %w", err)
 	}
-	metaout.Write(buf.Bytes())
+
+	if _, err := metaout.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing metadata: %w", err)
+	}
 
 	//
 	// Done with metadata, and we know the file exists, and that we have permission to it.
@@ -136,7 +139,10 @@ func addStreamToZip(z *zip.Writer, name string, modTime time.Time, reader io.Rea
 	if err := json.Indent(&buf, b, "", "  "); err != nil {
 		return fmt.Errorf("indenting json: %w", err)
 	}
-	metaout.Write(buf.Bytes())
+
+	if _, err := metaout.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing metadata: %w", err)
+	}
 
 	// Create the main file in zip
 	header := &zip.FileHeader{


### PR DESCRIPTION
This pull request introduces significant changes to the `checkups` package, focusing on improving the handling of file zipping operations. The changes include adding new helper functions for zipping files and streams, and refactoring existing code to utilize these new functions.

Resolves #1949 

### Improvements to file zipping operations:

* [`ee/debug/checkups/util.go`](diffhunk://#diff-14db1f63a6e57752eafae429901220f869b2771acf3685bdd22c407fc43fd91dR119-R159): Added new helper function  `addStreamToZip` to streamline the process of adding files and streams to a zip archive with metadata. [[1]](diffhunk://#diff-14db1f63a6e57752eafae429901220f869b2771acf3685bdd22c407fc43fd91dR119-R159) [[2]](diffhunk://#diff-14db1f63a6e57752eafae429901220f869b2771acf3685bdd22c407fc43fd91dL98-R107) [[3]](diffhunk://#diff-14db1f63a6e57752eafae429901220f869b2771acf3685bdd22c407fc43fd91dL83) [[4]](diffhunk://#diff-14db1f63a6e57752eafae429901220f869b2771acf3685bdd22c407fc43fd91dR55-R68)

### Refactoring existing code to use new helper functions:

* [`ee/debug/checkups/download_directory.go`](diffhunk://#diff-16a3627c3d948bf8accd3e94ac27aff119cda0c1beae5bf967bbf0e5fe4ce40bR4): Updated the `Run` method to use `addFileToZip` for adding files to the zip archive and changed the extra file name to `kolide-installers-all-users.zip`. [[1]](diffhunk://#diff-16a3627c3d948bf8accd3e94ac27aff119cda0c1beae5bf967bbf0e5fe4ce40bR4) [[2]](diffhunk://#diff-16a3627c3d948bf8accd3e94ac27aff119cda0c1beae5bf967bbf0e5fe4ce40bR32-L36) [[3]](diffhunk://#diff-16a3627c3d948bf8accd3e94ac27aff119cda0c1beae5bf967bbf0e5fe4ce40bR49-R52) [[4]](diffhunk://#diff-16a3627c3d948bf8accd3e94ac27aff119cda0c1beae5bf967bbf0e5fe4ce40bL66-R77)
* `ee/debug/checkups/init_logs_darwin.go`, `ee/debug/checkups/init_logs_linux.go`, `ee/debug/checkups/init_logs_windows.go`: Refactored the `writeInitLogs` function to use `addFileToZip` and `addStreamToZip` for zipping log files and command outputs. [[1]](diffhunk://#diff-45fa507a60556aefb4e49f3a0de447d71bad562ad96c3823a0c044ee73fad17eL7-L8) [[2]](diffhunk://#diff-45fa507a60556aefb4e49f3a0de447d71bad562ad96c3823a0c044ee73fad17eL20-L33) [[3]](diffhunk://#diff-881a267060041cf013035d2a3daed82016a5696ab155671666689d92387bcae9R5-R8) [[4]](diffhunk://#diff-881a267060041cf013035d2a3daed82016a5696ab155671666689d92387bcae9L17-R24) [[5]](diffhunk://#diff-fcc2c6079a3df9578c739af5122a6e42aabd98e8714d9eb76a5fcb89905bcf3eR5-R8) [[6]](diffhunk://#diff-fcc2c6079a3df9578c739af5122a6e42aabd98e8714d9eb76a5fcb89905bcf3eL18-R26)
* [`ee/debug/checkups/install.go`](diffhunk://#diff-6e74ed56a88de5b2b35482bdb69791c6da463959b4b68212076ca3d63512f416L8): Simplified the `gatherInstallationLogs` and `gatherInstallerInfo` functions by using `addFileToZip` for zipping installation logs and installer info files. [[1]](diffhunk://#diff-6e74ed56a88de5b2b35482bdb69791c6da463959b4b68212076ca3d63512f416L8) [[2]](diffhunk://#diff-6e74ed56a88de5b2b35482bdb69791c6da463959b4b68212076ca3d63512f416L58-R68)
* [`ee/debug/checkups/launchd_darwin.go`](diffhunk://#diff-fc045fc9f99a977f5ff8a618ae820dad823e61f6d7428d8d0c2599b2ca02eeedL13-R14): Updated the `Run` method to use `addFileToZip` and `addStreamToZip` for zipping plist files and command outputs. [[1]](diffhunk://#diff-fc045fc9f99a977f5ff8a618ae820dad823e61f6d7428d8d0c2599b2ca02eeedL13-R14) [[2]](diffhunk://#diff-fc045fc9f99a977f5ff8a618ae820dad823e61f6d7428d8d0c2599b2ca02eeedL34-R73) [[3]](diffhunk://#diff-fc045fc9f99a977f5ff8a618ae820dad823e61f6d7428d8d0c2599b2ca02eeedL104)
* [`ee/debug/checkups/logs.go`](diffhunk://#diff-1991143204004cac68bbbfb2fb80680078c1b48a863cc0d3973f18843d500232L51-R57): Refactored the `Run` method to use `addFileToZip` for adding log files to the zip archive.
* [`ee/debug/checkups/power_windows.go`](diffhunk://#diff-cfb3fbab5bfa1d4aa92b7b934590bd4a137dd06aa263a937af085e0ef522af5fR8-R13): Simplified the `Run` method by using `addFileToZip` and `addStreamToZip` for zipping power reports and command outputs. [[1]](diffhunk://#diff-cfb3fbab5bfa1d4aa92b7b934590bd4a137dd06aa263a937af085e0ef522af5fR8-R13) [[2]](diffhunk://#diff-cfb3fbab5bfa1d4aa92b7b934590bd4a137dd06aa263a937af085e0ef522af5fL38-L98)…ror reporting