### PR TITLE
disclaim falconctl command for macos

### DIFF
--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -89,6 +89,11 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {
 	ctx := context.Background()
 	cmd, err := commandToDisclaim(ctx, args)
+	// this command is used to generate table data, do not error if the target binary is not found
+	if err != nil && errors.Is(err, allowedcmd.ErrCommandNotFound) {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("gathering subcommand: %w", err)
 	}

--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -66,7 +66,7 @@ import (
 
 type allowedCmdGenerator struct {
 	allowedOpts map[string]struct{}
-	generate    func(ctx context.Context, args []string) (*allowedcmd.TracedCmd, error)
+	generate    func(ctx context.Context, args ...string) (*allowedcmd.TracedCmd, error)
 }
 
 var allowedCmdGenerators = map[string]allowedCmdGenerator{
@@ -76,6 +76,13 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 			"--json":   {},
 		},
 		generate: generateBrewCommand,
+	},
+	"falconctl": {
+		allowedOpts: map[string]struct{}{
+			"stats": {},
+			"-p":    {},
+		},
+		generate: allowedcmd.Falconctl,
 	},
 }
 
@@ -145,7 +152,7 @@ func commandToDisclaim(ctx context.Context, args []string) (*allowedcmd.TracedCm
 		}
 	}
 
-	return generator.generate(ctx, cmdArgs)
+	return generator.generate(ctx, cmdArgs...)
 }
 
 func getCmdGenerator(cmd string) (*allowedCmdGenerator, error) {
@@ -156,7 +163,7 @@ func getCmdGenerator(cmd string) (*allowedCmdGenerator, error) {
 	return nil, fmt.Errorf("unsupported command '%s' for rundisclaimed", cmd)
 }
 
-func generateBrewCommand(ctx context.Context, args []string) (*allowedcmd.TracedCmd, error) {
+func generateBrewCommand(ctx context.Context, args ...string) (*allowedcmd.TracedCmd, error) {
 	cmd, err := allowedcmd.Brew(ctx, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -108,7 +108,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.TablePluginExec(k, slogger,
 			"kolide_diskutil_list", dataflattentable.PlistType, allowedcmd.Diskutil, []string{"list", "-plist"}),
 		dataflattentable.TablePluginExec(k, slogger,
-			"kolide_falconctl_stats", dataflattentable.PlistType, allowedcmd.Falconctl, []string{"stats", "-p"}),
+			"kolide_falconctl_stats", dataflattentable.PlistType, allowedcmd.Launcher, []string{"rundisclaimed", "falconctl", "stats", "-p"}),
 		dataflattentable.TablePluginExec(k, slogger,
 			"kolide_apfs_list", dataflattentable.PlistType, allowedcmd.Diskutil, []string{"apfs", "list", "-plist"}),
 		dataflattentable.TablePluginExec(k, slogger,


### PR DESCRIPTION
includes a few small changes to support disclaiming our `falconctl` execs for macos:
- updates command generation signatures to allow direct use of allowedcmds where additional logic is not needed
- adds `falconctl` to `allowedCmdGenerators`
- adds an early return without error for missing binaries from rundisclaimed to match behavior within our tablehelpers/run logic