### PR TITLE
A notification is successful as long as we can send to at least one user

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -437,13 +437,17 @@ func (r *DesktopUsersProcessesRunner) SendNotification(n notify.Notification) er
 
 	atLeastOneSuccess := false
 	errs := make([]error, 0)
-	for _, proc := range r.uidProcs {
+	for uid, proc := range r.uidProcs {
 		client := client.New(r.userServerAuthToken, proc.socketPath)
 		if err := client.Notify(n); err != nil {
 			errs = append(errs, err)
 			continue
 		}
 
+		r.slogger.Log(context.TODO(), slog.LevelDebug,
+			"sent notification",
+			"uid", uid,
+		)
 		atLeastOneSuccess = true
 	}
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -435,19 +435,24 @@ func (r *DesktopUsersProcessesRunner) SendNotification(n notify.Notification) er
 		return errors.New("cannot send notification, no child desktop processes")
 	}
 
+	atLeastOneSuccess := false
 	errs := make([]error, 0)
 	for _, proc := range r.uidProcs {
 		client := client.New(r.userServerAuthToken, proc.socketPath)
 		if err := client.Notify(n); err != nil {
 			errs = append(errs, err)
+			continue
 		}
+
+		atLeastOneSuccess = true
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("errors sending notifications: %+v", errs)
+	// We just need to be able to notify one user successfully.
+	if atLeastOneSuccess {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("errors sending notifications: %+v", errs)
 }
 
 // Update handles control server updates for the desktop-menu subsystem
@@ -501,7 +506,7 @@ func (r *DesktopUsersProcessesRunner) FlagsChanged(flagKeys ...keys.FlagKey) {
 				"sending refresh command to user desktop process",
 				"uid", uid,
 				"pid", proc.Process.Pid,
-				"path", proc.path,
+				"path", proc.socketPath,
 				"err", err,
 			)
 		}


### PR DESCRIPTION
Addresses part of https://github.com/kolide/launcher/issues/1999.

We realized that notifications were being successfully sent to user 501 but not 502, which launcher interpreted as a failure to notify. Therefore, it retried notification. However, the actual end user received the original notification when logged in as user 501 -- and then received repeat notifications every minute thereafter.

This PR corrects that issue, by counting one successfully sent notification as a success.

I also added a log for successfully sending a notification; it would have made tracking down this issue a little easier.