### PR TITLE
Add updated path for ws1HubUtil command

### DIFF
--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -160,7 +160,16 @@ func Systemctl(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 }
 
 func Ws1HubUtil(ctx context.Context, arg ...string) (*exec.Cmd, error) {
-	return validatedCommand(ctx, "/opt/vmware/ws1-hub/bin/ws1HubUtil", arg...)
+	for _, p := range []string{"/usr/bin/ws1HubUtil", "/opt/vmware/ws1-hub/bin/ws1HubUtil"} {
+		validatedCmd, err := validatedCommand(ctx, p, arg...)
+		if err != nil {
+			continue
+		}
+
+		return validatedCmd, nil
+	}
+
+	return nil, errors.New("ws1HubUtil not found")
 }
 
 func XdgOpen(ctx context.Context, arg ...string) (*exec.Cmd, error) {


### PR DESCRIPTION
The path for WorkspaceOne has moved on Linux. This PR updates the `allowedcmd` to look in the new location `/usr/bin/ws1HubUtil` and then fall back to the old location, to allow for any older installations.