### PR TITLE
Try running TestProc subtests in sequence rather than in parallel, to avoid pollution

### DIFF
--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -100,11 +100,9 @@ func TestProc(t *testing.T) {
 			errContainsStr:  "error waiting for osquery to create socket",
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var rootDir string
 			if tt.useShortRootDir {
 				rootDir = testRootDirectory(t)


### PR DESCRIPTION
https://github.com/kolide/launcher/actions/runs/14384377614/job/40336288590

Noticed that the osquery logs printed were from test case `socket path too long, the name of the test causes the socket path to be to long to be created, resulting in timeout waiting for the socket`, but the test that failed was `flags` -- wondering if there could be some pollution between test runs somehow.