### PR TITLE
Sleep before running tmutil

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -214,6 +214,9 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		runOsqueryVersionCheckAndAddToKnapsack(ctx, slogger, k, k.LatestOsquerydPath(ctx))
 	})
 	gowrapper.Go(ctx, slogger, func() {
+		// Wait a little bit before adding exclusions -- some osquery files get created right after
+		// startup and we want to let that settle before handling exclusions.
+		time.Sleep(2 * time.Minute)
 		timemachine.AddExclusions(ctx, k)
 	})
 


### PR DESCRIPTION
Hopeful this helps with errors like `exit status 22","output":"/var/kolide-k2/k2device.kolide.com/osquery-01JN724NCYYA96QNGDNXHYYZF1.sock.5748: Error (100002) while attempting to change exclusion setting.`.