### PR TITLE
enable predeclared linter, fixup existing offenses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - misspell
     - nakedret
     - paralleltest
+    - predeclared
     - revive
     - rowserrcheck
     - sloglint

--- a/ee/agent/flags/flag_value_duration.go
+++ b/ee/agent/flags/flag_value_duration.go
@@ -24,15 +24,15 @@ func WithDefault(defaultVal time.Duration) durationOption {
 	}
 }
 
-func WithMin(min time.Duration) durationOption {
+func WithMin(minimum time.Duration) durationOption {
 	return func(d *durationFlagValue) {
-		d.min = int64(min)
+		d.min = int64(minimum)
 	}
 }
 
-func WithMax(max time.Duration) durationOption {
+func WithMax(maximum time.Duration) durationOption {
 	return func(d *durationFlagValue) {
-		d.max = int64(max)
+		d.max = int64(maximum)
 	}
 }
 
@@ -91,12 +91,12 @@ func (d *durationFlagValue) get(controlServerValue []byte) time.Duration {
 }
 
 // clampValue returns a value that is clamped to be within the range defined by min and max.
-func clampValue(value int64, min, max int64) int64 {
+func clampValue(value int64, minimum, maximum int64) int64 {
 	switch {
-	case value < min:
-		return min
-	case value > max:
-		return max
+	case value < minimum:
+		return minimum
+	case value > maximum:
+		return maximum
 	default:
 		return value
 	}

--- a/ee/agent/flags/flag_value_float64.go
+++ b/ee/agent/flags/flag_value_float64.go
@@ -89,12 +89,12 @@ func (f *float64FlagValue) get(controlServerValue []byte) float64 {
 }
 
 // clampValue returns a value that is clamped to be within the range defined by min and max.
-func clampFloat64Value(value float64, min, max float64) float64 {
+func clampFloat64Value(value float64, minimum, maximum float64) float64 {
 	switch {
-	case value < min:
-		return min
-	case value > max:
-		return max
+	case value < minimum:
+		return minimum
+	case value > maximum:
+		return maximum
 	default:
 		return value
 	}

--- a/ee/agent/flags/flag_value_float64.go
+++ b/ee/agent/flags/flag_value_float64.go
@@ -23,15 +23,15 @@ func WithFloat64ValueDefault(defaultVal float64) float64Option {
 	}
 }
 
-func WithFloat64ValueMin(min float64) float64Option {
+func WithFloat64ValueMin(minimum float64) float64Option {
 	return func(f *float64FlagValue) {
-		f.min = min
+		f.min = minimum
 	}
 }
 
-func WithFloat64ValueMax(max float64) float64Option {
+func WithFloat64ValueMax(maximum float64) float64Option {
 	return func(f *float64FlagValue) {
-		f.max = max
+		f.max = maximum
 	}
 }
 

--- a/ee/agent/flags/flag_value_int.go
+++ b/ee/agent/flags/flag_value_int.go
@@ -23,15 +23,15 @@ func WithIntValueDefault(defaultVal int) intOption {
 	}
 }
 
-func WithIntValueMin(min int) intOption {
+func WithIntValueMin(minimum int) intOption {
 	return func(i *intFlagValue) {
-		i.min = min
+		i.min = minimum
 	}
 }
 
-func WithIntValueMax(max int) intOption {
+func WithIntValueMax(maximum int) intOption {
 	return func(i *intFlagValue) {
-		i.max = max
+		i.max = maximum
 	}
 }
 

--- a/ee/agent/flags/flag_value_int.go
+++ b/ee/agent/flags/flag_value_int.go
@@ -89,12 +89,12 @@ func (i *intFlagValue) get(controlServerValue []byte) int {
 }
 
 // clampValue returns a value that is clamped to be within the range defined by min and max.
-func clampIntValue(value int, min, max int) int {
+func clampIntValue(value int, minimum, maximum int) int {
 	switch {
-	case value < min:
-		return min
-	case value > max:
-		return max
+	case value < minimum:
+		return minimum
+	case value > maximum:
+		return maximum
 	default:
 		return value
 	}

--- a/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
+++ b/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
@@ -239,14 +239,14 @@ func (s *bboltKeyValueStore) Count() (int, error) {
 		return 0, NoDbError{}
 	}
 
-	var len int
+	var numKeys int
 	if err := s.db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket([]byte(s.bucketName))
 		if b == nil {
 			return NewNoBucketError(s.bucketName)
 		}
 
-		len = b.Stats().KeyN
+		numKeys = b.Stats().KeyN
 		return nil
 	}); err != nil {
 		s.slogger.Log(context.TODO(), slog.LevelError,
@@ -256,7 +256,7 @@ func (s *bboltKeyValueStore) Count() (int, error) {
 		return 0, err
 	}
 
-	return len, nil
+	return numKeys, nil
 }
 
 // AppendValues utlizes bbolts NextSequence functionality to add ordered values

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -263,7 +263,7 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 	flare := zip.NewWriter(flareStream)
 	combinedSummary := bytes.Buffer{}
 
-	close := func() error {
+	finalize := func() error {
 		closeFlares := func() error {
 			return errors.Join(flare.Close(), flareStream.Close())
 		}
@@ -284,13 +284,13 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 	// Note our runtime context.
 	writeSummary(&combinedSummary, Informational, "flare", fmt.Sprintf("running %s", runtimeEnvironment))
 	if err := writeFlareEnv(flare, runtimeEnvironment); err != nil {
-		return errors.Join(fmt.Errorf("writing flare environment: %w", err), close())
+		return errors.Join(fmt.Errorf("writing flare environment: %w", err), finalize())
 	}
 
 	for _, c := range checkupsFor(k, flareSupported) {
 		flareCheckup(ctx, c, &combinedSummary, flare)
 		if err := flare.Flush(); err != nil {
-			return errors.Join(fmt.Errorf("writing flare zip: %w", err), close())
+			return errors.Join(fmt.Errorf("writing flare zip: %w", err), finalize())
 		}
 	}
 
@@ -299,7 +299,7 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 	noteMultipleInstallations(flare)
 
 	// we could defer this close, but we want to return any errors
-	return close()
+	return finalize()
 }
 
 // noteMultipleInstallations checks for whether the results of running flare for this installation may be complicated

--- a/ee/tables/execparsers/data_table/parser.go
+++ b/ee/tables/execparsers/data_table/parser.go
@@ -83,12 +83,12 @@ func (p parser) parseLines(reader io.Reader) ([]map[string]string, error) {
 		row := make(map[string]string)
 		fields := p.lineSplit(line, headerCount)
 		// It's possible we don't have the same number of fields to headers, so use
-		// min here to avoid a possible array out-of-bounds exception.
-		min := min(headerCount, len(fields))
+		// minimum here to avoid a possible array out-of-bounds exception.
+		minimum := min(headerCount, len(fields))
 
 		// For each header, add the corresponding line field to the result row.
 		// Duplicate headers overwrite the set value.
-		for i := 0; i < min; i++ {
+		for i := 0; i < minimum; i++ {
 			row[strings.TrimSpace(p.headers[i])] = strings.TrimSpace(fields[i])
 		}
 

--- a/pkg/make/builder.go
+++ b/pkg/make/builder.go
@@ -6,7 +6,7 @@ We used to do this with gnumake rules, but as we added windows
 compatibility, we found make too limiting. Moving this into go allows
 us to write cleaner cross-platform code.
 */
-package make
+package make //nolint:predeclared
 
 import (
 	"bytes"

--- a/pkg/make/builder_test.go
+++ b/pkg/make/builder_test.go
@@ -1,4 +1,4 @@
-package make
+package make //nolint:predeclared
 
 import (
 	"context"

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -971,9 +971,9 @@ func TestExtensionPurgeBufferedLogs(t *testing.T) {
 	k.On("ResultLogsStore").Return(resultLogsStore)
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 
-	max := 10
+	maximum := 10
 	e, err := NewExtension(context.TODO(), m, settingsstoremock.NewSettingsStoreWriter(t), k, ulid.New(), ExtensionOpts{
-		MaxBufferedLogs: max,
+		MaxBufferedLogs: maximum,
 	})
 	require.Nil(t, err)
 
@@ -991,12 +991,12 @@ func TestExtensionPurgeBufferedLogs(t *testing.T) {
 
 		e.writeAndPurgeLogs()
 
-		if i < max {
+		if i < maximum {
 			assert.Equal(t, expectedStatusLogs, gotStatusLogs)
 			assert.Equal(t, expectedResultLogs, gotResultLogs)
 		} else {
-			assert.Equal(t, expectedStatusLogs[i-max:], gotStatusLogs)
-			assert.Equal(t, expectedResultLogs[i-max:], gotResultLogs)
+			assert.Equal(t, expectedStatusLogs[i-maximum:], gotStatusLogs)
+			assert.Equal(t, expectedResultLogs[i-maximum:], gotResultLogs)
 		}
 	}
 }

--- a/pkg/service/client_jsonrpc_test.go
+++ b/pkg/service/client_jsonrpc_test.go
@@ -28,8 +28,8 @@ func TestForceNoChunkedEncoding(t *testing.T) {
 
 	// Check contents are still as expected
 	content := &bytes.Buffer{}
-	len, err := io.Copy(content, req.Body)
+	written, err := io.Copy(content, req.Body)
 	require.NoError(t, err)
-	require.Equal(t, int64(11), len)
+	require.Equal(t, int64(11), written)
 	require.Equal(t, "Hello World", content.String())
 }


### PR DESCRIPTION
the `predeclared` linter finds code that shadows builtin golang keywords (docs [here](https://golangci-lint.run/usage/linters/#predeclared)).

this will flag confusingly named variables (e.g. `len`) or things like naming a func `close` (which shadows the builtin close function)