### PR TITLE
Refactor goroutine panic handling to use GoWithRecoveryAction

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -194,11 +194,6 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 				"err", err,
 			)
 		}
-	}, func(r any) {
-		slogger.Log(context.TODO(), slog.LevelError,
-			"exiting after runGroup panic",
-			"err", r,
-		)
 	})
 
 	// if desktop is not enabled at start up, wait for send on show desktop channel

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -180,7 +180,7 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	ctx = ctxlog.NewContext(ctx, w.logger)
 	runLauncherResults := make(chan struct{})
 
-	gowrapper.Go(ctx, w.systemSlogger.Logger, func() {
+	gowrapper.GoWithRecoveryAction(ctx, w.systemSlogger.Logger, func() {
 		err := runLauncher(ctx, cancel, w.slogger, w.systemSlogger, w.opts)
 		if err != nil {
 			w.systemSlogger.Log(ctx, slog.LevelInfo,

--- a/ee/control/consumers/remoterestartconsumer/remoterestartconsumer.go
+++ b/ee/control/consumers/remoterestartconsumer/remoterestartconsumer.go
@@ -102,7 +102,7 @@ func (r *RemoteRestartConsumer) Do(data io.Reader) error {
 			)
 			return
 		}
-	}, func(err any) {})
+	})
 
 	return nil
 }

--- a/ee/debug/shipper/shipper.go
+++ b/ee/debug/shipper/shipper.go
@@ -112,7 +112,7 @@ func (s *shipper) Write(p []byte) (n int, err error) {
 		defer s.uploadRequestWg.Done()
 		// will close the body in the close function
 		s.uploadResponse, s.uploadRequestErr = http.DefaultClient.Do(s.uploadRequest) //nolint:bodyclose
-	}, func(r any) {})
+	})
 
 	return s.writer.Write(p)
 }

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -195,7 +195,7 @@ func New(k types.Knapsack, messenger runnerserver.Messenger, opts ...desktopUser
 				"err", err,
 			)
 		}
-	}, func(err any) {})
+	})
 
 	if runtime.GOOS == "darwin" {
 		runner.osVersion, err = osversion()
@@ -339,7 +339,7 @@ func (r *DesktopUsersProcessesRunner) killDesktopProcesses(ctx context.Context) 
 	gowrapper.Go(context.TODO(), r.slogger, func() {
 		defer close(wgDone)
 		r.procsWg.Wait()
-	}, func(err any) {})
+	})
 
 	shutdownRequestCount := 0
 	for uid, proc := range r.uidProcs {
@@ -834,7 +834,7 @@ func (r *DesktopUsersProcessesRunner) waitOnProcessAsync(uid string, proc *os.Pr
 				"state", state,
 			)
 		}
-	}, func(err any) {})
+	})
 }
 
 // determineExecutablePath returns DesktopUsersProcessesRunner.executablePath if it is set,

--- a/ee/desktop/user/menu/menu_systray.go
+++ b/ee/desktop/user/menu/menu_systray.go
@@ -133,5 +133,5 @@ func (m *menu) makeActionHandler(item *systray.MenuItem, ap ActionPerformer) {
 				return
 			}
 		}
-	}, func(r any) {})
+	})
 }

--- a/ee/gowrapper/goroutine.go
+++ b/ee/gowrapper/goroutine.go
@@ -9,9 +9,15 @@ import (
 )
 
 // Go is a thin wrapper around `go func()` that ensures we log panics
-// and then handle them appropriately. `onPanic` defines the behavior
-// that should happen after recovering from a panic.
-func Go(ctx context.Context, slogger *slog.Logger, goroutine func(), onPanic func(r any)) {
+func Go(ctx context.Context, slogger *slog.Logger, goroutine func()) {
+	GoWithRecoveryAction(ctx, slogger, goroutine, func(r any) {
+		// Panic is already logged in GoWithRecoveryAction
+	})
+}
+
+// GoWithRecoveryAction wraps `go func()` with panic recovery and custom handling
+// onPanic defines the behavior that should happen after recovering from a panic
+func GoWithRecoveryAction(ctx context.Context, slogger *slog.Logger, goroutine func(), onPanic func(r any)) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/ee/gowrapper/goroutine_test.go
+++ b/ee/gowrapper/goroutine_test.go
@@ -38,7 +38,7 @@ func TestGo_WithPanic(t *testing.T) {
 	}))
 
 	// Kick off goroutine
-	Go(context.TODO(), slogger, g, p)
+	GoWithRecoveryAction(context.TODO(), slogger, g, p)
 	timeoutGracePeriod := 200 * time.Millisecond
 
 	goroutineExecuted := false
@@ -86,7 +86,7 @@ func TestGo_WithoutPanic(t *testing.T) {
 	}
 
 	// Kick off goroutine
