### PR TITLE
update krypto

### DIFF
--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -228,7 +228,7 @@ func TestKryptoEcMiddleware(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, challengeId, responseUnmarshalled.ChallengeId)
 
-					opened, err := responseUnmarshalled.Open(*privateEncryptionKey)
+					opened, err := responseUnmarshalled.Open(privateEncryptionKey)
 					require.NoError(t, err)
 					require.Equal(t, challengeData, opened.ChallengeData)
 
@@ -402,7 +402,7 @@ func Test_AllowedOrigin(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, challengeId, responseUnmarshalled.ChallengeId)
 
-			opened, err := responseUnmarshalled.Open(*privateEncryptionKey)
+			opened, err := responseUnmarshalled.Open(privateEncryptionKey)
 			require.NoError(t, err)
 			require.Equal(t, challengeData, opened.ChallengeData)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/groob/plist v0.0.0-20190114192801-a99fbe489d03
 	github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc
 	github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a
-	github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121
+	github.com/kolide/krypto v0.1.1-0.20241212211625-46a8d5cad1cc
 	github.com/mat/besticon v3.9.0+incompatible
 	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6 h1:6/RKW8FQlrtaBe
 github.com/kolide/goleveldb v0.0.0-20240514204455-8d30cd4d31c6/go.mod h1:zgOxCKTwS/xpJtz6LH60b3lZoQ30kqtc252N+SM4enc=
 github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a h1:QCPXSz6xocQ6V3Qph0H+qSnA1ewlr7GsVZ3FNZsYR/Y=
 github.com/kolide/kit v0.0.0-20241126150023-fbf6f0f5bf6a/go.mod h1:pFbEKXFww1uqu4RRO7qCnUmQ2EIwKYRzUqpJbODNlfc=
-github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121 h1:f7APX9VNsCkD/tdlAjbU4A22FyfTOCF6QadlvnzZElg=
-github.com/kolide/krypto v0.1.1-0.20231229162826-db516b7e0121/go.mod h1:/0sxd3OIxciTlMTeZI/9WTaUHsx/K/+3f+NbD5dywTY=
+github.com/kolide/krypto v0.1.1-0.20241212211625-46a8d5cad1cc h1:tuEDXi6ZftPX6JYR4JwRkRe1oPPS1Y+OUUNOEwBXwOg=
+github.com/kolide/krypto v0.1.1-0.20241212211625-46a8d5cad1cc/go.mod h1:wGQHTBFhzTJKIVMbzvanNO1r3Uz4xD20WEPkF0sTN9A=
 github.com/kolide/systray v1.10.5-0.20241021175748-13aef6380bdb h1:d2pfEh5Yd6+C+D096YQlHwcq28TPOjoeoG+lCQojkJM=
 github.com/kolide/systray v1.10.5-0.20241021175748-13aef6380bdb/go.mod h1:rnPcECLGM9DY/+fb3O9WNKiPBPMCdNg3rkyadLWOCTU=
 github.com/kolide/toast v1.0.2 h1:BQlIfO3wbKIEWfF0c8v4UkdhSIZYnSWaKkZl+Yarptk=


### PR DESCRIPTION
update krypto, go mod tidy

Bumps krypto [golang.org/x/crypto](https://github.com/golang/crypto) from 0.17.0 to 0.31.0.