### PR TITLE
Run osquery runner restart test on Windows

### DIFF
--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -125,34 +125,3 @@ func TestExtensionSocketPath(t *testing.T) {
 
 	waitShutdown(t, runner, logBytes)
 }
-
-// TestRestart tests that the launcher can restart the osqueryd process.
-// This test causes time outs on windows, so it is only run on non-windows platforms.
-// Should investigate why this is the case.
-func TestRestart(t *testing.T) {
-	t.Parallel()
-	runner, logBytes, teardown := setupOsqueryInstanceForTests(t)
-	defer teardown()
-
-	previousStats := runner.instances[types.DefaultRegistrationID].stats
-
-	require.NoError(t, runner.Restart())
-	waitHealthy(t, runner, logBytes)
-
-	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.StartTime, "start time should be set on latest instance stats after restart")
-	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.ConnectTime, "connect time should be set on latest instance stats after restart")
-
-	require.NotEmpty(t, previousStats.ExitTime, "exit time should be set on last instance stats when restarted")
-	require.NotEmpty(t, previousStats.Error, "stats instance should have an error on restart")
-
-	previousStats = runner.instances[types.DefaultRegistrationID].stats
-
-	require.NoError(t, runner.Restart())
-	waitHealthy(t, runner, logBytes)
-
-	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.StartTime, "start time should be added to latest instance stats after restart")
-	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.ConnectTime, "connect time should be added to latest instance stats after restart")
-
-	require.NotEmpty(t, previousStats.ExitTime, "exit time should be set on instance stats when restarted")
-	require.NotEmpty(t, previousStats.Error, "stats instance should have an error on restart")
-}

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -598,6 +598,8 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 
 	// Ensure we've waited at least 32s
 	<-timer1.C
+
+	waitShutdown(t, runner, logBytes)
 }
 
 // TestRestart tests that the launcher can restart the osqueryd process.
@@ -627,6 +629,8 @@ func TestRestart(t *testing.T) {
 
 	require.NotEmpty(t, previousStats.ExitTime, "exit time should be set on instance stats when restarted")
 	require.NotEmpty(t, previousStats.Error, "stats instance should have an error on restart")
+
+	waitShutdown(t, runner, logBytes)
 }
 
 // sets up an osquery instance with a running extension to be used in tests.

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -600,6 +600,35 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 	<-timer1.C
 }
 
+// TestRestart tests that the launcher can restart the osqueryd process.
+func TestRestart(t *testing.T) {
+	t.Parallel()
+	runner, logBytes, teardown := setupOsqueryInstanceForTests(t)
+	defer teardown()
+
+	previousStats := runner.instances[types.DefaultRegistrationID].stats
+
+	require.NoError(t, runner.Restart())
+	waitHealthy(t, runner, logBytes)
+
+	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.StartTime, "start time should be set on latest instance stats after restart")
+	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.ConnectTime, "connect time should be set on latest instance stats after restart")
+
+	require.NotEmpty(t, previousStats.ExitTime, "exit time should be set on last instance stats when restarted")
+	require.NotEmpty(t, previousStats.Error, "stats instance should have an error on restart")
+
+	previousStats = runner.instances[types.DefaultRegistrationID].stats
+
+	require.NoError(t, runner.Restart())
+	waitHealthy(t, runner, logBytes)
+
+	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.StartTime, "start time should be added to latest instance stats after restart")
+	require.NotEmpty(t, runner.instances[types.DefaultRegistrationID].stats.ConnectTime, "connect time should be added to latest instance stats after restart")
+
+	require.NotEmpty(t, previousStats.ExitTime, "exit time should be set on instance stats when restarted")
+	require.NotEmpty(t, previousStats.Error, "stats instance should have an error on restart")
+}
+
 // sets up an osquery instance with a running extension to be used in tests.
 func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, teardown func()) {
 	rootDirectory := testRootDirectory(t)


### PR DESCRIPTION
I think previous improvements to this test (namely `waitHealthy`) will now let us run it comfortably in CI without timeout.