### PR TITLE
Ship "Executing scheduled query pack" logs

### DIFF
--- a/ee/log/osquerylogs/log.go
+++ b/ee/log/osquerylogs/log.go
@@ -59,13 +59,6 @@ func NewOsqueryLogAdapter(slogger *slog.Logger, rootDirectory string, opts ...Op
 }
 
 func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
-	// Work around osquery being overly verbose with it's logs
-	// see: https://github.com/osquery/osquery/pull/6271
-	level := l.level
-	if bytes.Contains(p, []byte("Executing scheduled query pack")) {
-		level = slog.LevelDebug
-	}
-
 	if bytes.Contains(p, []byte("Accelerating distributed query checkins")) {
 		// Skip writing this. But we still return len(p) so the caller thinks it was written
 		return len(p), nil
@@ -105,7 +98,7 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 
 	msg := strings.TrimSpace(string(p))
 	caller := extractOsqueryCaller(msg)
-	l.slogger.Log(context.TODO(), level, // nolint:sloglint // it's fine to not have a constant or literal here
+	l.slogger.Log(context.TODO(), l.level, // nolint:sloglint // it's fine to not have a constant or literal here
 		msg,
 		"caller", caller,
 	)

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -742,7 +742,7 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 			"instance_run_id", i.runId,
 		),
 		i.knapsack.RootDirectory(),
-		kolidelog.WithLevel(slog.LevelInfo),
+		kolidelog.WithLevel(slog.LevelDebug),
 	)
 
 	// Apply user-provided flags last so that they can override other flags set

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -742,7 +742,7 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 			"instance_run_id", i.runId,
 		),
 		i.knapsack.RootDirectory(),
-		kolidelog.WithLevel(slog.LevelDebug),
+		kolidelog.WithLevel(slog.LevelInfo),
 	)
 
 	// Apply user-provided flags last so that they can override other flags set


### PR DESCRIPTION
These logs are usually info-level, but we have been overwriting their level to debug instead -- so they don't usually get shipped to the cloud. However, these logs would be useful to have. This PR removes overwriting the level for this log so that they will remain at the info level and get shipped.