### PR TITLE
Enforce a timeout when shutting down errgroup

### DIFF
--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -185,7 +185,11 @@ func (l *LoggedErrgroup) Wait() error {
 	case err := <-errChan:
 		return err
 	case <-time.After(maxErrgroupShutdownDuration):
-		return fmt.Errorf("instance did not complete shutdown within %s", maxErrgroupShutdownDuration.String())
+		l.slogger.Log(context.TODO(), slog.LevelWarn,
+			"errgroup did not complete shutdown within timeout",
+			"timeout", maxErrgroupShutdownDuration.String(),
+		)
+		return nil
 	}
 }
 

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -19,7 +19,7 @@ type LoggedErrgroup struct {
 
 const (
 	maxShutdownGoroutineDuration = 3 * time.Second
-	maxErrgroupShutdownDuration  = 20 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
+	maxErrgroupShutdownDuration  = 30 * time.Second
 )
 
 func NewLoggedErrgroup(ctx context.Context, slogger *slog.Logger) *LoggedErrgroup {

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -158,7 +158,6 @@ func (l *LoggedErrgroup) AddShutdownGoroutine(ctx context.Context, goroutineName
 		}
 		slogger.Log(ctx, logLevel,
 			"exiting shutdown goroutine in errgroup",
-			"goroutine_name", goroutineName,
 			"goroutine_run_time", elapsedTime.String(),
 			"goroutine_err", err,
 		)

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -19,7 +19,7 @@ type LoggedErrgroup struct {
 
 const (
 	maxShutdownGoroutineDuration = 3 * time.Second
-	maxErrgroupShutdownDuration  = 8 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
+	maxErrgroupShutdownDuration  = 30 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
 )
 
 func NewLoggedErrgroup(ctx context.Context, slogger *slog.Logger) *LoggedErrgroup {

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -19,7 +19,7 @@ type LoggedErrgroup struct {
 
 const (
 	maxShutdownGoroutineDuration = 3 * time.Second
-	maxErrgroupShutdownDuration  = 5 * time.Second
+	maxErrgroupShutdownDuration  = 8 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
 )
 
 func NewLoggedErrgroup(ctx context.Context, slogger *slog.Logger) *LoggedErrgroup {

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -19,7 +19,7 @@ type LoggedErrgroup struct {
 
 const (
 	maxShutdownGoroutineDuration = 3 * time.Second
-	maxErrgroupShutdownDuration  = 30 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
+	maxErrgroupShutdownDuration  = 20 * time.Second // shutdown timeout should be shorter than rungroup.InterruptTimeout
 )
 
 func NewLoggedErrgroup(ctx context.Context, slogger *slog.Logger) *LoggedErrgroup {

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/errgroup"
@@ -176,12 +175,6 @@ type osqueryOptions struct {
 	// options included by the caller of LaunchOsqueryInstance
 	augeasLensFunc      func(dir string) error
 	extensionSocketPath string
-}
-
-func init() {
-	// Override the default shutdown behavior for our extension server, so that it does not
-	// take too long to shut down.
-	thrift.ServerStopTimeout = 3 * time.Second
 }
 
 func newInstance(registrationId string, knapsack types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *OsqueryInstance {

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/errgroup"
@@ -804,6 +805,9 @@ func (i *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 
 	i.emsLock.Lock()
 	defer i.emsLock.Unlock()
+
+	// Make sure we will stop the server during shutdown
+	thrift.ServerStopTimeout = 1 * time.Second
 
 	i.extensionManagerServers = append(i.extensionManagerServers, extensionManagerServer)
 

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -831,6 +831,9 @@ func (i *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 				"extension_name", name,
 			)
 		}
+		if client != nil {
+			client.Close()
+		}
 		return nil
 	})
 

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/errgroup"
@@ -175,6 +176,12 @@ type osqueryOptions struct {
 	// options included by the caller of LaunchOsqueryInstance
 	augeasLensFunc      func(dir string) error
 	extensionSocketPath string
+}
+
+func init() {
+	// Override the default shutdown behavior for our extension server, so that it does not
+	// take too long to shut down.
+	thrift.ServerStopTimeout = 3 * time.Second
 }
 
 func newInstance(registrationId string, knapsack types.Knapsack, serviceClient service.KolideService, opts ...OsqueryInstanceOption) *OsqueryInstance {

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -35,6 +35,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func init() {
+	// Make sure we will stop the extension manager server during shutdown.
+	// We set this during `init` to avoid data races.
+	thrift.ServerStopTimeout = 1 * time.Second
+}
+
 const (
 	// KolideSaasExtensionName is the name of the extension that provides the config,
 	// distributed queries, and log destination for the osquery process. It also provides
@@ -805,9 +811,6 @@ func (i *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, socket
 
 	i.emsLock.Lock()
 	defer i.emsLock.Unlock()
-
-	// Make sure we will stop the server during shutdown
-	thrift.ServerStopTimeout = 1 * time.Second
 
 	i.extensionManagerServers = append(i.extensionManagerServers, extensionManagerServer)
 

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -298,7 +298,7 @@ func TestLaunch(t *testing.T) {
 
 	select {
 	case err := <-shutdownErr:
-		require.True(t, errors.Is(err, context.Canceled), fmt.Sprintf("instance logs:\n\n%s", logBytes.String()))
+		require.True(t, errors.Is(err, context.Canceled), fmt.Sprintf("unexpected err %v; instance logs:\n\n%s", err, logBytes.String()))
 	case <-time.After(1 * time.Minute):
 		t.Error("instance did not shut down within timeout", fmt.Sprintf("instance logs: %s", logBytes.String()))
 		t.FailNow()

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -298,7 +298,7 @@ func TestLaunch(t *testing.T) {
 
 	select {
 	case err := <-shutdownErr:
-		require.True(t, errors.Is(err, context.Canceled), fmt.Sprintf("unexpected err %v; instance logs:\n\n%s", err, logBytes.String()))
+		require.True(t, errors.Is(err, context.Canceled), fmt.Sprintf("unexpected err at %s: %v; instance logs:\n\n%s", time.Now().String(), err, logBytes.String()))
 	case <-time.After(1 * time.Minute):
 		t.Error("instance did not shut down within timeout", fmt.Sprintf("instance logs: %s", logBytes.String()))
 		t.FailNow()

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -665,8 +665,8 @@ func TestOsqueryDies(t *testing.T) {
 	runner.instanceLock.Unlock()
 
 	waitHealthy(t, runner, logBytes)
-	require.NotEmpty(t, previousStats.Error, "error should be added to stats when unexpected shutdown")
-	require.NotEmpty(t, previousStats.ExitTime, "exit time should be added to instance when unexpected shutdown")
+	require.NotEmpty(t, previousStats.Error, "error should be added to stats when unexpected shutdown occurs")
+	require.NotEmpty(t, previousStats.ExitTime, "exit time should be added to instance when unexpected shutdown occurs")
 
 	waitShutdown(t, runner, logBytes)
 }


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2046.

We want to ensure that a failed instance will eventually shut down, so that the runner is able to start a new one. This PR updates our errgroup implementation to enforce a timeout on call to `errgroup.Wait()` so that the caller does not wait indefinitely.

I chose to err on the side of a longer timeout rather than a shorter one. It can be a little painful if the osquery instance doesn't shut down correctly (see: https://github.com/kolide/launcher/issues/2004), so I want to make sure we gave the instance ample time to shut down. A thirty-second delay is still an improvement on an indefinite delay. 😅 