### PR TITLE
disclaim repcli command for macos

### DIFF
--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -84,6 +84,12 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 		},
 		generate: allowedcmd.Falconctl,
 	},
+	"carbonblack_repcli": {
+		allowedOpts: map[string]struct{}{
+			"status": {},
+		},
+		generate: allowedcmd.Repcli,
+	},
 }
 
 func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -128,7 +128,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_socketfilterfw_apps", socketfilterfw.Parser, allowedcmd.Socketfilterfw, []string{"--listapps"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Repcli, []string{"status"}, dataflattentable.WithIncludeStderr()),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "carbonblack_repcli", "status"}),
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
 	}


### PR DESCRIPTION
Runs repcli status calls through rundisclaimed. The only functional change should be that stderr will no longer be included directly with stdout for this call (we have to disregard to avoid getting the launcher startup logs).

I do not have repcli installation available for testing, so this was tested by creating a fake `/tmp/repcli` binary that just outputs the data from ee/tables/execparsers/repcli/test-data/repcli_darwin.txt, and pointing our allowedcmd there - parsing worked as expected