### PR TITLE
Use gowrapper

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -329,7 +329,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 	// For now, remediation is not performed -- we only log the hardware change. So we can
 	// perform this operation in the background to avoid slowing down launcher startup.
-	go agent.DetectAndRemediateHardwareChange(ctx, k)
+	gowrapper.Go(ctx, slogger, func() {
+		agent.DetectAndRemediateHardwareChange(ctx, k)
+	})
 
 	powerEventSubscriber := powereventwatcher.NewKnapsackSleepStateUpdater(slogger, k)
 	powerEventWatcher, err := powereventwatcher.New(ctx, slogger, powerEventSubscriber)

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -182,9 +183,9 @@ func (l *LoggedErrgroup) Wait(ctx context.Context) error {
 	defer span.End()
 
 	errChan := make(chan error)
-	go func() {
+	gowrapper.Go(ctx, l.slogger, func() {
 		errChan <- l.errgroup.Wait()
-	}()
+	})
 
 	// Wait to receive an error from l.errgroup.Wait(), but only until our shutdown timeout.
 	select {


### PR DESCRIPTION
I neglected to use `gowrapper` in https://github.com/kolide/launcher/pull/2065 and in https://github.com/kolide/launcher/pull/2047 -- this PR updates to use `gowrapper` in those instances.