### PR TITLE
Pass registration ID in to osquery extension

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -36,6 +36,7 @@ import (
 type Extension struct {
 	NodeKey             string
 	Opts                ExtensionOpts
+	registrationId      string
 	knapsack            types.Knapsack
 	serviceClient       service.KolideService
 	enrollMutex         sync.Mutex
@@ -97,11 +98,11 @@ func (e iterationTerminatedError) Error() string {
 // NewExtension creates a new Extension from the provided service.KolideService
 // implementation. The background routines should be started by calling
 // Start().
-func NewExtension(ctx context.Context, client service.KolideService, k types.Knapsack, opts ExtensionOpts) (*Extension, error) {
+func NewExtension(ctx context.Context, client service.KolideService, k types.Knapsack, registrationId string, opts ExtensionOpts) (*Extension, error) {
 	_, span := traces.StartSpan(ctx)
 	defer span.End()
 
-	slogger := k.Slogger().With("component", "osquery_extension")
+	slogger := k.Slogger().With("component", "osquery_extension", "registration_id", registrationId)
 
 	if opts.MaxBytesPerBatch == 0 {
 		opts.MaxBytesPerBatch = defaultMaxBytesPerBatch
@@ -137,6 +138,7 @@ func NewExtension(ctx context.Context, client service.KolideService, k types.Kna
 	return &Extension{
 		slogger:             slogger,
 		serviceClient:       client,
+		registrationId:      registrationId,
 		knapsack:            k,
 		NodeKey:             nodekey,
 		Opts:                opts,

--- a/pkg/osquery/log_publication_state_test.go
+++ b/pkg/osquery/log_publication_state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/pkg/service/mock"
 	"github.com/osquery/osquery-go/plugin/logger"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ func TestExtensionLogPublicationHappyPath(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
+	e, err := NewExtension(context.TODO(), m, k, ulid.New(), ExtensionOpts{
 		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)
@@ -59,7 +60,7 @@ func TestExtensionLogPublicationRespondsToNetworkTimeouts(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
+	e, err := NewExtension(context.TODO(), m, k, ulid.New(), ExtensionOpts{
 		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)
@@ -110,7 +111,7 @@ func TestExtensionLogPublicationIgnoresNonTimeoutErrors(t *testing.T) {
 	db, cleanup := makeTempDB(t)
 	defer cleanup()
 	k := makeKnapsack(t, db)
-	e, err := NewExtension(context.TODO(), m, k, ExtensionOpts{
+	e, err := NewExtension(context.TODO(), m, k, ulid.New(), ExtensionOpts{
 		MaxBytesPerBatch: startingBatchLimitBytes,
 	})
 	require.Nil(t, err)

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -598,7 +598,7 @@ func (i *OsqueryInstance) startKolideSaasExtension(ctx context.Context) error {
 
 	// Create the extension
 	var err error
-	i.saasExtension, err = launcherosq.NewExtension(ctx, i.serviceClient, i.knapsack, extOpts)
+	i.saasExtension, err = launcherosq.NewExtension(ctx, i.serviceClient, i.knapsack, i.registrationId, extOpts)
 	if err != nil {
 		return fmt.Errorf("creating new extension: %w", err)
 	}


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1939 -- just another quick PR to get some easy boilerplate out of the way.

The osquery extension will need access to its registration ID to be able to query the database for the correct registration -- this PR gives it access to its registration ID, and updates its logs to include the registration ID so we'll be able to distinguish between extension logs when we have more than one osquery instance.