### PR TITLE
Check that ATC config exists before making a plugin out of it

### DIFF
--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -2,6 +2,7 @@ package interactive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -207,6 +208,9 @@ func generateConfigPlugin(slogger *slog.Logger, launcherDaemonRootDir string) (*
 	atcConfig, err := r.Get(string(atcConfigKey))
 	if err != nil {
 		return nil, fmt.Errorf("error getting auto_table_construction from startup settings: %w", err)
+	}
+	if atcConfig == "" {
+		return nil, errors.New("auto_table_construction is not set in startup settings")
 	}
 
 	return config.NewPlugin(defaultConfigPluginName, func(ctx context.Context) (map[string]string, error) {


### PR DESCRIPTION
A consequence of https://github.com/kolide/launcher/pull/2165