### PR TITLE
[KATC] If sqlite db cannot be queried, continue to query other dbs

### DIFF
--- a/ee/katc/sqlite.go
+++ b/ee/katc/sqlite.go
@@ -42,7 +42,12 @@ func sqliteData(ctx context.Context, slogger *slog.Logger, sourcePaths []string,
 
 			rowsFromDb, err := querySqliteDb(ctx, slogger, sqliteDb, query)
 			if err != nil {
-				return nil, fmt.Errorf("querying %s: %w", sqliteDb, err)
+				slogger.Log(ctx, slog.LevelWarn,
+					"could not query sqlite database at path",
+					"sqlite_db_path", sqliteDb,
+					"err", err,
+				)
+				continue
 			}
 			results = append(results, sourceData{
 				path: sqliteDb,


### PR DESCRIPTION
Our source paths may be broad enough that they necessarily include dbs that don't have the tables we expect in them. If we fail to query one of these dbs, log the error but proceed to trying other dbs matched by the source paths wildcard.