### PR TITLE
Do not suppress errors when running CheckExecutable

### DIFF
--- a/ee/tuf/ci/valid_executable.go
+++ b/ee/tuf/ci/valid_executable.go
@@ -1,15 +1,73 @@
 package tufci
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/pkg/packaging"
 	"github.com/stretchr/testify/require"
 )
 
-func CopyBinary(t *testing.T, executablePath string) {
-	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
+var testOsqueryBinary string
 
-	require.NoError(t, os.Symlink(os.Args[0], executablePath))
+// downloadOnceFunc downloads a real osquery binary for use in tests. This function
+// can be called multiple times but will only execute once -- the osquery binary is
+// stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
+var downloadOnceFunc = sync.OnceFunc(func() {
+	downloadDir, err := os.MkdirTemp("", "tufci")
+	if err != nil {
+		fmt.Printf("failed to make temp dir for test osquery binary: %v", err)
+		os.Exit(1) //nolint:forbidigo // Fine to use os.Exit inside tests
+	}
+
+	target := packaging.Target{}
+	if err := target.PlatformFromString(runtime.GOOS); err != nil {
+		fmt.Printf("error parsing platform %s: %v", runtime.GOOS, err)
+		os.RemoveAll(downloadDir) // explicit removal as defer will not run when os.Exit is called
+		os.Exit(1)                //nolint:forbidigo // Fine to use os.Exit inside tests
+	}
+	target.Arch = packaging.ArchFlavor(runtime.GOARCH)
+	if runtime.GOOS == "darwin" {
+		target.Arch = packaging.Universal
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dlPath, err := packaging.FetchBinary(ctx, downloadDir, "osqueryd", target.PlatformBinaryName("osqueryd"), "nightly", target)
+	if err != nil {
+		fmt.Printf("error fetching binary osqueryd binary: %v", err)
+		cancel()                  // explicit cancel as defer will not run when os.Exit is called
+		os.RemoveAll(downloadDir) // explicit removal as defer will not run when os.Exit is called
+		os.Exit(1)                //nolint:forbidigo // Fine to use os.Exit inside tests
+	}
+
+	testOsqueryBinary = filepath.Join(downloadDir, filepath.Base(dlPath))
+	if runtime.GOOS == "windows" {
+		testOsqueryBinary += ".exe"
+	}
+
+	if err := fsutil.CopyFile(dlPath, testOsqueryBinary); err != nil {
+		fmt.Printf("error copying osqueryd binary: %v", err)
+		cancel()                  // explicit cancel as defer will not run when os.Exit is called
+		os.RemoveAll(downloadDir) // explicit removal as defer will not run when os.Exit is called
+		os.Exit(1)                //nolint:forbidigo // Fine to use os.Exit inside tests
+	}
+})
+
+// CopyBinary ensures we've downloaded a test osquery binary, then creates a symlink
+// between the real binary and the expected `executablePath` location. (We used to
+// actually copy the entire binary, but found that was very slow.)
+func CopyBinary(t *testing.T, executablePath string) {
+	downloadOnceFunc()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
+	require.NoError(t, os.Symlink(testOsqueryBinary, executablePath))
 }

--- a/ee/tuf/util_test.go
+++ b/ee/tuf/util_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	tufci "github.com/kolide/launcher/ee/tuf/ci"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
@@ -71,7 +70,10 @@ func TestCheckExecutable(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryName := windowsAddExe("testbinary")
 	targetExe := filepath.Join(tmpDir, binaryName)
-	tufci.CopyBinary(t, targetExe)
+	require.NoError(t, os.MkdirAll(filepath.Dir(tmpDir), 0755))
+
+	// We use the golang test binary here so we can run `TestHelperProcess` with the desired outcome
+	require.NoError(t, os.Symlink(os.Args[0], targetExe))
 	require.NoError(t, os.Chmod(targetExe, 0755))
 
 	var tests = []struct {
@@ -84,11 +86,11 @@ func TestCheckExecutable(t *testing.T) {
 		},
 		{
 			testName:    "exit1",
-			expectedErr: false,
+			expectedErr: true,
 		},
 		{
 			testName:    "exit2",
-			expectedErr: false,
+			expectedErr: true,
 		},
 		{
 			testName:    "sleep",


### PR DESCRIPTION
We discovered yesterday and this morning that the `supressRoutineErrors` function can unfortunately suppress critical errors too. Most pertinently, the exit code for the error documented in https://github.com/kolide/launcher/issues/952 is 1, which was suppressed by `CheckExecutable`.

This PR updates `CheckExecutable` to no longer suppress errors.

I believe we may have originally added this in order to use the golang test binary as our test binary (since the test binary does not accept e.g. the `-version` flag). In order to handle this, I have updated nearly all of our autoupdate tests to use an actual osquery binary, which is a pattern we use in other tests too. The only test that still uses the golang test binary is `TestCheckExecutable`.

As a continuation of https://github.com/kolide/launcher/pull/2150 -- here's what the logs look like now for exit code 1, exit code 2, and a timeout:

```json
{
    "time":"2025-03-14T10:07:30.258568-04:00",
    "level":"WARN",
    "source":{"function":"github.com/kolide/launcher/ee/tuf.CheckExecutable","file":"/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/util.go","line":64},
    "msg":"executable check returned error",
    "subcomponent":"CheckExecutable",
    "binary_path":"/var/folders/4d/jfl75r312llb4k5j5kgp4j240000gn/T/TestCheckExecutable225282483/001/testbinary",
    "args":"[-test.run=TestHelperProcess -- exit1]",
    "exec_err":"exit status 1",
    "command_output":"example stdout text"
}

{
    "time":"2025-03-14T10:07:30.271901-04:00",
    "level":"WARN",
    "source":{"function":"github.com/kolide/launcher/ee/tuf.CheckExecutable","file":"/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/util.go","line":64},
    "msg":"executable check returned error",
    "subcomponent":"CheckExecutable",
    "binary_path":"/var/folders/4d/jfl75r312llb4k5j5kgp4j240000gn/T/TestCheckExecutable225282483/001/testbinary",
    "args":"[-test.run=TestHelperProcess -- exit2]",
    "exec_err":"exit status 2",
    "command_output":"example stdout text again\nthis time we have stderr too"
}

{
    "time":"2025-03-14T10:07:35.276516-04:00",
    "level":"WARN",
    "source":{"function":"github.com/kolide/launcher/ee/tuf.CheckExecutable","file":"/Users/rebeccamahany-horton/Repos/launcher/ee/tuf/util.go","line":64},
    "msg":"executable check returned error",
    "subcomponent":"CheckExecutable",
    "binary_path":"/var/folders/4d/jfl75r312llb4k5j5kgp4j240000gn/T/TestCheckExecutable225282483/001/testbinary",
    "args":"[-test.run=TestHelperProcess -- sleep]",
    "exec_err":"timeout when checking executable: context deadline exceeded",
    "command_output":""
}
```