### PR TITLE
Refactor trace exporter to utilize enrollment details from knapsack 

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -395,10 +395,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		"build", versionInfo.Revision,
 	)
 
-	if traceExporter != nil {
-		traceExporter.SetOsqueryClient(osqueryRunner)
-	}
-
 	// Create the control service and services that depend on it
 	var runner *desktopRunner.DesktopUsersProcessesRunner
 	var actionsQueue *actionqueue.ActionQueue

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -33,6 +33,8 @@ var archAttributeMap = map[string]attribute.KeyValue{
 	"arm":   semconv.HostArchARM32,
 }
 
+var enrollmentDetailsRecheckInterval = 30 * time.Second
+
 type TraceExporter struct {
 	provider                  *sdktrace.TracerProvider
 	providerLock              sync.Mutex
@@ -187,7 +189,7 @@ func (t *TraceExporter) addAttributesFromOsquery() {
 				"trace exporter interrupted while waiting for enrollment details",
 			)
 			return
-		case <-time.After(5 * time.Second):
+		case <-time.After(enrollmentDetailsRecheckInterval):
 			continue
 		}
 	}

--- a/pkg/traces/exporter/exporter.go
+++ b/pkg/traces/exporter/exporter.go
@@ -2,7 +2,6 @@ package exporter
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -11,7 +10,6 @@ import (
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/storage"
 	"github.com/kolide/launcher/ee/agent/types"
-	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/pkg/traces"
 	"github.com/kolide/launcher/pkg/traces/bufspanprocessor"
 	osquerygotraces "github.com/osquery/osquery-go/traces"
@@ -35,18 +33,11 @@ var archAttributeMap = map[string]attribute.KeyValue{
 	"arm":   semconv.HostArchARM32,
 }
 
-var osqueryClientRecheckInterval = 30 * time.Second
-
-type querier interface {
-	Query(query string) ([]map[string]string, error)
-}
-
 type TraceExporter struct {
 	provider                  *sdktrace.TracerProvider
 	providerLock              sync.Mutex
 	bufSpanProcessor          *bufspanprocessor.BufSpanProcessor
 	knapsack                  types.Knapsack
-	osqueryClient             querier
 	slogger                   *slog.Logger
 	attrs                     []attribute.KeyValue // resource attributes, identifying this device + installation
 	attrLock                  sync.RWMutex
@@ -112,16 +103,9 @@ func NewTraceExporter(ctx context.Context, k types.Knapsack, initialTraceBuffer 
 	))
 
 	t.addDeviceIdentifyingAttributes()
+	t.addAttributesFromOsquery()
 
 	return t, nil
-}
-
-func (t *TraceExporter) SetOsqueryClient(client querier) {
-	t.osqueryClient = client
-
-	gowrapper.Go(context.TODO(), t.slogger, func() {
-		t.addAttributesFromOsquery()
-	})
 }
 
 // addDeviceIdentifyingAttributes gets device identifiers from the server-provided
@@ -168,64 +152,61 @@ func (t *TraceExporter) addDeviceIdentifyingAttributes() {
 	}
 }
 
-// addAttributesFromOsquery retrieves device and OS details from osquery and adds them
-// to our resource attributes. Since this is called on startup when the osquery client
-// may not be ready yet, we perform a few retries.
+// hasRequiredEnrollmentDetails checks if the provided enrollment details contain
+// all the required fields for adding trace attributes
+func hasRequiredEnrollmentDetails(details types.EnrollmentDetails) bool {
+	// Check that all required fields have values
+	return details.OsqueryVersion != "" &&
+		details.OSName != "" &&
+		details.OSVersion != "" &&
+		details.Hostname != ""
+}
+
+// addAttributesFromOsquery waits for enrollment details to be available
+// and then adds the relevant attributes
 func (t *TraceExporter) addAttributesFromOsquery() {
-	t.attrLock.Lock()
-	defer t.attrLock.Unlock()
-
-	osqueryInfoQuery := `
-	SELECT
-		osquery_info.version as osquery_version,
-		os_version.name as os_name,
-		os_version.version as os_version,
-		system_info.hostname
-	FROM
-		os_version,
-		system_info,
-		osquery_info;
-	`
-
-	// The osqueryd client may not have initialized yet, so retry for up to three minutes on error.
-	var resp []map[string]string
-	var err error
+	// Wait until enrollment details are available
 	retryTimeout := time.Now().Add(3 * time.Minute)
 	for {
 		if time.Now().After(retryTimeout) {
-			err = errors.New("could not get osquery details before timeout")
-			break
+			t.slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not get enrollment details before timeout",
+			)
+			return
 		}
 
-		resp, err = t.osqueryClient.Query(osqueryInfoQuery)
-		if err == nil && len(resp) > 0 {
-			break
+		enrollmentDetails := t.knapsack.GetEnrollmentDetails()
+		if hasRequiredEnrollmentDetails(enrollmentDetails) {
+			t.addAttributesFromEnrollmentDetails(enrollmentDetails)
+			return
 		}
 
 		select {
 		case <-t.ctx.Done():
 			t.slogger.Log(context.TODO(), slog.LevelDebug,
-				"trace exporter interrupted while waiting to add osquery attributes",
+				"trace exporter interrupted while waiting for enrollment details",
 			)
 			return
-		case <-time.After(osqueryClientRecheckInterval):
+		case <-time.After(5 * time.Second):
 			continue
 		}
 	}
+}
 
