### PR TITLE
secure enclave - dont set no console user as span error

### DIFF
--- a/ee/secureenclaverunner/secureenclaverunner.go
+++ b/ee/secureenclaverunner/secureenclaverunner.go
@@ -191,7 +191,7 @@ func (ser *secureEnclaveRunner) currentConsoleUserKey(ctx context.Context) (*ecd
 			"err", err,
 		)
 
-		traces.SetError(span, fmt.Errorf("getting first console user: %w", err))
+		span.AddEvent("no_console_user_found")
 		return nil, nil
 	}
 


### PR DESCRIPTION
Updates secure enclave runner to just set no console user as an event instead of an error.