### PR TITLE
One log adapter per osquery instance; set registration ID and instance run ID on log adapter

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -42,7 +42,6 @@ import (
 	"github.com/kolide/launcher/ee/debug/checkups"
 	desktopRunner "github.com/kolide/launcher/ee/desktop/runner"
 	"github.com/kolide/launcher/ee/localserver"
-	kolidelog "github.com/kolide/launcher/ee/log/osquerylogs"
 	"github.com/kolide/launcher/ee/powereventwatcher"
 	"github.com/kolide/launcher/ee/tuf"
 	"github.com/kolide/launcher/ee/watchdog"
@@ -371,22 +370,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	osqueryRunner := osqueryruntime.New(
 		k,
 		client,
-		osqueryruntime.WithStdout(kolidelog.NewOsqueryLogAdapter(
-			k.Slogger().With(
-				"component", "osquery",
-				"osqlevel", "stdout",
-			),
-			k.RootDirectory(),
-			kolidelog.WithLevel(slog.LevelDebug),
-		)),
-		osqueryruntime.WithStderr(kolidelog.NewOsqueryLogAdapter(
-			k.Slogger().With(
-				"component", "osquery",
-				"osqlevel", "stderr",
-			),
-			k.RootDirectory(),
-			kolidelog.WithLevel(slog.LevelInfo),
-		)),
 		osqueryruntime.WithAugeasLensFunction(augeas.InstallLenses),
 	)
 	runGroup.Add("osqueryRunner", osqueryRunner.Run, osqueryRunner.Interrupt)

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -61,13 +60,12 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
 	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("RootDirectory").Return("")
 
-	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(), WithStdout(os.Stdout), WithStderr(os.Stderr))
+	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
 
-	cmd, err := i.createOsquerydCommand(osquerydPath, paths)
+	_, err := i.createOsquerydCommand(osquerydPath, paths)
 	require.NoError(t, err)
-	require.Equal(t, os.Stderr, cmd.Stderr)
-	require.Equal(t, os.Stdout, cmd.Stdout)
 
 	k.AssertExpectations(t)
 }
@@ -83,6 +81,7 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	k.On("OsqueryFlags").Return([]string{"verbose=false", "windows_event_channels=foo,bar"})
 	k.On("OsqueryVerbose").Return(true)
 	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("RootDirectory").Return("")
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
 
@@ -116,6 +115,7 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
+	k.On("RootDirectory").Return("")
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
 
