### PR TITLE
Add tests-docs label to release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,6 +15,9 @@ changelog:
     - title: Bug Fixes
       labels:
         - "bug-fixes"
+    - title: Tests, Docs, and Other No-op Changes
+      labels:
+        - "tests-docs"
     - title: General # Non-code changes like tests, CI, documentation
       labels:
         - "*"


### PR DESCRIPTION
This PR introduces a new label for PRs that don't include code changes -- hopefully making it easier to scan releases for meaningful changes.