### PR TITLE
rename zta to dt4a as much as possible

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -74,7 +74,7 @@ const (
 	desktopMenuSubsystemName = "kolide_desktop_menu"
 	authTokensSubsystemName  = "auth_tokens"
 	katcSubsystemName        = "katc_config" // Kolide ATC
-	ztaInfoSubsystemName     = "zta_info"
+	dt4aInfoSubsystemName    = "zta_info"
 )
 
 // runLauncher is the entry point into running launcher. It creates a
@@ -505,10 +505,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			metadataWriter.Ping()
 		}
 
-		// Set up consumer to receive ZTA info from the control server
-		ztaInfoConsumer := keyvalueconsumer.NewConfigConsumer(k.ZtaInfoStore())
-		if err := controlService.RegisterConsumer(ztaInfoSubsystemName, ztaInfoConsumer); err != nil {
-			return fmt.Errorf("failed to register ZTA info consumer: %w", err)
+		// Set up consumer to receive dt4a info from the control server
+		dt4aInfoConsumer := keyvalueconsumer.NewConfigConsumer(k.Dt4aInfoStore())
+		if err := controlService.RegisterConsumer(dt4aInfoSubsystemName, dt4aInfoConsumer); err != nil {
+			return fmt.Errorf("failed to register dt4a info consumer: %w", err)
 		}
 	}
 

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -506,7 +506,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			metadataWriter.Ping()
 		}
 
-		// Set up consumer to receive dt4a info from the control server
+		// Set up consumer to receive DT4A info from the control server in both current and legacy subsystem
 		dt4aInfoConsumer := keyvalueconsumer.NewConfigConsumer(k.Dt4aInfoStore())
 		if err := controlService.RegisterConsumer(dt4aInfoSubsystemName, dt4aInfoConsumer); err != nil {
 			return fmt.Errorf("failed to register dt4a info consumer: %w", err)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -74,7 +74,8 @@ const (
 	desktopMenuSubsystemName = "kolide_desktop_menu"
 	authTokensSubsystemName  = "auth_tokens"
 	katcSubsystemName        = "katc_config" // Kolide ATC
-	dt4aInfoSubsystemName    = "zta_info"
+	ztaInfoSubsystemName     = "zta_info"    // legacy name for dt4aInfo subsystem
+	dt4aInfoSubsystemName    = "dt4a_info"
 )
 
 // runLauncher is the entry point into running launcher. It creates a
@@ -508,6 +509,11 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		// Set up consumer to receive dt4a info from the control server
 		dt4aInfoConsumer := keyvalueconsumer.NewConfigConsumer(k.Dt4aInfoStore())
 		if err := controlService.RegisterConsumer(dt4aInfoSubsystemName, dt4aInfoConsumer); err != nil {
+			return fmt.Errorf("failed to register dt4a info consumer: %w", err)
+		}
+
+		//ztaInfoConsumer is the legacy consumer for zta
+		if err := controlService.RegisterConsumer(ztaInfoSubsystemName, dt4aInfoConsumer); err != nil {
 			return fmt.Errorf("failed to register dt4a info consumer: %w", err)
 		}
 	}

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -180,8 +180,8 @@ func (k *knapsack) LauncherHistoryStore() types.KVStore {
 	return k.getKVStore(storage.LauncherHistoryStore)
 }
 
