### PR TITLE
add min interval between presence detections

### DIFF
--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -431,6 +431,7 @@ func (ls *localServer) presenceDetectionHandler(next http.Handler) http.Handler 
 		if time.Since(ls.lastPresenceDetectionAttempt) < minTimeBetweenPresenceDetection {
 			ls.slogger.Log(r.Context(), slog.LevelInfo,
 				"presence detection attempted too soon",
+				"min_interval", minTimeBetweenPresenceDetection,
 			)
 
 			w.Header().Add(kolideDurationSinceLastPresenceDetectionHeaderKey, presencedetection.DetectionFailedDurationValue.String())


### PR DESCRIPTION
Fixes an annoyance where if you cancel a presence detection request, another one can't immediately pop up. 