### PR TITLE
Move launcher tests to their own job to make it faster to re-run on failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -122,6 +122,7 @@ jobs:
 
   launcher_test:
     name: test
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -131,6 +132,13 @@ jobs:
           - macos-13
           - windows-latest
     steps:
+    - name: cache restore build output
+      uses: actions/cache/restore@v4
+      with:
+        path: ./build
+        key: ${{ runner.os }}-${{ github.run_id }}
+        enableCrossOsArchive: true
+
     - name: Check out code
       id: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -111,6 +111,7 @@ jobs:
 
   launcher_test:
     name: test
+    needs: build # a desktop runner test requires a build to exist
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -132,6 +133,13 @@ jobs:
         go-version-file: './go.mod'
         check-latest: true
         cache: false
+
+    - name: cache restore build output
+      uses: actions/cache/restore@v4
+      with:
+        path: ./build
+        key: ${{ runner.os }}-${{ github.run_id }}
+        enableCrossOsArchive: true
 
     - name: Test
       run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,9 @@ jobs:
           - ubuntu-20.04
           - macos-13
           - windows-latest
+    outputs:
+      go-build-path: ${{ steps.go-cache-paths.outputs.go-build }}
+      go-mod-path: ${{ steps.go-cache-paths.outputs.go-mod }}
     steps:
     - name: Check out code
       id: checkout
@@ -134,11 +137,25 @@ jobs:
         check-latest: true
         cache: false
 
-    - name: cache restore build output
+    - name: cache restore - build output
       uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
+        enableCrossOsArchive: true
+
+    - name: cache restore - go-build
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ needs.build.outputs.go-build-path }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+        enableCrossOsArchive: true
+
+    - name: cache restore - go-mod
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ needs.build.outputs.go-mod-path }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
         enableCrossOsArchive: true
 
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ on:
 
 
 jobs:
-  build_and_test:
+  build:
     name: launcher
     runs-on: ${{ matrix.os }}
     strategy:
@@ -103,7 +103,7 @@ jobs:
   version_baseline:
     name: Version Baseline
     runs-on: ubuntu-20.04
-    needs: build_and_test
+    needs: build
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -119,6 +119,33 @@ jobs:
       working-directory: build
       shell: bash
       run: ./launcher --version 2>/dev/null | awk '/version /{print "version="$4}' >> "$GITHUB_OUTPUT"
+
+  launcher_test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-13
+          - windows-latest
+    steps:
+    - name: Check out code
+      id: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # need a full checkout for `git describe`
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: './go.mod'
+        check-latest: true
+        cache: false
+
+    - name: Test
+      run: make test
 
   exec_testing:
     name: Exec Test
@@ -270,6 +297,7 @@ jobs:
     steps:
       - run: true
     needs:
-      - build_and_test
+      - build
+      - launcher_test
       - package_builder_test
       - exec_testing

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,9 +22,6 @@ jobs:
           - ubuntu-20.04
           - macos-13
           - windows-latest
-    outputs:
-      go-build-path: ${{ steps.go-cache-paths.outputs.go-build }}
-      go-mod-path: ${{ steps.go-cache-paths.outputs.go-mod }}
     steps:
     - name: Check out code
       id: checkout
@@ -144,17 +141,23 @@ jobs:
         key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
+    - id: go-cache-paths
+      shell: bash
+      run: |
+        echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
     - name: cache restore - GOCACHE
       uses: actions/cache/restore@v4
       with:
-        path: ${{ needs.build.outputs.go-build-path }}
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         enableCrossOsArchive: true
 
     - name: cache restore - GOMODCACHE
       uses: actions/cache/restore@v4
       with:
-        path: ${{ needs.build.outputs.go-mod-path }}
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
         enableCrossOsArchive: true
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -137,21 +137,21 @@ jobs:
         check-latest: true
         cache: false
 
-    - name: cache restore - build output
+    - name: cache restore - build
       uses: actions/cache/restore@v4
       with:
         path: ./build
         key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
-    - name: cache restore - go-build
+    - name: cache restore - GOCACHE
       uses: actions/cache/restore@v4
       with:
         path: ${{ needs.build.outputs.go-build-path }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         enableCrossOsArchive: true
 
-    - name: cache restore - go-mod
+    - name: cache restore - GOMODCACHE
       uses: actions/cache/restore@v4
       with:
         path: ${{ needs.build.outputs.go-mod-path }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,9 +79,6 @@ jobs:
       run: make github-launcherapp
       if: ${{ contains(matrix.os, 'macos') }}
 
-    - name: Test
-      run: make test
-
     - name: Cache build output
       uses: actions/cache@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -111,7 +111,6 @@ jobs:
 
   launcher_test:
     name: test
-    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -121,13 +120,6 @@ jobs:
           - macos-13
           - windows-latest
     steps:
-    - name: cache restore build output
-      uses: actions/cache/restore@v4
-      with:
-        path: ./build
-        key: ${{ runner.os }}-${{ github.run_id }}
-        enableCrossOsArchive: true
-
     - name: Check out code
       id: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,14 +86,6 @@ jobs:
         key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
-    # upload coverage here, because we don't cache it with the build
-    - name: Upload coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ runner.os }}-coverage.out
-        path: ./coverage.out
-        if-no-files-found: error
-
   # this job captures the version of launcher on one of the runners then that version is
   # compared to the version of all other runners during exec testing. This is to ensure
   # that the version of launcher is the same across all runners.
@@ -151,6 +143,13 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ runner.os }}-coverage.out
+        path: ./coverage.out
+        if-no-files-found: error
 
   exec_testing:
     name: Exec Test

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ proto:
 	@echo "Generated code from proto definitions."
 
 test: generate
-	go test -cover -coverprofile=coverage.out -race $(shell go list ./... | grep -v /vendor/)
+	go test -cover -coverprofile=coverage.out -race ./...
 
 ##
 ## Lint

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -42,7 +42,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 	}
 
 	// due to flakey tests we are tracking the time it takes to build and attempting emit a meaningful error if we time out
-	timeout := time.Second * 60
+	timeout := time.Minute * 2
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2001.

Some of our tests are flaky, which means we have to re-run failed jobs. This PR updates our workflow to move the tests to their own job, so we don't have to perform a full build before re-running tests.