### PR TITLE
add tenv linter, fix up os.Setenv offenses in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,9 @@ linters:
     - sloglint
     - sqlclosecheck
     - staticcheck
+    - tenv
     - unconvert
     - unused
-    - tenv
   disable:
     - errcheck
     - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
+    - tenv
   disable:
     - errcheck
     - gosec

--- a/ee/tables/xfconf/xfconf_test.go
+++ b/ee/tables/xfconf/xfconf_test.go
@@ -17,9 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_getUserConfig(t *testing.T) {
-	t.Parallel()
-
+func Test_getUserConfig(t *testing.T) { //nolint:paralleltest
 	tmpDefaultDir, tmpUserDir := setUpConfigFiles(t)
 
 	xfconf := xfconfTable{

--- a/ee/tables/xfconf/xfconf_test.go
+++ b/ee/tables/xfconf/xfconf_test.go
@@ -120,7 +120,7 @@ func setUpConfigFiles(t *testing.T) (string, string) {
 	fsutil.CopyFile(filepath.Join("testdata", "xfce4-power-manager-default.xml"), filepath.Join(tmpDefaultDir, xfconfChannelXmlPath, "xfce4-power-manager.xml"))
 
 	// Set the environment variable for the default directory
-	os.Setenv("XDG_CONFIG_DIRS", tmpDefaultDir)
+	t.Setenv("XDG_CONFIG_DIRS", tmpDefaultDir)
 
 	// Make a temporary directory for user-specific config, put config files there
 	tmpUserDir := t.TempDir()
@@ -129,7 +129,7 @@ func setUpConfigFiles(t *testing.T) (string, string) {
 	fsutil.CopyFile(filepath.Join("testdata", "thunar-volman.xml"), filepath.Join(tmpUserDir, xfconfChannelXmlPath, "thunar-volman.xml"))
 
 	// Set the environment variable for the user config directory
-	os.Setenv("XDG_CONFIG_HOME", tmpUserDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpUserDir)
 
 	return tmpDefaultDir, tmpUserDir
 }

--- a/pkg/launcher/options_test.go
+++ b/pkg/launcher/options_test.go
@@ -106,7 +106,7 @@ func TestOptionsFromEnv(t *testing.T) { //nolint:paralleltest
 			val = "true"
 		}
 		name := fmt.Sprintf("KOLIDE_LAUNCHER_%s", strings.ToUpper(strings.TrimLeft(k, "-")))
-		require.NoError(t, os.Setenv(name, val))
+		t.Setenv(name, val)
 	}
 	opts, err := ParseOptions("", []string{})
 	require.NoError(t, err)

--- a/pkg/make/builder_test.go
+++ b/pkg/make/builder_test.go
@@ -197,7 +197,7 @@ func TestGetVersion(t *testing.T) {
 			defer cancel()
 
 			ctx = context.WithValue(ctx, contextKeyEnv, []string{fmt.Sprintf("FAKE_GIT_DESCRIBE=%s", tt.in)})
-			os.Setenv("FAKE_GIT_DESCRIBE", tt.in)
+			t.Setenv("FAKE_GIT_DESCRIBE", tt.in)
 			ver, err := b.getVersion(ctx)
 			if tt.err == true {
 				require.Error(t, err, tt.in)

--- a/pkg/make/builder_test.go
+++ b/pkg/make/builder_test.go
@@ -140,8 +140,7 @@ func TestExecOut(t *testing.T) {
 
 }
 
-func TestGetVersion(t *testing.T) {
-	t.Parallel()
+func TestGetVersion(t *testing.T) { //nolint:paralleltest
 	var tests = []struct {
 		in  string
 		out string
@@ -190,9 +189,7 @@ func TestGetVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.in, func(t *testing.T) {
-			t.Parallel()
-
+		t.Run(tt.in, func(t *testing.T) { //nolint:paralleltest
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 


### PR DESCRIPTION
the tenv linter (docs [here](https://golangci-lint.run/usage/linters/#tenv)) runs against test files and ensures that we use `t.Setenv` inside of tests instead of `os.Setenv`. This ensures the env variables set are cleaned up after being set, and will ensure that env manipulation in parallel tests is flagged.

For the instances where this was flagged after update, I have removed the parallel calls. The reason it is flagged in the first place is because manipulating these variables could have unintended side effects for concurrently running tests