-func (k *knapsack) ZtaInfoStore() types.KVStore {
-	return k.getKVStore(storage.ZtaInfoStore)
+func (k *knapsack) Dt4aInfoStore() types.KVStore {
+	return k.getKVStore(storage.Dt4aInfoStore)
 }
 
 func (k *knapsack) SetLauncherWatchdogEnabled(enabled bool) error {

--- a/ee/agent/storage/bbolt/stores_bbolt.go
+++ b/ee/agent/storage/bbolt/stores_bbolt.go
@@ -34,7 +34,7 @@ func MakeStores(ctx context.Context, slogger *slog.Logger, db *bbolt.DB) (map[st
 		storage.TokenStore,
 		storage.ControlServerActionsStore,
 		storage.LauncherHistoryStore,
-		storage.ZtaInfoStore,
+		storage.Dt4aInfoStore,
 	}
 
 	for _, storeName := range storeNames {

--- a/ee/agent/storage/ci/stores_ci.go
+++ b/ee/agent/storage/ci/stores_ci.go
@@ -32,7 +32,7 @@ func MakeStores(t *testing.T, slogger *slog.Logger, db *bbolt.DB) (map[storage.S
 		storage.ServerProvidedDataStore,
 		storage.TokenStore,
 		storage.LauncherHistoryStore,
-		storage.ZtaInfoStore,
+		storage.Dt4aInfoStore,
 	}
 
 	if os.Getenv("CI") == "true" {

--- a/ee/agent/storage/stores.go
+++ b/ee/agent/storage/stores.go
@@ -19,7 +19,7 @@ const (
 	TokenStore                  Store = "token_store"              // The store used for holding bearer auth tokens, e.g. the ones used to authenticate with the observability ingest server.
 	ControlServerActionsStore   Store = "action_store"             // The store used for storing actions sent by control server.
 	LauncherHistoryStore        Store = "launcher_history"         // The store used for storing launcher start time history currently.
-	ZtaInfoStore                Store = "zta_info"                 // The store used for storing ZTA info about this device
+	Dt4aInfoStore               Store = "zta_info"                 // The store used for storing dt4a info about this device
 )
 
 func (storeType Store) String() string {

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -2363,12 +2363,12 @@ func (_m *Knapsack) WatchdogUtilizationLimitPercent() int {
 	return r0
 }
 
-// ZtaInfoStore provides a mock function with given fields:
-func (_m *Knapsack) ZtaInfoStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
+// Dt4aInfoStore provides a mock function with given fields:
+func (_m *Knapsack) Dt4aInfoStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for ZtaInfoStore")
+		panic("no return value specified for Dt4aInfoStore")
 	}
 
 	var r0 types.GetterSetterDeleterIteratorUpdaterCounterAppender

--- a/ee/agent/types/stores.go
+++ b/ee/agent/types/stores.go
@@ -18,5 +18,5 @@ type Stores interface {
 	ServerProvidedDataStore() KVStore
 	TokenStore() KVStore
 	LauncherHistoryStore() KVStore
-	ZtaInfoStore() KVStore
+	Dt4aInfoStore() KVStore
 }

--- a/ee/localserver/dt4a.go
+++ b/ee/localserver/dt4a.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	localserverDt4aInfoKey = []byte("localserver_dt4a_info")
+	localserverDt4aInfoKey = []byte("localserver_zta_info")
 
 	// allowlistedDt4aOriginsLookup contains the complete list of origins that are permitted to access the /dt4a endpoint.
 	allowlistedDt4aOriginsLookup = map[string]struct{}{

--- a/ee/localserver/dt4a.go
+++ b/ee/localserver/dt4a.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	localserverZtaInfoKey = []byte("localserver_zta_info")
+	localserverDt4aInfoKey = []byte("localserver_dt4a_info")
 
-	// allowlistedZtaOriginsLookup contains the complete list of origins that are permitted to access the /zta endpoint.
-	allowlistedZtaOriginsLookup = map[string]struct{}{
+	// allowlistedDt4aOriginsLookup contains the complete list of origins that are permitted to access the /dt4a endpoint.
+	allowlistedDt4aOriginsLookup = map[string]struct{}{
 		// Release extension
 		"chrome-extension://gejiddohjgogedgjnonbofjigllpkmbf":  {},
 		"chrome-extension://khgocmkkpikpnmmkgmdnfckapcdkgfaf":  {},
@@ -34,11 +34,11 @@ const (
 	safariWebExtensionScheme = "safari-web-extension://"
 )
 
-func (ls *localServer) requestZtaInfoHandler() http.Handler {
-	return http.HandlerFunc(ls.requestZtaInfoHandlerFunc)
+func (ls *localServer) requestDt4aInfoHandler() http.Handler {
+	return http.HandlerFunc(ls.requestDt4aInfoHandlerFunc)
 }
 
-func (ls *localServer) requestZtaInfoHandlerFunc(w http.ResponseWriter, r *http.Request) {
+func (ls *localServer) requestDt4aInfoHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	r, span := traces.StartHttpRequestSpan(r, "path", r.URL.Path)
 	defer span.End()
 
@@ -47,10 +47,10 @@ func (ls *localServer) requestZtaInfoHandlerFunc(w http.ResponseWriter, r *http.
 	// that is not in the allowlist.
 	requestOrigin := r.Header.Get("Origin")
 	if requestOrigin != "" {
-		if _, ok := allowlistedZtaOriginsLookup[requestOrigin]; !ok && !strings.HasPrefix(requestOrigin, safariWebExtensionScheme) {
+		if _, ok := allowlistedDt4aOriginsLookup[requestOrigin]; !ok && !strings.HasPrefix(requestOrigin, safariWebExtensionScheme) {
 			escapedOrigin := strings.ReplaceAll(strings.ReplaceAll(requestOrigin, "\n", ""), "\r", "") // remove any newlines
 			ls.slogger.Log(r.Context(), slog.LevelInfo,
-				"received zta request with origin not in allowlist",
+				"received dt4a request with origin not in allowlist",
 				"req_origin", escapedOrigin,
 			)
 			w.WriteHeader(http.StatusForbidden)
@@ -58,11 +58,11 @@ func (ls *localServer) requestZtaInfoHandlerFunc(w http.ResponseWriter, r *http.
 		}
 	}
 
-	ztaInfo, err := ls.knapsack.ZtaInfoStore().Get(localserverZtaInfoKey)
+	dt4aInfo, err := ls.knapsack.Dt4aInfoStore().Get(localserverDt4aInfoKey)
 	if err != nil {
 		traces.SetError(span, err)
 		ls.slogger.Log(r.Context(), slog.LevelError,
-			"could not retrieve ZTA info from store",
+			"could not retrieve dt4a info from store",
 			"err", err,
 		)
 
@@ -70,11 +70,11 @@ func (ls *localServer) requestZtaInfoHandlerFunc(w http.ResponseWriter, r *http.
 		return
 	}
 	// No data stored yet
-	if len(ztaInfo) == 0 {
+	if len(dt4aInfo) == 0 {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(ztaInfo)
+	w.Write(dt4aInfo)
 }

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -21,10 +21,10 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-func Test_ZtaAuthMiddleware(t *testing.T) {
+func Test_Dt4aAuthMiddleware(t *testing.T) {
 	rootTrustedEcKey := mustGenEcdsaKey(t)
 
-	ztaMiddleware := &ztaAuthMiddleware{
+	dt4aMiddleware := &dt4aAuthMiddleware{
 		counterPartyKeys: map[string]*ecdsa.PublicKey{
 			"for_funzies": mustGenEcdsaKey(t).Public().(*ecdsa.PublicKey),
 			"0":           rootTrustedEcKey.Public().(*ecdsa.PublicKey), // this is the trusted root
@@ -34,7 +34,7 @@ func Test_ZtaAuthMiddleware(t *testing.T) {
 
 	returnData := []byte("Congrats!, you got the data back!")
 
-	handler := ztaMiddleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := dt4aMiddleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(returnData)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -136,7 +136,7 @@ func Test_ZtaAuthMiddleware(t *testing.T) {
 		bodyDecoded, err := base64.StdEncoding.DecodeString(string(bodyBytes))
 		require.NoError(t, err)
 
-		var z ztaResponse
+		var z dt4aResponse
 		require.NoError(t, json.Unmarshal(bodyDecoded, &z))
 
 		opened, err := echelper.OpenNaCl(z.Data, z.PubKey, callerPrivKey)

--- a/ee/localserver/dt4a_test.go
+++ b/ee/localserver/dt4a_test.go
@@ -16,39 +16,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_requestZtaInfoHandler(t *testing.T) {
+func Test_requestDt4aInfoHandler(t *testing.T) {
 	t.Parallel()
 
-	// Set up our ZTA store with some test data in it
+	// Set up our dt4a store with some test data in it
 	slogger := multislogger.NewNopLogger()
-	ztaInfoStore, err := storageci.NewStore(t, slogger, storage.ZtaInfoStore.String())
+	dt4aInfoStore, err := storageci.NewStore(t, slogger, storage.Dt4aInfoStore.String())
 	require.NoError(t, err)
-	testZtaInfo, err := json.Marshal(map[string]string{
+	testDt4aInfo, err := json.Marshal(map[string]string{
 		"some_test_data": "some_test_value",
 	})
 	require.NoError(t, err)
-	require.NoError(t, ztaInfoStore.Set(localserverZtaInfoKey, testZtaInfo))
+	require.NoError(t, dt4aInfoStore.Set(localserverDt4aInfoKey, testDt4aInfo))
 
 	// Set up the rest of our localserver dependencies
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(slogger)
-	k.On("ZtaInfoStore").Return(ztaInfoStore)
+	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
 	require.NoError(t, err)
 
 	// Make a request to our handler
-	request := httptest.NewRequest(http.MethodGet, "/zta", nil)
+	request := httptest.NewRequest(http.MethodGet, "/dt4a", nil)
 	request.Header.Set("origin", acceptableOrigin(t))
 	responseRecorder := httptest.NewRecorder()
-	ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+	ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 	// Make sure response was successful and contains the data we expect
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	require.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	require.Equal(t, testZtaInfo, responseRecorder.Body.Bytes())
+	require.Equal(t, testDt4aInfo, responseRecorder.Body.Bytes())
 
 	k.AssertExpectations(t)
 }
@@ -56,7 +56,7 @@ func Test_requestZtaInfoHandler(t *testing.T) {
 func acceptableOrigin(t *testing.T) string {
 	// Just grab the first origin available in our allowlist
 	acceptableOrigin := ""
-	for k := range allowlistedZtaOriginsLookup {
+	for k := range allowlistedDt4aOriginsLookup {
 		acceptableOrigin = k
 		break
 	}
@@ -68,117 +68,117 @@ func acceptableOrigin(t *testing.T) string {
 	return acceptableOrigin
 }
 
-func Test_requestZtaInfoHandler_allowsAllSafariWebExtensionOrigins(t *testing.T) {
+func Test_requestDt4aInfoHandler_allowsAllSafariWebExtensionOrigins(t *testing.T) {
 	t.Parallel()
 
-	// Set up our ZTA store with some test data in it
+	// Set up our dt4a store with some test data in it
 	slogger := multislogger.NewNopLogger()
-	ztaInfoStore, err := storageci.NewStore(t, slogger, storage.ZtaInfoStore.String())
+	dt4aInfoStore, err := storageci.NewStore(t, slogger, storage.Dt4aInfoStore.String())
 	require.NoError(t, err)
-	testZtaInfo, err := json.Marshal(map[string]string{
+	testDt4aInfo, err := json.Marshal(map[string]string{
 		"some_test_data": "some_test_value",
 	})
 	require.NoError(t, err)
-	require.NoError(t, ztaInfoStore.Set(localserverZtaInfoKey, testZtaInfo))
+	require.NoError(t, dt4aInfoStore.Set(localserverDt4aInfoKey, testDt4aInfo))
 
 	// Set up the rest of our localserver dependencies
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(slogger)
-	k.On("ZtaInfoStore").Return(ztaInfoStore)
+	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
 	require.NoError(t, err)
 
 	// Make a request to our handler
-	request := httptest.NewRequest(http.MethodGet, "/zta", nil)
+	request := httptest.NewRequest(http.MethodGet, "/dt4a", nil)
 	request.Header.Set("origin", fmt.Sprintf("%sexample.com", safariWebExtensionScheme))
 	responseRecorder := httptest.NewRecorder()
-	ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+	ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 	// Make sure response was successful and contains the data we expect
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	require.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	require.Equal(t, testZtaInfo, responseRecorder.Body.Bytes())
+	require.Equal(t, testDt4aInfo, responseRecorder.Body.Bytes())
 
 	k.AssertExpectations(t)
 }
 
-func Test_requestZtaInfoHandler_allowsMissingOrigin(t *testing.T) {
+func Test_requestDt4aInfoHandler_allowsMissingOrigin(t *testing.T) {
 	t.Parallel()
 
-	// Set up our ZTA store with some test data in it
+	// Set up our dt4a store with some test data in it
 	slogger := multislogger.NewNopLogger()
-	ztaInfoStore, err := storageci.NewStore(t, slogger, storage.ZtaInfoStore.String())
+	dt4aInfoStore, err := storageci.NewStore(t, slogger, storage.Dt4aInfoStore.String())
 	require.NoError(t, err)
-	testZtaInfo, err := json.Marshal(map[string]string{
+	testDt4aInfo, err := json.Marshal(map[string]string{
 		"some_test_data": "some_test_value",
 	})
 	require.NoError(t, err)
-	require.NoError(t, ztaInfoStore.Set(localserverZtaInfoKey, testZtaInfo))
+	require.NoError(t, dt4aInfoStore.Set(localserverDt4aInfoKey, testDt4aInfo))
 
 	// Set up the rest of our localserver dependencies
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(slogger)
-	k.On("ZtaInfoStore").Return(ztaInfoStore)
+	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
 	require.NoError(t, err)
 
 	// Make a request to our handler
-	request := httptest.NewRequest(http.MethodGet, "/zta", nil)
+	request := httptest.NewRequest(http.MethodGet, "/dt4a", nil)
 	responseRecorder := httptest.NewRecorder()
-	ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+	ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 	// Make sure response was successful and contains the data we expect
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	require.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	require.Equal(t, testZtaInfo, responseRecorder.Body.Bytes())
+	require.Equal(t, testDt4aInfo, responseRecorder.Body.Bytes())
 
 	k.AssertExpectations(t)
 }
 
-func Test_requestZtaInfoHandler_allowsEmptyOrigin(t *testing.T) {
+func Test_requestDt4aInfoHandler_allowsEmptyOrigin(t *testing.T) {
 	t.Parallel()
 
-	// Set up our ZTA store with some test data in it
+	// Set up our dt4a store with some test data in it
 	slogger := multislogger.NewNopLogger()
-	ztaInfoStore, err := storageci.NewStore(t, slogger, storage.ZtaInfoStore.String())
+	dt4aInfoStore, err := storageci.NewStore(t, slogger, storage.Dt4aInfoStore.String())
 	require.NoError(t, err)
-	testZtaInfo, err := json.Marshal(map[string]string{
+	testDt4aInfo, err := json.Marshal(map[string]string{
 		"some_test_data": "some_test_value",
 	})
 	require.NoError(t, err)
-	require.NoError(t, ztaInfoStore.Set(localserverZtaInfoKey, testZtaInfo))
+	require.NoError(t, dt4aInfoStore.Set(localserverDt4aInfoKey, testDt4aInfo))
 
 	// Set up the rest of our localserver dependencies
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(slogger)
-	k.On("ZtaInfoStore").Return(ztaInfoStore)
+	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
 	require.NoError(t, err)
 
 	// Make a request to our handler
-	request := httptest.NewRequest(http.MethodGet, "/zta", nil)
+	request := httptest.NewRequest(http.MethodGet, "/dt4a", nil)
 	request.Header.Set("origin", "")
 	responseRecorder := httptest.NewRecorder()
-	ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+	ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 	// Make sure response was successful and contains the data we expect
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	require.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	require.Equal(t, testZtaInfo, responseRecorder.Body.Bytes())
+	require.Equal(t, testDt4aInfo, responseRecorder.Body.Bytes())
 
 	k.AssertExpectations(t)
 }
 
-func Test_requestZtaInfoHandler_badRequest(t *testing.T) {
+func Test_requestDt4aInfoHandler_badRequest(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
@@ -211,10 +211,10 @@ func Test_requestZtaInfoHandler_badRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			// Make a request to our handler
-			request := httptest.NewRequest(tt.httpMethod, "/zta", tt.requestBody)
+			request := httptest.NewRequest(tt.httpMethod, "/dt4a", tt.requestBody)
 			request.Header.Set("origin", tt.requestOrigin)
 			responseRecorder := httptest.NewRecorder()
-			ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+			ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 			// Make sure we got back an expected response status code (4xx-level)
 			require.Equal(t, tt.expectedResponseStatus, responseRecorder.Code)
@@ -224,29 +224,29 @@ func Test_requestZtaInfoHandler_badRequest(t *testing.T) {
 	}
 }
 
-func Test_requestZtaInfoHandler_noDataAvailable(t *testing.T) {
+func Test_requestDt4aInfoHandler_noDataAvailable(t *testing.T) {
 	t.Parallel()
 
-	// Set up our ZTA store, but do not store any data in it under the `localserverZtaInfoKey` key
+	// Set up our dt4a store, but do not store any data in it under the `localserverDt4aInfoKey` key
 	slogger := multislogger.NewNopLogger()
-	ztaInfoStore, err := storageci.NewStore(t, slogger, storage.ZtaInfoStore.String())
+	dt4aInfoStore, err := storageci.NewStore(t, slogger, storage.Dt4aInfoStore.String())
 	require.NoError(t, err)
 
 	// Set up the rest of our localserver dependencies
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(slogger)
-	k.On("ZtaInfoStore").Return(ztaInfoStore)
+	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
 	require.NoError(t, err)
 
 	// Make a request to our handler
-	request := httptest.NewRequest(http.MethodGet, "/zta", nil)
+	request := httptest.NewRequest(http.MethodGet, "/dt4a", nil)
 	request.Header.Set("origin", acceptableOrigin(t))
 	responseRecorder := httptest.NewRecorder()
-	ls.requestZtaInfoHandler().ServeHTTP(responseRecorder, request)
+	ls.requestDt4aInfoHandler().ServeHTTP(responseRecorder, request)
 
 	// Make sure response was a 404
 	require.Equal(t, http.StatusNotFound, responseRecorder.Code)

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -109,17 +109,17 @@ func New(ctx context.Context, k types.Knapsack, presenceDetector presenceDetecto
 		return nil, fmt.Errorf("loading dt4a keys %w", err)
 	}
 
-	ztaAuthMiddleware := &ztaAuthMiddleware{
+	dt4aAuthMiddleware := &dt4aAuthMiddleware{
 		counterPartyKeys: trustedDt4aKeys,
 		slogger:          k.Slogger().With("component", "dt4a_auth_middleware"),
 	}
 
 	// In the future, we will want to make this authenticated; for now, it is not authenticated.
 	// TODO: make this authenticated or remove
-	mux.Handle("/zta", ls.requestZtaInfoHandler())
+	mux.Handle("/dt4a", ls.requestDt4aInfoHandler())
 
-	// mux.Handle("/zta", ztaAuthMiddleware.Wrap(ls.requestZtaInfoHandler()))
-	mux.Handle("/v3/dt4a", ztaAuthMiddleware.Wrap(ls.requestZtaInfoHandler()))
+	// mux.Handle("/dt4a", dt4aAuthMiddleware.Wrap(ls.requestDt4aInfoHandler()))
+	mux.Handle("/v3/dt4a", dt4aAuthMiddleware.Wrap(ls.requestDt4aInfoHandler()))
 
 	// uncomment to test without going through middleware
 	// for example:

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -116,9 +116,8 @@ func New(ctx context.Context, k types.Knapsack, presenceDetector presenceDetecto
 
 	// In the future, we will want to make this authenticated; for now, it is not authenticated.
 	// TODO: make this authenticated or remove
-	mux.Handle("/dt4a", ls.requestDt4aInfoHandler())
+	mux.Handle("/zta", ls.requestDt4aInfoHandler())
 
-	// mux.Handle("/dt4a", dt4aAuthMiddleware.Wrap(ls.requestDt4aInfoHandler()))
 	mux.Handle("/v3/dt4a", dt4aAuthMiddleware.Wrap(ls.requestDt4aInfoHandler()))
 
 	// uncomment to test without going through middleware


### PR DESCRIPTION
Renames everything from zta to dt4a, except a handful of literals where things would break if name changed.