### PR TITLE
test updates: favor cleanups over defers, and only log from cleanup methods

### DIFF
--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -79,6 +79,7 @@ func TestOsquerySlowStart(t *testing.T) {
 		}()
 		return nil
 	}))
+	ensureShutdownOnCleanup(t, runner, logBytes)
 	go runner.Run()
 	waitHealthy(t, runner, logBytes)
 
@@ -122,6 +123,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	extensionSocketPath := filepath.Join(rootDirectory, "sock")
 
 	runner := New(k, mockServiceClient(t), WithExtensionSocketPath(extensionSocketPath))
+	ensureShutdownOnCleanup(t, runner, logBytes)
 	go runner.Run()
 
 	waitHealthy(t, runner, logBytes)


### PR DESCRIPTION
A few improvements after reading more about best practices and parsing confusing test output:
- we should try to favor `t.Cleanup()` over `defer` in tests, especially where we run in parallel
- we should try to keep actual tests out of cleanup methods

This has a few small changes to accomplish this within the runtime tests:
- adds an `ensureShutdownOnCleanup` helper function to ensure even failing tests call shutdown on the runner. this function does not act as a test, but will log additional info if there is an unexpected failure during shutdown
  - it is safe to use this alongside `waitShutdown`, and the differences should be well documented in the code
  - the hope here is that we will stop getting in situations where an early failure leads to no shutdown being triggered which leads to failure to cleanup the test root directory, and noisy output
- removes the teardown func that we were previously returning from `setupOsqueryInstanceForTests`. tests should test the shutdown methodology with `waitShutdown` (happy path), and rely on the shutdown from `ensureShutdownOnCleanup` if anything goes wrong before we get a chance to `waitShutdown`
- updates the cleanup func from `testRootDirectory` to log any issues, but not fail the test itself to avoid any confusion (failures here should only be a symptom of some previous issue)