### PR TITLE
clear osquery distributed_denylist_duration when watchdog is disabled

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -706,6 +706,10 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string, paths *os
 		args = append(args, fmt.Sprintf("--watchdog_delay=%d", i.knapsack.WatchdogDelaySec()))
 	} else {
 		args = append(args, "--disable_watchdog")
+		// if we aren't enabling watchdog then we don't want the denylist functionality either. Currently
+		// any distributed queries that are running when osquery is restarted will be added to the denylist.
+		// without this arg those queries would be skipped for the default duration of 24 hours
+		args = append(args, "--distributed_denylist_duration=0")
 	}
 
 	cmd := exec.Command( //nolint:forbidigo // We trust the autoupdate library to find the correct path


### PR DESCRIPTION
We have found that osquery's distributed denylisting will happen regardless of whether the osquery watchdog is enabled. This behavior will be updated within osquery for scheduled queries soon (and potentially for distributed queries next) but until then this should prevent the distributed denylist behavior from having any adverse effects by causing any denylisted queries to be immediately eligible for re-running