### PR TITLE
make uninitialized osquery history informational for doctor output

### DIFF
--- a/ee/debug/checkups/osquery_restarts.go
+++ b/ee/debug/checkups/osquery_restarts.go
@@ -29,7 +29,10 @@ func (orc *osqRestartCheckup) Run(ctx context.Context, extraFH io.Writer) error 
 
 	osqHistory := orc.k.OsqueryHistory()
 	if osqHistory == nil {
-		return errors.New("osquery history is not initialized in knapsack")
+		// We are probably running standalone instead of in situ
+		orc.status = Informational
+		orc.summary = "No osquery restart history instances available"
+		return nil
 	}
 
 	results, err := osqHistory.GetHistory()


### PR DESCRIPTION
we may run doctor/flare in standalone mode, where osquery restart history access wouldn't be possible. to accommodate this without alarming flare consumers, we should just make this state informational (not erroring)