### PR TITLE
add numeric install version value to windows registry on install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03
 	github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc
-	github.com/kolide/kit v0.0.0-20240411131714-94dd1939cf50
+	github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279
 	github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121
 	github.com/mat/besticon v3.9.0+incompatible
 	github.com/mattn/go-sqlite3 v1.14.19

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767 h1:kcLxfX6wdtztSwpgz
 github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6 h1:6/RKW8FQlrtaBeL7We3SdpdoiGZk3Pm5STXsSxbm9ho=
 github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6/go.mod h1:zgOxCKTwS/xpJtz6LH60b3lZoQ30kqtc252N+SM4enc=
-github.com/kolide/kit v0.0.0-20240411131714-94dd1939cf50 h1:N7RaYBPTK5o4y2z1z8kl/G3iAeP73QCfAUH4y39GRCc=
-github.com/kolide/kit v0.0.0-20240411131714-94dd1939cf50/go.mod h1:pFbEKXFww1uqu4RRO7qCnUmQ2EIwKYRzUqpJbODNlfc=
+github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279 h1:nFN/UwsX1OuTgekQWuynr1SwWlcPT8t1iNtjtm81sMA=
+github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279/go.mod h1:pFbEKXFww1uqu4RRO7qCnUmQ2EIwKYRzUqpJbODNlfc=
 github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121 h1:f7APX9VNsCkD/tdlAjbU4A22FyfTOCF6QadlvnzZElg=
 github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121/go.mod h1:/0sxd3OIxciTlMTeZI/9WTaUHsx/K/+3f+NbD5dywTY=
 github.com/kolide/systray v1.10.5-0.20241021175748-13aef6380bdb h1:d2pfEh5Yd6+C+D096YQlHwcq28TPOjoeoG+lCQojkJM=

--- a/pkg/packagekit/assets/main.wxs
+++ b/pkg/packagekit/assets/main.wxs
@@ -57,7 +57,7 @@
 	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
 	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
 	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
-	  <RegistryValue Key="VersionNum" Value="{{.Opts.VersionNum}}" Type="integer" />
+	  <RegistryValue Key="InstalledVersionNum" Value="{{.Opts.VersionNum}}" Type="integer" />
 	</RegistryKey>
       </Component>
     </DirectoryRef>

--- a/pkg/packagekit/assets/main.wxs
+++ b/pkg/packagekit/assets/main.wxs
@@ -57,6 +57,7 @@
 	  <RegistryValue Key="Identifier" Value="{{.Opts.Identifier}}" Type="string" />
 	  <RegistryValue Key="User" Value="[LogonUser]" Type="string" />
 	  <RegistryValue Key="Version" Value="{{.Opts.Version}}" Type="string" />
+	  <RegistryValue Key="VersionNum" Value="{{.Opts.VersionNum}}" Type="integer" />
 	</RegistryKey>
       </Component>
     </DirectoryRef>

--- a/pkg/packagekit/package.go
+++ b/pkg/packagekit/package.go
@@ -9,6 +9,7 @@ type PackageOptions struct {
 	Root       string // source directory to package
 	Scripts    string // directory of packaging scripts (postinst, prerm, etc)
 	Version    string // package version
+	VersionNum int    // package version in numeric format. used to create comparable windows registry keys
 	FlagFile   string // Path to the flagfile for configuration
 
 	DisableService bool // Whether to install a system service in a disabled state

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
+	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/pkg/packagekit/authenticode"
 	"github.com/kolide/launcher/pkg/packagekit/wix"
 	"golang.org/x/text/cases"
@@ -50,6 +51,13 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 
 	if err := isDirectory(po.Root); err != nil {
 		return err
+	}
+
+	// populate VersionNum if it isn't already set by the caller. we'll
+	// store this in the registry on install to give a comparable field
+	// for intune to drive upgrade behavior from
+	if po.VersionNum == 0 {
+		po.VersionNum = version.VersionNum()
 	}
 
 	// We include a random nonce as part of the ProductCode


### PR DESCRIPTION
This is part 2 towards allowing us to improve our intune setup recommendations. This adds a new `InstalledVersionNum` registry key and value which is inserted during our MSI installation. This will give a `REG_DWORD` type version entry for intune configurations to compare against when determining update/reinstallation behavior for new packages, effectively allowing an "upgrade only" type setup.

Installing from an MSI built with these changes yields the following:

```powershell
PS C:\Users\zack-\code\launcher> Get-ItemProperty 'HKLM:\Software\Kolide\Launcher\Kolide-nababe-k2\InstalledVersionNum'

(default)    : 1011006
PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\Software\Kolide\Launcher\Kolide-nababe-k2\InstalledVersionNum
PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\Software\Kolide\Launcher\Kolide-nababe-k2
PSChildName  : InstalledVersionNum
PSDrive      : HKLM
PSProvider   : Microsoft.PowerShell.Core\Registry
```

See the full issue [here](https://github.com/kolide/k2/issues/10843) for additional context.

This is just the installation portion, follow up PRs will include a similar entry to indicate the `CurrentVersionNum` which will  take the autoupdated launcher versions into account, as well as report the value of these entries within flares