### PR TITLE
More flaky test improvements

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -30,7 +30,6 @@ import (
 	"github.com/osquery/osquery-go/plugin/config"
 	"github.com/osquery/osquery-go/plugin/distributed"
 	osquerylogger "github.com/osquery/osquery-go/plugin/logger"
-	"github.com/shirou/gopsutil/v3/process"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -405,13 +404,7 @@ func (i *OsqueryInstance) Launch() error {
 	i.extensionManagerClient, err = i.StartOsqueryClient(paths)
 	if err != nil {
 		traces.SetError(span, fmt.Errorf("could not create an extension client: %w", err))
-
-		isRunning, checkProcErr := i.isOsqueryProcessRunning(ctx)
-		if checkProcErr != nil {
-			return fmt.Errorf("could not create an extension client: %w; could not check if process is running: %v", err, checkProcErr)
-		}
-
-		return fmt.Errorf("could not create an extension client: %w; process is running: %v", err, isRunning)
+		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")
 
@@ -488,20 +481,6 @@ func (i *OsqueryInstance) Launch() error {
 	})
 
 	return nil
-}
-
-func (i *OsqueryInstance) isOsqueryProcessRunning(ctx context.Context) (bool, error) {
-	osqueryProc, err := process.NewProcessWithContext(ctx, int32(i.cmd.Process.Pid))
-	if err != nil {
-		return false, fmt.Errorf("getting process: %w", err)
-	}
-
-	isRunning, err := osqueryProc.IsRunningWithContext(ctx)
-	if err != nil {
-		return false, fmt.Errorf("checking if osquery process is running: %w", err)
-	}
-
-	return isRunning, nil
 }
 
 // healthcheckWithRetries returns an error if it cannot get a non-error response from

--- a/pkg/osquery/runtime/osqueryinstance_windows_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_windows_test.go
@@ -28,7 +28,7 @@ func TestCreateOsqueryCommandEnvVars(t *testing.T) {
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("RootDirectory").Return("")
 
-	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient())
+	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t))
 
 	cmd, err := i.createOsquerydCommand(osquerydPath, &osqueryFilePaths{
 		pidfilePath:           "/foo/bar/osquery-abcd.pid",

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/osquery/osquery-go"
@@ -56,9 +57,15 @@ func TestOsquerySlowStart(t *testing.T) {
 	k.On("Transport").Return("jsonrpc").Maybe()
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	k.On("InModernStandby").Return(false).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()
+	k.On("UpdateChannel").Return("stable").Maybe()
+	k.On("PinnedLauncherVersion").Return("").Maybe()
+	k.On("PinnedOsquerydVersion").Return("").Maybe()
 	setUpMockStores(t, k)
 
-	runner := New(k, mockServiceClient(), WithStartFunc(func(cmd *exec.Cmd) error {
+	runner := New(k, mockServiceClient(t), WithStartFunc(func(cmd *exec.Cmd) error {
 		err := cmd.Start()
 		if err != nil {
 			return fmt.Errorf("unexpected error starting command: %w", err)
@@ -104,11 +111,17 @@ func TestExtensionSocketPath(t *testing.T) {
 	k.On("Transport").Return("jsonrpc").Maybe()
 	k.On("ReadEnrollSecret").Return("", nil).Maybe()
 	k.On("InModernStandby").Return(false).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
+	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()
+	k.On("UpdateChannel").Return("stable").Maybe()
+	k.On("PinnedLauncherVersion").Return("").Maybe()
+	k.On("PinnedOsquerydVersion").Return("").Maybe()
 	setUpMockStores(t, k)
 
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
 
-	runner := New(k, mockServiceClient(), WithExtensionSocketPath(extensionSocketPath))
+	runner := New(k, mockServiceClient(t), WithExtensionSocketPath(extensionSocketPath))
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -197,9 +197,7 @@ func TestFlagsChanged(t *testing.T) {
 	k := typesMocks.NewKnapsack(t)
 	k.On("RegistrationIDs").Return([]string{types.DefaultRegistrationID})
 	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
-	// First, it should return false, then on the next call, it should return true
-	k.On("WatchdogEnabled").Return(false).Once()
-	k.On("WatchdogEnabled").Return(true).Once()
+	k.On("WatchdogEnabled").Return(false).Once() // WatchdogEnabled should initially return false
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)
 	k.On("WatchdogDelaySec").Return(120)
@@ -235,9 +233,11 @@ func TestFlagsChanged(t *testing.T) {
 
 	startingInstance := runner.instances[types.DefaultRegistrationID]
 
+	// Now, WatchdogEnabled should return false
+	k.On("WatchdogEnabled").Return(true).Once()
 	runner.FlagsChanged(keys.WatchdogEnabled)
 
-	// Wait for the instance to restart
+	// Wait for the instance to restart, then confirm it's healthy post-restart
 	time.Sleep(2 * time.Second)
 	waitHealthy(t, runner, logBytes)
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -254,7 +254,7 @@ func TestFlagsChanged(t *testing.T) {
 
 	startingInstance := runner.instances[types.DefaultRegistrationID]
 
-	// Now, WatchdogEnabled should return false
+	// Now, WatchdogEnabled should return true
 	k.On("WatchdogEnabled").Return(true).Once()
 	runner.FlagsChanged(keys.WatchdogEnabled)
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -221,7 +221,6 @@ func TestFlagsChanged(t *testing.T) {
 	go runner.Run()
 
 	// Wait for the instance to start
-	time.Sleep(2 * time.Second)
 	waitHealthy(t, runner, logBytes)
 
 	// Confirm watchdog is disabled


### PR DESCRIPTION
More attempts to get the osquery tests in a more reasonable state:

* If the instance doesn't become healthy by the timeout, check to see if the osquery process is in a running state or not
* Configure the device server service client mock to return a config and distributed queries, in case the error responses or missing configs was affecting the test osquery process
* Retry removing root dir during test cleanup