### PR TITLE
Make flaky tests less flaky

### DIFF
--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -836,7 +836,7 @@ func TestDo_WillNotExecuteDuringInitialDelay(t *testing.T) {
 	require.NoError(t, autoupdater.Do(data), "should not have received error when performing request during initial delay")
 
 	// Give autoupdater a chance to run
-	time.Sleep(initialDelay + interval)
+	time.Sleep(2*initialDelay + 2*interval)
 
 	// Assert expectation that we did not add the expected `testReleaseVersion` to the updates library
 	mockLibraryManager.AssertExpectations(t)

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -42,6 +42,12 @@ const (
 	// communication with Kolide SaaS happens over JSONRPC.
 	KolideSaasExtensionName = "kolide_grpc"
 
+	// How long to wait before erroring because the osquery process has not started up successfully
+	osqueryStartupTimeout = 1 * time.Minute
+
+	// How often to check whether the osquery process has started up successfully
+	osqueryStartupRecheckInterval = 1 * time.Second
+
 	// How long to wait before erroring because we cannot open the osquery
 	// extension socket.
 	socketOpenTimeout = 10 * time.Second
@@ -328,7 +334,7 @@ func (i *OsqueryInstance) Launch() error {
 			)
 		}
 		return err
-	}, 1*time.Minute, 1*time.Second); err != nil {
+	}, osqueryStartupTimeout, osqueryStartupRecheckInterval); err != nil {
 		traces.SetError(span, fmt.Errorf("timeout waiting for osqueryd to create socket at %s: %w", paths.extensionSocketPath, err))
 		return fmt.Errorf("timeout waiting for osqueryd to create socket at %s: %w", paths.extensionSocketPath, err)
 	}

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -319,7 +319,7 @@ func waitHealthy(t *testing.T, runner *Runner, logBytes *threadsafebuffer.Thread
 
 		// Good to go
 		return nil
-	}, 30*time.Second, 1*time.Second), fmt.Sprintf("instance not healthy by %s: runner logs:\n\n%s", time.Now().String(), logBytes.String()))
+	}, osqueryStartupTimeout+socketOpenTimeout, 1*time.Second), fmt.Sprintf("instance not healthy by %s: runner logs:\n\n%s", time.Now().String(), logBytes.String()))
 
 	// Give the instance just a little bit of buffer before we proceed
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
Autoupdate tests:

* Looks like this one just needed more time to run 🤞 

Rungroup tests:

* Not sure what's up here yet, so I'm capturing the logs from rungroup and printing them on error, so we can figure out why we sometimes don't see all of the rungroup actors interrupt successfully

Osquery tests:

* Standardize `waitHealthy` to wait for the osquery instance to become healthy for as long as we actually wait (1 min for the socket file to be created, 10 seconds for the socket file to become available)