### PR TITLE
reorder presence detection write headers to remove warnings

### DIFF
--- a/ee/desktop/user/server/server.go
+++ b/ee/desktop/user/server/server.go
@@ -230,8 +230,8 @@ func (s *UserServer) detectPresence(w http.ResponseWriter, req *http.Request) {
 
 	// write response
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(responseBytes)
 	w.WriteHeader(http.StatusOK)
+	w.Write(responseBytes)
 }
 
 func (s *UserServer) refreshHandler(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
noticed these logs while debugging:
```
"msg":"2025/01/03 10:24:42 http: superfluous response.WriteHeader call from github.com/kolide/launcher/ee/desktop/user/server.(*UserServer).detectPresence (server.go:234)","component":"desktop_runner"
```

reading the docs this happens when `WriteHeader` is called multiple times, or after `Write` is called. this is harmless in our current invocation because http package will write a default OK status, but ordering these correctly should remove the warnings