### PR TITLE
Set all env vars on osquery process

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -805,6 +805,19 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 	// https://github.com/osquery/osquery/pull/6824
 	cmd.Env = append(cmd.Env, "SYSTEM_VERSION_COMPAT=0")
 
+	// On Windows, we need to ensure the `SystemDrive` environment variable is set to _something_,
+	// so if it isn't already set, we set it to an empty string.
+	systemDriveEnvVarFound := false
+	for _, e := range cmd.Env {
+		if strings.Contains(strings.ToLower(e), "systemdrive") {
+			systemDriveEnvVarFound = true
+			break
+		}
+	}
+	if !systemDriveEnvVarFound {
+		cmd.Env = append(cmd.Env, "SystemDrive=")
+	}
+
 	return cmd, nil
 }
 

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -794,6 +794,9 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 		fmt.Sprintf("--extensions_require=%s", KolideSaasExtensionName),
 	)
 
+	// We need environment variables to be set to ensure paths can be resolved appropriately.
+	cmd.Env = cmd.Environ()
+
 	// On darwin, run osquery using a magic macOS variable to ensure we
 	// get proper versions strings back. I'm not totally sure why apple
 	// did this, but reading SystemVersion.plist is different when this is set.
@@ -801,14 +804,6 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 	// https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
 	// https://github.com/osquery/osquery/pull/6824
 	cmd.Env = append(cmd.Env, "SYSTEM_VERSION_COMPAT=0")
-
-	// On Windows, we want the `SystemDrive` environment variable to be set to ensure paths can be resolved appropriately.
-	// The cmd handles setting `SystemRoot` for us.
-	if runtime.GOOS == "windows" {
-		if systemDrive, found := os.LookupEnv("SystemDrive"); found {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("SystemDrive=%s", systemDrive))
-		}
-	}
 
 	return cmd, nil
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/kolide/launcher/pull/1960:

* We may want other env vars set, so this PR updates to grab all of the env vars from `cmd.Environ()` -- this is the default behavior for `cmd` when nothing is set in `cmd.Env`
* In the case that `SystemDrive` happens to be unset, we can prevent undesirable behavior by setting `SystemDrive=` in the env instead -- so this PR adds a check for that as well