### PR TITLE
always check fallback paths against identifier

### DIFF
--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -101,6 +101,11 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL, packageI
 		return optsRootDirectory
 	}
 
+	// assume the default identifier if none is provided
+	if strings.TrimSpace(packageIdentifier) == "" {
+		packageIdentifier = DefaultLauncherIdentifier
+	}
+
 	optsDBLocation := filepath.Join(optsRootDirectory, "launcher.db")
 	dbExists, err := nonEmptyFileExists(optsDBLocation)
 	// If we get an unknown error, back out from making any options changes. This is an
@@ -123,8 +128,8 @@ func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL, packageI
 			continue
 		}
 
-		// If the identifier is set, the path MUST contain the identifier
-		if packageIdentifier != "" && !strings.Contains(path, packageIdentifier) {
+		// the fallaback path MUST contain the identifier
+		if !strings.Contains(path, packageIdentifier) {
 			continue
 		}
 


### PR DESCRIPTION
There is a path for dual installations to pick the wrong fallback root directory - specifically if an installation using an unset (default) identifier is installed after an agent installation with a non-standard identifier, and without a previously existing database in it's configured root directory, it can incorrectly select the non-standard identifier root directory as the override before checking it's own identifier's fallback path.

To remove this possibility, we can just ensure that the identifier is populated with our default value if empty before performing the fallback lookup logic