### PR TITLE
add current version to windows registry on startup

### DIFF
--- a/cmd/launcher/svc_config_windows.go
+++ b/cmd/launcher/svc_config_windows.go
@@ -308,6 +308,8 @@ func checkCurrentVersionMetadata(logger *slog.Logger, identifier string) {
 			"encountered error setting current version to registry",
 			"err", err,
 		)
+
+		return
 	}
 
 	logger.Log(context.TODO(), slog.LevelInfo,

--- a/cmd/launcher/svc_config_windows.go
+++ b/cmd/launcher/svc_config_windows.go
@@ -269,17 +269,17 @@ func recoveryActionsAreSet(curRecoveryActions, recoveryActions []mgr.RecoveryAct
 // maintain consistency with the pattern set by our installer info metadata.
 // for additional details on the difference, see here https://devblogs.microsoft.com/oldnewthing/20080118-00/?p=23773
 func checkCurrentVersionMetadata(logger *slog.Logger, identifier string) {
-	installedVersionRegistryKeyName := fmt.Sprintf(currentVersionRegistryKeyFmt, identifier, currentVersionKeyName)
-	launcherVersionKey, err := registry.OpenKey(registry.LOCAL_MACHINE, installedVersionRegistryKeyName, registry.ALL_ACCESS)
+	versionKeyPath := fmt.Sprintf(currentVersionRegistryKeyFmt, identifier, currentVersionKeyName)
+	launcherVersionKey, err := registry.OpenKey(registry.LOCAL_MACHINE, versionKeyPath, registry.ALL_ACCESS)
 	// create the key if it doesn't already exist
 	if err != nil && err.Error() == notFoundInRegistryError {
-		launcherVersionKey, _, err = registry.CreateKey(registry.LOCAL_MACHINE, installedVersionRegistryKeyName, registry.ALL_ACCESS)
+		launcherVersionKey, _, err = registry.CreateKey(registry.LOCAL_MACHINE, versionKeyPath, registry.ALL_ACCESS)
 	}
 
 	if err != nil {
 		logger.Log(context.TODO(), slog.LevelError,
 			"could not create or open new registry key",
-			"key_name", installedVersionRegistryKeyName,
+			"key_path", versionKeyPath,
 			"err", err,
 		)
 


### PR DESCRIPTION
Part 3: This builds on the changes [here](https://github.com/kolide/launcher/pull/1953) and adds the current running version to windows registry on startup if it is unset or needs to be updated.

See the full issue [here](https://github.com/kolide/k2/issues/10843) for additional context.