### PR TITLE
Ensure enrollment details are set

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -208,7 +208,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	initLauncherHistory(k)
 
 	gowrapper.Go(ctx, slogger, func() {
-		osquery.CollectAndSetEnrollmentDetails(ctx, slogger, k, 30*time.Second, 5*time.Second)
+		osquery.CollectAndSetEnrollmentDetails(ctx, slogger, k, 60*time.Second, 6*time.Second)
 	})
 	gowrapper.Go(ctx, slogger, func() {
 		runOsqueryVersionCheckAndAddToKnapsack(ctx, slogger, k, k.LatestOsquerydPath(ctx))

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -248,24 +248,13 @@ func (k *knapsack) CurrentEnrollmentStatus() (types.EnrollmentStatus, error) {
 	return types.Enrolled, nil
 }
 
-func (k *knapsack) SetEnrollmentDetails(details types.EnrollmentDetails) {
-	if enrollmentDetails == nil {
-		enrollmentDetails = &details
-		k.Slogger().Log(context.Background(), slog.LevelDebug,
-			"initializing enrollment details",
-			"details", fmt.Sprintf("%+v", enrollmentDetails),
-		)
-
-	}
-
-	current := *enrollmentDetails
-
+func (k *knapsack) SetEnrollmentDetails(newDetails types.EnrollmentDetails) {
 	k.Slogger().Log(context.Background(), slog.LevelDebug,
 		"updating enrollment details",
-		"old_details", fmt.Sprintf("%+v", current),
-		"new_details", fmt.Sprintf("%+v", details),
+		"old_details", fmt.Sprintf("%+v", enrollmentDetails),
+		"new_details", fmt.Sprintf("%+v", newDetails),
 	)
-	enrollmentDetails = &details
+	enrollmentDetails = &newDetails
 }
 
 func (k *knapsack) GetEnrollmentDetails() types.EnrollmentDetails {

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -262,10 +262,10 @@ func (k *knapsack) SetEnrollmentDetails(details types.EnrollmentDetails) {
 
 	k.Slogger().Log(context.Background(), slog.LevelDebug,
 		"updating enrollment details",
-		"old_details", fmt.Sprintf("%+v", enrollmentDetails),
-		"new_details", fmt.Sprintf("%+v", current),
+		"old_details", fmt.Sprintf("%+v", current),
+		"new_details", fmt.Sprintf("%+v", details),
 	)
-	enrollmentDetails = &current
+	enrollmentDetails = &details
 }
 
 func (k *knapsack) GetEnrollmentDetails() types.EnrollmentDetails {


### PR DESCRIPTION
In `SetEnrollmentDetails` we were setting the enrollment details to the old, rather than the updated, value.

Additionally, I gave us a longer timeout before failing to set enrollment details -- since it's happening in the background, I figure a longer timeout can only help. I also added a couple more logs to help us debug this issue in the future.