### PR TITLE
make sure db reset logs encapsulate change values

### DIFF
--- a/ee/agent/reset.go
+++ b/ee/agent/reset.go
@@ -62,11 +62,13 @@ func DetectAndRemediateHardwareChange(ctx context.Context, k types.Knapsack) {
 	hardwareUUIDChanged := false
 	munemoChanged := false
 
-	defer k.Slogger().Log(ctx, slog.LevelDebug, "finished check to see if database should be reset...",
-		"serial", serialChanged,
-		"hardware_uuid", hardwareUUIDChanged,
-		"munemo", munemoChanged,
-	)
+	defer func() {
+		k.Slogger().Log(ctx, slog.LevelDebug, "finished check to see if database should be reset...",
+			"serial", serialChanged,
+			"hardware_uuid", hardwareUUIDChanged,
+			"munemo", munemoChanged,
+		)
+	}()
 
 	currentSerial, currentHardwareUUID, err := currentSerialAndHardwareUUID(ctx, k)
 	if err != nil {


### PR DESCRIPTION
I noticed in a flare recently that we had logged a change to serial and hardware uuid values, but then immediately logged `"finished check to see if database should be reset..."` without any of those changed values being reflected.

This was just because the deferred log was done outside of an anonymous function, causing all values to be evaluated when the defer was processed instead of during its execution later. This wraps the call in a func to ensure those values reflect any updates at the time of logging