### PR TITLE
Revert "Switch from CoInitialize to CoInitializeEx"

### DIFF
--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -229,9 +229,9 @@ func installWatchdogTask(identifier, configFilePath string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitializeEx because it
+	// init COM - we discard the error returned by CoInitialize because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
+	ole.CoInitialize(0)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object
@@ -530,9 +530,9 @@ func RemoveWatchdogTask(identifier string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitializeEx because it
+	// init COM - we discard the error returned by CoInitialize because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
+	ole.CoInitialize(0)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object
@@ -581,9 +581,9 @@ func watchdogTaskExists(identifier string) (bool, error) {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitializeEx because it
+	// init COM - we discard the error returned by CoInitialize because it
 	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
+	ole.CoInitialize(0)
 	defer ole.CoUninitialize()
 
 	// create our scheduler object


### PR DESCRIPTION
Reverts kolide/launcher#1973

We think it's possible this is causing launcher to crash on first-time startup. Reverting to check that theory out.