### PR TITLE
Improvements after reviewing new tracing data

### DIFF
--- a/ee/indexeddb/values.go
+++ b/ee/indexeddb/values.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kolide/launcher/pkg/traces"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -50,6 +51,9 @@ const (
 // DeserializeChrome deserializes a JS object that has been stored by Chrome
 // in IndexedDB LevelDB-backed databases.
 func DeserializeChrome(ctx context.Context, slogger *slog.Logger, row map[string][]byte) (map[string][]byte, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	data, ok := row["data"]
 	if !ok {
 		return nil, errors.New("row missing top-level data key")
@@ -113,6 +117,9 @@ func readHeader(srcReader *bytes.Reader) (uint64, error) {
 
 // deserializeObject deserializes the next object from the srcReader.
 func deserializeObject(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) (map[string][]byte, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	obj := make(map[string][]byte)
 
 	for {
@@ -350,6 +357,9 @@ func deserializeSparseArray(ctx context.Context, slogger *slog.Logger, srcReader
 // deserializeDenseArray deserializes the next dense array from the srcReader.
 // Dense arrays are arrays of items that are NOT paired with indices, as in sparse arrays.
 func deserializeDenseArray(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) ([]byte, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	// After an array start, the next byte will be the length of the array.
 	arrayLen, err := binary.ReadUvarint(srcReader)
 	if err != nil {
@@ -405,6 +415,9 @@ func deserializeDenseArray(ctx context.Context, slogger *slog.Logger, srcReader 
 }
 
 func deserializeNestedObject(ctx context.Context, slogger *slog.Logger, srcReader *bytes.Reader) ([]byte, error) {
+	ctx, span := traces.StartSpan(ctx)
+	defer span.End()
+
 	nestedObj, err := deserializeObject(ctx, slogger, srcReader)
 	if err != nil {
 		return nil, fmt.Errorf("deserializing nested object: %w", err)

--- a/ee/katc/indexeddb_leveldb.go
+++ b/ee/katc/indexeddb_leveldb.go
@@ -17,7 +17,7 @@ import (
 // and object store specified in `query`, which it expects to be in the format
 // `<db name>.<object store name>`.
 func indexeddbLeveldbData(ctx context.Context, slogger *slog.Logger, sourcePaths []string, query string, queryContext table.QueryContext) ([]sourceData, error) {
-	_, span := traces.StartSpan(ctx)
+	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
 
 	// Pull out path constraints from the query against the KATC table, to avoid querying more leveldb files than we need to.
@@ -49,7 +49,7 @@ func indexeddbLeveldbData(ctx context.Context, slogger *slog.Logger, sourcePaths
 				continue
 			}
 
-			rowsFromDb, err := indexeddb.QueryIndexeddbObjectStore(db, dbName, objectStoreName)
+			rowsFromDb, err := indexeddb.QueryIndexeddbObjectStore(ctx, db, dbName, objectStoreName)
 			if err != nil {
 				return nil, fmt.Errorf("querying %s: %w", db, err)
 			}

--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -121,6 +121,7 @@ func (wt *wrappedTable) generate(ctx context.Context, queryContext table.QueryCo
 	}
 
 	// Kick off running the query
+	queryStartTime := time.Now()
 	resultChan := make(chan *generateResult)
 	gowrapper.Go(ctx, wt.slogger, func() {
 		rows, err := wt.gen(ctx, queryContext)
@@ -141,6 +142,8 @@ func (wt *wrappedTable) generate(ctx context.Context, queryContext table.QueryCo
 		wt.slogger.Log(ctx, slog.LevelWarn,
 			"query timed out",
 			"queried_columns", fmt.Sprintf("%+v", queriedColumns),
+			"query_start_time", queryStartTime.String(),
+			"query_timeout", genTimeout.String(),
 		)
 		return nil, fmt.Errorf("querying %s timed out after %s (queried columns: %v)", wt.name, genTimeout.String(), queriedColumns)
 	}

--- a/pkg/osquery/runtime/runtime_helpers_windows.go
+++ b/pkg/osquery/runtime/runtime_helpers_windows.go
@@ -25,7 +25,7 @@ func killProcessGroup(origCmd *exec.Cmd) error {
 	ctx, span := traces.StartSpan(context.Background())
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	// some discussion here https://github.com/golang/dep/pull/857


### PR DESCRIPTION
Observability improvements:

* Add more spans where useful
* Add more info to logs and spans

Improvements in response to trace data:

* Calling `taskkill` often seems to time out at the 10-second mark. We have a full 30 seconds available to wait for the errgroup to shut down, so I increased the timeout slightly to 15 seconds.