### PR TITLE
Switch from default freelist type to more performant option

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -177,7 +177,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	// unimplemented on windows, though empirically it seems to
 	// work.
 	agentbbolt.UseBackupDbIfNeeded(rootDirectory, slogger)
-	boltOptions := &bbolt.Options{Timeout: time.Duration(30) * time.Second}
+	boltOptions := &bbolt.Options{
+		Timeout:      time.Duration(30) * time.Second,
+		FreelistType: bbolt.FreelistMapType,
+	}
 	db, err := bbolt.Open(agentbbolt.LauncherDbLocation(rootDirectory), 0600, boltOptions)
 	if err != nil {
 		return fmt.Errorf("open launcher db: %w", err)


### PR DESCRIPTION
From bbolt documentation:

```
// FreelistType sets the backend freelist type. There are two options. Array which is simple but endures
// dramatic performance degradation if database is large and framentation in freelist is common.
// The alternative one is using hashmap, it is faster in almost all circumstances
// but it doesn't guarantee that it offers the smallest page id available. In normal case it is safe.
// The default type is array
```

It appears to be fine to switch types. We might as well use the option that doesn't involve dramatic performance degradation.