### PR TITLE
Set config on interactive command in osquery checkup

### DIFF
--- a/ee/debug/checkups/osquery.go
+++ b/ee/debug/checkups/osquery.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/pkg/launcher"
 )
 
 type osqueryCheckup struct {
@@ -66,10 +67,15 @@ func (o *osqueryCheckup) interactive(ctx context.Context) error {
 		return fmt.Errorf("getting current running executable: %w", err)
 	}
 
+	flagFilePath := launcher.DefaultPath(launcher.ConfigFile)
+	if o.k != nil && o.k.Identifier() != "" {
+		flagFilePath = strings.ReplaceAll(flagFilePath, launcher.DefaultLauncherIdentifier, o.k.Identifier())
+	}
+
 	cmdCtx, cmdCancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cmdCancel()
 
-	cmd := exec.CommandContext(cmdCtx, launcherPath, "interactive", "--osqueryd_path", o.k.LatestOsquerydPath(ctx)) //nolint:forbidigo // It is safe to exec the current running executable
+	cmd := exec.CommandContext(cmdCtx, launcherPath, "interactive", "--config", flagFilePath) //nolint:forbidigo // It is safe to exec the current running executable
 	hideWindow(cmd)
 	cmd.Stdin = strings.NewReader(`select * from osquery_info;`)
 

--- a/ee/debug/checkups/osquery.go
+++ b/ee/debug/checkups/osquery.go
@@ -75,7 +75,7 @@ func (o *osqueryCheckup) interactive(ctx context.Context) error {
 	cmdCtx, cmdCancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cmdCancel()
 
-	cmd := exec.CommandContext(cmdCtx, launcherPath, "interactive", "--config", flagFilePath) //nolint:forbidigo // It is safe to exec the current running executable
+	cmd := exec.CommandContext(cmdCtx, launcherPath, "interactive", "--config", flagFilePath, "--osqueryd_path", o.k.LatestOsquerydPath(ctx)) //nolint:forbidigo // It is safe to exec the current running executable
 	hideWindow(cmd)
 	cmd.Stdin = strings.NewReader(`select * from osquery_info;`)
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1892.

https://github.com/kolide/launcher/pull/1958 appeared to fix the above issue. However, during validation for v1.12.3, we saw a new iteration of the same error -- this time, though, it wasn't a timeout error.

When testing, I am finding that whether the osquery checkup fails depends on my `localdev_path` setting (which also explains why I did not see this issue when testing the previous PR).

| `localdev_path` | Checkup fails |
|---|---|
| Not set -- launcher path will be found at `<bin-dir>\launcher.exe`  | Yes |
| Not set -- launcher path will be found at`<updates-dir>\launcher\<nightly>\launcher.exe` | Yes |
| Path to my locally-built version of main | No |
| Path to `<bin-dir>\launcher.exe` | No |
| Path to `<updates-dir>\launcher\<nightly>\launcher.exe` | Yes |

I'm not quite sure how to explain this behavior yet, especially when I can't reproduce it in my test environment. (Plus -- for my secondary install on the same computer, as well as for both installs on @zackattack01's Windows machine, this checkup consistently passes now.)

In this PR, I'm trying setting the `--config` flag to see if that will change any of the behavior here. Regardless, it's useful to set the `--config` flag so e.g. the root directory can be picked up correctly by the interactive command.