### PR TITLE
Clean up a couple places not yet using gowrapper

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kolide/launcher/ee/control/consumers/uninstallconsumer"
 	"github.com/kolide/launcher/ee/debug/checkups"
 	desktopRunner "github.com/kolide/launcher/ee/desktop/runner"
+	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/ee/localserver"
 	"github.com/kolide/launcher/ee/powereventwatcher"
 	"github.com/kolide/launcher/ee/tuf"
@@ -206,8 +207,12 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 	k.LauncherHistoryStore().Set([]byte("process_start_time"), []byte(processStartTime.Format(time.RFC3339)))
 
-	go runOsqueryVersionCheckAndAddToKnapsack(ctx, slogger, k, k.LatestOsquerydPath(ctx))
-	go timemachine.AddExclusions(ctx, k)
+	gowrapper.Go(ctx, slogger, func() {
+		runOsqueryVersionCheckAndAddToKnapsack(ctx, slogger, k, k.LatestOsquerydPath(ctx))
+	})
+	gowrapper.Go(ctx, slogger, func() {
+		timemachine.AddExclusions(ctx, k)
+	})
 
 	if k.Debug() && runtime.GOOS != "windows" {
 		// If we're in debug mode, then we assume we want to echo _all_ logs to stderr.
@@ -299,7 +304,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// Add the log checkpoints to the rungroup, and run it once early, to try to get data into the logs.
 	// The checkpointer can take up to 5 seconds to run, so do this in the background.
 	checkpointer := checkups.NewCheckupLogger(slogger, k)
-	go checkpointer.Once(ctx)
+	gowrapper.Go(ctx, slogger, func() {
+		checkpointer.Once(ctx)
+	})
 	runGroup.Add("logcheckpoint", checkpointer.Run, checkpointer.Interrupt)
 
 	watchdogController, err := watchdog.NewController(ctx, k, opts.ConfigFilePath)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -175,7 +175,9 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 
 	// Confirm that service configuration is up-to-date
-	go checkServiceConfiguration(w.slogger.Logger, w.opts)
+	gowrapper.Go(ctx, w.systemSlogger.Logger, func() {
+		checkServiceConfiguration(w.slogger.Logger, w.opts)
+	})
 
 	ctx = ctxlog.NewContext(ctx, w.logger)
 	runLauncherResults := make(chan struct{})

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -999,7 +999,9 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		return nil, fmt.Errorf("getting stdout pipe: %w", err)
 	}
 
-	go r.processLogs(uid, stdErr, stdOut)
+	gowrapper.Go(context.TODO(), r.slogger, func() {
+		r.processLogs(uid, stdErr, stdOut)
+	})
 
 	return cmd, nil
 }

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kolide/krypto"
 	"github.com/kolide/krypto/pkg/challenge"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/traces"
 	"go.opentelemetry.io/otel/attribute"
@@ -222,7 +223,9 @@ func (e *kryptoEcMiddleware) Wrap(next http.Handler) http.Handler {
 						context.WithValue(callbackReq.Context(), multislogger.KolideSessionIdKey, kolideSessionId[0]),
 					)
 				}
-				go e.sendCallback(callbackReq, callbackData)
+				gowrapper.Go(r.Context(), e.slogger, func() {
+					e.sendCallback(callbackReq, callbackData)
+				})
 			}()
 		}
 

--- a/ee/log/osquerylogs/log.go
+++ b/ee/log/osquerylogs/log.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/process"
 )
@@ -18,7 +19,7 @@ import (
 // OsqueryLogAdapater creates an io.Writer implementation useful for attaching
 // to the osquery stdout/stderr
 type OsqueryLogAdapter struct {
-	slogger             slog.Logger
+	slogger             *slog.Logger
 	level               slog.Level
 	rootDirectory       string
 	lastLockfileLogTime time.Time
@@ -44,7 +45,7 @@ func extractOsqueryCaller(msg string) string {
 
 func NewOsqueryLogAdapter(slogger *slog.Logger, rootDirectory string, opts ...Option) *OsqueryLogAdapter {
 	l := &OsqueryLogAdapter{
-		slogger:       *slogger,
+		slogger:       slogger,
 		level:         slog.LevelInfo,
 		rootDirectory: rootDirectory,
 	}
@@ -79,7 +80,9 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 		l.slogger.Log(context.TODO(), slog.LevelError,
 			"detected non-osqueryd process using pidfile, logging info about process",
 		)
-		go l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
+		gowrapper.Go(context.TODO(), l.slogger, func() {
+			l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
+		})
 	}
 
 	// We have noticed the lock file occasionally locked when it shouldn't be -- we think this can happen
@@ -94,7 +97,9 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 			l.slogger.Log(context.TODO(), slog.LevelError,
 				"detected stale lockfile, logging info about file",
 			)
-			go l.logInfoAboutProcessHoldingLockfile(context.TODO(), p)
+			gowrapper.Go(context.TODO(), l.slogger, func() {
+				l.logInfoAboutProcessHoldingLockfile(context.TODO(), p)
+			})
 		}
 	}
 

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/storage"
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/kolide/launcher/pkg/traces/bufspanprocessor"
 	osquerygotraces "github.com/osquery/osquery-go/traces"
@@ -118,7 +119,9 @@ func NewTraceExporter(ctx context.Context, k types.Knapsack, initialTraceBuffer 
 func (t *TraceExporter) SetOsqueryClient(client querier) {
 	t.osqueryClient = client
 
-	go t.addAttributesFromOsquery()
+	gowrapper.Go(context.TODO(), t.slogger, func() {
+		t.addAttributesFromOsquery()
+	})
 }
 
 // addDeviceIdentifyingAttributes gets device identifiers from the server-provided


### PR DESCRIPTION
Found a couple places that didn't match our `go func` pattern, so golangci-lint didn't catch them. Cleaning them up for now without adding a new golangci-lint rule.