### PR TITLE
Add rungroup actor name to error when recovering after panic

### DIFF
--- a/pkg/rungroup/rungroup.go
+++ b/pkg/rungroup/rungroup.go
@@ -88,7 +88,7 @@ func (g *Group) Run() error {
 			// add it now.
 			actorErrors <- actorError{
 				errorSourceName: a.name,
-				err:             fmt.Errorf("execute panicked: %+v", r),
+				err:             fmt.Errorf("executing rungroup actor %s panicked: %+v", a.name, r),
 			}
 		})
 	}


### PR DESCRIPTION
This will help us trace through the error stack more easily when the rungroup returns this error.