@@ -165,6 +165,7 @@ func TestCreateOsqueryCommand_SetsDisabledWatchdogSettingsAppropriately(t *testi
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
+	k.On("RootDirectory").Return("")
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
 

--- a/pkg/osquery/runtime/osqueryinstance_windows_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_windows_test.go
@@ -26,6 +26,7 @@ func TestCreateOsqueryCommandEnvVars(t *testing.T) {
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
 	k.On("Slogger").Return(multislogger.NewNopLogger())
+	k.On("RootDirectory").Return("")
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
 

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -39,7 +39,7 @@ func TestOsquerySlowStart(t *testing.T) {
 
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -57,7 +57,7 @@ func TestOsquerySlowStart(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	opts = append(opts, WithStartFunc(func(cmd *exec.Cmd) error {
+	runner := New(k, mockServiceClient(), WithStartFunc(func(cmd *exec.Cmd) error {
 		err := cmd.Start()
 		if err != nil {
 			return fmt.Errorf("unexpected error starting command: %w", err)
@@ -71,8 +71,6 @@ func TestOsquerySlowStart(t *testing.T) {
 		}()
 		return nil
 	}))
-
-	runner := New(k, mockServiceClient(), opts...)
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 
@@ -88,7 +86,7 @@ func TestExtensionSocketPath(t *testing.T) {
 
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -107,9 +105,8 @@ func TestExtensionSocketPath(t *testing.T) {
 	setUpMockStores(t, k)
 
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
-	opts = append(opts, WithExtensionSocketPath(extensionSocketPath))
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient(), WithExtensionSocketPath(extensionSocketPath))
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kolide/launcher/ee/agent/storage/inmemory"
 	"github.com/kolide/launcher/ee/agent/types"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
-	kolidelog "github.com/kolide/launcher/ee/log/osquerylogs"
 	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
@@ -119,7 +118,7 @@ func TestBadBinaryPath(t *testing.T) {
 	t.Parallel()
 	rootDirectory := t.TempDir()
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -137,7 +136,7 @@ func TestBadBinaryPath(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 
 	// The runner will repeatedly try to launch the instance, so `Run`
 	// won't return an error until we shut it down. Kick off `Run`,
@@ -156,7 +155,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -174,7 +173,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 	waitShutdown(t, runner, logBytes)
@@ -185,7 +184,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -209,7 +208,7 @@ func TestFlagsChanged(t *testing.T) {
 	setUpMockStores(t, k)
 
 	// Start the runner
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 	go runner.Run()
 
 	// Wait for the instance to start
@@ -321,7 +320,7 @@ func TestSimplePath(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -339,7 +338,7 @@ func TestSimplePath(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)
@@ -354,7 +353,7 @@ func TestMultipleInstances(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	// Add in an extra instance
 	extraRegistrationId := ulid.New()
@@ -376,7 +375,7 @@ func TestMultipleInstances(t *testing.T) {
 	setUpMockStores(t, k)
 	serviceClient := mockServiceClient()
 
-	runner := New(k, serviceClient, opts...)
+	runner := New(k, serviceClient)
 
 	// Start the instance
 	go runner.Run()
@@ -416,7 +415,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -435,7 +434,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	setUpMockStores(t, k)
 	serviceClient := mockServiceClient()
 
-	runner := New(k, serviceClient, opts...)
+	runner := New(k, serviceClient)
 
 	// Add in an extra instance
 	extraRegistrationId := ulid.New()
@@ -467,7 +466,7 @@ func TestMultipleShutdowns(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -485,7 +484,7 @@ func TestMultipleShutdowns(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)
@@ -499,7 +498,7 @@ func TestOsqueryDies(t *testing.T) {
 	t.Parallel()
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -517,7 +516,7 @@ func TestOsqueryDies(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), opts...)
+	runner := New(k, mockServiceClient())
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)
@@ -598,7 +597,7 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, teardown func()) {
 	rootDirectory := testRootDirectory(t)
 
-	logBytes, slogger, opts := setUpTestSlogger(rootDirectory)
+	logBytes, slogger := setUpTestSlogger()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
@@ -619,7 +618,7 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	setUpMockStores(t, k)
 
-	runner = New(k, mockServiceClient(), opts...)
+	runner = New(k, mockServiceClient())
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 
@@ -672,7 +671,7 @@ func mockServiceClient() *servicemock.KolideService {
 }
 
 // setUpTestSlogger sets up a logger that will log to a buffer.
-func setUpTestSlogger(rootDirectory string) (*threadsafebuffer.ThreadSafeBuffer, *slog.Logger, []OsqueryInstanceOption) {
+func setUpTestSlogger() (*threadsafebuffer.ThreadSafeBuffer, *slog.Logger) {
 	logBytes := &threadsafebuffer.ThreadSafeBuffer{}
 
 	slogger := slog.New(slog.NewTextHandler(logBytes, &slog.HandlerOptions{
@@ -680,27 +679,7 @@ func setUpTestSlogger(rootDirectory string) (*threadsafebuffer.ThreadSafeBuffer,
 		Level:     slog.LevelDebug,
 	}))
 
-	// Capture osquery logs too
-	opts := []OsqueryInstanceOption{
-		WithStdout(kolidelog.NewOsqueryLogAdapter(
-			slogger.With(
-				"component", "osquery",
-				"osqlevel", "stdout",
-			),
-			rootDirectory,
-			kolidelog.WithLevel(slog.LevelDebug),
-		)),
-		WithStderr(kolidelog.NewOsqueryLogAdapter(
-			slogger.With(
-				"component", "osquery",
-				"osqlevel", "stderr",
-			),
-			rootDirectory,
-			kolidelog.WithLevel(slog.LevelDebug),
-		)),
-	}
-
-	return logBytes, slogger, opts
+	return logBytes, slogger
 }
 
 // testRootDirectory returns a temporary directory suitable for use in these tests.


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1827

This PR updates where we set stdout/stderr for the osquery command and sets the instance run ID and registration ID on the log adapter's slogger, so that we can distinguish between logs from different instances more easily.