### PR TITLE
[KATC] Add row transform step to decode hex-encoded strings

### DIFF
--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -78,6 +78,7 @@ type rowTransformStep struct {
 
 const (
 	snappyDecodeTransformStep       = "snappy"
+	hexDecodeTransformStep          = "hex"
 	deserializeFirefoxTransformStep = "deserialize_firefox"
 	deserializeChromeTransformStep  = "deserialize_chrome"
 	camelToSnakeTransformStep       = "camel_to_snake"
@@ -94,6 +95,10 @@ func (r *rowTransformStep) UnmarshalJSON(data []byte) error {
 	case snappyDecodeTransformStep:
 		r.name = snappyDecodeTransformStep
 		r.transformFunc = snappyDecode
+		return nil
+	case hexDecodeTransformStep:
+		r.name = hexDecodeTransformStep
+		r.transformFunc = hexDecode
 		return nil
 	case deserializeFirefoxTransformStep:
 		r.name = deserializeFirefoxTransformStep

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -37,6 +37,20 @@ func TestConstructKATCTables(t *testing.T) {
 			expectedPluginCount: 1,
 		},
 		{
+			testCaseName: "other_sqlite",
+			katcConfig: map[string]string{
+				"kolide_other_sqlite_test": `{
+					"source_type": "sqlite",
+					"columns": ["data"],
+					"source_paths": ["/some/path/to/db.sqlite"],
+					"source_query": "SELECT QUOTE(value) FROM data;",
+					"row_transform_steps": ["hex"],
+					"overlays": []
+				}`,
+			},
+			expectedPluginCount: 1,
+		},
+		{
 			testCaseName: "indexeddb_leveldb",
 			katcConfig: map[string]string{
 				"kolide_indexeddb_leveldb_test": `{

--- a/ee/katc/hex.go
+++ b/ee/katc/hex.go
@@ -1,0 +1,32 @@
+package katc
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/kolide/launcher/pkg/traces"
+)
+
+// hexDecode is a dataProcessingStep that decodes data that is hex-encoded.
+func hexDecode(ctx context.Context, _ *slog.Logger, row map[string][]byte) (map[string][]byte, error) {
+	_, span := traces.StartSpan(ctx)
+	defer span.End()
+
+	decodedRow := make(map[string][]byte)
+
+	for k, v := range row {
+		// Hex value may look like `X'<value here>'` -- remove surrounding chars if so.
+		v := strings.TrimSuffix(strings.TrimPrefix(string(v), "X'"), "'")
+		decodedBytes, err := hex.DecodeString(v)
+		if err != nil {
+			return nil, fmt.Errorf("decoding data for key %s: %w", k, err)
+		}
+
+		decodedRow[k] = decodedBytes
+	}
+
+	return decodedRow, nil
+}

--- a/ee/katc/hex_test.go
+++ b/ee/katc/hex_test.go
@@ -1,0 +1,26 @@
+package katc
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_hexDecode(t *testing.T) {
+	t.Parallel()
+
+	originalValue := []byte("some_test_data")
+	encodedStr := hex.EncodeToString(originalValue)
+	encodedStrQuoted := fmt.Sprintf("X'%s'", encodedStr)
+
+	results, err := hexDecode(context.TODO(), multislogger.NewNopLogger(), map[string][]byte{
+		"data": []byte(encodedStrQuoted),
+	})
+	require.NoError(t, err)
+	require.Contains(t, results, "data")
+	require.Equal(t, originalValue, results["data"])
+}


### PR DESCRIPTION
This is a quality-of-life improvement to make querying hex-encoded data simpler.