### PR TITLE
Set Access-Control-Allow-Credentials: true in localserver

### DIFF
--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -381,6 +381,9 @@ func (ls *localServer) preflightCorsHandler(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Headers",
 			"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 
+		// We need this for device trust to work in newer versions of Chrome with experimental features toggled on
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+
 		// Some modern chrome and derivatives use Access-Control-Allow-Private-Network
 		// https://developer.chrome.com/blog/private-network-access-preflight/
 		// Though it's unclear if this is still needed, see https://developer.chrome.com/blog/private-network-access-update/


### PR DESCRIPTION
@levicole discovered that a new feature in Chrome's experimental web platform features breaks device trust because it requires the `Access-Control-Allow-Credentials` header to be set, and we don't currently set it. This PR updates to set it.

Tested in Chrome, Firefox, Safari and confirmed device trust works for all three.