### PR TITLE
Expose osquery instance status to knapsack

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -389,6 +389,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		osqueryruntime.WithAugeasLensFunction(augeas.InstallLenses),
 	)
 	runGroup.Add("osqueryRunner", osqueryRunner.Run, osqueryRunner.Interrupt)
+	k.SetInstanceQuerier(osqueryRunner)
 
 	versionInfo := version.Version()
 	k.SystemSlogger().Log(ctx, slog.LevelInfo,

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -39,9 +39,9 @@ type knapsack struct {
 
 	slogger, systemSlogger *multislogger.MultiSlogger
 
+	querier types.InstanceQuerier
+
 	// This struct is a work in progress, and will be iteratively added to as needs arise.
-	// Some potential future additions include:
-	// Querier
 }
 
 func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB, slogger, systemSlogger *multislogger.MultiSlogger) *knapsack {
@@ -85,6 +85,18 @@ func (k *knapsack) SystemSlogger() *slog.Logger {
 func (k *knapsack) AddSlogHandler(handler ...slog.Handler) {
 	k.slogger.AddHandler(handler...)
 	k.systemSlogger.AddHandler(handler...)
+}
+
+// Osquery instance querier
+func (k *knapsack) SetInstanceQuerier(q types.InstanceQuerier) {
+	k.querier = q
+}
+
+func (k *knapsack) InstanceStatuses() map[string]types.InstanceStatus {
+	if k.querier == nil {
+		return nil
+	}
+	return k.querier.InstanceStatuses()
 }
 
 // BboltDB interface methods

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -92,6 +92,8 @@ func (k *knapsack) SetInstanceQuerier(q types.InstanceQuerier) {
 	k.querier = q
 }
 
+// InstanceStatuses returns the current status of each osquery instance.
+// It performs a healthcheck against each existing instance.
 func (k *knapsack) InstanceStatuses() map[string]types.InstanceStatus {
 	if k.querier == nil {
 		return nil

--- a/ee/agent/types/knapsack.go
+++ b/ee/agent/types/knapsack.go
@@ -9,6 +9,8 @@ type Knapsack interface {
 	BboltDB
 	Flags
 	Slogger
+	InstanceQuerier
+	SetInstanceQuerier(q InstanceQuerier)
 	// LatestOsquerydPath finds the path to the latest osqueryd binary, after accounting for updates.
 	LatestOsquerydPath(ctx context.Context) string
 	// ReadEnrollSecret returns the enroll secret value, checking in various locations.

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -672,6 +672,26 @@ func (_m *Knapsack) InsecureTransportTLS() bool {
 	return r0
 }
 
+// InstanceStatuses provides a mock function with given fields:
+func (_m *Knapsack) InstanceStatuses() map[string]types.InstanceStatus {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstanceStatuses")
+	}
+
+	var r0 map[string]types.InstanceStatus
+	if rf, ok := ret.Get(0).(func() map[string]types.InstanceStatus); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]types.InstanceStatus)
+		}
+	}
+
+	return r0
+}
+
 // KatcConfigStore provides a mock function with given fields:
 func (_m *Knapsack) KatcConfigStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
 	ret := _m.Called()
@@ -1528,6 +1548,11 @@ func (_m *Knapsack) SetInsecureTransportTLS(insecure bool) error {
 	}
 
 	return r0
+}
+
+// SetInstanceQuerier provides a mock function with given fields: q
+func (_m *Knapsack) SetInstanceQuerier(q types.InstanceQuerier) {
+	_m.Called(q)
 }
 
 // SetKolideServerURL provides a mock function with given fields: url

--- a/ee/agent/types/querier.go
+++ b/ee/agent/types/querier.go
@@ -1,0 +1,14 @@
+package types
+
+type InstanceStatus string
+
+const (
+	InstanceStatusNotStarted InstanceStatus = "not_started"
+	InstanceStatusHealthy    InstanceStatus = "healthy"
+	InstanceStatusUnhealthy  InstanceStatus = "unhealthy"
+)
+
+// InstanceQuerier is implemented by pkg/osquery/runtime/runner.go
+type InstanceQuerier interface {
+	InstanceStatuses() map[string]InstanceStatus
+}

