### PR TITLE
Add Windows-friendly alternative for our checkup status emojis

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -46,23 +46,6 @@ const (
 	Failing       Status = "Failing"       // Checkup is failing
 )
 
-func (s Status) Emoji() string {
-	switch s {
-	case Informational:
-		return " "
-	case Passing:
-		return "✅"
-	case Warning:
-		return "⚠️"
-	case Failing:
-		return "❌"
-	case Erroring:
-		return "❌"
-	default:
-		return "? "
-	}
-}
-
 func writeSummary(w io.Writer, s Status, name, msg string) {
 	fmt.Fprintf(w, "%s\t%s: %s\n", s.Emoji(), name, msg)
 }

--- a/ee/debug/checkups/checkups_other.go
+++ b/ee/debug/checkups/checkups_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+// +build !windows
+
+package checkups
+
+func (s Status) Emoji() string {
+	switch s {
+	case Informational:
+		return " "
+	case Passing:
+		return "✅"
+	case Warning:
+		return "⚠️"
+	case Failing:
+		return "❌"
+	case Erroring:
+		return "❌"
+	default:
+		return "? "
+	}
+}

--- a/ee/debug/checkups/checkups_windows.go
+++ b/ee/debug/checkups/checkups_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package checkups
+
+// Emoji returns the Windows-friendly symbol for the given status. Powershell will not
+// display actual emojis.
+func (s Status) Emoji() string {
+	switch s {
+	case Informational:
+		return " "
+	case Passing:
+		return "OK "
+	case Warning:
+		return "! "
+	case Failing:
+		return "X "
+	case Erroring:
+		return "X "
+	default:
+		return "? "
+	}
+}


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1433 (again).

After more research, everything I can find indicates that Powershell cannot display emojis -- oh well! This PR updates Windows only to use safe character options when displaying the status of a particular checkup.