### PR TITLE
Add logs to indicate when launcher is checking for updates

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -235,6 +235,10 @@ func (ta *TufAutoupdater) Execute() (err error) {
 		break
 	}
 
+	ta.slogger.Log(context.TODO(), slog.LevelInfo,
+		"exiting initial delay",
+	)
+
 	// For now, tidy the library on startup. In the future, we will tidy the library
 	// earlier, after version selection.
 	ta.tidyLibrary()
@@ -245,11 +249,18 @@ func (ta *TufAutoupdater) Execute() (err error) {
 	defer cleanupTicker.Stop()
 
 	for {
+		ta.slogger.Log(context.TODO(), slog.LevelInfo,
+			"checking for updates",
+		)
 		if err := ta.checkForUpdate(context.TODO(), binaries); err != nil {
 			ta.storeError(err)
 			ta.slogger.Log(context.TODO(), slog.LevelError,
 				"error checking for update",
 				"err", err,
+			)
+		} else {
+			ta.slogger.Log(context.TODO(), slog.LevelInfo,
+				"completed check for update",
 			)
 		}
 
@@ -402,7 +413,15 @@ func (ta *TufAutoupdater) FlagsChanged(ctx context.Context, flagKeys ...keys.Fla
 			"pinned_osqueryd_version", ta.knapsack.PinnedOsquerydVersion(),
 			"err", err,
 		)
+		return
 	}
+
+	ta.slogger.Log(ctx, slog.LevelInfo,
+		"checked for update after autoupdate setting changed",
+		"update_channel", ta.updateChannel,
+		"pinned_launcher_version", ta.knapsack.PinnedLauncherVersion(),
+		"pinned_osqueryd_version", ta.knapsack.PinnedOsquerydVersion(),
+	)
 }
 
 // tidyLibrary gets the current running version for each binary (so that the current version is not removed)

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -242,7 +242,14 @@ func TestExecute_osquerydUpdate(t *testing.T) {
 	require.GreaterOrEqual(t, len(logLines), 1)
 
 	// Check that we restarted osqueryd
-	require.Contains(t, logLines[len(logLines)-1], "restarted binary after update", fmt.Sprintf("logs missing restart: %s", strings.Join(logLines, "\n")))
+	restartFound := false
+	for _, logLine := range logLines {
+		if strings.Contains(logLine, "restarted binary after update") {
+			restartFound = true
+			break
+		}
+	}
+	require.True(t, restartFound, fmt.Sprintf("logs missing restart: %s", strings.Join(logLines, "\n")))
 
 	// The autoupdater won't stop after an osqueryd download, so interrupt it and let it shut down
 	autoupdater.Interrupt(errors.New("test error"))

--- a/ee/tuf/library_manager.go
+++ b/ee/tuf/library_manager.go
@@ -378,6 +378,7 @@ func (ulm *updateLibraryManager) TidyLibrary(binary autoupdatableBinary, current
 	if currentVersion == "" {
 		ulm.slogger.Log(context.TODO(), slog.LevelWarn,
 			"cannot tidy update library without knowing current running version",
+			"binary", binary,
 		)
 		return
 	}
@@ -388,6 +389,7 @@ func (ulm *updateLibraryManager) TidyLibrary(binary autoupdatableBinary, current
 	if err != nil {
 		ulm.slogger.Log(context.TODO(), slog.LevelWarn,
 			"could not get versions in library to tidy update library",
+			"binary", binary,
 			"err", err,
 		)
 		return
@@ -397,12 +399,17 @@ func (ulm *updateLibraryManager) TidyLibrary(binary autoupdatableBinary, current
 		ulm.slogger.Log(context.TODO(), slog.LevelWarn,
 			"updates library contains invalid version",
 			"library_path", invalidVersion,
+			"binary", binary,
 			"err", err,
 		)
 		ulm.removeUpdate(binary, invalidVersion)
 	}
 
 	if len(versionsInLibrary) <= numberOfVersionsToKeep {
+		ulm.slogger.Log(context.TODO(), slog.LevelInfo,
+			"no need to tidy library",
+			"binary", binary,
+		)
 		return
 	}
 
@@ -423,6 +430,11 @@ func (ulm *updateLibraryManager) TidyLibrary(binary autoupdatableBinary, current
 
 		nonCurrentlyRunningVersionsKept += 1
 	}
+
+	ulm.slogger.Log(context.TODO(), slog.LevelInfo,
+		"tidied update library",
+		"binary", binary,
+	)
 }
 
 // sortedVersionsInLibrary looks through the update library for the given binary to validate and sort all


### PR DESCRIPTION
Sometimes it is not clear from the logs why launcher hasn't autoupdated. Is it checking for updates periodically? Has it gotten stuck somewhere? This PR adds more logs indicating what actions the autoupdater is taking and when.