### PR TITLE
Allow for manipulating osquery's effective distributed_interval within 5 seconds

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -68,26 +68,27 @@ const (
 	// (applies per log type).
 	defaultMaxBufferedLogs = 500000
 
-	// How frequently osquery should check for distributed queries to run during
-	// osquery instance startup -- an accelerated interval, where the unit is seconds.
-	// This shorter interval should hopefully help launcher begin to process stale,
-	// slow-running queries as quickly as possible after device startup.
-	startupDistributedInterval = 5
+	// How frequently osquery should check for distributed queries to run.
+	// We set this to 5 seconds, which is more frequent than we think the
+	// server can comfortably handle, so we only forward these requests
+	// to the cloud once every 60 seconds.
+	osqueryDistributedInterval = 5
 )
 
 var (
 	// Osquery configuration options that we set during the osquery instance's startup period.
 	// These are the override, non-standard values.
 	startupOsqueryConfigOptions = map[string]any{
-		"verbose":              true,                       // receive as many osquery logs as we can, in case we need to troubleshoot an issue
-		"distributed_interval": startupDistributedInterval, // request distributed queries more frequently, so stale checks run ASAP
+		"verbose":              true, // receive as many osquery logs as we can, in case we need to troubleshoot an issue
+		"distributed_interval": osqueryDistributedInterval,
 	}
 
 	// Osquery configuration options that we set after the osquery instance has been up and running
-	// for at least 10 minutes. These are the "normal" values. We don't set the distributed interval
-	// here so that the cloud can set it instead.
+	// for at least 10 minutes. These are the "normal" values. We continue to override the distributed
+	// interval to 5 seconds.
 	postStartupOsqueryConfigOptions = map[string]any{
-		"verbose": false,
+		"verbose":              false,
+		"distributed_interval": osqueryDistributedInterval,
 	}
 )
 

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -35,17 +35,20 @@ type settingsStoreWriter interface {
 // and servers -- It provides a grpc and jsonrpc interface for
 // osquery. It does not provide any tables.
 type Extension struct {
-	NodeKey             string
-	Opts                ExtensionOpts
-	registrationId      string
-	knapsack            types.Knapsack
-	serviceClient       service.KolideService
-	settingsWriter      settingsStoreWriter
-	enrollMutex         sync.Mutex
-	done                chan struct{}
-	interrupted         atomic.Bool
-	slogger             *slog.Logger
-	logPublicationState *logPublicationState
+	NodeKey                       string
+	Opts                          ExtensionOpts
+	registrationId                string
+	knapsack                      types.Knapsack
+	serviceClient                 service.KolideService
+	settingsWriter                settingsStoreWriter
+	enrollMutex                   sync.Mutex
+	done                          chan struct{}
+	interrupted                   atomic.Bool
+	slogger                       *slog.Logger
+	logPublicationState           *logPublicationState
+	lastRequestQueriesTimestamp   *atomic.Int64
+	distributedForwardingInterval *atomic.Int64 // how frequently to forward RequestQueries requests to the cloud, in seconds
+	forwardAllDistributedUntil    *atomic.Int64 // allows for accelerated distributed requests until given timestamp
 }
 
 const (
@@ -154,16 +157,28 @@ func NewExtension(ctx context.Context, client service.KolideService, settingsWri
 		)
 	}
 
+	initialTimestamp := &atomic.Int64{}
+	initialTimestamp.Store(0)
+
+	distributedForwardingInterval := &atomic.Int64{}
+	distributedForwardingInterval.Store(60) // forward RequestQueries to the cloud once every 60 seconds
+
+	forwardAllDistributedUntil := &atomic.Int64{}
+	forwardAllDistributedUntil.Store(time.Now().Unix() + 120) // forward all queries for the first 2 minutes after startup
+
 	return &Extension{
-		slogger:             slogger,
-		serviceClient:       client,
-		settingsWriter:      settingsWriter,
-		registrationId:      registrationId,
-		knapsack:            k,
-		NodeKey:             nodekey,
-		Opts:                opts,
-		done:                make(chan struct{}),
-		logPublicationState: NewLogPublicationState(opts.MaxBytesPerBatch),
+		slogger:                       slogger,
+		serviceClient:                 client,
+		settingsWriter:                settingsWriter,
+		registrationId:                registrationId,
+		knapsack:                      k,
+		NodeKey:                       nodekey,
+		Opts:                          opts,
+		done:                          make(chan struct{}),
+		logPublicationState:           NewLogPublicationState(opts.MaxBytesPerBatch),
+		lastRequestQueriesTimestamp:   initialTimestamp,
+		distributedForwardingInterval: distributedForwardingInterval,
+		forwardAllDistributedUntil:    forwardAllDistributedUntil,
 	}, nil
 }
 
