### PR TITLE
add more logging to hardware runners

### DIFF
--- a/ee/secureenclaverunner/secureenclaverunner.go
+++ b/ee/secureenclaverunner/secureenclaverunner.go
@@ -197,6 +197,10 @@ func (ser *secureEnclaveRunner) currentConsoleUserKey(ctx context.Context) (*ecd
 
 	key, ok := ser.uidPubKeyMap[cu.Uid]
 	if ok {
+		ser.slogger.Log(ctx, slog.LevelDebug,
+			"found existing key for console user",
+			"uid", cu.Uid,
+		)
 		span.AddEvent("found_existing_key_for_console_user")
 		return key, nil
 	}
@@ -207,6 +211,10 @@ func (ser *secureEnclaveRunner) currentConsoleUserKey(ctx context.Context) (*ecd
 		return nil, fmt.Errorf("creating key: %w", err)
 	}
 
+	ser.slogger.Log(ctx, slog.LevelInfo,
+		"created new key for console user",
+		"uid", cu.Uid,
+	)
 	span.AddEvent("created_new_key_for_console_user")
 
 	ser.uidPubKeyMap[cu.Uid] = key

--- a/ee/tpmrunner/tpmrunner.go
+++ b/ee/tpmrunner/tpmrunner.go
@@ -98,7 +98,7 @@ func (tr *tpmRunner) Execute() error {
 			continue
 		case <-tr.interrupt:
 			tr.slogger.Log(context.TODO(), slog.LevelDebug,
-				"interrupt received, exiting secure enclave signer execute loop",
+				"interrupt received, exiting tpm signer execute loop",
 			)
 			return nil
 		}
@@ -208,10 +208,6 @@ func (tr *tpmRunner) loadOrCreateKeys(ctx context.Context) error {
 	}
 
 	if pubData == nil || priData == nil {
-		tr.slogger.Log(ctx, slog.LevelInfo,
-			"generating new tpm keys",
-		)
-
 		var err error
 		priData, pubData, err = tr.signerCreator.CreateKey()
 		if err != nil {
@@ -230,6 +226,9 @@ func (tr *tpmRunner) loadOrCreateKeys(ctx context.Context) error {
 			return thisErr
 		}
 
+		tr.slogger.Log(ctx, slog.LevelInfo,
+			"new tpm keys generated",
+		)
 		span.AddEvent("generated_new_tpm_keys")
 	}
 
@@ -242,6 +241,9 @@ func (tr *tpmRunner) loadOrCreateKeys(ctx context.Context) error {
 
 	tr.signer = k
 
+	tr.slogger.Log(ctx, slog.LevelDebug,
+		"tpm signer created",
+	)
 	span.AddEvent("created_tpm_signer")
 
 	return nil


### PR DESCRIPTION
For the hardware runners, nearly all of the logging only happened when there was an error. This PR adds logging for when keys are generated or retrieved successfully.