-	if err != nil || len(resp) == 0 {
-		t.slogger.Log(context.TODO(), slog.LevelWarn,
-			"trace exporter could not fetch osquery attributes",
-			"err", err,
-		)
-		return
-	}
+func (t *TraceExporter) addAttributesFromEnrollmentDetails(details types.EnrollmentDetails) {
+	t.attrLock.Lock()
+	defer t.attrLock.Unlock()
 
+	// Add OS and system attributes from enrollment details
 	t.attrs = append(t.attrs,
-		attribute.String("launcher.osquery_version", resp[0]["osquery_version"]),
-		semconv.OSName(resp[0]["os_name"]),
-		semconv.OSVersion(resp[0]["os_version"]),
-		semconv.HostName(resp[0]["hostname"]),
+		attribute.String("launcher.osquery_version", details.OsqueryVersion),
+		semconv.OSName(details.OSName),
+		semconv.OSVersion(details.OSVersion),
+		semconv.HostName(details.Hostname),
+	)
+
+	t.slogger.Log(context.TODO(), slog.LevelDebug,
+		"added attributes from enrollment details",
 	)
 }
 

--- a/pkg/traces/exporter/exporter_test.go
+++ b/pkg/traces/exporter/exporter_test.go
@@ -218,9 +218,9 @@ func Test_addDeviceIdentifyingAttributes(t *testing.T) {
 func Test_addAttributesFromOsquery(t *testing.T) {
 	t.Parallel()
 
-	expectedOsqueryVersion := "5.8.0"
+	expectedOsqueryVersion := "5.7.1"
 	expectedOsName := runtime.GOOS
-	expectedOsVersion := "3.4.5"
+	expectedOsVersion := "1.2.3"
 	expectedHostname := "Test-Hostname"
 
 	mockKnapsack := typesmocks.NewKnapsack(t)


### PR DESCRIPTION
This pull request includes significant changes to the `TraceExporter` class and related tests, focusing on removing the dependency on the `osqueryClient` and refactoring the way attributes are added from enrollment details.

Resolves #2076 

### Refactoring `TraceExporter`:

* Removed the `osqueryClient` dependency from `TraceExporter` and related methods. (`pkg/traces/exporter/exporter.go`) [[1]](diffhunk://#diff-cc2b349bd719b8e32044a95b35118d020ddf642edd2fc909c4b92da468d2611fL38-L49) [[2]](diffhunk://#diff-cc2b349bd719b8e32044a95b35118d020ddf642edd2fc909c4b92da468d2611fR106-L126)
* Changed the method `addAttributesFromOsquery` to use enrollment details instead of querying `osquery`. (`pkg/traces/exporter/exporter.go`)
* Updated the initialization of `TraceExporter` to call `addAttributesFromOsquery` directly. (`pkg/traces/exporter/exporter.go`)

### Test Updates:

* Removed mocks and expectations related to `osqueryClient` from tests. (`pkg/traces/exporter/exporter_test.go`) [[1]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL49-L61) [[2]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL78) [[3]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL192) [[4]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL229-R235) [[5]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL277) [[6]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL365-L383) [[7]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL403) [[8]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL451-L457) [[9]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL521-L527) [[10]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL594-L602) [[11]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL671-L677)
* Updated test cases to use `GetEnrollmentDetails` for providing necessary attributes. (`pkg/traces/exporter/exporter_test.go`) [[1]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL49-L61) [[2]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL229-R235) [[3]](diffhunk://#diff-3c58c9d50234dd5da717d7d8cf7cc5227e621dbc99e724adb7b107d9b0b6b04bL365-L383)

### Minor Cleanup:

* Removed unused imports and variables. (`pkg/traces/exporter/exporter.go`) [[1]](diffhunk://#diff-cc2b349bd719b8e32044a95b35118d020ddf642edd2fc909c4b92da468d2611fL5) [[2]](diffhunk://#diff-cc2b349bd719b8e32044a95b35118d020ddf642edd2fc909c4b92da468d2611fL14) [[3]](diffhunk://#diff-cc2b349bd719b8e32044a95b35118d020ddf642edd2fc909c4b92da468d2611fL38-L49)
* Removed the `SetOsqueryClient` method and related calls. (`pkg/traces/exporter/exporter.go`)

These changes streamline the `TraceExporter` class by eliminating the need for an `osqueryClient` and leveraging enrollment details directly, simplifying the code and improving maintainability.