### PR TITLE
Log CheckExecutable thoroughly

### DIFF
--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -261,9 +261,13 @@ func findExecutable(ctx context.Context, binary autoupdatableBinary, tufReposito
 	}
 
 	targetPath, targetVersion := pathToTargetVersionExecutable(binary, targetName, baseUpdateDirectory)
+	if _, err := os.Stat(targetPath); err != nil && errors.Is(err, os.ErrNotExist) {
+		traces.SetError(span, err)
+		return nil, fmt.Errorf("version %s from target %s at %s is either originally installed version or not yet downloaded", targetVersion, targetName, targetPath)
+	}
 	if err := CheckExecutable(ctx, slogger, targetPath, "--version"); err != nil {
 		traces.SetError(span, err)
-		return nil, fmt.Errorf("version %s from target %s at %s is either originally installed version, not yet downloaded, or corrupted: %w", targetVersion, targetName, targetPath, err)
+		return nil, fmt.Errorf("version %s from target %s at %s is corrupted: %w", targetVersion, targetName, targetPath, err)
 	}
 
 	return &BinaryUpdateInfo{

--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -261,7 +261,7 @@ func findExecutable(ctx context.Context, binary autoupdatableBinary, tufReposito
 	}
 
 	targetPath, targetVersion := pathToTargetVersionExecutable(binary, targetName, baseUpdateDirectory)
-	if err := CheckExecutable(ctx, targetPath, "--version"); err != nil {
+	if err := CheckExecutable(ctx, slogger, targetPath, "--version"); err != nil {
 		traces.SetError(span, err)
 		return nil, fmt.Errorf("version %s from target %s at %s is either originally installed version, not yet downloaded, or corrupted: %w", targetVersion, targetName, targetPath, err)
 	}

--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -69,6 +70,10 @@ func updatesDirectory(binary autoupdatableBinary, baseUpdateDirectory string) st
 // Available determines if the given target is already available in the update library.
 func (ulm *updateLibraryManager) Available(binary autoupdatableBinary, targetFilename string) bool {
 	executablePath, _ := pathToTargetVersionExecutable(binary, targetFilename, ulm.baseDir)
+	// First, check if the file even exists, before we do a full executable check
+	if _, err := os.Stat(executablePath); err != nil && errors.Is(err, os.ErrNotExist) {
+		return false
+	}
 	return CheckExecutable(context.TODO(), ulm.slogger, executablePath, "--version") == nil
 }
 

--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -69,7 +69,7 @@ func updatesDirectory(binary autoupdatableBinary, baseUpdateDirectory string) st
 // Available determines if the given target is already available in the update library.
 func (ulm *updateLibraryManager) Available(binary autoupdatableBinary, targetFilename string) bool {
 	executablePath, _ := pathToTargetVersionExecutable(binary, targetFilename, ulm.baseDir)
-	return CheckExecutable(context.TODO(), executablePath, "--version") == nil
+	return CheckExecutable(context.TODO(), ulm.slogger, executablePath, "--version") == nil
 }
 
 // pathToTargetVersionExecutable returns the path to the executable for the desired target,
@@ -240,7 +240,7 @@ func (ulm *updateLibraryManager) moveVerifiedUpdate(binary autoupdatableBinary, 
 	// Validate the executable -- the executable check will occasionally time out, especially on Windows,
 	// and we aren't in a rush here, so we retry a couple times.
 	if err := backoff.WaitFor(func() error {
-		return CheckExecutable(context.TODO(), executableLocation(stagedVersionedDirectory, binary), "--version")
+		return CheckExecutable(context.TODO(), ulm.slogger, executableLocation(stagedVersionedDirectory, binary), "--version")
 	}, 45*time.Second, 15*time.Second); err != nil {
 		return fmt.Errorf("could not verify executable after retries: %w", err)
 	}
@@ -450,7 +450,7 @@ func sortedVersionsInLibrary(ctx context.Context, slogger *slog.Logger, binary a
 		}
 
 		versionDir := filepath.Join(updatesDirectory(binary, baseUpdateDirectory), rawVersion)
-		if err := CheckExecutable(ctx, executableLocation(versionDir, binary), "--version"); err != nil {
+		if err := CheckExecutable(ctx, slogger, executableLocation(versionDir, binary), "--version"); err != nil {
 			traces.SetError(span, err)
 			slogger.Log(ctx, slog.LevelWarn,
 				"detected invalid binary version while checking executable",

--- a/ee/tuf/library_manager_test.go
+++ b/ee/tuf/library_manager_test.go
@@ -209,7 +209,7 @@ func TestAddToLibrary_alreadyAdded(t *testing.T) {
 			require.NoError(t, os.Chmod(executablePath, 0755))
 			_, err := os.Stat(executablePath)
 			require.NoError(t, err, "did not create binary for test")
-			require.NoError(t, CheckExecutable(context.TODO(), executablePath, "--version"), "binary created for test is corrupt")
+			require.NoError(t, CheckExecutable(context.TODO(), multislogger.NewNopLogger(), executablePath, "--version"), "binary created for test is corrupt")
 
 			// Ask the library manager to perform the download
 			targetFilename := fmt.Sprintf("%s-%s.tar.gz", binary, testVersion)
@@ -681,7 +681,7 @@ func Test_sortedVersionsInLibrary(t *testing.T) {
 		require.NoError(t, os.Chmod(executablePath, 0755))
 		_, err := os.Stat(executablePath)
 		require.NoError(t, err, "did not create binary for test")
-		require.NoError(t, CheckExecutable(context.TODO(), executablePath, "--version"), "binary created for test is corrupt")
+		require.NoError(t, CheckExecutable(context.TODO(), multislogger.NewNopLogger(), executablePath, "--version"), "binary created for test is corrupt")
 	}
 
 	// Get sorted versions
@@ -721,7 +721,7 @@ func Test_sortedVersionsInLibrary_devBuilds(t *testing.T) {
 		require.NoError(t, os.Chmod(executablePath, 0755))
 		_, err := os.Stat(executablePath)
 		require.NoError(t, err, "did not create binary for test")
-		require.NoError(t, CheckExecutable(context.TODO(), executablePath, "--version"), "binary created for test is corrupt")
+		require.NoError(t, CheckExecutable(context.TODO(), multislogger.NewNopLogger(), executablePath, "--version"), "binary created for test is corrupt")
 	}
 
 	// Get sorted versions

--- a/ee/tuf/util_test.go
+++ b/ee/tuf/util_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tufci "github.com/kolide/launcher/ee/tuf/ci"
+	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,7 +99,7 @@ func TestCheckExecutable(t *testing.T) {
 	for _, tt := range tests { // nolint:paralleltest
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			err := CheckExecutable(context.TODO(), targetExe, "-test.run=TestHelperProcess", "--", tt.testName)
+			err := CheckExecutable(context.TODO(), multislogger.NewNopLogger(), targetExe, "-test.run=TestHelperProcess", "--", tt.testName)
 			if tt.expectedErr {
 				require.Error(t, err, tt.testName)
 
@@ -107,7 +108,7 @@ func TestCheckExecutable(t *testing.T) {
 				// trigger the match against os.Executable and don't
 				// invoked. This is here, and not a dedicated test,
 				// because we ensure the same test arguments.
-				require.NoError(t, CheckExecutable(context.TODO(), os.Args[0], "-test.run=TestHelperProcess", "--", tt.testName), "calling self with %s", tt.testName)
+				require.NoError(t, CheckExecutable(context.TODO(), multislogger.NewNopLogger(), os.Args[0], "-test.run=TestHelperProcess", "--", tt.testName), "calling self with %s", tt.testName)
 			} else {
 				require.NoError(t, err, tt.testName)
 			}
@@ -129,7 +130,7 @@ func TestCheckExecutableTruncated(t *testing.T) {
 	require.NoError(t, os.Chmod(truncatedBinary.Name(), 0755))
 
 	require.Error(t,
-		CheckExecutable(context.TODO(), truncatedBinary.Name(), "-test.run=TestHelperProcess", "--", "exit0"),
+		CheckExecutable(context.TODO(), multislogger.NewNopLogger(), truncatedBinary.Name(), "-test.run=TestHelperProcess", "--", "exit0"),
 		"truncated binary")
 }
 


### PR DESCRIPTION
Ensures we always log the results of CheckExecutable. Also adds `"subcomponent": "CheckExecutable"` to make cloud log searching very easy.

Example logs:

```json
{
    "time":"2025-03-14T13:39:17.546184Z",
    "level":"INFO",
    "source":{"function":"github.com/kolide/launcher/ee/tuf.CheckExecutable","file":"/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/util.go","line":64},
    "msg":"successfully checked executable",
    "component":"tuf_autoupdater_library_manager",
    "subcomponent":"CheckExecutable",
    "binary_path":"/var/kolide-nababe-k2/k2device-preprod.kolide.com/updates/launcher/1.16.1-1-g2ab5e981-1741959556042873/Kolide.app/Contents/MacOS/launcher",
    "args":"[--version]"
}

{
    "time":"2025-03-14T09:45:57.793986-04:00",
    "level":"WARN",
    "source":{"function":"github.com/kolide/launcher/ee/tuf.CheckExecutable","file":"/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/util.go","line":56},
    "msg":"executable check returned error",
    "subcomponent":"CheckExecutable",
    "binary_path":"/var/folders/4d/jfl75r312llb4k5j5kgp4j240000gn/T/TestCheckExecutable1295805027/001/testbinary",
    "args":"[-test.run=TestHelperProcess -- sleep]",
    "err":"exec error: output: ``, err: timeout when checking executable: context deadline exceeded",
    "exec_err":"timeout when checking executable: context deadline exceeded",
    "command_output":""
}
```

Additionally, ensures we _don't_ log CheckExecutable when the file doesn't actually exist (e.g. when we're looking for a version we haven't downloaded yet). This fixes the kind of confusing log `version 5.16.0 from target osqueryd-5.16.0.tar.gz at /var/kolide-nababe-k2/k2device-preprod.kolide.com/updates/osqueryd/5.16.0/osqueryd is either originally installed version, not yet downloaded, or corrupted: checking executable permissions: no such file` to have a much clearer message: `version 5.16.0 from target osqueryd-5.16.0.tar.gz at /var/kolide-nababe-k2/k2device-preprod.kolide.com/updates/osqueryd/5.16.0/osqueryd is either originally installed version or not yet downloaded`.