### PR TITLE
Add logs when CollectAndSetEnrollmentDetails fails

### DIFF
--- a/pkg/osquery/enrollment_details.go
+++ b/pkg/osquery/enrollment_details.go
@@ -173,6 +173,11 @@ func CollectAndSetEnrollmentDetails(ctx context.Context, slogger *slog.Logger, k
 		err := getOsqEnrollDetails(ctx, latestOsquerydPath, &details)
 		if err != nil {
 			span.AddEvent("failed to get enrollment details")
+			slogger.Log(ctx, slog.LevelDebug,
+				"failed to get enrollment details",
+				"osqueryd_path", latestOsquerydPath,
+				"err", err,
+			)
 		}
 		return err
 	}, collectTimeout, collectRetryInterval); err != nil {


### PR DESCRIPTION
We already set errors on the traces when `CollectAndSetEnrollmentDetails`, which is great -- this PR adds logs as well, so that it's easier to identify this issue when looking through flares.