### PR TITLE
Don't flag errors related to running flare as standalone

### DIFF
--- a/ee/debug/checkups/bboltdb.go
+++ b/ee/debug/checkups/bboltdb.go
@@ -3,7 +3,6 @@ package checkups
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,7 +26,8 @@ func (c *bboltdbCheckup) Name() string {
 func (c *bboltdbCheckup) Run(_ context.Context, extraFH io.Writer) error {
 	db := c.k.BboltDB()
 	if db == nil {
-		return errors.New("no DB available")
+		// Not an error -- we are probably running standalone instead of in situ
+		return nil
 	}
 
 	stats, err := agent.GetStats(db)

--- a/ee/debug/checkups/server_data.go
+++ b/ee/debug/checkups/server_data.go
@@ -42,8 +42,9 @@ func (sdc *serverDataCheckup) Run(ctx context.Context, extraFH io.Writer) error 
 	}
 
 	if store == nil {
-		sdc.status = Warning
-		sdc.summary = "no server_data store in knapsack"
+		// We are probably running standalone instead of in situ
+		sdc.status = Informational
+		sdc.summary = "server_data not available"
 		return nil
 	}
 


### PR DESCRIPTION
A couple of our checkups can't run if the flare is running standalone because they can't access bboltdb -- a) the server data checkup and b) the bboltdb checkup. In these cases, we are currently including a fairly alarming error message and flagging as either erroring or warning. The server data checkup reports a warning emoji plus `Server Data: no server_data store in knapsack`, and the bboltdb checkup reports an erroring emoji plus `bboltdb: failed to run: no DB available`. When someone is not familiar with how flares work, this will be unnecessarily concerning to them.

This PR updates these two checkups to return an informational status if the database connection isn't available, and adjusts the language in the summary to be less concerning. (The server data checkup will now report `Server Data: server_data not available` without an emoji, and the bbolt checkup will now report `bboltdb: N/A` without an emoji.)

In the future, I think we may want to pass through whether the checkup is running in situ or standalone to the `Run` function so that we can adjust behavior accordingly -- but I didn't think it was worth it at this time.