### PR TITLE
Enable rowserrcheck linter and fix existing violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - nakedret
     - paralleltest
     - revive
+    - rowserrcheck
     - sloglint
     - sqlclosecheck
     - staticcheck

--- a/ee/agent/startupsettings/reader.go
+++ b/ee/agent/startupsettings/reader.go
@@ -3,6 +3,7 @@ package startupsettings
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	agentsqlite "github.com/kolide/launcher/ee/agent/storage/sqlite"
 	"github.com/kolide/launcher/ee/agent/types"
@@ -12,8 +13,8 @@ type startupSettingsReader struct {
 	kvStore types.GetterCloser
 }
 
-func OpenReader(ctx context.Context, rootDirectory string) (*startupSettingsReader, error) {
-	store, err := agentsqlite.OpenRO(ctx, rootDirectory, agentsqlite.StartupSettingsStore)
+func OpenReader(ctx context.Context, slogger *slog.Logger, rootDirectory string) (*startupSettingsReader, error) {
+	store, err := agentsqlite.OpenRO(ctx, slogger, rootDirectory, agentsqlite.StartupSettingsStore)
 	if err != nil {
 		return nil, fmt.Errorf("opening startup db in %s: %w", rootDirectory, err)
 	}

--- a/ee/agent/startupsettings/reader_test.go
+++ b/ee/agent/startupsettings/reader_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	agentsqlite "github.com/kolide/launcher/ee/agent/storage/sqlite"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func TestGet(t *testing.T) {
 	require.NoError(t, store.Set([]byte(flagKey), []byte(flagVal)), "setting key")
 	require.NoError(t, store.Close(), "closing setup connection")
 
-	r, err := OpenReader(context.TODO(), testRootDir)
+	r, err := OpenReader(context.TODO(), multislogger.NewNopLogger(), testRootDir)
 	require.NoError(t, err, "creating reader")
 
 	returnedVal, err := r.Get(flagKey)
@@ -38,7 +39,7 @@ func TestGet_DbNotExist(t *testing.T) {
 	testRootDir := t.TempDir()
 	flagKey := keys.UpdateChannel.String()
 
-	r, err := OpenReader(context.TODO(), testRootDir)
+	r, err := OpenReader(context.TODO(), multislogger.NewNopLogger(), testRootDir)
 	require.NoError(t, err, "creating reader")
 	_, err = r.Get(flagKey)
 	require.Error(t, err, "expected error getting startup value when database does not exist")

--- a/ee/agent/storage/sqlite/keyvalue_store_sqlite.go
+++ b/ee/agent/storage/sqlite/keyvalue_store_sqlite.go
@@ -334,7 +334,7 @@ ON CONFLICT (name) DO UPDATE SET value=excluded.value;`
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			s.slogger.Log(context.TODO(), slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
+++ b/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +24,7 @@ func TestOpenRO_DatabaseExists(t *testing.T) {
 	require.NoError(t, s1.Close(), "closing database")
 
 	// Create RO-connection to database
-	s2, err := OpenRO(context.TODO(), testRootDir, StartupSettingsStore)
+	s2, err := OpenRO(context.TODO(), multislogger.NewNopLogger(), testRootDir, StartupSettingsStore)
 	require.NoError(t, err, "setting up database")
 	require.NoError(t, s2.Close(), "closing database")
 }
@@ -33,7 +34,7 @@ func TestOpenRO_DatabaseDoesNotExist(t *testing.T) {
 
 	testRootDir := t.TempDir()
 
-	s, err := OpenRO(context.TODO(), testRootDir, StartupSettingsStore)
+	s, err := OpenRO(context.TODO(), multislogger.NewNopLogger(), testRootDir, StartupSettingsStore)
 	require.NoError(t, err, "no validation should be performed on RO connection")
 	require.NoFileExists(t, dbLocation(testRootDir), "database should not have been created")
 	require.NoError(t, s.Close(), "closing database")
@@ -227,7 +228,7 @@ func TestSetUpdate_RO(t *testing.T) {
 
 	testRootDir := t.TempDir()
 
-	s, err := OpenRO(context.TODO(), testRootDir, StartupSettingsStore)
+	s, err := OpenRO(context.TODO(), multislogger.NewNopLogger(), testRootDir, StartupSettingsStore)
 	require.NoError(t, err, "creating test store")
 
 	require.Error(t, s.Set([]byte(keys.UpdateChannel.String()), []byte("beta")), "should not be able to perform set with RO connection")

--- a/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
+++ b/ee/agent/storage/sqlite/keyvalue_store_sqlite_test.go
@@ -200,7 +200,7 @@ func TestUpdate(t *testing.T) {
 				require.NoError(t, err, "expected no error on update")
 			}
 
-			rows, err := s.conn.Query(`SELECT name, value FROM startup_settings;`)
+			rows, err := s.conn.Query(`SELECT name, value FROM startup_settings;`) //nolint:rowserrcheck // Can't defer rows.Close() AND check rows.Err() in a way that's meaningful in a test
 			require.NoError(t, err, "querying kv pairs")
 			defer rows.Close()
 

--- a/ee/agent/storage/sqlite/logstore_sqlite.go
+++ b/ee/agent/storage/sqlite/logstore_sqlite.go
@@ -91,7 +91,7 @@ func (s *sqliteStore) ForEach(fn func(rowid, timestamp int64, v []byte) error) e
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			s.slogger.Log(context.TODO(), slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/ee/katc/sqlite.go
+++ b/ee/katc/sqlite.go
@@ -92,6 +92,12 @@ func querySqliteDb(ctx context.Context, slogger *slog.Logger, path string, query
 				"err", err,
 			)
 		}
+		if rows.Err() != nil {
+			slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
 	}()
 
 	results := make([]map[string][]byte, 0)

--- a/ee/katc/sqlite.go
+++ b/ee/katc/sqlite.go
@@ -92,7 +92,7 @@ func querySqliteDb(ctx context.Context, slogger *slog.Logger, path string, query
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -61,7 +61,7 @@ func CheckOutLatestWithoutConfig(binary autoupdatableBinary, slogger *slog.Logge
 	}
 
 	// Get update channel from startup settings
-	pinnedVersion, updateChannel, err := getUpdateSettingsFromStartupSettings(ctx, binary, cfg.rootDirectory)
+	pinnedVersion, updateChannel, err := getUpdateSettingsFromStartupSettings(ctx, slogger, binary, cfg.rootDirectory)
 	if err != nil {
 		slogger.Log(ctx, slog.LevelWarn,
 			"could not get startup settings",
@@ -79,11 +79,11 @@ func CheckOutLatestWithoutConfig(binary autoupdatableBinary, slogger *slog.Logge
 // getUpdateSettingsFromStartupSettings queries the startup settings database to fetch the
 // pinned version and update channel. This accounts for e.g. the control server sending down
 // a particular value for the update channel, overriding the config file.
-func getUpdateSettingsFromStartupSettings(ctx context.Context, binary autoupdatableBinary, rootDirectory string) (string, string, error) {
+func getUpdateSettingsFromStartupSettings(ctx context.Context, slogger *slog.Logger, binary autoupdatableBinary, rootDirectory string) (string, string, error) {
 	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
 
-	r, err := startupsettings.OpenReader(ctx, rootDirectory)
+	r, err := startupsettings.OpenReader(ctx, slogger, rootDirectory)
 	if err != nil {
 		return "", "", fmt.Errorf("opening startupsettings reader: %w", err)
 	}

--- a/ee/tuf/library_lookup_test.go
+++ b/ee/tuf/library_lookup_test.go
@@ -29,7 +29,7 @@ func Test_getUpdateSettingsFromStartupSettings(t *testing.T) {
 	require.NoError(t, store.Set([]byte(keys.PinnedOsquerydVersion.String()), []byte("5.5.5")), "setting key")
 	require.NoError(t, store.Close(), "closing test db")
 
-	actualVersion, actualChannel, err := getUpdateSettingsFromStartupSettings(context.TODO(), "launcher", rootDir)
+	actualVersion, actualChannel, err := getUpdateSettingsFromStartupSettings(context.TODO(), multislogger.NewNopLogger(), "launcher", rootDir)
 	require.NoError(t, err, "did not expect error getting update settings from startup settings")
 	require.Equal(t, expectedPinnedVersion, actualVersion, "did not get expected version")
 	require.Equal(t, expectedChannel, actualChannel, "did not get expected channel")

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -67,7 +67,7 @@ func StartProcess(knapsack types.Knapsack, interactiveRootDir string) (*os.Proce
 	// if we were not provided a config path flag, try to add default config
 	if !haveConfigPathOsqFlag {
 		// check to see if we can actually get a config plugin
-		configPlugin, err := generateConfigPlugin(knapsack.RootDirectory())
+		configPlugin, err := generateConfigPlugin(knapsack.Slogger(), knapsack.RootDirectory())
 		if err != nil {
 			knapsack.Slogger().Log(context.TODO(), slog.LevelDebug,
 				"error creating config plugin",
@@ -194,8 +194,8 @@ func waitForFile(path string, interval, timeout time.Duration) error {
 	}
 }
 
-func generateConfigPlugin(launcherDaemonRootDir string) (*config.Plugin, error) {
-	r, err := startupsettings.OpenReader(context.TODO(), launcherDaemonRootDir)
+func generateConfigPlugin(slogger *slog.Logger, launcherDaemonRootDir string) (*config.Plugin, error) {
+	r, err := startupsettings.OpenReader(context.TODO(), slogger, launcherDaemonRootDir)
 	if err != nil {
 		return nil, fmt.Errorf("error opening startup settings reader: %w", err)
 	}

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -72,7 +72,7 @@ func (c *ChromeLoginDataEmailsTable) generateForPath(ctx context.Context, file u
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			c.slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/pkg/osquery/table/chrome_login_data_emails.go
+++ b/pkg/osquery/table/chrome_login_data_emails.go
@@ -65,7 +65,20 @@ func (c *ChromeLoginDataEmailsTable) generateForPath(ctx context.Context, file u
 	if err != nil {
 		return nil, fmt.Errorf("query rows from chrome login keychain db: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			c.slogger.Log(ctx, slog.LevelWarn,
+				"closing rows after scanning results",
+				"err", err,
+			)
+		}
+		if rows.Err() != nil {
+			c.slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
+	}()
 
 	var results []map[string]string
 

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -60,7 +60,20 @@ func (c *ChromeLoginKeychain) generateForPath(ctx context.Context, path string) 
 	if err != nil {
 		return nil, fmt.Errorf("query rows from chrome login keychain db: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			c.slogger.Log(ctx, slog.LevelWarn,
+				"closing rows after scanning results",
+				"err", err,
+			)
+		}
+		if rows.Err() != nil {
+			c.slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
+	}()
 
 	var results []map[string]string
 

--- a/pkg/osquery/table/chrome_login_keychain.go
+++ b/pkg/osquery/table/chrome_login_keychain.go
@@ -67,7 +67,7 @@ func (c *ChromeLoginKeychain) generateForPath(ctx context.Context, path string) 
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			c.slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -63,7 +63,20 @@ func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string
 	if err != nil {
 		return nil, fmt.Errorf("query rows from gdrive sync config db: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			g.slogger.Log(ctx, slog.LevelWarn,
+				"closing rows after scanning results",
+				"err", err,
+			)
+		}
+		if rows.Err() != nil {
+			g.slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
+	}()
 
 	var email string
 	var localsyncpath string

--- a/pkg/osquery/table/gdrive_sync.go
+++ b/pkg/osquery/table/gdrive_sync.go
@@ -70,7 +70,7 @@ func (g *gdrive) generateForPath(ctx context.Context, path string) ([]map[string
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			g.slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -62,7 +62,20 @@ func (g *GDriveSyncHistory) generateForPath(ctx context.Context, path string) ([
 	if err != nil {
 		return nil, fmt.Errorf("query rows from gdrive sync history db: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			g.slogger.Log(ctx, slog.LevelWarn,
+				"closing rows after scanning results",
+				"err", err,
+			)
+		}
+		if rows.Err() != nil {
+			g.slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
+	}()
 
 	var results []map[string]string
 

--- a/pkg/osquery/table/gdrive_sync_history.go
+++ b/pkg/osquery/table/gdrive_sync_history.go
@@ -69,7 +69,7 @@ func (g *GDriveSyncHistory) generateForPath(ctx context.Context, path string) ([
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			g.slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -76,7 +76,20 @@ func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo
 	if err != nil {
 		return nil, fmt.Errorf("query rows from onepassword account configuration db: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			o.slogger.Log(ctx, slog.LevelWarn,
+				"closing rows after scanning results",
+				"err", err,
+			)
+		}
+		if rows.Err() != nil {
+			o.slogger.Log(ctx, slog.LevelWarn,
+				"encountered iteration error",
+				"err", err,
+			)
+		}
+	}()
 
 	var results []map[string]string
 	for rows.Next() {

--- a/pkg/osquery/table/onepassword_config.go
+++ b/pkg/osquery/table/onepassword_config.go
@@ -83,7 +83,7 @@ func (o *onePasswordAccountsTable) generateForPath(ctx context.Context, fileInfo
 				"err", err,
 			)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			o.slogger.Log(ctx, slog.LevelWarn,
 				"encountered iteration error",
 				"err", err,

--- a/pkg/osquery/table/table.go
+++ b/pkg/osquery/table/table.go
@@ -122,7 +122,7 @@ func katcFromDb(k types.Knapsack, registrationId string) (map[string]string, err
 }
 
 func katcFromStartupSettings(k types.Knapsack, registrationId string) (map[string]string, error) {
-	r, err := startupsettings.OpenReader(context.TODO(), k.RootDirectory())
+	r, err := startupsettings.OpenReader(context.TODO(), k.Slogger(), k.RootDirectory())
 	if err != nil {
 		return nil, fmt.Errorf("error opening startup settings reader: %w", err)
 	}


### PR DESCRIPTION
Makes sure we check and log `rows.Err()` after calling `rows.Close()`.