-	Go(context.TODO(), multislogger.NewNopLogger(), g, p)
+	GoWithRecoveryAction(context.TODO(), multislogger.NewNopLogger(), g, p)
 	timeoutGracePeriod := 200 * time.Millisecond
 	goroutineEndTime := time.Now().Add(funcDelay + funcDelay + timeoutGracePeriod)
 

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -277,7 +277,7 @@ func (ls *localServer) Start() error {
 				}
 			}
 		}
-	}, func(r any) {})
+	})
 
 	l, err := ls.startListener()
 	if err != nil {

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -50,7 +50,7 @@ func startDebugServer(addrPath string, slogger *slog.Logger) (*http.Server, erro
 				"err", err,
 			)
 		}
-	}, func(r any) {})
+	})
 
 	url := url.URL{
 		Scheme:   "http",

--- a/pkg/debug/signal_debug.go
+++ b/pkg/debug/signal_debug.go
@@ -47,6 +47,6 @@ func AttachDebugHandler(addrPath string, slogger *slog.Logger) {
 				"shutdown debug server",
 			)
 		}
-	}, func(r any) {})
+	})
 
 }

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -117,7 +117,7 @@ func (ls *LogShipper) Ping() {
 	ls.isShippingStarted = true
 	gowrapper.Go(context.TODO(), ls.knapsack.Slogger(), func() {
 		ls.startShippingChan <- struct{}{}
-	}, func(r any) {})
+	})
 
 }
 

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -596,7 +596,7 @@ func (i *OsqueryInstance) startKolideSaasExtension(ctx context.Context) error {
 				"err", err,
 			)
 		}
-	}, func(r any) {})
+	})
 
 	// Run extension
 	i.addGoroutineToErrgroup(ctx, "saas_extension_execute", func() error {

--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -68,7 +68,7 @@ func (g *Group) Run() error {
 	actorErrors := make(chan actorError, len(g.actors))
 	for _, a := range g.actors {
 		a := a
-		gowrapper.Go(context.TODO(), g.slogger, func() {
+		gowrapper.GoWithRecoveryAction(context.TODO(), g.slogger, func() {
 			g.slogger.Log(context.TODO(), slog.LevelDebug,
 				"starting actor",
 				"actor", a.name,
@@ -124,7 +124,7 @@ func (g *Group) Run() error {
 				"interrupt complete",
 				"actor", a.name,
 			)
-		}, func(r any) {})
+		})
 	}
 
 	interruptCtx, interruptCancel := context.WithTimeout(context.Background(), InterruptTimeout)

--- a/pkg/threadas/threadas.go
+++ b/pkg/threadas/threadas.go
@@ -79,7 +79,7 @@ func ThreadAs(fn func() error, timeout time.Duration, uid uint32, gid uint32) er
 	// sequence starting the child and our listener.
 	errChan := make(chan error, 1)
 
-	gowrapper.Go(context.TODO(), slog.Default(), func() {
+	gowrapper.GoWithRecoveryAction(context.TODO(), slog.Default(), func() {
 		// Calling LockOSThread, without a subsequent Unlock,
 		// will cause the thread to terminate when the
 		// goroutine does. This seems simpler than resetting


### PR DESCRIPTION
This pull request focuses on simplifying the error handling in various functions by removing the redundant panic recovery handlers. Additionally, it introduces a new function, `GoWithRecoveryAction`, to handle custom panic recovery actions. Here are the most important changes:

### Error Handling Simplification:

* Removed redundant panic recovery handlers in multiple functions across different files. For example:
  * `cmd/launcher/desktop.go`
  * `ee/control/consumers/remoterestartconsumer/remoterestartconsumer.go`
  * `ee/debug/shipper/shipper.go`
  * `ee/desktop/runner/runner.go` [[1]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL198-R198) [[2]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL342-R342) [[3]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL837-R837)
  * `ee/desktop/user/menu/menu_systray.go`

### Introduction of `GoWithRecoveryAction`:

* Added a new function `GoWithRecoveryAction` in `ee/gowrapper/goroutine.go` to handle custom panic recovery actions. This function wraps `go func()` with panic recovery and allows custom handling of the panic.

### Test Updates:

* Updated tests to use the new `GoWithRecoveryAction` function instead of the old `Go` function in `ee/gowrapper/goroutine_test.go`. [[1]](diffhunk://#diff-dbb7de54dad9762c78cb1157774b24e121030fe14c002d7ad1f8be47c3321c28L41-R41) [[2]](diffhunk://#diff-dbb7de54dad9762c78cb1157774b24e121030fe14c002d7ad1f8be47c3321c28L89-R89)

### Code Refactoring:

* Refactored `pkg/rungroup/rungroup.go` to use `GoWithRecoveryAction` for better panic recovery handling. [[1]](diffhunk://#diff-fc24f26fcb5a14cf0f64a050d2fb2acd825d3d663e03e3707d6d4e8957a183d7L71-R71) [[2]](diffhunk://#diff-fc24f26fcb5a14cf0f64a050d2fb2acd825d3d663e03e3707d6d4e8957a183d7L127-R127)
* Refactored `pkg/threadas/threadas.go` to use `GoWithRecoveryAction` for managing thread termination upon goroutine completion.