### PR TITLE
Give launcher interactive enough time to run during doctor

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -233,7 +233,7 @@ func RunDoctor(ctx context.Context, k types.Knapsack, w io.Writer) {
 	warningCheckups := []string{}
 
 	for _, c := range checkupsFor(k, doctorSupported) {
-		ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), 20*time.Second)
 		defer cancel()
 
 		doctorCheckup(ctx, c, w)

--- a/ee/debug/checkups/osquery.go
+++ b/ee/debug/checkups/osquery.go
@@ -77,7 +77,7 @@ func (o *osqueryCheckup) interactive(ctx context.Context) error {
 	out, err := cmd.CombinedOutput()
 	o.executionTimes[cmd.String()] = fmt.Sprintf("%d ms", time.Now().UnixMilli()-startTime)
 	if err != nil {
-		return fmt.Errorf("running %s interactive: err %w, output %s", launcherPath, err, string(out))
+		return fmt.Errorf("running %s interactive: err %w, output %s; ctx err: %+v", launcherPath, err, string(out), cmdCtx.Err())
 	}
 
 	return nil


### PR DESCRIPTION
Resolves https://github.com/kolide/launcher/issues/1892

In test, `launcher interactive` took about 10 seconds to run (due to https://github.com/kolide/launcher/issues/902 -- exiting the command takes a while). With a 10-second timeout, it was consistently failing and we were returning an error due to the timeout. Simply increasing the timeout to 20 seconds fixes the issue -- we no longer get false positives for the launcher interactive portion of the checkup.