--- a/ee/debug/checkups/osquery.go
+++ b/ee/debug/checkups/osquery.go
@@ -14,10 +14,11 @@ import (
 )
 
 type osqueryCheckup struct {
-	k              types.Knapsack
-	status         Status
-	executionTimes map[string]any // maps command to how long it took to run, in ms
-	summary        string
+	k                types.Knapsack
+	status           Status
+	executionTimes   map[string]any // maps command to how long it took to run, in ms
+	instanceStatuses map[string]types.InstanceStatus
+	summary          string
 }
 
 func (o *osqueryCheckup) Name() string {
@@ -39,6 +40,8 @@ func (o *osqueryCheckup) Run(ctx context.Context, extraWriter io.Writer) error {
 	if err := o.interactive(ctx); err != nil {
 		return fmt.Errorf("running launcher interactive: %w", err)
 	}
+
+	o.instanceStatuses = o.k.InstanceStatuses()
 
 	return nil
 }
@@ -102,5 +105,8 @@ func (o *osqueryCheckup) Summary() string {
 }
 
 func (o *osqueryCheckup) Data() any {
-	return o.executionTimes
+	return map[string]any{
+		"execution_time":    o.executionTimes,
+		"instance_statuses": o.instanceStatuses,
+	}
 }

--- a/ee/localserver/request-id.go
+++ b/ee/localserver/request-id.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/ulid"
+	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/traces"
 )
 
@@ -30,6 +31,7 @@ type (
 
 	status struct {
 		EnrollmentStatus string
+		InstanceStatuses map[string]types.InstanceStatus
 	}
 )
 
@@ -82,6 +84,7 @@ func (ls *localServer) requestIdHandlerFunc(w http.ResponseWriter, r *http.Reque
 		Origin:    r.Header.Get("Origin"),
 		Status: status{
 			EnrollmentStatus: string(enrollmentStatus),
+			InstanceStatuses: ls.knapsack.InstanceStatuses(),
 		},
 	}
 	response.identifiers = ls.identifiers

--- a/ee/localserver/request-id_test.go
+++ b/ee/localserver/request-id_test.go
@@ -27,6 +27,7 @@ func Test_localServer_requestIdHandler(t *testing.T) {
 	mockKnapsack.On("ConfigStore").Return(storageci.NewStore(t, multislogger.NewNopLogger(), storage.ConfigStore.String()))
 	mockKnapsack.On("KolideServerURL").Return("localhost")
 	mockKnapsack.On("CurrentEnrollmentStatus").Return(types.Enrolled, nil)
+	mockKnapsack.On("InstanceStatuses").Return(map[string]types.InstanceStatus{"default": types.InstanceStatusHealthy})
 
 	var logBytes bytes.Buffer
 	slogger := slog.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -315,3 +315,26 @@ func (r *Runner) Healthy() error {
 
 	return nil
 }
+
+func (r *Runner) InstanceStatuses() map[string]types.InstanceStatus {
+	r.instanceLock.Lock()
+	defer r.instanceLock.Unlock()
+
+	instanceStatuses := make(map[string]types.InstanceStatus)
+	for _, registrationId := range r.registrationIds {
+		instance, ok := r.instances[registrationId]
+		if !ok {
+			instanceStatuses[registrationId] = types.InstanceStatusNotStarted
+			continue
+		}
+
+		if err := instance.Healthy(); err != nil {
+			instanceStatuses[registrationId] = types.InstanceStatusUnhealthy
+			continue
+		}
+
+		instanceStatuses[registrationId] = types.InstanceStatusHealthy
+	}
+
+	return instanceStatuses
+}

--- a/pkg/osquery/runtime/runtime_helpers.go
+++ b/pkg/osquery/runtime/runtime_helpers.go
@@ -30,6 +30,6 @@ func platformArgs() []string {
 	return nil
 }
 
-func isExitOk(err error) bool {
+func isExitOk(_ error) bool {
 	return false
 }

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/storage"
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	"github.com/kolide/launcher/ee/agent/storage/inmemory"
+	"github.com/kolide/launcher/ee/agent/types"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	kolidelog "github.com/kolide/launcher/ee/log/osquerylogs"
 	"github.com/kolide/launcher/pkg/backoff"
@@ -388,6 +389,13 @@ func TestMultipleInstances(t *testing.T) {
 	require.NotNil(t, runner.instances[extraRegistrationId].stats)
 	require.NotEmpty(t, runner.instances[extraRegistrationId].stats.StartTime, "start time should be added to secondary instance stats on start up")
 	require.NotEmpty(t, runner.instances[extraRegistrationId].stats.ConnectTime, "connect time should be added to secondary instance stats on start up")
+
+	// Confirm instance statuses are reported correctly
+	instanceStatuses := runner.InstanceStatuses()
+	require.Contains(t, instanceStatuses, defaultRegistrationId)
+	require.Equal(t, instanceStatuses[defaultRegistrationId], types.InstanceStatusHealthy)
+	require.Contains(t, instanceStatuses, extraRegistrationId)
+	require.Equal(t, instanceStatuses[extraRegistrationId], types.InstanceStatusHealthy)
 
 	waitShutdown(t, runner, logBytes)
 


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/1938

Adds a new function to expose the current status (not yet started, healthy, or unhealthy) of each instance. Adds this data to the status blob returned by the /id localserver endpoint, and to the osquery checkup.

This also makes the osquery runner available in the knapsack, which may be useful in the future.