### PR TITLE
Enable perfsprint linter with limited ruleset and fix existing violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - nakedret
     - noctx
     - paralleltest
+    - perfsprint
     - predeclared
     - revive
     - rowserrcheck
@@ -88,5 +89,20 @@ issues:
     - linters:
         - paralleltest
       text: "does not use range value in test Run"
+    # We prefer fmt.Sprintf over string concatenation for readability
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with string concatenation"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatInt"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.Itoa"
+    - linters: [perfsprint]
+      text: "fmt.Sprint can be replaced with faster strconv.Itoa"
   exclude-dirs:
     - test-cmds

--- a/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
+++ b/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
@@ -3,6 +3,7 @@ package agentbbolt
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -263,7 +264,7 @@ func (s *bboltKeyValueStore) Count() (int, error) {
 // after generating the next autoincrementing key for each
 func (s *bboltKeyValueStore) AppendValues(values ...[]byte) error {
 	if s == nil || s.db == nil {
-		return fmt.Errorf("unable to append values into uninitialized bbolt db store")
+		return errors.New("unable to append values into uninitialized bbolt db store")
 	}
 
 	return s.db.Update(func(tx *bbolt.Tx) error {

--- a/ee/agent/storage/inmemory/keyvalue_store_in_memory.go
+++ b/ee/agent/storage/inmemory/keyvalue_store_in_memory.go
@@ -3,7 +3,6 @@ package inmemory
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -147,7 +146,7 @@ func (s *inMemoryKeyValueStore) Count() (int, error) {
 
 func (s *inMemoryKeyValueStore) AppendValues(values ...[]byte) error {
 	if s == nil {
-		return fmt.Errorf("unable to append values into uninitialized inmemory db store")
+		return errors.New("unable to append values into uninitialized inmemory db store")
 	}
 
 	for _, value := range values {

--- a/ee/cryptoinfo/try_pem.go
+++ b/ee/cryptoinfo/try_pem.go
@@ -2,6 +2,7 @@ package cryptoinfo
 
 import (
 	"encoding/pem"
+	"errors"
 	"fmt"
 )
 
@@ -22,7 +23,7 @@ func tryPem(pemBytes []byte, _password string) ([]*KeyInfo, error) {
 	}
 
 	if len(expanded) == 0 {
-		return nil, fmt.Errorf("no pem decoded")
+		return nil, errors.New("no pem decoded")
 	}
 
 	return expanded, nil

--- a/ee/debug/checkups/desktop_menu.go
+++ b/ee/debug/checkups/desktop_menu.go
@@ -57,7 +57,7 @@ func (d *desktopMenu) Run(_ context.Context, fullFH io.Writer) error {
 	}
 
 	d.status = Passing
-	d.summary = fmt.Sprintf("menu.json exists and is valid json")
+	d.summary = "menu.json exists and is valid json"
 
 	return nil
 }

--- a/ee/debug/checkups/dns.go
+++ b/ee/debug/checkups/dns.go
@@ -2,6 +2,7 @@ package checkups
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -96,7 +97,7 @@ func (dc *dnsCheckup) resolveHost(ctx context.Context, host string) (string, err
 	}
 
 	if len(ips) == 0 {
-		return "", fmt.Errorf("host was valid but did not resolve")
+		return "", errors.New("host was valid but did not resolve")
 	}
 
 	return strings.Join(ips, ","), nil

--- a/ee/debug/checkups/dns_test.go
+++ b/ee/debug/checkups/dns_test.go
@@ -2,7 +2,7 @@ package checkups
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -71,7 +71,7 @@ func Test_dnsCheckup_Run(t *testing.T) {
 				"InsecureTransportTLS": false,
 			},
 			onLookupHostReturns: map[string]resolution{
-				"kolide-server.example.com":  {ips: []string{}, err: fmt.Errorf("Unable to resolve: No Such Host")},
+				"kolide-server.example.com":  {ips: []string{}, err: errors.New("Unable to resolve: No Such Host")},
 				"control-server.example.com": {ips: []string{"111.2.3.4", "111.2.3.5"}, err: nil},
 				"tuf-server.example.com":     {ips: []string{"34.149.84.181"}, err: nil},
 				"google.com":                 {ips: []string{"2620:149:af0::10", "17.253.144.10"}, err: nil},

--- a/ee/desktop/user/menu/menu_template.go
+++ b/ee/desktop/user/menu/menu_template.go
@@ -1,6 +1,7 @@
 package menu
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -44,7 +45,7 @@ func NewTemplateParser(td *TemplateData) *templateParser {
 // if an error occurs while parsing, an empty string is returned along with the error
 func (tp *templateParser) Parse(text string) (string, error) {
 	if tp == nil || tp.td == nil {
-		return "", fmt.Errorf("templateData is nil")
+		return "", errors.New("templateData is nil")
 	}
 
 	t, err := template.New("menu_template").Funcs(template.FuncMap{

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -317,7 +317,7 @@ func extractChallenge(r *http.Request) (*challenge.OuterChallenge, error) {
 
 	// now check body
 	if r.Body == nil {
-		return nil, fmt.Errorf("no box found in url params or request body: body nil")
+		return nil, errors.New("no box found in url params or request body: body nil")
 	}
 
 	var body map[string]any
@@ -327,12 +327,12 @@ func extractChallenge(r *http.Request) (*challenge.OuterChallenge, error) {
 
 	val, ok := body["box"]
 	if !ok {
-		return nil, fmt.Errorf("no box key found in request body json")
+		return nil, errors.New("no box key found in request body json")
 	}
 
 	valStr, ok := val.(string)
 	if !ok {
-		return nil, fmt.Errorf("box value is not a string")
+		return nil, errors.New("box value is not a string")
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(valStr)

--- a/ee/presencedetection/presencedetection.go
+++ b/ee/presencedetection/presencedetection.go
@@ -1,6 +1,7 @@
 package presencedetection
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -57,5 +58,5 @@ func (pd *PresenceDetector) DetectPresence(reason string, detectionInterval time
 
 	// if we got here it means we failed without an error
 	// this "should" never happen, but here for completeness
-	return DetectionFailedDurationValue, fmt.Errorf("detection failed without OS error")
+	return DetectionFailedDurationValue, errors.New("detection failed without OS error")
 }

--- a/ee/secureenclaverunner/secureenclaverunner.go
+++ b/ee/secureenclaverunner/secureenclaverunner.go
@@ -174,7 +174,7 @@ func (ser *secureEnclaveRunner) Type() string {
 }
 
 func (ser *secureEnclaveRunner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (ser *secureEnclaveRunner) currentConsoleUserKey(ctx context.Context) (*ecdsa.PublicKey, error) {
@@ -266,7 +266,7 @@ func (ser *secureEnclaveRunner) UnmarshalJSON(data []byte) error {
 
 		ecdsaPubKey, ok := pubKey.(*ecdsa.PublicKey)
 		if !ok {
-			return fmt.Errorf("public key is not ecdsa")
+			return errors.New("public key is not ecdsa")
 		}
 
 		ser.uidPubKeyMap[k] = ecdsaPubKey

--- a/ee/tables/cryptsetup/parser.go
+++ b/ee/tables/cryptsetup/parser.go
@@ -61,7 +61,7 @@ var firstLineRegexp = regexp.MustCompile(`^(?:Device (.*) (not found))|(?:(.*?) 
 // examples)
 func parseFirstLine(line string) (map[string]interface{}, error) {
 	if line == "" {
-		return nil, fmt.Errorf("Invalid first line")
+		return nil, errors.New("Invalid first line")
 	}
 
 	m := firstLineRegexp.FindAllStringSubmatch(line, -1)

--- a/ee/tables/execparsers/data_table/parser.go
+++ b/ee/tables/execparsers/data_table/parser.go
@@ -2,7 +2,7 @@ package data_table
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"io"
 	"strings"
 )
@@ -64,7 +64,7 @@ func (p parser) parseLines(reader io.Reader) ([]map[string]string, error) {
 		p.skipLines--
 
 		if !scanner.Scan() {
-			return results, fmt.Errorf("skipped past all lines of data")
+			return results, errors.New("skipped past all lines of data")
 		}
 	}
 

--- a/ee/tables/execparsers/dsregcmd/parse.go
+++ b/ee/tables/execparsers/dsregcmd/parse.go
@@ -2,6 +2,7 @@ package dsregcmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -35,7 +36,7 @@ func parseDsreg(reader io.Reader) (any, error) {
 		// Check if we've found a section header. If so, grab the next line and get the section title.
 		if startHeaderRegex.MatchString(line) {
 			if ok := scanner.Scan(); !ok {
-				return nil, fmt.Errorf("failed to read second section header line")
+				return nil, errors.New("failed to read second section header line")
 			}
 			line = scanner.Text()
 			m := titleRegex.FindStringSubmatch(line)
@@ -47,7 +48,7 @@ func parseDsreg(reader io.Reader) (any, error) {
 
 			// Consume the last line of the section header.
 			if ok := scanner.Scan(); !ok {
-				return nil, fmt.Errorf("failed to read third section header line")
+				return nil, errors.New("failed to read third section header line")
 			} else {
 				line := scanner.Text()
 				if !startHeaderRegex.MatchString(line) {

--- a/ee/tables/execparsers/remotectl/parse.go
+++ b/ee/tables/execparsers/remotectl/parse.go
@@ -47,7 +47,7 @@ func (p *parser) parseDumpstate(reader io.Reader) (any, error) {
 			continue
 		}
 
-		return nil, fmt.Errorf("no device name(s) given in remotectl dumpstate output")
+		return nil, errors.New("no device name(s) given in remotectl dumpstate output")
 	}
 
 	return results, nil

--- a/ee/tables/jwt/jwt.go
+++ b/ee/tables/jwt/jwt.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -70,7 +69,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	paths := tablehelpers.GetConstraints(queryContext, "path")
 	if len(paths) < 1 {
-		return nil, fmt.Errorf("kolide_jwt requires at least one path to be specified")
+		return nil, errors.New("kolide_jwt requires at least one path to be specified")
 	}
 
 	for _, path := range paths {

--- a/ee/tables/macos_software_update/software_update_table.go
+++ b/ee/tables/macos_software_update/software_update_table.go
@@ -13,6 +13,7 @@ import (
 )
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -117,7 +118,7 @@ func macOSBuildVersionPrefix() (int, error) {
 
 	parts := strings.Split(version, ".")
 	if len(parts) < 1 {
-		return 0, fmt.Errorf("failed to parse build train prefix from sysctl call for kern.osrelease")
+		return 0, errors.New("failed to parse build train prefix from sysctl call for kern.osrelease")
 	}
 
 	buildPrefix, err := strconv.Atoi(parts[0])

--- a/ee/tables/nix_env/upgradeable/upgradeable.go
+++ b/ee/tables/nix_env/upgradeable/upgradeable.go
@@ -6,7 +6,7 @@ package nix_env_upgradeable
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
 	"strings"
 
@@ -46,7 +46,7 @@ func (t *Table) generate(ctx context.Context, queryContext table.QueryContext) (
 
 	uids := tablehelpers.GetConstraints(queryContext, "uid", tablehelpers.WithAllowedCharacters(allowedCharacters))
 	if len(uids) < 1 {
-		return results, fmt.Errorf("kolide_nix_upgradeable requires at least one user id to be specified")
+		return results, errors.New("kolide_nix_upgradeable requires at least one user id to be specified")
 	}
 
 	for _, uid := range uids {

--- a/ee/tables/wifi_networks/wifi_networks.go
+++ b/ee/tables/wifi_networks/wifi_networks.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -110,7 +111,7 @@ func execPwsh(slogger *slog.Logger) execer {
 			)
 
 			if err == nil {
-				err = fmt.Errorf("exec succeeded, but emitted to stderr")
+				err = errors.New("exec succeeded, but emitted to stderr")
 			}
 			return fmt.Errorf("execing powershell, got: %s: %w", errOutput, err)
 		}

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -6,6 +6,7 @@ package watchdog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -388,7 +389,7 @@ func installWatchdogTask(identifier, configFilePath string) error {
 	defer trigger.Release()
 
 	if _, err = oleutil.PutProperty(trigger, "ExecutionTimeLimit", "PT1M"); err != nil {
-		return fmt.Errorf("setting execution time limit property")
+		return errors.New("setting execution time limit property")
 	}
 
 	// found the guid here https://github.com/capnspacehook/taskmaster/blob/1629df7c85e96aab410af7f1747ba264d3276505/fill.go#L168
@@ -434,7 +435,7 @@ func installWatchdogTask(identifier, configFilePath string) error {
 	defer noDelayEventTrigger.Release()
 
 	if _, err = oleutil.PutProperty(noDelayEventTrigger, "ExecutionTimeLimit", "PT1M"); err != nil {
-		return fmt.Errorf("setting execution time limit property")
+		return errors.New("setting execution time limit property")
 	}
 
 	secondaryEventTrigger, err := noDelayEventTrigger.QueryInterface(ole.NewGUID("{d45b0167-9653-4eef-b94f-0732ca7af251}"))

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -275,7 +275,7 @@ func (ls *LogShipper) updateSenderAuthToken() error {
 	}
 
 	if len(token) == 0 {
-		return fmt.Errorf("no token found")
+		return errors.New("no token found")
 	}
 
 	ls.sender.authtoken = string(token)

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -149,7 +150,7 @@ func decodeJsonL(data io.Reader) ([]any, error) {
 		count += 1
 
 		if count > 50 {
-			return nil, fmt.Errorf("stuck in a loop. Count exceeds 50")
+			return nil, errors.New("stuck in a loop. Count exceeds 50")
 		}
 	}
 }

--- a/pkg/packagekit/wix/wix.go
+++ b/pkg/packagekit/wix/wix.go
@@ -315,7 +315,7 @@ func (wo *wixTool) addServices(ctx context.Context) error {
 
 			if strings.Contains(line, "osqueryd.exe") {
 				if currentArchSpecificBinDir == none {
-					return fmt.Errorf("osqueryd.exe found, but not in a bin directory")
+					return errors.New("osqueryd.exe found, but not in a bin directory")
 				}
 
 				// create a condition based on architecture


### PR DESCRIPTION
Supersedes https://github.com/kolide/launcher/pull/2091.

We might want to consider enabling the `fmt.Sprintf can be replaced with faster strconv/etc functions` rules in the future -- while working through this in a previous branch, I was finding that there were a lot to update and sometimes it wasn't clear how they should be updated, so I didn't bother for this first pass.

I also didn't enable `fmt.Sprintf can be replaced with string concatenation` -- we have preferred to use fmt.Sprintf in this codebase for readability purposes, and I didn't want to change that.