### PR TITLE
return proper error for homebrew not found on macos

### DIFF
--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -5,7 +5,7 @@ package allowedcmd
 
 import (
 	"context"
-	"errors"
+	"fmt"
 )
 
 func Airport(ctx context.Context, arg ...string) (*TracedCmd, error) {
@@ -32,7 +32,7 @@ func Brew(ctx context.Context, arg ...string) (*TracedCmd, error) {
 		return validatedCmd, nil
 	}
 
-	return nil, errors.New("homebrew not found")
+	return nil, fmt.Errorf("%w: homebrew", ErrCommandNotFound)
 }
 
 func Diskutil(ctx context.Context, arg ...string) (*TracedCmd, error) {


### PR DESCRIPTION
we had previously made updates to ensure we don't error out table generation for devices that just don't have homebrew installed. this logic was added to `validatedCommand`, but unfortunately for macos devices we check two possible locations with `validatedCommand` and then explicitly return an error that would not be matched by `errors.Is(err, allowedcmd.ErrCommandNotFound)`. this updates the brew command for macos to return the correct error in these cases