### PR TITLE
add timeout to osqueryinstance Healthy calls

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -162,7 +162,11 @@ func (i *OsqueryInstance) Healthy() error {
 	// Wait until we either receive an error or nil result from the healthcheck goroutine, or exceed our timeout threshold
 	select {
 	case maybeErr := <-resultsChan:
-		return maybeErr
+		if maybeErr != nil {
+			return fmt.Errorf("encountered error during healthcheck: %w", maybeErr)
+		}
+
+		return nil
 	case <-time.After(healtcheckTimeout):
 		return fmt.Errorf("osqueryinstance healthcheck exceeded timeout of %s", healtcheckTimeout.String())
 	}

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -73,7 +73,7 @@ const (
 	maxSocketWaitTime = 30 * time.Second
 
 	// How long to wait for a single osqueryinstance healthcheck before forcibly returning error
-	healtcheckTimeout = 10 * time.Second
+	healthcheckTimeout = 10 * time.Second
 )
 
 // OsqueryInstanceOption is a functional option pattern for defining how an
@@ -167,8 +167,8 @@ func (i *OsqueryInstance) Healthy() error {
 		}
 
 		return nil
-	case <-time.After(healtcheckTimeout):
-		return fmt.Errorf("osqueryinstance healthcheck exceeded timeout of %s", healtcheckTimeout.String())
+	case <-time.After(healthcheckTimeout):
+		return fmt.Errorf("osqueryinstance healthcheck exceeded timeout of %s", healthcheckTimeout.String())
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/kolide/launcher/issues/2050 (see issue for additional context)
I'm not exactly sure what the best timeout value would be, ten seconds seemed safe enough. the point here is only to prevent the healthchecking goroutine from becoming hung indefinitely