### PR TITLE
Enable noctx linter and fix existing violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - noctx
     - paralleltest
     - predeclared
     - revive
@@ -25,7 +26,6 @@ linters:
     - errcheck
     - gosec
     - gosimple
-    - noctx
 
 linters-settings:
   errcheck:

--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -246,9 +246,6 @@ func makeGetRequest(client desktopClient, requestUrl string, timeout time.Durati
 }
 
 func notifyRunnerServerMenuOpened(slogger *slog.Logger, rootServerUrl, authToken string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	client := authedclient.New(authToken, 2*time.Second)
 	menuOpenedUrl := fmt.Sprintf("%s%s", rootServerUrl, runnerserver.MenuOpenedEndpoint)
 
@@ -257,7 +254,7 @@ func notifyRunnerServerMenuOpened(slogger *slog.Logger, rootServerUrl, authToken
 
 		response, err := makeGetRequest(client, menuOpenedUrl, client.Timeout)
 		if err != nil {
-			slogger.Log(ctx, slog.LevelError,
+			slogger.Log(context.TODO(), slog.LevelError,
 				"sending menu opened request to root server",
 				"err", err,
 			)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -62,6 +62,7 @@ import (
 	"github.com/kolide/launcher/pkg/service"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/kolide/launcher/pkg/traces/exporter"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"go.etcd.io/bbolt"
 )
@@ -532,8 +533,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	if k.Autoupdate() {
 		metadataClient := http.DefaultClient
 		metadataClient.Timeout = 30 * time.Second
+		metadataClient.Transport = otelhttp.NewTransport(metadataClient.Transport)
 		mirrorClient := http.DefaultClient
 		mirrorClient.Timeout = 8 * time.Minute // gives us extra time to avoid a timeout on download
+		mirrorClient.Transport = otelhttp.NewTransport(mirrorClient.Transport)
 		tufAutoupdater, err := tuf.NewTufAutoupdater(
 			ctx,
 			k,

--- a/ee/debug/checkups/connectivity.go
+++ b/ee/debug/checkups/connectivity.go
@@ -70,7 +70,7 @@ func (c *Connectivity) Run(ctx context.Context, extraFH io.Writer) error {
 			continue
 		}
 
-		body, err := checkKolideServer(c.k, httpClient, extraFH, versionEndpoint)
+		body, err := checkKolideServer(ctx, httpClient, versionEndpoint)
 		if err != nil {
 			fmt.Fprintf(extraFH, "error: %s\n", err)
 			c.data[n] = err.Error()
@@ -109,8 +109,12 @@ func (c *Connectivity) Data() any {
 	return c.data
 }
 
-func checkKolideServer(k types.Knapsack, client *http.Client, fh io.Writer, server string) ([]byte, error) {
-	response, err := client.Get(server)
+func checkKolideServer(ctx context.Context, client *http.Client, server string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	response, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching url: %w", err)
 	}

--- a/ee/debug/checkups/connectivity.go
+++ b/ee/debug/checkups/connectivity.go
@@ -110,6 +110,9 @@ func (c *Connectivity) Data() any {
 }
 
 func checkKolideServer(ctx context.Context, client *http.Client, server string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)

--- a/ee/desktop/runner/server/server_test.go
+++ b/ee/desktop/runner/server/server_test.go
@@ -38,34 +38,34 @@ func TestRootServer(t *testing.T) {
 	token := monitorServer.RegisterClient("0")
 	client := authedclient.New(token, 1*time.Second)
 
-	response, err := client.Get(endpointUrl(monitorServer.Url(), HealthCheckEndpoint))
+	response, err := client.Get(endpointUrl(monitorServer.Url(), HealthCheckEndpoint)) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode)
 
-	response, err = client.Get(endpointUrl(monitorServer.Url(), MenuOpenedEndpoint))
+	response, err = client.Get(endpointUrl(monitorServer.Url(), MenuOpenedEndpoint)) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode)
 
-	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", nil)
+	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", nil) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":""}`)))
+	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":""}`))) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 
 	messenger.On("SendMessage", "test", mock.Anything).Return(errors.New("some error")).Once()
-	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":"test"}`)))
+	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":"test"}`))) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, response.StatusCode)
 
 	messenger.On("SendMessage", "test", mock.Anything).Return(nil).Once()
-	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":"test"}`)))
+	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", bytes.NewReader([]byte(`{"method":"test"}`))) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode)
@@ -73,17 +73,17 @@ func TestRootServer(t *testing.T) {
 	// deregister and make sure we get unauthorized status codes
 	monitorServer.DeRegisterClient("0")
 
-	response, err = client.Get(endpointUrl(monitorServer.Url(), HealthCheckEndpoint))
+	response, err = client.Get(endpointUrl(monitorServer.Url(), HealthCheckEndpoint)) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 
-	response, err = client.Get(endpointUrl(monitorServer.Url(), MenuOpenedEndpoint))
+	response, err = client.Get(endpointUrl(monitorServer.Url(), MenuOpenedEndpoint)) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 
-	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", nil)
+	response, err = client.Post(endpointUrl(monitorServer.Url(), MessageEndpoint), "application/json", nil) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, response.Body.Close())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, response.StatusCode)

--- a/ee/desktop/user/client/client.go
+++ b/ee/desktop/user/client/client.go
@@ -83,7 +83,17 @@ func (c *client) DetectPresence(reason string, interval time.Duration) (time.Dur
 	encodedInterval := url.QueryEscape(interval.String())
 
 	// default time out of 30s is set in New()
-	resp, requestErr := c.base.Get(fmt.Sprintf("http://unix/detect_presence?reason=%s&interval=%s", encodedReason, encodedInterval))
+	timeout := c.base.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://unix/detect_presence?reason=%s&interval=%s", encodedReason, encodedInterval), nil)
+	if err != nil {
+		return presencedetection.DetectionFailedDurationValue, fmt.Errorf("creating presence request: %w", err)
+	}
+	resp, requestErr := c.base.Do(req)
 	if requestErr != nil {
 		return presencedetection.DetectionFailedDurationValue, fmt.Errorf("getting presence: %w", requestErr)
 	}
@@ -111,7 +121,20 @@ func (c *client) DetectPresence(reason string, interval time.Duration) (time.Dur
 }
 
 func (c *client) CreateSecureEnclaveKey() ([]byte, error) {
-	resp, err := c.base.Post("http://unix/secure_enclave_key", "application/json", http.NoBody)
+	timeout := c.base.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://unix/secure_enclave_key", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating secure enclave key request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.base.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("getting secure enclave key: %w", err)
 	}
@@ -135,6 +158,14 @@ func (c *client) CreateSecureEnclaveKey() ([]byte, error) {
 }
 
 func (c *client) Notify(n notify.Notification) error {
+	timeout := c.base.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	notificationToSend := notify.Notification{
 		Title:     n.Title,
 		Body:      n.Body,
@@ -145,7 +176,13 @@ func (c *client) Notify(n notify.Notification) error {
 		return fmt.Errorf("could not marshal notification: %w", err)
 	}
 
-	resp, err := c.base.Post("http://unix/notification", "application/json", bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://unix/notification", bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("creating notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.base.Do(req)
 	if err != nil {
 		return fmt.Errorf("could not send notification: %w", err)
 	}
@@ -160,25 +197,20 @@ func (c *client) Notify(n notify.Notification) error {
 }
 
 func (c *client) get(path string) error {
-	resp, err := c.base.Get(fmt.Sprintf("http://unix/%s", path))
-	if err != nil {
-		return err
-	}
-
-	if resp.Body != nil {
-		resp.Body.Close()
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return c.getWithContext(context.Background(), path)
 }
 
 func (c *client) getWithContext(ctx context.Context, path string) error {
 	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
+
+	timeout := c.base.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://unix/%s", path), nil)
 	if err != nil {

--- a/ee/desktop/user/menu/action_message.go
+++ b/ee/desktop/user/menu/action_message.go
@@ -50,7 +50,21 @@ func (a actionMessage) Perform(m *menu) {
 		return
 	}
 
-	response, err := client.Post(runnerMessageUrl, "application/json", bytes.NewReader(jsonBody))
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, runnerMessageUrl, bytes.NewReader(jsonBody))
+	if err != nil {
+		m.slogger.Log(context.TODO(), slog.LevelError,
+			"failed to create request",
+			"err", err,
+		)
+
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	response, err := client.Do(req)
 	if err != nil {
 		m.slogger.Log(context.TODO(), slog.LevelError,
 			"failed to perform message action",

--- a/ee/desktop/user/server/server_test.go
+++ b/ee/desktop/user/server/server_test.go
@@ -49,7 +49,7 @@ func TestUserServer_authMiddleware(t *testing.T) {
 			var logBytes bytes.Buffer
 			server, _ := testServer(t, validAuthHeader, testSocketPath(t), &logBytes)
 
-			req, err := http.NewRequest("GET", "https://127.0.0.1:8080", nil)
+			req, err := http.NewRequest("GET", "https://127.0.0.1:8080", nil) //nolint:noctx // We don't care about this in tests
 			require.NoError(t, err)
 
 			if tt.authHeader != "" {
@@ -92,7 +92,7 @@ func TestUserServer_shutdownHandler(t *testing.T) {
 				<-shutdownChan
 			}()
 
-			req, err := http.NewRequest("", "", nil)
+			req, err := http.NewRequest("", "", nil) //nolint:noctx // We don't care about this in tests
 			require.NoError(t, err)
 
 			handler := http.HandlerFunc(server.shutdownHandler)

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -53,7 +53,7 @@ func (cmdReq v2CmdRequestType) CallbackReq() (*http.Request, error) {
 		return nil, nil
 	}
 
-	req, err := http.NewRequest(http.MethodPost, cmdReq.CallbackUrl, nil)
+	req, err := http.NewRequest(http.MethodPost, cmdReq.CallbackUrl, nil) //nolint:noctx // Context added in sendCallback()
 	if err != nil {
 		return nil, fmt.Errorf("making http request: %w", err)
 	}
@@ -127,8 +127,10 @@ func (e *kryptoEcMiddleware) sendCallback(req *http.Request, data *callbackDataS
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		e.slogger.Log(req.Context(), slog.LevelError,
 			"got error in callback",

--- a/ee/localserver/krypto-ec-middleware_test.go
+++ b/ee/localserver/krypto-ec-middleware_test.go
@@ -449,7 +449,7 @@ func makeGetRequest(t *testing.T, boxParameter string) *http.Request {
 
 	urlString := "https://127.0.0.1:8080?" + v.Encode()
 
-	req, err := http.NewRequest(http.MethodGet, urlString, nil)
+	req, err := http.NewRequest(http.MethodGet, urlString, nil) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, err)
 
 	return req
@@ -463,7 +463,7 @@ func makePostRequest(t *testing.T, boxValue string) *http.Request {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, urlString, bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, urlString, bytes.NewBuffer(body)) //nolint:noctx // We don't care about this in tests
 	require.NoError(t, err)
 
 	return req

--- a/ee/localserver/request-id_test.go
+++ b/ee/localserver/request-id_test.go
@@ -36,7 +36,7 @@ func Test_localServer_requestIdHandler(t *testing.T) {
 
 	server := testServer(t, mockKnapsack)
 
-	req, err := http.NewRequest("", "", nil)
+	req, err := http.NewRequest("", "", nil) //nolint:noctx // Don't care about this in tests
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(server.requestIdHandlerFunc)

--- a/ee/localserver/request-query_test.go
+++ b/ee/localserver/request-query_test.go
@@ -74,7 +74,7 @@ func Test_localServer_requestQueryHandler(t *testing.T) {
 				"query": tt.query,
 			})
 			require.NoError(t, err)
-			req, err := http.NewRequest("", "", bytes.NewBuffer(jsonBytes))
+			req, err := http.NewRequest("", "", bytes.NewBuffer(jsonBytes)) //nolint:noctx // Don't care about this in tests
 			require.NoError(t, err)
 
 			queryParams := req.URL.Query()
@@ -248,7 +248,7 @@ func Test_localServer_requestRunScheduledQueryHandler(t *testing.T) {
 			require.NoError(t, err)
 
 			// set up request
-			req, err := http.NewRequest("", "", bytes.NewBuffer(jsonBytes))
+			req, err := http.NewRequest("", "", bytes.NewBuffer(jsonBytes)) //nolint:noctx // Don't care about this in tests
 			require.NoError(t, err)
 
 			// set up handler

--- a/pkg/authedclient/authedclient.go
+++ b/pkg/authedclient/authedclient.go
@@ -22,7 +22,7 @@ type authedClient struct {
 
 // New returns a new authed client that will add the provided auth token as an
 // Authorization header to each request.
-func New(authToken string, timeout time.Duration) authedClient {
+func New(authToken string, timeout time.Duration) *authedClient {
 	transport := &transport{
 		authToken: authToken,
 	}
@@ -34,5 +34,5 @@ func New(authToken string, timeout time.Duration) authedClient {
 		},
 	}
 
-	return client
+	return &client
 }

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -32,7 +32,7 @@ func TestStartDebugServer(t *testing.T) {
 	require.Nil(t, err)
 
 	url := getDebugURL(t, tokenFile.Name())
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:noctx // We don't care about this in tests
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
@@ -50,7 +50,7 @@ func TestDebugServerUnauthorized(t *testing.T) {
 	require.Nil(t, err)
 
 	url := getDebugURL(t, tokenFile.Name())
-	resp, err := http.Get(url + "bad_token")
+	resp, err := http.Get(url + "bad_token") //nolint:noctx // We don't care about this in tests
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	resp.Body.Close()
@@ -72,7 +72,7 @@ func TestAttachDebugHandler(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	url := getDebugURL(t, tokenFile.Name())
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:noctx // We don't care about this in tests
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	defer resp.Body.Close()
@@ -81,7 +81,7 @@ func TestAttachDebugHandler(t *testing.T) {
 	syscall.Kill(syscall.Getpid(), debugSignal)
 	time.Sleep(1 * time.Second)
 
-	_, err = http.Get(url)
+	_, err = http.Get(url) //nolint:noctx // We don't care about this in tests
 	require.NotNil(t, err)
 
 	// Start server
@@ -91,7 +91,7 @@ func TestAttachDebugHandler(t *testing.T) {
 	newUrl := getDebugURL(t, tokenFile.Name())
 	assert.NotEqual(t, url, newUrl)
 
-	_, err = http.Get(newUrl)
+	_, err = http.Get(newUrl) //nolint:noctx // We don't care about this in tests
 	require.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
@@ -100,6 +100,6 @@ func TestAttachDebugHandler(t *testing.T) {
 	syscall.Kill(syscall.Getpid(), debugSignal)
 	time.Sleep(1 * time.Second)
 
-	_, err = http.Get(url)
+	_, err = http.Get(url) //nolint:noctx // We don't care about this in tests
 	require.NotNil(t, err)
 }

--- a/pkg/log/logshipper/authedhttpsender.go
+++ b/pkg/log/logshipper/authedhttpsender.go
@@ -1,6 +1,7 @@
 package logshipper
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +24,10 @@ func newAuthHttpSender() *authedHttpSender {
 }
 
 func (a *authedHttpSender) Send(r io.Reader) error {
-	req, err := http.NewRequest("POST", a.endpoint, r)
+	ctx, cancel := context.WithTimeout(context.Background(), a.client.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint, r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `noctx` linter alerts on sending http requests without `context.Context`.