@@ -836,7 +851,32 @@ func (e *Extension) GetQueries(ctx context.Context) (*distributed.GetQueriesResu
 	ctx, span := traces.StartSpan(ctx)
 	defer span.End()
 
-	return e.getQueriesWithReenroll(ctx, true)
+	// Check to see whether we should forward this request --
+	// 1. Check to see if we currently want to forward all distributed query requests to the cloud.
+	// 2. Check to see if we forwarded a request to the cloud within the last minute.
+	now := time.Now().Unix()
+	if now >= e.forwardAllDistributedUntil.Load() && now < e.lastRequestQueriesTimestamp.Load()+e.distributedForwardingInterval.Load() {
+		// Return an empty result to osquery.
+		return &distributed.GetQueriesResult{}, nil
+	}
+
+	// We haven't requested queries from the cloud within the last minute --
+	// forward this request.
+	e.lastRequestQueriesTimestamp.Store(now)
+
+	queries, err := e.getQueriesWithReenroll(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the cloud wants us to accelerate distributed requests by forwarding
+	// all requests to the cloud for the next `queries.AccelerateSeconds` seconds.
+	if queries.AccelerateSeconds > 0 {
+		// Store the timestamp when the acceleration ends
+		e.forwardAllDistributedUntil.Store(time.Now().Unix() + int64(queries.AccelerateSeconds))
+	}
+
+	return queries, nil
 }
 
 // Helper to allow for a single attempt at re-enrollment

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1191,7 +1191,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 			expectedConfig: map[string]any{
 				"options": map[string]any{
 					"verbose":              true,
-					"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1201,7 +1201,8 @@ func Test_setOsqueryOptions(t *testing.T) {
 			overrideOpts:  postStartupOsqueryConfigOptions,
 			expectedConfig: map[string]any{
 				"options": map[string]any{
-					"verbose": false,
+					"verbose":              false,
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1216,7 +1217,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 			expectedConfig: map[string]any{
 				"options": map[string]any{
 					"verbose":              true,
-					"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1230,7 +1231,8 @@ func Test_setOsqueryOptions(t *testing.T) {
 			overrideOpts: postStartupOsqueryConfigOptions,
 			expectedConfig: map[string]any{
 				"options": map[string]any{
-					"verbose": false,
+					"verbose":              false,
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1245,7 +1247,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 			expectedConfig: map[string]any{
 				"options": map[string]any{
 					"verbose":              true,
-					"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1260,7 +1262,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 			expectedConfig: map[string]any{
 				"options": map[string]any{
 					"verbose":              false,
-					"distributed_interval": float64(25), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1276,7 +1278,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 				"options": map[string]any{
 					"audit_allow_config":   false,
 					"verbose":              true,
-					"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 			},
 		},
@@ -1299,7 +1301,8 @@ func Test_setOsqueryOptions(t *testing.T) {
 			overrideOpts: postStartupOsqueryConfigOptions,
 			expectedConfig: map[string]any{
 				"options": map[string]any{
-					"verbose": false,
+					"verbose":              false,
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 				"decorators": map[string]any{
 					"load": []any{
@@ -1336,7 +1339,7 @@ func Test_setOsqueryOptions(t *testing.T) {
 			expectedConfig: map[string]any{
 				"options": map[string]any{
 					"verbose":              true,
-					"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+					"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 				},
 				"auto_table_construction": map[string]any{
 					"tcc_system_entries": map[string]any{
@@ -1387,7 +1390,7 @@ func Test_setOsqueryOptions_EmptyConfig(t *testing.T) {
 	expectedCfg := map[string]any{
 		"options": map[string]any{
 			"verbose":              true,
-			"distributed_interval": float64(startupDistributedInterval), // has to be a float64 due to json unmarshal nonsense
+			"distributed_interval": float64(osqueryDistributedInterval), // has to be a float64 due to json unmarshal nonsense
 		},
 	}
 

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -168,17 +167,21 @@ func (mw logmw) RequestQueries(ctx context.Context, nodeKey string) (res *distri
 	defer func(begin time.Time) {
 		resJSON, _ := json.Marshal(res)
 		uuid, _ := uuid.FromContext(ctx)
+
+		message := "success"
 		if err != nil {
-			mw.knapsack.Slogger().Log(ctx, slog.LevelError,
-				"failure",
-				"method", "RequestQueries",
-				"uuid", uuid,
-				"res", string(resJSON),
-				"reauth", reauth,
-				"err", err,
-				"took", time.Since(begin),
-			)
+			message = "failure"
 		}
+
+		mw.knapsack.Slogger().Log(ctx, levelForError(err), // nolint:sloglint // it's fine to not have a constant or literal here
+			message,
+			"method", "RequestQueries",
+			"uuid", uuid,
+			"res", string(resJSON),
+			"reauth", reauth,
+			"err", err,
+			"took", time.Since(begin),
+		)
 	}(time.Now())
 
 	res, reauth, err = mw.next.RequestQueries(ctx, nodeKey)


### PR DESCRIPTION
We need osquery to respond to distributed queries very quickly -- we think a distributed_interval of 5 seconds is adequate. However, we do not think the cloud can handle receiving `GetQueries` at that rate.

Therefore, this PR updates the osquery configuration to have a `distributed_interval` of 5 seconds, and updates the extension to only forward those requests to the cloud once per minute. There are two exceptions to this rule:

1. If the extension receives a `GetQueries` response that includes `accelerate` in the response, it will forward all requests for the given number of seconds -- this matches how osquery would respond to receiving the `accelerate` field in the response.
2. On startup, the extension will also forward every request for the first two minutes -- this is similar to prior extension behavior (the period was longer than two minutes before).

In the future, there will be a third exception: launcher will be able to additionally toggle this setting, to allow for accelerating the distributed_interval on demand via e.g. localserver.

This PR also updates the `GetQueries` logging middleware to log successes as well as failures. The successes will be logged at the debug level, so they generally won't be shipped to our cloud logs. I think this will be useful to have in flares, to determine whether launcher is requesting distributed queries, but am not sure if it will be too noisy, so I'd like to get input on whether we think it's a good idea to add this logging.