### PR TITLE
Use atomic.Bool for rungroup actors that should not run interrupt routines more than once

### DIFF
--- a/ee/debug/checkups/checkpoint.go
+++ b/ee/debug/checkups/checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/kolide/launcher/ee/agent/types"
@@ -14,7 +15,7 @@ type (
 		slogger     *slog.Logger
 		knapsack    types.Knapsack
 		interrupt   chan struct{}
-		interrupted bool
+		interrupted atomic.Bool
 	}
 )
 
@@ -49,11 +50,11 @@ func (c *logCheckPointer) Run() error {
 
 func (c *logCheckPointer) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if c.interrupted {
+	if c.interrupted.Load() {
 		return
 	}
 
-	c.interrupted = true
+	c.interrupted.Store(true)
 
 	c.interrupt <- struct{}{}
 }

--- a/ee/desktop/user/notify/notify_darwin.go
+++ b/ee/desktop/user/notify/notify_darwin.go
@@ -20,11 +20,13 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync/atomic"
 	"unsafe"
 )
 
 type macNotifier struct {
-	interrupt chan struct{}
+	interrupt   chan struct{}
+	interrupted atomic.Bool
 }
 
 func NewDesktopNotifier(_ *slog.Logger, _ string) *macNotifier {
@@ -39,6 +41,12 @@ func (m *macNotifier) Execute() error {
 }
 
 func (m *macNotifier) Interrupt(err error) {
+	if m.interrupted.Load() {
+		return
+	}
+
+	m.interrupted.Store(true)
+
 	m.interrupt <- struct{}{}
 }
 

--- a/ee/desktop/user/notify/notify_windows.go
+++ b/ee/desktop/user/notify/notify_windows.go
@@ -5,6 +5,7 @@ package notify
 
 import (
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/kolide/toast"
 )
@@ -12,6 +13,7 @@ import (
 type windowsNotifier struct {
 	iconFilepath string
 	interrupt    chan struct{}
+	interrupted  atomic.Bool
 }
 
 func NewDesktopNotifier(_ *slog.Logger, iconFilepath string) *windowsNotifier {
@@ -32,6 +34,11 @@ func (w *windowsNotifier) Execute() error {
 func (w *windowsNotifier) Listen() {}
 
 func (w *windowsNotifier) Interrupt(err error) {
+	if w.interrupted.Load() {
+		return
+	}
+	w.interrupted.Store(true)
+
 	w.interrupt <- struct{}{}
 }
 

--- a/ee/desktop/user/universallink/handler_other.go
+++ b/ee/desktop/user/universallink/handler_other.go
@@ -5,12 +5,13 @@ package universallink
 
 import (
 	"log/slog"
+	"sync/atomic"
 )
 
 // On other OSes, universal link handling is a no-op.
 type noopUniversalLinkHandler struct {
 	unusedInput chan string
-	interrupted bool
+	interrupted atomic.Bool
 	interrupt   chan struct{}
 }
 
@@ -29,10 +30,10 @@ func (n *noopUniversalLinkHandler) Execute() error {
 
 func (n *noopUniversalLinkHandler) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if n.interrupted {
+	if n.interrupted.Load() {
 		return
 	}
-	n.interrupted = true
+	n.interrupted.Store(true)
 
 	n.interrupt <- struct{}{}
 	close(n.unusedInput)

--- a/ee/powereventwatcher/power_event_watcher_other.go
+++ b/ee/powereventwatcher/power_event_watcher_other.go
@@ -6,6 +6,7 @@ package powereventwatcher
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/pkg/traces"
@@ -13,7 +14,7 @@ import (
 
 type noOpPowerEventWatcher struct {
 	interrupt   chan struct{}
-	interrupted bool
+	interrupted atomic.Bool
 }
 
 type noOpKnapsackSleepStateUpdater struct{}
@@ -38,11 +39,11 @@ func (n *noOpPowerEventWatcher) Execute() error {
 
 func (n *noOpPowerEventWatcher) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if n.interrupted {
+	if n.interrupted.Load() {
 		return
 	}
 
-	n.interrupted = true
+	n.interrupted.Store(true)
 
 	n.interrupt <- struct{}{}
 }

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,7 +43,7 @@ type Extension struct {
 	serviceClient       service.KolideService
 	enrollMutex         sync.Mutex
 	done                chan struct{}
-	interrupted         bool
+	interrupted         atomic.Bool
 	slogger             *slog.Logger
 	logPublicationState *logPublicationState
 }
@@ -172,10 +173,10 @@ func (e *Extension) Execute() error {
 // with this extension.
 func (e *Extension) Shutdown(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if e.interrupted {
+	if e.interrupted.Load() {
 		return
 	}
-	e.interrupted = true
+	e.interrupted.Store(true)
 
 	close(e.done)
 }


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2010.

Might prevent some data races in flaky tests?