### PR TITLE
Build for linux in ubuntu 20.04 container

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -150,7 +150,8 @@ jobs:
 
   # this job captures the version of launcher on one of the runners then that version is
   # compared to the version of all other runners during exec testing. This is to ensure
-  # that the version of launcher is the same across all runners.
+  # that the version of launcher is the same across all runners. We run this job in a container
+  # to confirm launcher support on ubuntu 20.04, since runners no longer support ubuntu 20.04.
   version_baseline:
     name: Version Baseline
     runs-on: ubuntu-22.04

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -102,6 +102,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0 # need a full checkout for `git describe`
+    
+    - name: Ignore dubious ownership
+      run: git config --global --add safe.directory /__w/launcher/launcher
 
     - name: Setup Go
       uses: actions/setup-go@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,8 @@ on:
 
 
 jobs:
+  # Our non-containerized launcher builds -- macOS and Windows. Linux is handled separately
+  # below to preserve Ubuntu 20.04 support.
   build:
     name: launcher
     runs-on: ${{ matrix.os }}
@@ -19,7 +21,6 @@ jobs:
       fail-fast: false # Consider changing this sometime
       matrix:
         os:
-          - ubuntu-22.04
           - macos-13
           - windows-latest
     steps:
@@ -59,10 +60,6 @@ jobs:
     - name: Get dependencies
       run: make deps
 
-    - name: Set up zig
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      uses: goto-bus-stop/setup-zig@v2
-
     - name: Build
       run: make -j2 github-build
 
@@ -86,10 +83,13 @@ jobs:
         key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
-  buildubuntu2004:
-    name: launcher - ubuntu 20.04
+  # Our containerized launcher build -- we need to build launcher on Ubuntu 20.04
+  # in order to continue to support that platform, but that GH runner has been EOL'ed --
+  # so we have a separate build here in an ubuntu:20.04 container instead.
+  build_linux:
+    name: launcher (linux)
     runs-on: ubuntu-22.04
-    container: ubuntu:20.04
+    container: ubuntu:20.04 # Required to support launcher on Ubuntu 20.04
     steps:
     - name: Install build dependencies
       run: |
@@ -114,9 +114,7 @@ jobs:
         cache: false
       id: go
 
-    # use bash, because the powershell syntax is different and this is a cross platform workflow
     - id: go-cache-paths
-      shell: bash
       run: |
         echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
@@ -156,7 +154,7 @@ jobs:
     name: Version Baseline
     runs-on: ubuntu-22.04
     container: ubuntu:20.04
-    needs: buildubuntu2004
+    needs: build_linux
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -175,7 +173,9 @@ jobs:
 
   launcher_test:
     name: test
-    needs: build # a desktop runner test requires a build to exist
+    needs:
+      - build # a desktop runner test requires a build to exist
+      - build_linux
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -250,7 +250,9 @@ jobs:
           - macos-15
           - windows-2019
           - windows-2022
-    needs: version_baseline
+    needs:
+      - version_baseline # version_baseline implies build_linux
+      - build # need the other builds too
     steps:
     - name: cache restore build output
       uses: actions/cache/restore@v4
@@ -312,7 +314,6 @@ jobs:
         name: ${{ matrix.artifactos }}-build
         path: build/
         if-no-files-found: error
-
 
   package_builder_test:
     name: package_builder
@@ -386,6 +387,7 @@ jobs:
       - run: true
     needs:
       - build
+      - build_linux
       - launcher_test
       - package_builder_test
       - exec_testing

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,6 +86,60 @@ jobs:
         key: ${{ runner.os }}-${{ github.run_id }}
         enableCrossOsArchive: true
 
+  buildubuntu2004:
+    name: launcher - ubuntu 20.04
+    runs-on: ubuntu-22.04
+    container: ubuntu:20.04
+    steps:
+    - name: Check out code
+      id: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # need a full checkout for `git describe`
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: './go.mod'
+        check-latest: true
+        cache: false
+      id: go
+
+    # use bash, because the powershell syntax is different and this is a cross platform workflow
+    - id: go-cache-paths
+      shell: bash
+      run: |
+        echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    - name: Go Build Cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+    - name: Go Mod Cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+    - name: Get dependencies
+      run: make deps
+
+    - name: Set up zig
+      uses: goto-bus-stop/setup-zig@v2
+
+    - name: Build
+      run: make -j2 github-build
+
+    - name: Cache build output
+      uses: actions/cache@v4
+      with:
+        path: ./build
+        key: ${{ runner.os }}-${{ github.run_id }}
+        enableCrossOsArchive: true
+
   # this job captures the version of launcher on one of the runners then that version is
   # compared to the version of all other runners during exec testing. This is to ensure
   # that the version of launcher is the same across all runners.
@@ -93,7 +147,7 @@ jobs:
     name: Version Baseline
     runs-on: ubuntu-22.04
     container: ubuntu:20.04
-    needs: build
+    needs: buildubuntu2004
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,10 +91,11 @@ jobs:
     runs-on: ubuntu-22.04
     container: ubuntu:20.04 # Required to support launcher on Ubuntu 20.04
     steps:
+    # zstd is needed so we can restore cache later -- see https://github.com/actions/cache/issues/1455#issuecomment-2328358604
     - name: Install build dependencies
       run: |
         apt-get -y update
-        apt-get -y install build-essential ca-certificates openssl git
+        apt-get -y install build-essential ca-certificates openssl git zstd
         update-ca-certificates
 
     - name: Check out code
@@ -158,6 +159,11 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+    # Needed so we can restore cache -- see https://github.com/actions/cache/issues/1455#issuecomment-2328358604
+    - name: Install zstd
+      run: |
+        apt-get -y update
+        apt-get -y install zstd
     - name: cache restore build output
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -92,6 +92,7 @@ jobs:
   version_baseline:
     name: Version Baseline
     runs-on: ubuntu-22.04
+    container: ubuntu:20.04
     needs: build
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,6 +91,12 @@ jobs:
     runs-on: ubuntu-22.04
     container: ubuntu:20.04
     steps:
+    - name: Install build dependencies
+      run: |
+        apt-get -y update
+        apt-get -y install build-essential ca-certificates openssl git
+        update-ca-certificates
+
     - name: Check out code
       id: checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Resolves https://github.com/kolide/launcher/issues/952.

We need to continue to build for linux on Ubuntu 20.04, but the ubuntu-20.04 runners have been EOL'ed. When researching the linked issue, I found that using an ubuntu:20.04 container was widely regarded as the easiest solution. Accordingly, this PR updates to use an ubuntu:20.04 container for the linux build.

I think ideally we'd maintain a docker image that has the build dependencies (`build-essential ca-certificates openssl git zstd`) pre-installed, instead of pulling the image and apt-get installing the small handful of deps we need. This would allow us to skip the extra install steps on each build. Plus, we currently can't run the container as the runner user because we aren't allowed to apt-get install as the runner user -- but if the dependencies were pre-installed in the image, we could run the container as the runner user and thereby avoid the `Ignore dubious ownership` workaround I had to add. However, I think the implementation in this PR is okay for the time being.