### PR TITLE
Enable exhaustive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   enable:
     - bodyclose
     - containedctx
+    - exhaustive
     - forbidigo
     - gofmt
     - govet

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -225,6 +225,8 @@ func (w *winSvc) Execute(args []string, r <-chan svc.ChangeRequest, changes chan
 				time.Sleep(2 * time.Second) // give rungroups enough time to shut down
 				changes <- svc.Status{State: svc.Stopped, Accepts: cmdsAccepted}
 				return ssec, errno
+			case svc.Pause, svc.Continue, svc.ParamChange, svc.NetBindAdd, svc.NetBindRemove, svc.NetBindEnable, svc.NetBindDisable, svc.DeviceEvent, svc.HardwareProfileChange, svc.PowerEvent, svc.SessionChange, svc.PreShutdown:
+				fallthrough
 			default:
 				w.systemSlogger.Log(ctx, slog.LevelInfo,
 					"unexpected change request",

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -221,6 +221,8 @@ func RunDoctor(ctx context.Context, k types.Knapsack, w io.Writer) {
 			warningCheckups = append(warningCheckups, c.Name())
 		case Failing, Erroring:
 			failingCheckups = append(failingCheckups, c.Name())
+		case Unknown, Informational, Passing:
+			// No need to print additional information about unknown, informational, or passing checkups
 		}
 	}
 

--- a/ee/debug/checkups/checkups_other.go
+++ b/ee/debug/checkups/checkups_other.go
@@ -15,7 +15,9 @@ func (s Status) Emoji() string {
 		return "❌"
 	case Erroring:
 		return "❌"
-	default:
+	case Unknown:
 		return "? "
+	default:
+		return " "
 	}
 }

--- a/ee/debug/checkups/checkups_windows.go
+++ b/ee/debug/checkups/checkups_windows.go
@@ -17,7 +17,9 @@ func (s Status) Emoji() string {
 		return "X "
 	case Erroring:
 		return "X "
-	default:
+	case Unknown:
 		return "? "
+	default:
+		return " "
 	}
 }

--- a/ee/tuf/util_darwin.go
+++ b/ee/tuf/util_darwin.go
@@ -17,9 +17,9 @@ import (
 // For launcher, and versions of osquery after 5.9.1, this means a path inside the app bundle.
 func executableLocation(updateDirectory string, binary autoupdatableBinary) string {
 	switch binary {
-	case "launcher":
+	case binaryLauncher:
 		return filepath.Join(updateDirectory, "Kolide.app", "Contents", "MacOS", string(binary))
-	case "osqueryd":
+	case binaryOsqueryd:
 		// Only return the path to the app bundle executable if it exists
 		appBundleExecutable := filepath.Join(updateDirectory, "osquery.app", "Contents", "MacOS", string(binary))
 		if _, err := os.Stat(appBundleExecutable); err == nil {

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -50,7 +50,7 @@ func DefaultPath(path defaultPath) string {
 		switch path {
 		case RootDirectory:
 			return "C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data"
-		case WindowsConfigDirectory:
+		case EtcDirectory, WindowsConfigDirectory:
 			return "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf"
 		case BinDirectory:
 			return "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin"
@@ -82,6 +82,9 @@ func DefaultPath(path defaultPath) string {
 		return filepath.Join(DefaultPath(EtcDirectory), "launcher.flags")
 	case SecretFile:
 		return filepath.Join(DefaultPath(EtcDirectory), "secret")
+	case WindowsConfigDirectory:
+		// Not valid for non-Windows, but included for completeness
+		fallthrough
 	default:
 		return ""
 	}

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -703,9 +703,10 @@ func storeForLogType(s types.Stores, typ logger.LogType) (types.KVStore, error) 
 		return s.ResultLogsStore(), nil
 	case logger.LogTypeStatus:
 		return s.StatusLogsStore(), nil
+	case logger.LogTypeHealth, logger.LogTypeInit:
+		return nil, fmt.Errorf("storing log type %v is unsupported", typ)
 	default:
 		return nil, fmt.Errorf("unknown log type: %v", typ)
-
 	}
 }
 

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -560,6 +560,8 @@ func TestExtensionWriteBufferedLogs(t *testing.T) {
 				gotStatusLogs = logs
 			case logger.LogTypeString:
 				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
 			default:
 				t.Error("Unknown log type")
 			}
@@ -675,6 +677,8 @@ func TestExtensionWriteBufferedLogsLimit(t *testing.T) {
 				gotStatusLogs = logs
 			case logger.LogTypeString:
 				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
 			default:
 				t.Error("Unknown log type")
 			}
@@ -749,6 +753,8 @@ func TestExtensionWriteBufferedLogsDropsBigLog(t *testing.T) {
 				gotStatusLogs = logs
 			case logger.LogTypeString:
 				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
 			default:
 				t.Error("Unknown log type")
 			}
@@ -829,6 +835,8 @@ func TestExtensionWriteLogsLoop(t *testing.T) {
 				gotStatusLogs = logs
 			case logger.LogTypeString:
 				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
 			default:
 				t.Error("Unknown log type")
 			}
@@ -951,6 +959,8 @@ func TestExtensionPurgeBufferedLogs(t *testing.T) {
 				gotStatusLogs = logs
 			case logger.LogTypeString:
 				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
 			default:
 				t.Error("Unknown log type")
 			}

--- a/pkg/packaging/detectLauncherVersion.go
+++ b/pkg/packaging/detectLauncherVersion.go
@@ -114,7 +114,9 @@ func formatVersion(rawVersion string, platform PlatformFlavor) (string, error) {
 	case Darwin:
 		// Darwin expects a <major>.<minor>.<patch> packaging string
 		return fmt.Sprintf("%s.%s.%s", major, minor, patch), nil
+	case Linux:
+		return rawVersion, nil
+	default:
+		return "", fmt.Errorf("unsupported platform %v", platform)
 	}
-
-	return rawVersion, nil
 }

--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -47,7 +47,7 @@ func decodeGRPCLogCollection(_ context.Context, grpcReq interface{}) (interface{
 	// For now this should be enough because we don't use the Agent LogType anywhere.
 	// A more robust fix should come from fixing https://github.com/kolide/launcher/issues/183
 	var typ logger.LogType
-	switch req.LogType {
+	switch req.LogType { //nolint:exhaustive // This code is old and not in use
 	case pb.LogCollection_STATUS:
 		typ = logger.LogTypeStatus
 	case pb.LogCollection_RESULT:
@@ -83,7 +83,7 @@ func encodeGRPCLogCollection(_ context.Context, request interface{}) (interface{
 	}
 
 	var typ pb.LogCollection_LogType
-	switch req.LogType {
+	switch req.LogType { //nolint:exhaustive // This code is old and not in use
 	case logger.LogTypeStatus:
 		typ = pb.LogCollection_STATUS
 	case logger.LogTypeString, logger.LogTypeSnapshot:


### PR DESCRIPTION
The `exhaustive` linter checks exhaustiveness of enum switch statements. This PR enables that linter and fixes existing violations.