### PR TITLE
drop reqs when detection locked

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -290,21 +290,20 @@ func (r *DesktopUsersProcessesRunner) DetectPresence(reason string, interval tim
 	}
 
 	var lastErr error
-	var lastDurationSinceLastDetection time.Duration
 
 	for _, proc := range r.uidProcs {
 		client := client.New(r.userServerAuthToken, proc.socketPath)
-		lastDurationSinceLastDetection, err := client.DetectPresence(reason, interval)
 
+		durationSinceLastDetection, err := client.DetectPresence(reason, interval)
 		if err != nil {
 			lastErr = err
 			continue
 		}
 
-		return lastDurationSinceLastDetection, nil
+		return durationSinceLastDetection, nil
 	}
 
-	return lastDurationSinceLastDetection, fmt.Errorf("no desktop processes detected presence, last error: %w", lastErr)
+	return presencedetection.DetectionFailedDurationValue, fmt.Errorf("no desktop processes detected presence, last error: %w", lastErr)
 }
 
 // killDesktopProcesses kills any existing desktop processes

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -513,10 +513,10 @@ func TestDesktopUsersProcessesRunner_DetectPresence(t *testing.T) {
 		u, err := user.Current()
 		require.NoError(t, err)
 
-		runner := DesktopUsersProcessesRunner{}
-		runner.uidProcs = make(map[string]processRecord)
-		runner.uidProcs[u.Uid] = processRecord{
-			socketPath: "/tmp/doesntexist",
+		runner := DesktopUsersProcessesRunner{
+			uidProcs: map[string]processRecord{
+				u.Uid: {},
+			},
 		}
 
 		d, err := runner.DetectPresence("whatevs", time.Second)

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/desktop/user/notify"
+	"github.com/kolide/launcher/ee/presencedetection"
 	"github.com/kolide/launcher/pkg/backoff"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/threadsafebuffer"
@@ -492,4 +493,34 @@ func countFilesWithPrefix(folderPath, prefix string) (int, error) {
 	}
 
 	return count, nil
+}
+
+func TestDesktopUsersProcessesRunner_DetectPresence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no user procs", func(t *testing.T) {
+		t.Parallel()
+
+		runner := DesktopUsersProcessesRunner{}
+		d, err := runner.DetectPresence("whatevs", time.Second)
+		require.Error(t, err)
+		require.Equal(t, presencedetection.DetectionFailedDurationValue, d)
+	})
+
+	t.Run("cant connect to user server", func(t *testing.T) {
+		t.Parallel()
+
+		u, err := user.Current()
+		require.NoError(t, err)
+
+		runner := DesktopUsersProcessesRunner{}
+		runner.uidProcs = make(map[string]processRecord)
+		runner.uidProcs[u.Uid] = processRecord{
+			socketPath: "/tmp/doesntexist",
+		}
+
+		d, err := runner.DetectPresence("whatevs", time.Second)
+		require.Error(t, err)
+		require.Equal(t, presencedetection.DetectionFailedDurationValue, d)
+	})
 }

--- a/ee/localserver/request-id.go
+++ b/ee/localserver/request-id.go
@@ -84,7 +84,6 @@ func (ls *localServer) requestIdHandlerFunc(w http.ResponseWriter, r *http.Reque
 		Origin:    r.Header.Get("Origin"),
 		Status: status{
 			EnrollmentStatus: string(enrollmentStatus),
-			InstanceStatuses: ls.knapsack.InstanceStatuses(),
 		},
 	}
 	response.identifiers = ls.identifiers

--- a/ee/localserver/request-id_test.go
+++ b/ee/localserver/request-id_test.go
@@ -27,7 +27,6 @@ func Test_localServer_requestIdHandler(t *testing.T) {
 	mockKnapsack.On("ConfigStore").Return(storageci.NewStore(t, multislogger.NewNopLogger(), storage.ConfigStore.String()))
 	mockKnapsack.On("KolideServerURL").Return("localhost")
 	mockKnapsack.On("CurrentEnrollmentStatus").Return(types.Enrolled, nil)
-	mockKnapsack.On("InstanceStatuses").Return(map[string]types.InstanceStatus{"default": types.InstanceStatusHealthy})
 
 	var logBytes bytes.Buffer
 	slogger := slog.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{


### PR DESCRIPTION
* try lock before presence detection, drop if can't get lock
* fix bug where desktop runner returned 0s on error
* drop call to ls.knapsack.InstanceStatuses() in `/id` endpoint that was causing request to be slow immediately after start up