### PR TITLE
osquery history cleanup part 2

### DIFF
--- a/pkg/osquery/runtime/history/history.go
+++ b/pkg/osquery/runtime/history/history.go
@@ -13,7 +13,7 @@ const maxInstances = 10
 
 type History struct {
 	sync.Mutex
-	instances []*Instance
+	instances []*instance
 	store     types.GetterSetter
 }
 
@@ -26,7 +26,7 @@ func (c NoInstancesError) Error() string {
 // InitHistory loads the osquery instance history from bbolt DB if exists, sets up bucket if it does not
 func InitHistory(store types.GetterSetter) (*History, error) {
 	history := History{
-		instances: make([]*Instance, 0),
+		instances: make([]*instance, 0),
 		store:     store,
 	}
 
@@ -58,7 +58,7 @@ func (h *History) GetHistory() ([]map[string]string, error) {
 // by registration id. it does not lock history because many of our exposed methods
 // need to do further manipulation after grabbing the instance here, so that
 // responsibility is maintained outside of this
-func (h *History) latestInstance(registrationId string) (*Instance, error) {
+func (h *History) latestInstance(registrationId string) (*instance, error) {
 	if len(h.instances) == 0 {
 		return nil, NoInstancesError{}
 	}
@@ -135,7 +135,7 @@ func (h *History) NewInstance(registrationId string, runId string) error {
 		return err
 	}
 
-	newInstance := &Instance{
+	newInstance := &instance{
 		RegistrationId: registrationId,
 		RunId:          runId,
 		StartTime:      timeNow(),
@@ -210,13 +210,13 @@ func (h *History) SetExited(runID string, exitError error) error {
 	return nil
 }
 
-func (h *History) addInstanceToHistory(instance *Instance) {
+func (h *History) addInstanceToHistory(newInstance *instance) {
 	if h.instances == nil {
-		h.instances = []*Instance{instance}
+		h.instances = []*instance{newInstance}
 		return
 	}
 
-	h.instances = append(h.instances, instance)
+	h.instances = append(h.instances, newInstance)
 
 	if len(h.instances) >= maxInstances {
 		h.instances = h.instances[len(h.instances)-maxInstances:]

--- a/pkg/osquery/runtime/history/history_test.go
+++ b/pkg/osquery/runtime/history/history_test.go
@@ -23,7 +23,7 @@ func TestNewInstance(t *testing.T) {
 		name string
 		// registrationId will automatically be added to any new instances (if missing in test case) before seeding
 		registrationId   string
-		initialInstances []*Instance
+		initialInstances []*instance
 		wantNumInstances int
 		wantErr          error
 	}{
@@ -34,7 +34,7 @@ func TestNewInstance(t *testing.T) {
 		},
 		{
 			name: "existing_instances",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					StartTime: "first_start_time",
 					ExitTime:  "first_exit_time",
@@ -49,7 +49,7 @@ func TestNewInstance(t *testing.T) {
 		},
 		{
 			name: "max_instances_reached",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{}, {}, {}, {}, {}, {}, {}, {}, {},
 				{
 					ExitTime: "last_exit_time",
@@ -104,13 +104,13 @@ func TestGetHistory(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name             string
-		initialInstances []*Instance
+		initialInstances []*instance
 		want             []map[string]string
 		errString        string
 	}{
 		{
 			name: "success",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					StartTime: "first_expected_start_time",
 				},
@@ -150,13 +150,13 @@ func TestLatestInstance(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name             string
-		initialInstances []*Instance
-		want             *Instance
+		initialInstances []*instance
+		want             *instance
 		errString        string
 	}{
 		{
 			name: "success",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					StartTime:      "first_expected_start_time",
 					RegistrationId: types.DefaultRegistrationID,
@@ -166,7 +166,7 @@ func TestLatestInstance(t *testing.T) {
 					RegistrationId: types.DefaultRegistrationID,
 				},
 			},
-			want: &Instance{
+			want: &instance{
 				StartTime:      "second_expected_start_time",
 				RegistrationId: types.DefaultRegistrationID,
 			},
@@ -198,14 +198,14 @@ func TestLatestInstanceStats(t *testing.T) {
 	tests := []struct {
 		name             string
 		registrationID   string
-		initialInstances []*Instance
+		initialInstances []*instance
 		want             map[string]string
 		errString        string
 	}{
 		{
 			name:           "success",
 			registrationID: "test",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					StartTime:      "first_expected_start_time",
 					RegistrationId: "some other",
@@ -243,7 +243,7 @@ func TestLatestInstanceStats(t *testing.T) {
 		{
 			name:           "no matching instances",
 			registrationID: "test3",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					StartTime:      "first_expected_start_time",
 					RegistrationId: "test",
@@ -282,14 +282,14 @@ func TestLatestInstanceUptimeMinutes(t *testing.T) {
 	tests := []struct {
 		name             string
 		registrationId   string
-		initialInstances []*Instance
+		initialInstances []*instance
 		want             int64
 		expectedErr      bool
 	}{
 		{
 			name:           "success",
 			registrationId: types.DefaultRegistrationID,
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -305,7 +305,7 @@ func TestLatestInstanceUptimeMinutes(t *testing.T) {
 		{
 			name:           "success_different_registration_ids",
 			registrationId: "notTheDefault",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-45 * time.Minute).Format(time.RFC3339),
@@ -358,7 +358,7 @@ func TestLatestInstanceId(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name             string
-		initialInstances []*Instance
+		initialInstances []*instance
 		registrationId   string
 		want             string
 		expectedErr      bool
@@ -366,7 +366,7 @@ func TestLatestInstanceId(t *testing.T) {
 		{
 			name:           "success_same_registration_ids",
 			registrationId: types.DefaultRegistrationID,
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -389,7 +389,7 @@ func TestLatestInstanceId(t *testing.T) {
 		{
 			name:           "success_different_registration_ids",
 			registrationId: types.DefaultRegistrationID,
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -446,7 +446,7 @@ func TestSetConnected(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name               string
-		initialInstances   []*Instance
+		initialInstances   []*instance
 		querierReturn      func() ([]map[string]string, error)
 		runId              string
 		expectedInstanceId string
@@ -464,7 +464,7 @@ func TestSetConnected(t *testing.T) {
 					},
 				}, nil
 			},
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -495,7 +495,7 @@ func TestSetConnected(t *testing.T) {
 					},
 				}, nil
 			},
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -534,7 +534,7 @@ func TestSetConnected(t *testing.T) {
 			querierReturn: func() ([]map[string]string, error) {
 				return nil, ExpectedAtLeastOneRowError{}
 			},
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339),
@@ -587,7 +587,7 @@ func TestSetExited(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name             string
-		initialInstances []*Instance
+		initialInstances []*instance
 		runId            string
 		expectedErr      error
 		exitErr          error
@@ -595,7 +595,7 @@ func TestSetExited(t *testing.T) {
 		{
 			name:  "success_same_registration_ids",
 			runId: "99999999-9999-9999-9999-999999999999",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -618,7 +618,7 @@ func TestSetExited(t *testing.T) {
 		{
 			name:  "success_different_registration_ids",
 			runId: "99999999-9999-9999-9999-999999999999",
-			initialInstances: []*Instance{
+			initialInstances: []*instance{
 				{
 					RegistrationId: types.DefaultRegistrationID,
 					StartTime:      time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339),
@@ -685,7 +685,7 @@ func TestSetExited(t *testing.T) {
 }
 
 // setupStorage creates storage and seeds it with the given instances.
-func setupStorage(t *testing.T, seedInstances ...*Instance) types.KVStore {
+func setupStorage(t *testing.T, seedInstances ...*instance) types.KVStore {
 	s, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.OsqueryHistoryInstanceStore.String())
 	require.NoError(t, err)
 

--- a/pkg/osquery/runtime/history/instance.go
+++ b/pkg/osquery/runtime/history/instance.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kolide/launcher/ee/agent/types"
 )
 
-type Instance struct {
+type instance struct {
 	RegistrationId string // which registration this instance belongs to
 	RunId          string // ID for instance, assigned by launcher
 	StartTime      string
@@ -25,13 +25,13 @@ func (e ExpectedAtLeastOneRowError) Error() string {
 }
 
 // Connected sets the connect time and instance id of the current osquery instance
-func (i *Instance) Connected(querier types.Querier) error {
+func (i *instance) Connected(querier types.Querier) error {
 	results, err := querier.Query("select instance_id, version from osquery_info order by start_time limit 1")
 	if err != nil {
 		return err
 	}
 
-	if results == nil || len(results) < 1 {
+	if len(results) < 1 {
 		return ExpectedAtLeastOneRowError{}
 	}
 
@@ -53,7 +53,7 @@ func (i *Instance) Connected(querier types.Querier) error {
 }
 
 // Exited sets the exit time and appends provided error (if any) to current osquery instance
-func (i *Instance) Exited(exitError error) error {
+func (i *instance) Exited(exitError error) error {
 	if exitError != nil {
 		i.Error = exitError.Error()
 	}
@@ -63,7 +63,7 @@ func (i *Instance) Exited(exitError error) error {
 	return nil
 }
 
-func (i *Instance) toMap() map[string]string {
+func (i *instance) toMap() map[string]string {
 	if i == nil {
 		return nil
 	}

--- a/pkg/osquery/runtime/history/instance_test.go
+++ b/pkg/osquery/runtime/history/instance_test.go
@@ -57,7 +57,7 @@ func TestInstance_Connected(t *testing.T) {
 			_, err := InitHistory(setupStorage(t))
 			require.NoError(t, err, "expected to be able to initialize history without error")
 
-			i := &Instance{}
+			i := &instance{}
 			querier := &mocks.Querier{}
 			querier.On("Query", "select instance_id, version from osquery_info order by start_time limit 1").Return(tt.querierReturn()).Once()
 
@@ -104,7 +104,7 @@ func TestInstance_Exited(t *testing.T) {
 			_, err := InitHistory(setupStorage(t))
 			require.NoError(t, err, "expected to be able to initialize history without error")
 
-			i := &Instance{}
+			i := &instance{}
 			i.Exited(tt.args.exitError)
 
 			assert.Equal(t, tt.wantErr, i.Error)

--- a/pkg/osquery/runtime/history/storage.go
+++ b/pkg/osquery/runtime/history/storage.go
@@ -17,7 +17,7 @@ func (h *History) load() error {
 		return fmt.Errorf("error reading osquery_instance_history from db: %w", err)
 	}
 
-	var instances []*Instance
+	var instances []*instance
 
 	if instancesBytes == nil {
 		return nil

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -375,14 +375,13 @@ func (i *OsqueryInstance) Launch() error {
 		return fmt.Errorf("starting osqueryd process: %w", err)
 	}
 
-	osqHistory := i.knapsack.OsqueryHistory()
-	if osqHistory == nil {
+	if i.history == nil {
 		i.slogger.Log(ctx, slog.LevelWarn,
 			"osquery history is not initialized in knapsack, unable to record stats",
 			"err", err,
 		)
 	} else {
-		err := osqHistory.NewInstance(i.registrationId, i.runId)
+		err := i.history.NewInstance(i.registrationId, i.runId)
 		if err != nil {
 			i.slogger.Log(ctx, slog.LevelWarn,
 				"could not create new osquery instance history",

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -610,7 +610,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	go runner.Run()
 
 	// Wait briefly for the launch routines to begin, then shut it down
-	time.Sleep(10 * time.Second)
+	waitHealthy(t, runner, logBytes, osqHistory)
 	waitShutdown(t, runner, logBytes)
 
 	// Confirm the default instance was started, and then exited
@@ -627,7 +627,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	// Confirm the additional instance was started, and then exited
 	require.Contains(t, runner.instances, extraRegistrationId)
 	require.NotNil(t, runner.instances[extraRegistrationId].history)
-	extraInstanceStats, err := osqHistory.LatestInstanceStats(types.DefaultRegistrationID)
+	extraInstanceStats, err := osqHistory.LatestInstanceStats(extraRegistrationId)
 	require.NoError(t, err)
 	require.Contains(t, extraInstanceStats, "start_time")
 	require.NotEmpty(t, extraInstanceStats["start_time"], "start time should be added to secondary instance stats on start up")


### PR DESCRIPTION
this has some additional cleanup + things I had wanted to include with https://github.com/kolide/launcher/pull/2104, but opted to push forward to keep the changeset smaller. The only changes in here are:
- we no longer export the history.Instance struct. The new historian interface we added was designed to prevent individual instance manipulation, and there is no reason to expose this type externally anymore
- respond to remaining feedback from the original PR (changes in pkg/osquery/runtime/osqueryinstance.go)
- fixes a runtime test 