### PR TITLE
Make socket path length shorter for launcher interactive

### DIFF
--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -31,7 +31,10 @@ func StartProcess(knapsack types.Knapsack, interactiveRootDir string) (*os.Proce
 		return nil, nil, fmt.Errorf("creating root dir for interactive mode: %w", err)
 	}
 
-	socketPath := osqueryRuntime.SocketPath(interactiveRootDir, ulid.New())
+	// We need a shorter ulid to avoid running into socket path length issues.
+	socketId := ulid.New()
+	truncatedSocketId := socketId[len(socketId)-4:]
+	socketPath := osqueryRuntime.SocketPath(interactiveRootDir, truncatedSocketId)
 	augeasLensesPath := filepath.Join(interactiveRootDir, "augeas-lenses")
 
 	// only install augeas lenses on non-windows platforms


### PR DESCRIPTION
If running launcher interactive as a regular user and not as root on macOS, we encounter:

```
W1203 10:47:40.111027 1834905600 interface.cpp:303] Extensions disabled: cannot start extension manager (/var/folders/4d/jfl75r312llb4k5j5kgp4j240000gn/T/launcher-interactive964752058/osquery-01JE6K9AS0MRYM0NKZRRTKVMWM.sock) ( Unix Domain socket path too long)
```

This is because the temporary directory location is different (and longer) when running as a user.

In this PR, we truncate the ULID used to identify the socket to a safer length.