### PR TITLE
Switch from CoInitialize to CoInitializeEx

### DIFF
--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -228,9 +228,9 @@ func installWatchdogTask(identifier, configFilePath string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
+	// init COM - we discard the error returned by CoInitializeEx because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
+	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object
@@ -504,9 +504,9 @@ func RemoveWatchdogTask(identifier string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
+	// init COM - we discard the error returned by CoInitializeEx because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
+	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object
@@ -555,9 +555,9 @@ func watchdogTaskExists(identifier string) (bool, error) {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
+	// init COM - we discard the error returned by CoInitializeEx because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
+	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object


### PR DESCRIPTION
I noticed some errors in the logs for the test devices with the watchdog enabled:

```
encountered error checking if watchdog task exists: creating schedule service object: CoInitialize has not been called.
```

We have already called `CoInitialize` immediately prior to creating the schedule service object, so this error doesn't make a ton of sense.

When looking through the go-ole issues, I found https://github.com/go-ole/go-ole/issues/124 and https://github.com/go-ole/go-ole/issues/246, both of which seem to indicate that calling `CoInitialize` instead of `CoInitializeEx` may be the culprit. I've updated accordingly.

My test device has not emitted this error, but I have regression tested that publishing watchdog logs works; I also tested reinstalling the watchdog task.

This is not a terribly high-priority item -- I think the worst this error could do is prevent us from publishing watchdog logs.