### PR TITLE
Add wrapper to enforce timeout for extension tables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,8 @@ linters-settings:
         msg: use gowrapper.Go() instead of raw goroutines for proper panic handling
       - p: \.Cmd\.(Run|Start|Output|CombinedOutput)
         msg: "Do not call embedded exec.Cmd methods directly on TracedCmd; call TracedCmd.Run(), TracedCmd.Start(), etc. instead"
+      - p: ^table\.NewPlugin.*$
+        msg: use ee/tables/tablewrapper to enforce timeouts on table queries
   sloglint:
     kv-only: true
     context: "all"

--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/kolide/launcher/ee/indexeddb"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -144,7 +145,7 @@ func ConstructKATCTables(config map[string]string, slogger *slog.Logger) []osque
 		}
 
 		t, columns := newKatcTable(tableName, cfg, slogger)
-		plugins = append(plugins, table.NewPlugin(tableName, columns, t.generate))
+		plugins = append(plugins, tablewrapper.New(slogger, tableName, columns, t.generate))
 	}
 
 	return plugins

--- a/ee/tables/airport/table_darwin.go
+++ b/ee/tables/airport/table_darwin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -41,7 +42,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("name", tableName),
 	}
 
-	return table.NewPlugin(t.name, columns, t.generate)
+	return tablewrapper.New(slogger, t.name, columns, t.generate)
 }
 
 type airportExecutor struct {

--- a/ee/tables/app-icons/app_icons_darwin.go
+++ b/ee/tables/app-icons/app_icons_darwin.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 
 	"fmt"
 	"hash/crc64"
@@ -34,6 +35,7 @@ import (
 	"image/png"
 	"unsafe"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/nfnt/resize"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -43,13 +45,13 @@ import (
 
 var crcTable = crc64.MakeTable(crc64.ECMA)
 
-func AppIcons() *table.Plugin {
+func AppIcons(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("path"),
 		table.TextColumn("icon"),
 		table.TextColumn("hash"),
 	}
-	return table.NewPlugin("kolide_app_icons", columns, generateAppIcons)
+	return tablewrapper.New(slogger, "kolide_app_icons", columns, generateAppIcons)
 }
 
 func generateAppIcons(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/apple_silicon_security_policy/table.go
+++ b/ee/tables/apple_silicon_security_policy/table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -32,7 +33,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(tableName, columns, t.generate)
+	return tablewrapper.New(slogger, tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/crowdstrike/falcon_kernel_check/table.go
+++ b/ee/tables/crowdstrike/falcon_kernel_check/table.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -32,7 +33,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(tableName, columns, t.generate)
+	return tablewrapper.New(slogger, tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/crowdstrike/falconctl/table.go
+++ b/ee/tables/crowdstrike/falconctl/table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -58,11 +59,11 @@ func NewFalconctlOptionTable(slogger *slog.Logger) *table.Plugin {
 		execFunc:  tablehelpers.RunSimple,
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *falconctlOptionsTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	ctx, span := traces.StartSpan(ctx, "table_name", "kolide_falconctl_options")
+	ctx, span := traces.StartSpan(ctx, "table_name", t.tableName)
 	defer span.End()
 
 	var results []map[string]string

--- a/ee/tables/cryptoinfotable/table.go
+++ b/ee/tables/cryptoinfotable/table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -32,7 +33,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_cryptinfo"),
 	}
 
-	return table.NewPlugin("kolide_cryptoinfo", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_cryptinfo", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/cryptsetup/table.go
+++ b/ee/tables/cryptsetup/table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -34,7 +35,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		name:    "kolide_cryptsetup_status",
 	}
 
-	return table.NewPlugin(t.name, columns, t.generate)
+	return tablewrapper.New(slogger, t.name, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/dataflattentable/exec.go
+++ b/ee/tables/dataflattentable/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ func TablePluginExec(slogger *slog.Logger, tableName string, dataSourceType Data
 
 	t.flattenBytesFunc = dataSourceType.FlattenBytesFunc(t.keyValueSeparator)
 
-	return table.NewPlugin(t.tableName, columns, t.generateExec)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generateExec)
 }
 
 func (t *Table) generateExec(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/dataflattentable/exec_and_parse.go
+++ b/ee/tables/dataflattentable/exec_and_parse.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
@@ -66,7 +67,7 @@ func NewExecAndParseTable(slogger *slog.Logger, tableName string, p parser, cmd 
 		opt(t)
 	}
 
-	return table.NewPlugin(t.tableName, Columns(), t.generate)
+	return tablewrapper.New(slogger, t.tableName, Columns(), t.generate)
 }
 
 func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/dataflattentable/tables.go
+++ b/ee/tables/dataflattentable/tables.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -125,7 +126,7 @@ func TablePlugin(slogger *slog.Logger, dataSourceType DataSourceType) osquery.Os
 
 	t.slogger = slogger.With("table", t.tableName)
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 
 }
 

--- a/ee/tables/desktopprocs/desktopprocs.go
+++ b/ee/tables/desktopprocs/desktopprocs.go
@@ -3,20 +3,22 @@ package desktopprocs
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/kolide/launcher/ee/desktop/runner"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func TablePlugin() *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("uid"),
 		table.TextColumn("pid"),
 		table.TextColumn("start_time"),
 		table.TextColumn("last_health_check"),
 	}
-	return table.NewPlugin("kolide_desktop_procs", columns, generate())
+	return tablewrapper.New(slogger, "kolide_desktop_procs", columns, generate())
 }
 
 func generate() table.GenerateFunc {

--- a/ee/tables/dev_table_tooling/table.go
+++ b/ee/tables/dev_table_tooling/table.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -37,7 +38,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(tableName, columns, t.generate)
+	return tablewrapper.New(slogger, tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/dsim_default_associations/dsim_default_associations.go
+++ b/ee/tables/dsim_default_associations/dsim_default_associations.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -33,7 +34,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_dsim_default_associations"),
 	}
 
-	return table.NewPlugin("kolide_dsim_default_associations", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_dsim_default_associations", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/filevault/filevault.go
+++ b/ee/tables/filevault/filevault.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_filevault"),
 	}
 
-	return table.NewPlugin("kolide_filevault", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_filevault", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/firefox_preferences/table.go
+++ b/ee/tables/firefox_preferences/table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -44,7 +45,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(t.name, columns, t.generate)
+	return tablewrapper.New(slogger, t.name, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/firmwarepasswd/firmwarepasswd.go
+++ b/ee/tables/firmwarepasswd/firmwarepasswd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -36,7 +37,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 
 	t := New(slogger.With("table", "kolide_firmwarepasswd"))
 
-	return table.NewPlugin("kolide_firmwarepasswd", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_firmwarepasswd", columns, t.generate)
 
 }
 

--- a/ee/tables/fscrypt_info/table.go
+++ b/ee/tables/fscrypt_info/table.go
@@ -3,6 +3,7 @@ package fscrypt_info
 import (
 	"log/slog"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -29,5 +30,5 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	t := &Table{
 		slogger: slogger.With("table", tableName),
 	}
-	return table.NewPlugin(tableName, columns, t.generate)
+	return tablewrapper.New(slogger, tableName, columns, t.generate)
 }

--- a/ee/tables/gsettings/gsettings.go
+++ b/ee/tables/gsettings/gsettings.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -46,7 +47,7 @@ func Settings(slogger *slog.Logger) *table.Plugin {
 		getBytes: execGsettings,
 	}
 
-	return table.NewPlugin("kolide_gsettings", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_gsettings", columns, t.generate)
 }
 
 func (t *GsettingsValues) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/gsettings/metadata.go
+++ b/ee/tables/gsettings/metadata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -43,7 +44,7 @@ func Metadata(slogger *slog.Logger) *table.Plugin {
 		cmdRunner: execGsettingsCommand,
 	}
 
-	return table.NewPlugin("kolide_gsettings_metadata", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_gsettings_metadata", columns, t.generate)
 }
 
 func (t *GsettingsMetadata) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/homebrew/upgradeable.go
+++ b/ee/tables/homebrew/upgradeable.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -35,7 +36,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_brew_upgradeable"),
 	}
 
-	return table.NewPlugin("kolide_brew_upgradeable", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_brew_upgradeable", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/ioreg/ioreg.go
+++ b/ee/tables/ioreg/ioreg.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -47,7 +48,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_ioreg",
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/jwt/jwt.go
+++ b/ee/tables/jwt/jwt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -57,7 +58,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_jwt"),
 	}
 
-	return table.NewPlugin("kolide_jwt", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_jwt", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/launcher_db/launcher_db.go
+++ b/ee/tables/launcher_db/launcher_db.go
@@ -3,21 +3,23 @@ package launcher_db
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 // TablePlugin provides an osquery table plugin that exposes data found in the server_provided_data launcher.db bucket.
 // This data is intended to be updated by the control server.
-func TablePlugin(tableName string, iterator types.Iterator) *table.Plugin {
+func TablePlugin(slogger *slog.Logger, tableName string, iterator types.Iterator) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("key"),
 		table.TextColumn("value"),
 	}
 
-	return table.NewPlugin(tableName, columns, generateServerDataTable(tableName, iterator))
+	return tablewrapper.New(slogger, tableName, columns, generateServerDataTable(tableName, iterator))
 }
 
 func generateServerDataTable(tableName string, iterator types.Iterator) table.GenerateFunc {

--- a/ee/tables/macos_software_update/available_products_table.go
+++ b/ee/tables/macos_software_update/available_products_table.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -36,7 +37,7 @@ func AvailableProducts(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(tableName, columns, t.generateAvailableProducts)
+	return tablewrapper.New(slogger, tableName, columns, t.generateAvailableProducts)
 }
 
 func (t *Table) generateAvailableProducts(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/macos_software_update/recommended_updates_table.go
+++ b/ee/tables/macos_software_update/recommended_updates_table.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -38,7 +39,7 @@ func RecommendedUpdates(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return table.NewPlugin(tableName, columns, t.generate)
+	return tablewrapper.NewTablePluginWithTimeout(slogger, tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/macos_software_update/recommended_updates_table.go
+++ b/ee/tables/macos_software_update/recommended_updates_table.go
@@ -39,7 +39,7 @@ func RecommendedUpdates(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", tableName),
 	}
 
-	return tablewrapper.NewTablePluginWithTimeout(slogger, tableName, columns, t.generate)
+	return tablewrapper.New(slogger, tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/macos_software_update/software_update_table.go
+++ b/ee/tables/macos_software_update/software_update_table.go
@@ -14,15 +14,17 @@ import (
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"golang.org/x/sys/unix"
 )
 
-func MacOSUpdate() *table.Plugin {
+func MacOSUpdate(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.IntegerColumn("autoupdate_managed"),
 		table.IntegerColumn("autoupdate_enabled"),
@@ -38,7 +40,7 @@ func MacOSUpdate() *table.Plugin {
 		table.IntegerColumn("last_successful_check_timestamp"),
 	}
 	tableGen := &osUpdateTable{}
-	return table.NewPlugin("kolide_macos_software_update", columns, tableGen.generateMacUpdate)
+	return tablewrapper.New(slogger, "kolide_macos_software_update", columns, tableGen.generateMacUpdate)
 }
 
 type osUpdateTable struct {

--- a/ee/tables/mdmclient/mdmclient.go
+++ b/ee/tables/mdmclient/mdmclient.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -63,7 +64,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_mdmclient",
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/munki/munki.go
+++ b/ee/tables/munki/munki.go
@@ -6,10 +6,12 @@ package munki
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
 	"github.com/groob/plist"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -27,7 +29,7 @@ func New() *MunkiInfo {
 	}
 }
 
-func (m *MunkiInfo) MunkiReport() *table.Plugin {
+func (m *MunkiInfo) MunkiReport(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("version"),
 		table.TextColumn("start_time"),
@@ -38,17 +40,17 @@ func (m *MunkiInfo) MunkiReport() *table.Plugin {
 		table.TextColumn("console_user"),
 		table.TextColumn("manifest_name"),
 	}
-	return table.NewPlugin("kolide_munki_report", columns, m.generateMunkiReport)
+	return tablewrapper.New(slogger, "kolide_munki_report", columns, m.generateMunkiReport)
 }
 
-func (m *MunkiInfo) ManagedInstalls() *table.Plugin {
+func (m *MunkiInfo) ManagedInstalls(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("installed_version"),
 		table.TextColumn("installed"),
 		table.TextColumn("name"),
 		table.TextColumn("end_time"),
 	}
-	return table.NewPlugin("kolide_munki_installs", columns, m.generateMunkiInstalls)
+	return tablewrapper.New(slogger, "kolide_munki_installs", columns, m.generateMunkiInstalls)
 }
 
 func (m *MunkiInfo) generateMunkiInstalls(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/nix_env/upgradeable/upgradeable.go
+++ b/ee/tables/nix_env/upgradeable/upgradeable.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -33,7 +34,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_nix_upgradeable"),
 	}
 
-	return table.NewPlugin("kolide_nix_upgradeable", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_nix_upgradeable", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/osquery_instance_history/osquery_instance_history.go
+++ b/ee/tables/osquery_instance_history/osquery_instance_history.go
@@ -2,13 +2,15 @@ package osquery_instance_history
 
 import (
 	"context"
+	"log/slog"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func TablePlugin() *table.Plugin {
+func TablePlugin(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("registration_id"),
 		table.TextColumn("instance_run_id"),
@@ -20,7 +22,7 @@ func TablePlugin() *table.Plugin {
 		table.TextColumn("version"),
 		table.TextColumn("errors"),
 	}
-	return table.NewPlugin("kolide_launcher_osquery_instance_history", columns, generate())
+	return tablewrapper.New(slogger, "kolide_launcher_osquery_instance_history", columns, generate())
 }
 
 func generate() table.GenerateFunc {

--- a/ee/tables/osquery_user_exec_table/table.go
+++ b/ee/tables/osquery_user_exec_table/table.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -51,7 +52,7 @@ func TablePlugin(
 		tablename: tablename,
 	}
 
-	return table.NewPlugin(t.tablename, columns, t.generate)
+	return tablewrapper.New(slogger, t.tablename, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/profiles/profiles.go
+++ b/ee/tables/profiles/profiles.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -56,7 +57,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_profiles",
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/pwpolicy/pwpolicy.go
+++ b/ee/tables/pwpolicy/pwpolicy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -44,7 +45,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		execCC:    allowedcmd.Pwpolicy,
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/secedit/secedit.go
+++ b/ee/tables/secedit/secedit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 
@@ -39,7 +40,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_secedit"),
 	}
 
-	return table.NewPlugin("kolide_secedit", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_secedit", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/secureboot/table.go
+++ b/ee/tables/secureboot/table.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/efi"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -24,7 +25,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_secureboot"),
 	}
 
-	return table.NewPlugin("kolide_secureboot", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_secureboot", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/spotlight/spotlight.go
+++ b/ee/tables/spotlight/spotlight.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -41,7 +42,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_spotlight"),
 	}
 
-	return table.NewPlugin("kolide_spotlight", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_spotlight", columns, t.generate)
 }
 
 func (t *spotlightTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/systemprofiler/systemprofiler.go
+++ b/ee/tables/systemprofiler/systemprofiler.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -98,7 +99,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_system_profiler",
 	}
 
-	return table.NewPlugin(t.tableName, columns, t.generate)
+	return tablewrapper.New(slogger, t.tableName, columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -51,7 +51,13 @@ func NewTablePluginWithCustomTimeout(slogger *slog.Logger, name string, columns 
 		case result := <-resultChan:
 			return result.rows, result.err
 		case <-ctx.Done():
-			return nil, fmt.Errorf("querying %s timed out after %s (queried columns: %v)", name, genTimeout.String(), columnsFromConstraints(queryContext))
+			queriedColumns := columnsFromConstraints(queryContext)
+			slogger.Log(ctx, slog.LevelWarn,
+				"query timed out",
+				"table_name", name,
+				"queried_columns", fmt.Sprintf("%+v", queriedColumns),
+			)
+			return nil, fmt.Errorf("querying %s timed out after %s (queried columns: %v)", name, genTimeout.String(), queriedColumns)
 		}
 	}
 

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -54,7 +54,7 @@ func New(slogger *slog.Logger, name string, columns []table.ColumnDefinition, ge
 // generate wraps `wt.gen`, ensuring the function is traced and that it does not run for longer
 // than `wt.genTimeout`.
 func (wt *wrappedTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	ctx, span := traces.StartSpan(ctx, "table_name", wt.name)
+	ctx, span := traces.StartSpan(ctx, "table_name", wt.name, "generate_timeout", wt.genTimeout.String())
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(ctx, wt.genTimeout)

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -48,7 +48,7 @@ func New(slogger *slog.Logger, name string, columns []table.ColumnDefinition, ge
 		opt(wt)
 	}
 
-	return table.NewPlugin(name, columns, wt.generate)
+	return table.NewPlugin(name, columns, wt.generate) //nolint:forbidigo // This is our one allowed usage of table.NewPlugin
 }
 
 // generate wraps `wt.gen`, ensuring the function is traced and that it does not run for longer

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-const DefaultTableTimeout = 2 * time.Minute
+const DefaultTableTimeout = 4 * time.Minute
 
 type generateResult struct {
 	rows []map[string]string

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -1,0 +1,69 @@
+package tablewrapper
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kolide/launcher/ee/gowrapper"
+	"github.com/kolide/launcher/pkg/traces"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const DefaultTableTimeout = 2 * time.Minute
+
+type generateResult struct {
+	rows []map[string]string
+	err  error
+}
+
+// NewTablePluginWithTimeout returns a table plugin using the default table timeout.
+// Most tables should use this function unless they have a specific need for a
+// custom timeout.
+func NewTablePluginWithTimeout(slogger *slog.Logger, name string, columns []table.ColumnDefinition, gen table.GenerateFunc) *table.Plugin {
+	return NewTablePluginWithCustomTimeout(slogger, name, columns, gen, DefaultTableTimeout)
+}
+
+// NewTablePluginWithCustomTimeout returns a table plugin that will attempt to execute a query
+// up until the given timeout, at which point it will instead return no rows and a timeout error.
+func NewTablePluginWithCustomTimeout(slogger *slog.Logger, name string, columns []table.ColumnDefinition, gen table.GenerateFunc, genTimeout time.Duration) *table.Plugin {
+	wrappedGen := func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		ctx, span := traces.StartSpan(ctx, "table_name", name)
+		defer span.End()
+
+		ctx, cancel := context.WithTimeout(ctx, genTimeout)
+		defer cancel()
+
+		// Kick off running the query
+		resultChan := make(chan *generateResult)
+		gowrapper.Go(ctx, slogger, func() {
+			rows, err := gen(ctx, queryContext)
+			span.AddEvent("generate_returned")
+			resultChan <- &generateResult{
+				rows: rows,
+				err:  err,
+			}
+		})
+
+		// Wait for results up until the timeout
+		select {
+		case result := <-resultChan:
+			return result.rows, result.err
+		case <-ctx.Done():
+			return nil, fmt.Errorf("querying %s timed out after %s (queried columns: %v)", name, genTimeout.String(), columnsFromConstraints(queryContext))
+		}
+	}
+
+	return table.NewPlugin(name, columns, wrappedGen)
+}
+
+// columnsFromConstraints extracts the column names from the query for logging purposes
+func columnsFromConstraints(queryContext table.QueryContext) []string {
+	keys := make([]string, 0, len(queryContext.Constraints))
+	for k := range queryContext.Constraints {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/ee/tables/tablewrapper/tablewrapper_test.go
+++ b/ee/tables/tablewrapper/tablewrapper_test.go
@@ -1,0 +1,74 @@
+package tablewrapper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/osquery/osquery-go/gen/osquery"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	expectedName := "test_table"
+	overrideTimeout := 3 * time.Second
+	expectedRow := map[string]string{
+		"somekey": "somevalue",
+	}
+	expectedRows := []map[string]string{
+		expectedRow,
+	}
+
+	w := New(multislogger.NewNopLogger(), expectedName, nil, func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		return expectedRows, nil
+	}, WithGenerateTimeout(overrideTimeout))
+
+	// The table name must be set correctly
+	require.Equal(t, expectedName, w.Name())
+
+	// The generate function must work
+	resp := w.Call(context.TODO(), map[string]string{"action": "generate", "context": "{}"})
+	require.Equal(t, int32(0), resp.Status.Code) // success
+	require.Equal(t, 1, len(resp.Response))
+	require.Equal(t, expectedRow, resp.Response[0])
+}
+
+func TestNew_handlesTimeout(t *testing.T) {
+	t.Parallel()
+
+	expectedName := "test_table"
+	overrideTimeout := 3 * time.Second
+
+	w := New(multislogger.NewNopLogger(), expectedName, nil, func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+		// The generate function must take longer than the timeout
+		time.Sleep(3 * overrideTimeout)
+		return []map[string]string{
+			{
+				"somekey": "1",
+			},
+		}, nil
+	}, WithGenerateTimeout(overrideTimeout))
+
+	// The table name must be set correctly
+	require.Equal(t, expectedName, w.Name())
+
+	// The call to generate must return by the time we hit `overrideTimeout`
+	resultChan := make(chan osquery.ExtensionResponse)
+	go func() {
+		resultChan <- w.Call(context.TODO(), map[string]string{"action": "generate", "context": "{}"})
+	}()
+
+	select {
+	case resp := <-resultChan:
+		// We got a result once we hit the timeout
+		require.Equal(t, int32(1), resp.Status.Code) // failure
+		require.Contains(t, resp.Status.Message, "error generating table")
+	case <-time.After(overrideTimeout + 1*time.Second):
+		t.Error("generate did not return within timeout")
+		t.FailNow()
+	}
+}

--- a/ee/tables/tdebug/gc.go
+++ b/ee/tables/tdebug/gc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -31,7 +32,7 @@ func LauncherGcInfo(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", gcTableName),
 	}
 
-	return table.NewPlugin(gcTableName, columns, t.generate)
+	return tablewrapper.New(slogger, gcTableName, columns, t.generate)
 }
 
 func (t *gcTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/tufinfo/release_version.go
+++ b/ee/tables/tufinfo/release_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,13 +14,14 @@ import (
 	"github.com/theupdateframework/go-tuf/data"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/ee/tuf"
 	"github.com/kolide/launcher/pkg/traces"
 )
 
 const tufReleaseVersionTableName = "kolide_tuf_release_version"
 
-func TufReleaseVersionTable(flags types.Flags) *table.Plugin {
+func TufReleaseVersionTable(slogger *slog.Logger, flags types.Flags) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("binary"),
 		table.TextColumn("operating_system"),
@@ -28,7 +30,7 @@ func TufReleaseVersionTable(flags types.Flags) *table.Plugin {
 		table.TextColumn("target"),
 	}
 
-	return table.NewPlugin(tufReleaseVersionTableName, columns, generateTufReleaseVersionTable(flags))
+	return tablewrapper.New(slogger, tufReleaseVersionTableName, columns, generateTufReleaseVersionTable(flags))
 }
 
 func generateTufReleaseVersionTable(flags types.Flags) table.GenerateFunc {

--- a/ee/tables/tufinfo/release_version_test.go
+++ b/ee/tables/tufinfo/release_version_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/tuf"
 	tufci "github.com/kolide/launcher/ee/tuf/ci"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/osquery/osquery-go/gen/osquery"
 
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestTufReleaseVersionTable(t *testing.T) {
 	mockFlags.On("RootDirectory").Return(testRootDir)
 
 	// Call table generate func and validate that our data matches what exists in the filesystem
-	testTable := TufReleaseVersionTable(mockFlags)
+	testTable := TufReleaseVersionTable(multislogger.NewNopLogger(), mockFlags)
 	resp := testTable.Call(context.Background(), osquery.ExtensionPluginRequest{
 		"action":  "generate",
 		"context": "{}",

--- a/ee/tables/wifi_networks/wifi_networks.go
+++ b/ee/tables/wifi_networks/wifi_networks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -50,7 +51,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		getBytes: execPwsh(slogger),
 	}
 
-	return table.NewPlugin("kolide_wifi_networks", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_wifi_networks", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/windowsupdatetable/windowsupdate.go
+++ b/ee/tables/windowsupdatetable/windowsupdate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/kolide/launcher/pkg/windows/windowsupdate"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -53,7 +54,7 @@ func TablePlugin(mode tableMode, slogger *slog.Logger) *table.Plugin {
 
 	t.slogger = slogger.With("name", t.name)
 
-	return table.NewPlugin(t.name, columns, t.generate)
+	return tablewrapper.New(slogger, t.name, columns, t.generate)
 }
 
 func queryUpdates(searcher *windowsupdate.IUpdateSearcher) (interface{}, error) {

--- a/ee/tables/wmitable/wmitable.go
+++ b/ee/tables/wmitable/wmitable.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/ee/wmi"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -37,8 +38,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_wmi"),
 	}
 
-	return table.NewPlugin("kolide_wmi", columns, t.generate)
-
+	return tablewrapper.New(slogger, "kolide_wmi", columns, t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/xfconf/xfconf.go
+++ b/ee/tables/xfconf/xfconf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"golang.org/x/exp/maps"
@@ -36,7 +37,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_xfconf"),
 	}
 
-	return table.NewPlugin("kolide_xfconf", dataflattentable.Columns(table.TextColumn("username"), table.TextColumn("path")), t.generate)
+	return tablewrapper.New(slogger, "kolide_xfconf", dataflattentable.Columns(table.TextColumn("username"), table.TextColumn("path")), t.generate)
 }
 
 func (t *xfconfTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/xrdb/xrdb.go
+++ b/ee/tables/xrdb/xrdb.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -46,7 +47,7 @@ func TablePlugin(slogger *slog.Logger) *table.Plugin {
 		getBytes: execXRDB,
 	}
 
-	return table.NewPlugin("kolide_xrdb", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_xrdb", columns, t.generate)
 }
 
 func (t *XRDBSettings) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/ee/tables/zfs/tables.go
+++ b/ee/tables/zfs/tables.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/pkg/errors"
@@ -43,7 +44,7 @@ func ZfsPropertiesPlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_zfs_properties",
 	}
 
-	return table.NewPlugin("kolide_zfs_properties", columns(), t.generate)
+	return tablewrapper.New(slogger, "kolide_zfs_properties", columns(), t.generate)
 }
 
 func ZpoolPropertiesPlugin(slogger *slog.Logger) *table.Plugin {
@@ -53,7 +54,7 @@ func ZpoolPropertiesPlugin(slogger *slog.Logger) *table.Plugin {
 		tableName: "kolide_zpool_properties",
 	}
 
-	return table.NewPlugin("kolide_zpool_properties", columns(), t.generate)
+	return tablewrapper.New(slogger, "kolide_zpool_properties", columns(), t.generate)
 }
 
 func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -424,7 +424,7 @@ func (i *OsqueryInstance) Launch() error {
 		osquerylogger.NewPlugin(KolideSaasExtensionName, i.saasExtension.LogString),
 	}
 	kolideSaasPlugins = append(kolideSaasPlugins, table.PlatformTables(i.knapsack, i.registrationId, i.knapsack.Slogger().With("component", "platform_tables"), currentOsquerydBinaryPath)...)
-	kolideSaasPlugins = append(kolideSaasPlugins, table.LauncherTables(i.knapsack)...)
+	kolideSaasPlugins = append(kolideSaasPlugins, table.LauncherTables(i.knapsack, i.knapsack.Slogger().With("component", "launcher_tables"))...)
 
 	if err := i.StartOsqueryExtensionManagerServer(KolideSaasExtensionName, paths.extensionSocketPath, i.extensionManagerClient, kolideSaasPlugins); err != nil {
 		i.slogger.Log(ctx, slog.LevelInfo,

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -31,7 +32,7 @@ func ChromeLoginDataEmails(slogger *slog.Logger) *table.Plugin {
 		table.TextColumn("email"),
 		table.BigIntColumn("count"),
 	}
-	return table.NewPlugin("kolide_chrome_login_data_emails", columns, c.generate)
+	return tablewrapper.New(slogger, "kolide_chrome_login_data_emails", columns, c.generate)
 }
 
 type ChromeLoginDataEmailsTable struct {

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -24,7 +25,7 @@ func ChromeLoginKeychainInfo(slogger *slog.Logger) *table.Plugin {
 		table.TextColumn("action_url"),
 		table.TextColumn("username_value"),
 	}
-	return table.NewPlugin("kolide_chrome_login_keychain", columns, c.generate)
+	return tablewrapper.New(slogger, "kolide_chrome_login_keychain", columns, c.generate)
 }
 
 type ChromeLoginKeychain struct {

--- a/pkg/osquery/table/chrome_user_profiles.go
+++ b/pkg/osquery/table/chrome_user_profiles.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -34,7 +35,7 @@ func ChromeUserProfiles(slogger *slog.Logger) *table.Plugin {
 		table.IntegerColumn("ephemeral"),
 	}
 
-	return table.NewPlugin("kolide_chrome_user_profiles", columns, c.generate)
+	return tablewrapper.New(slogger, "kolide_chrome_user_profiles", columns, c.generate)
 }
 
 type chromeUserProfilesTable struct {

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -23,7 +24,7 @@ func GDriveSyncConfig(slogger *slog.Logger) *table.Plugin {
 		table.TextColumn("user_email"),
 		table.TextColumn("local_sync_root_path"),
 	}
-	return table.NewPlugin("kolide_gdrive_sync_config", columns, g.generate)
+	return tablewrapper.New(slogger, "kolide_gdrive_sync_config", columns, g.generate)
 }
 
 type gdrive struct {

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -24,7 +25,7 @@ func GDriveSyncHistoryInfo(slogger *slog.Logger) *table.Plugin {
 		table.TextColumn("mtime"),
 		table.TextColumn("size"),
 	}
-	return table.NewPlugin("kolide_gdrive_sync_history", columns, g.generate)
+	return tablewrapper.New(slogger, "kolide_gdrive_sync_history", columns, g.generate)
 }
 
 type GDriveSyncHistory struct {

--- a/pkg/osquery/table/keyinfo.go
+++ b/pkg/osquery/table/keyinfo.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/kolide/launcher/ee/keyidentifier"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -42,7 +43,7 @@ func KeyInfo(slogger *slog.Logger) *table.Plugin {
 		kIdentifer: kIdentifer,
 	}
 
-	return table.NewPlugin("kolide_keyinfo", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_keyinfo", columns, t.generate)
 }
 
 func (t *KeyInfoTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/table/kolide_launcher_autoupdate_config.go
+++ b/pkg/osquery/table/kolide_launcher_autoupdate_config.go
@@ -2,15 +2,17 @@ package table
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 const launcherAutoupdateConfigTableName = "kolide_launcher_autoupdate_config"
 
-func LauncherAutoupdateConfigTable(flags types.Flags) *table.Plugin {
+func LauncherAutoupdateConfigTable(slogger *slog.Logger, flags types.Flags) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("autoupdate"),
 		table.TextColumn("mirror_server_url"),
@@ -19,7 +21,7 @@ func LauncherAutoupdateConfigTable(flags types.Flags) *table.Plugin {
 		table.TextColumn("update_channel"),
 	}
 
-	return table.NewPlugin(launcherAutoupdateConfigTableName, columns, generateLauncherAutoupdateConfigTable(flags))
+	return tablewrapper.New(slogger, launcherAutoupdateConfigTableName, columns, generateLauncherAutoupdateConfigTable(flags))
 }
 
 func boolToString(in bool) string {

--- a/pkg/osquery/table/launcher_config.go
+++ b/pkg/osquery/table/launcher_config.go
@@ -2,19 +2,21 @@ package table
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func LauncherConfigTable(store types.Getter, registrationTracker types.RegistrationTracker) *table.Plugin {
+func LauncherConfigTable(slogger *slog.Logger, store types.Getter, registrationTracker types.RegistrationTracker) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("config"),
 		table.TextColumn("registration_id"),
 	}
-	return table.NewPlugin("kolide_launcher_config", columns, generateLauncherConfig(store, registrationTracker))
+	return tablewrapper.New(slogger, "kolide_launcher_config", columns, generateLauncherConfig(store, registrationTracker))
 }
 
 func generateLauncherConfig(store types.Getter, registrationTracker types.RegistrationTracker) table.GenerateFunc {

--- a/pkg/osquery/table/launcher_db_info.go
+++ b/pkg/osquery/table/launcher_db_info.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/tables/dataflattentable"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 	"go.etcd.io/bbolt"
 )
 
-func LauncherDbInfo(db *bbolt.DB) *table.Plugin {
+func LauncherDbInfo(slogger *slog.Logger, db *bbolt.DB) *table.Plugin {
 	columns := dataflattentable.Columns()
-	return table.NewPlugin("kolide_launcher_db_info", columns, generateLauncherDbInfo(db))
+	return tablewrapper.New(slogger, "kolide_launcher_db_info", columns, generateLauncherDbInfo(db))
 }
 
 func generateLauncherDbInfo(db *bbolt.DB) table.GenerateFunc {

--- a/pkg/osquery/table/launcher_info.go
+++ b/pkg/osquery/table/launcher_info.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 	"time"
@@ -14,13 +15,14 @@ import (
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/ee/agent"
 	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/osquery"
 	"github.com/kolide/launcher/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func LauncherInfoTable(configStore types.GetterSetter, LauncherHistoryStore types.GetterSetter) *table.Plugin {
+func LauncherInfoTable(slogger *slog.Logger, configStore types.GetterSetter, LauncherHistoryStore types.GetterSetter) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("branch"),
 		table.TextColumn("build_date"),
@@ -49,7 +51,7 @@ func LauncherInfoTable(configStore types.GetterSetter, LauncherHistoryStore type
 		table.TextColumn("fingerprint"),
 		table.TextColumn("public_key"),
 	}
-	return table.NewPlugin("kolide_launcher_info", columns, generateLauncherInfoTable(configStore, LauncherHistoryStore))
+	return tablewrapper.New(slogger, "kolide_launcher_info", columns, generateLauncherInfoTable(configStore, LauncherHistoryStore))
 }
 
 func generateLauncherInfoTable(configStore types.GetterSetter, LauncherHistoryStore types.GetterSetter) table.GenerateFunc {

--- a/pkg/osquery/table/macho.go
+++ b/pkg/osquery/table/macho.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"debug/macho"
 	"errors"
+	"log/slog"
 	"strings"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func MachoInfo() *table.Plugin {
+func MachoInfo(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("path"),
 		table.TextColumn("name"),
 		table.TextColumn("cpu"),
 	}
 
-	return table.NewPlugin("kolide_macho_info", columns, generateMacho)
+	return tablewrapper.New(slogger, "kolide_macho_info", columns, generateMacho)
 }
 
 func generateMacho(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/table/mdm.go
+++ b/pkg/osquery/table/mdm.go
@@ -7,16 +7,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"time"
 
 	"github.com/groob/plist"
 	"github.com/kolide/launcher/ee/allowedcmd"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func MDMInfo() *table.Plugin {
+func MDMInfo(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("enrolled"),
 		table.TextColumn("server_url"),
@@ -31,7 +33,7 @@ func MDMInfo() *table.Plugin {
 		table.TextColumn("installed_from_dep"),
 		table.TextColumn("user_approved"),
 	}
-	return table.NewPlugin("kolide_mdm_info", columns, generateMDMInfo)
+	return tablewrapper.New(slogger, "kolide_mdm_info", columns, generateMDMInfo)
 }
 
 func generateMDMInfo(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/launcher/ee/agent"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -40,7 +41,7 @@ func OnePasswordAccounts(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_onepassword_accounts"),
 	}
 
-	return table.NewPlugin("kolide_onepassword_accounts", columns, o.generate)
+	return tablewrapper.New(slogger, "kolide_onepassword_accounts", columns, o.generate)
 }
 
 type onePasswordAccountsTable struct {

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kolide/launcher/ee/tables/execparsers/softwareupdate"
 	"github.com/kolide/launcher/ee/tables/filevault"
 	"github.com/kolide/launcher/ee/tables/firmwarepasswd"
-	"github.com/kolide/launcher/ee/tables/homebrew"
+	brew_upgradeable "github.com/kolide/launcher/ee/tables/homebrew"
 	"github.com/kolide/launcher/ee/tables/ioreg"
 	"github.com/kolide/launcher/ee/tables/macos_software_update"
 	"github.com/kolide/launcher/ee/tables/mdmclient"
@@ -82,17 +82,17 @@ func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath stri
 	return []osquery.OsqueryPlugin{
 		keychainAclsTable,
 		keychainItemsTable,
-		appicons.AppIcons(),
+		appicons.AppIcons(slogger),
 		brew_upgradeable.TablePlugin(slogger),
 		ChromeLoginKeychainInfo(slogger),
 		firmwarepasswd.TablePlugin(slogger),
 		GDriveSyncConfig(slogger),
 		GDriveSyncHistoryInfo(slogger),
-		MDMInfo(),
-		macos_software_update.MacOSUpdate(),
+		MDMInfo(slogger),
+		macos_software_update.MacOSUpdate(slogger),
 		macos_software_update.RecommendedUpdates(slogger),
 		macos_software_update.AvailableProducts(slogger),
-		MachoInfo(),
+		MachoInfo(slogger),
 		spotlight.TablePlugin(slogger),
 		TouchIDUserConfig(slogger),
 		TouchIDSystemConfig(slogger),
@@ -120,8 +120,8 @@ func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath stri
 		screenlockTable,
 		pwpolicy.TablePlugin(slogger),
 		systemprofiler.TablePlugin(slogger),
-		munki.ManagedInstalls(),
-		munki.MunkiReport(),
+		munki.ManagedInstalls(slogger),
+		munki.MunkiReport(slogger),
 		dataflattentable.TablePluginExec(slogger, "kolide_nix_upgradeable", dataflattentable.XmlType, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
 		dataflattentable.NewExecAndParseTable(slogger, "kolide_socketfilterfw", socketfilterfw.Parser, allowedcmd.Socketfilterfw, []string{"--getglobalstate", "--getblockall", "--getallowsigned", "--getstealthmode", "--getloggingmode", "--getloggingopt"}, dataflattentable.WithIncludeStderr()),

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -19,7 +19,7 @@ import (
 
 func platformSpecificTables(slogger *slog.Logger, currentOsquerydBinaryPath string) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
-		ProgramIcons(),
+		ProgramIcons(slogger),
 		dsim_default_associations.TablePlugin(slogger),
 		secedit.TablePlugin(slogger),
 		wifi_networks.TablePlugin(slogger),

--- a/pkg/osquery/table/program_icons_windows.go
+++ b/pkg/osquery/table/program_icons_windows.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"hash/crc64"
 	"image/png"
+	"log/slog"
 	"os"
 
 	"strings"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/mat/besticon/ico"
 	"github.com/nfnt/resize"
@@ -25,14 +27,14 @@ type icon struct {
 	hash   uint64
 }
 
-func ProgramIcons() *table.Plugin {
+func ProgramIcons(slogger *slog.Logger) *table.Plugin {
 	columns := []table.ColumnDefinition{
 		table.TextColumn("name"),
 		table.TextColumn("version"),
 		table.TextColumn("icon"),
 		table.TextColumn("hash"),
 	}
-	return table.NewPlugin("kolide_program_icons", columns, generateProgramIcons)
+	return tablewrapper.New(slogger, "kolide_program_icons", columns, generateProgramIcons)
 }
 
 func generateProgramIcons(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/table/slack_config.go
+++ b/pkg/osquery/table/slack_config.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -43,7 +44,7 @@ func SlackConfig(slogger *slog.Logger) *table.Plugin {
 		slogger: slogger.With("table", "kolide_slack_config"),
 	}
 
-	return table.NewPlugin("kolide_slack_config", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_slack_config", columns, t.generate)
 }
 
 type SlackConfigTable struct {

--- a/pkg/osquery/table/sshkeys.go
+++ b/pkg/osquery/table/sshkeys.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/kolide/launcher/ee/keyidentifier"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -53,7 +54,7 @@ func SshKeys(slogger *slog.Logger) *table.Plugin {
 		kIdentifer: kIdentifer,
 	}
 
-	return table.NewPlugin("kolide_ssh_keys", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_ssh_keys", columns, t.generate)
 }
 
 func (t *SshKeysTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -28,18 +28,18 @@ import (
 
 // LauncherTables returns launcher-specific tables. They're based
 // around _launcher_ things thus do not make sense in tables.ext
-func LauncherTables(k types.Knapsack) []osquery.OsqueryPlugin {
+func LauncherTables(k types.Knapsack, slogger *slog.Logger) []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
-		LauncherConfigTable(k.ConfigStore(), k),
-		LauncherDbInfo(k.BboltDB()),
-		LauncherInfoTable(k.ConfigStore(), k.LauncherHistoryStore()),
-		launcher_db.TablePlugin("kolide_server_data", k.ServerProvidedDataStore()),
-		launcher_db.TablePlugin("kolide_control_flags", k.AgentFlagsStore()),
-		LauncherAutoupdateConfigTable(k),
-		osquery_instance_history.TablePlugin(),
-		tufinfo.TufReleaseVersionTable(k),
-		launcher_db.TablePlugin("kolide_tuf_autoupdater_errors", k.AutoupdateErrorsStore()),
-		desktopprocs.TablePlugin(),
+		LauncherConfigTable(slogger, k.ConfigStore(), k),
+		LauncherDbInfo(slogger, k.BboltDB()),
+		LauncherInfoTable(slogger, k.ConfigStore(), k.LauncherHistoryStore()),
+		launcher_db.TablePlugin(slogger, "kolide_server_data", k.ServerProvidedDataStore()),
+		launcher_db.TablePlugin(slogger, "kolide_control_flags", k.AgentFlagsStore()),
+		LauncherAutoupdateConfigTable(slogger, k),
+		osquery_instance_history.TablePlugin(slogger),
+		tufinfo.TufReleaseVersionTable(slogger, k),
+		launcher_db.TablePlugin(slogger, "kolide_tuf_autoupdater_errors", k.AutoupdateErrorsStore()),
+		desktopprocs.TablePlugin(slogger),
 	}
 }
 

--- a/pkg/osquery/table/touchid_system_darwin.go
+++ b/pkg/osquery/table/touchid_system_darwin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -23,7 +24,7 @@ func TouchIDSystemConfig(slogger *slog.Logger) *table.Plugin {
 		table.IntegerColumn("touchid_unlock"),
 	}
 
-	return table.NewPlugin("kolide_touchid_system_config", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_touchid_system_config", columns, t.generate)
 }
 
 type touchIDSystemConfigTable struct {

--- a/pkg/osquery/table/touchid_user_darwin.go
+++ b/pkg/osquery/table/touchid_user_darwin.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/ee/tables/tablehelpers"
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -26,7 +27,7 @@ func TouchIDUserConfig(slogger *slog.Logger) *table.Plugin {
 		table.IntegerColumn("effective_applepay"),
 	}
 
-	return table.NewPlugin("kolide_touchid_user_config", columns, t.generate)
+	return tablewrapper.New(slogger, "kolide_touchid_user_config", columns, t.generate)
 }
 
 type touchIDUserConfigTable struct {

--- a/pkg/osquery/table/user_avatar_darwin.go
+++ b/pkg/osquery/table/user_avatar_darwin.go
@@ -48,6 +48,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/nfnt/resize"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -63,7 +64,7 @@ func UserAvatar(slogger *slog.Logger) *table.Plugin {
 		table.TextColumn("hash"),
 	}
 	t := &userAvatarTable{slogger: slogger.With("table", "kolide_user_avatars")}
-	return table.NewPlugin("kolide_user_avatars", columns, t.generateAvatars)
+	return tablewrapper.New(slogger, "kolide_user_avatars", columns, t.generateAvatars)
 }
 
 type userAvatarTable struct {


### PR DESCRIPTION
* Add a `tablewrapper` package to ensure that osquery does not ever have to wait on a call to `generate` for more than four minutes by default
* Update to use this package everywhere
* Enforce tablewrapper usage via lint rule