### PR TITLE
fix InstalledVersionNum for windows build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03
 	github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc
-	github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279
+	github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a
 	github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121
 	github.com/mat/besticon v3.9.0+incompatible
 	github.com/mattn/go-sqlite3 v1.14.19

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767 h1:kcLxfX6wdtztSwpgz
 github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6 h1:6/RKW8FQlrtaBeL7We3SdpdoiGZk3Pm5STXsSxbm9ho=
 github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6/go.mod h1:zgOxCKTwS/xpJtz6LH60b3lZoQ30kqtc252N+SM4enc=
-github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279 h1:nFN/UwsX1OuTgekQWuynr1SwWlcPT8t1iNtjtm81sMA=
-github.com/kolide/kit v0.0.0-20241104170139-c647b1ab5279/go.mod h1:pFbEKXFww1uqu4RRO7qCnUmQ2EIwKYRzUqpJbODNlfc=
+github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a h1:QCPXSz6xocQ6V3Qph0H+qSnA1ewlr7GsVZ3FNZsYR/Y=
+github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a/go.mod h1:pFbEKXFww1uqu4RRO7qCnUmQ2EIwKYRzUqpJbODNlfc=
 github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121 h1:f7APX9VNsCkD/tdlAjbU4A22FyfTOCF6QadlvnzZElg=
 github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121/go.mod h1:/0sxd3OIxciTlMTeZI/9WTaUHsx/K/+3f+NbD5dywTY=
 github.com/kolide/systray v1.10.5-0.20241021175748-13aef6380bdb h1:d2pfEh5Yd6+C+D096YQlHwcq28TPOjoeoG+lCQojkJM=

--- a/pkg/packagekit/package_wix.go
+++ b/pkg/packagekit/package_wix.go
@@ -57,7 +57,7 @@ func PackageWixMSI(ctx context.Context, w io.Writer, po *PackageOptions, include
 	// store this in the registry on install to give a comparable field
 	// for intune to drive upgrade behavior from
 	if po.VersionNum == 0 {
-		po.VersionNum = version.VersionNum()
+		po.VersionNum = version.VersionNumFromSemver(po.Version)
 	}
 
 	// We include a random nonce as part of the ProductCode


### PR DESCRIPTION
The previous attempt at setting the `InstalledVersionNum` does not work unless the proper kit/version value can be known and set ahead of build time by the packaging logic (e.g. only works when invoked from package-builder directly). To allow this logic to be included and built elsewhere, we can instead generate the VersionNum based on the detected version set in our packaging options