### PR TITLE
Update cache key for Store Artifacts job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -239,7 +239,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ./build
-        key: ${{ matrix.artifactos }}-${{ github.run_id }}
+        key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
     - name: Upload Build


### PR DESCRIPTION
Starting to see errors for the `Store Artifacts` job -- e.g. https://github.com/kolide/launcher/actions/runs/13243413425/job/36975714246.

It's unable to restore the cache -- it looks like casing has changed for `runner.os` so it no longer matches our `matrix.artifactos`. I opted for adjusting the key for the cache restore, rather than changing `matrix.artifactos`, to avoid changing the name of the resulting artifacts.