### PR TITLE
Update from trace-specific language to broader telemetry-specific language

### DIFF
--- a/ee/observability/exporter/exporter.go
+++ b/ee/observability/exporter/exporter.go
@@ -68,7 +68,7 @@ func NewTelemetryExporter(ctx context.Context, k types.Knapsack, initialTraceBuf
 	t := &TelemetryExporter{
 		providerLock:              sync.Mutex{},
 		knapsack:                  k,
-		slogger:                   k.Slogger().With("component", "trace_exporter"),
+		slogger:                   k.Slogger().With("component", "telemetry_exporter"),
 		attrLock:                  sync.RWMutex{},
 		ingestClientAuthenticator: newClientAuthenticator(string(currentToken), k.DisableTraceIngestTLS()),
 		ingestAuthToken:           string(currentToken),
@@ -102,7 +102,7 @@ func NewTelemetryExporter(ctx context.Context, k types.Knapsack, initialTraceBuf
 
 	// Set our own error handler to avoid otel printing errors
 	otel.SetErrorHandler(newErrorHandler(
-		k.Slogger().With("component", "trace_exporter"),
+		k.Slogger().With("component", "telemetry_exporter"),
 	))
 
 	t.addDeviceIdentifyingAttributes()

--- a/ee/observability/exporter/exporter_test.go
+++ b/ee/observability/exporter/exporter_test.go
@@ -52,21 +52,21 @@ func TestNewTraceExporter(t *testing.T) { //nolint:paralleltest
 		Hostname:       "Test-Hostname2",
 	})
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
+	telemetryExporter, err := NewTelemetryExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
 	require.NoError(t, err)
 
 	// Wait a few seconds to allow the osquery queries to go through
 	time.Sleep(500 * time.Millisecond)
 
 	// We expect a total of 12 attributes: 3 initial attributes, 5 from the ServerProvidedDataStore, and 4 from osquery
-	traceExporter.attrLock.RLock()
-	defer traceExporter.attrLock.RUnlock()
-	require.Equal(t, 12, len(traceExporter.attrs))
+	telemetryExporter.attrLock.RLock()
+	defer telemetryExporter.attrLock.RUnlock()
+	require.Equal(t, 12, len(telemetryExporter.attrs))
 
 	// Confirm we set a provider
-	traceExporter.providerLock.Lock()
-	defer traceExporter.providerLock.Unlock()
-	require.NotNil(t, traceExporter.provider, "expected provider to be created")
+	telemetryExporter.providerLock.Lock()
+	defer telemetryExporter.providerLock.Unlock()
+	require.NotNil(t, telemetryExporter.provider, "expected provider to be created")
 
 	mockKnapsack.AssertExpectations(t)
 }
@@ -86,15 +86,15 @@ func TestNewTraceExporter_exportNotEnabled(t *testing.T) {
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, nil)
+	telemetryExporter, err := NewTelemetryExporter(context.Background(), mockKnapsack, nil)
 	require.NoError(t, err)
 
 	// Confirm we didn't set a provider
-	require.Nil(t, traceExporter.provider, "expected disabled exporter to not create a provider but one was created")
+	require.Nil(t, telemetryExporter.provider, "expected disabled exporter to not create a provider but one was created")
 
 	// Confirm we added basic attributes
-	require.Equal(t, 3, len(traceExporter.attrs))
-	for _, actualAttr := range traceExporter.attrs {
+	require.Equal(t, 3, len(telemetryExporter.attrs))
+	for _, actualAttr := range telemetryExporter.attrs {
 		switch actualAttr.Key {
 		case "service.name":
 			require.Equal(t, applicationName, actualAttr.Value.AsString())
@@ -123,20 +123,20 @@ func TestInterrupt_Multiple(t *testing.T) { //nolint:paralleltest
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
-	traceExporter, err := NewTraceExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
+	telemetryExporter, err := NewTelemetryExporter(context.Background(), mockKnapsack, NewInitialTraceBuffer())
 	require.NoError(t, err)
 	mockKnapsack.AssertExpectations(t)
 
-	go traceExporter.Execute()
+	go telemetryExporter.Execute()
 	time.Sleep(3 * time.Second)
-	traceExporter.Interrupt(errors.New("test error"))
+	telemetryExporter.Interrupt(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
 	interruptComplete := make(chan struct{})
 	expectedInterrupts := 3
 	for i := 0; i < expectedInterrupts; i += 1 {
 		go func() {
-			traceExporter.Interrupt(nil)
+			telemetryExporter.Interrupt(nil)
 			interruptComplete <- struct{}{}
 		}()
 	}
@@ -180,7 +180,7 @@ func Test_addDeviceIdentifyingAttributes(t *testing.T) {
 	expectedSerialNumber := "abcd"
 	s.Set([]byte("serial_number"), []byte(expectedSerialNumber))
 
-	traceExporter := &TraceExporter{
+	traceExporter := &TelemetryExporter{
 		knapsack:                  mockKnapsack,
 		slogger:                   multislogger.NewNopLogger(),
 		attrs:                     make([]attribute.KeyValue, 0),
@@ -231,7 +231,7 @@ func Test_addAttributesFromOsquery(t *testing.T) {
 		Hostname:       expectedHostname,
 	})
 
-	traceExporter := &TraceExporter{
+	traceExporter := &TelemetryExporter{
 		knapsack:                  mockKnapsack,
 		slogger:                   multislogger.NewNopLogger(),
 		attrs:                     make([]attribute.KeyValue, 0),
@@ -276,7 +276,7 @@ func TestPing(t *testing.T) {
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("TokenStore").Return(s)
 
-	traceExporter := &TraceExporter{
+	traceExporter := &TelemetryExporter{
 		knapsack:                  mockKnapsack,
 		bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 		slogger:                   multislogger.NewNopLogger(),
@@ -361,7 +361,7 @@ func TestFlagsChanged_ExportTraces(t *testing.T) { //nolint:paralleltest
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
-			traceExporter := &TraceExporter{
+			traceExporter := &TelemetryExporter{
 				knapsack:                  mockKnapsack,
 				bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 				slogger:                   multislogger.NewNopLogger(),
@@ -432,7 +432,7 @@ func TestFlagsChanged_TraceSamplingRate(t *testing.T) { //nolint:paralleltest
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
-			traceExporter := &TraceExporter{
+			traceExporter := &TelemetryExporter{
 				knapsack:                  mockKnapsack,
 				bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 				slogger:                   multislogger.NewNopLogger(),
@@ -500,7 +500,7 @@ func TestFlagsChanged_TraceIngestServerURL(t *testing.T) { //nolint:paralleltest
 			mockKnapsack.On("TraceIngestServerURL").Return(tt.newObservabilityIngestServerURL)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			traceExporter := &TraceExporter{
+			traceExporter := &TelemetryExporter{
 				knapsack:                  mockKnapsack,
 				bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 				slogger:                   multislogger.NewNopLogger(),
@@ -573,7 +573,7 @@ func TestFlagsChanged_DisableTraceIngestTLS(t *testing.T) { //nolint:paralleltes
 			clientAuthenticator := newClientAuthenticator("test token", tt.currentDisableTraceIngestTLS)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			traceExporter := &TraceExporter{
+			traceExporter := &TelemetryExporter{
 				knapsack:                  mockKnapsack,
 				bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 				slogger:                   multislogger.NewNopLogger(),
@@ -645,7 +645,7 @@ func TestFlagsChanged_TraceBatchTimeout(t *testing.T) { //nolint:paralleltest
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
-			traceExporter := &TraceExporter{
+			traceExporter := &TelemetryExporter{
 				knapsack:                  mockKnapsack,
 				bufSpanProcessor:          &bufspanprocessor.BufSpanProcessor{},
 				slogger:                   multislogger.NewNopLogger(),

--- a/ee/observability/exporter/exporter_test.go
+++ b/ee/observability/exporter/exporter_test.go
@@ -66,7 +66,7 @@ func TestNewTraceExporter(t *testing.T) { //nolint:paralleltest
 	// Confirm we set a provider
 	telemetryExporter.providerLock.Lock()
 	defer telemetryExporter.providerLock.Unlock()
-	require.NotNil(t, telemetryExporter.provider, "expected provider to be created")
+	require.NotNil(t, telemetryExporter.tracerProvider, "expected provider to be created")
 
 	mockKnapsack.AssertExpectations(t)
 }
@@ -90,7 +90,7 @@ func TestNewTraceExporter_exportNotEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// Confirm we didn't set a provider
-	require.Nil(t, telemetryExporter.provider, "expected disabled exporter to not create a provider but one was created")
+	require.Nil(t, telemetryExporter.tracerProvider, "expected disabled exporter to not create a provider but one was created")
 
 	// Confirm we added basic attributes
 	require.Equal(t, 3, len(telemetryExporter.attrs))
@@ -384,7 +384,7 @@ func TestFlagsChanged_ExportTraces(t *testing.T) { //nolint:paralleltest
 			if tt.shouldReplaceProvider {
 				mockKnapsack.AssertExpectations(t)
 				require.Greater(t, len(traceExporter.attrs), 0)
-				require.NotNil(t, traceExporter.provider)
+				require.NotNil(t, traceExporter.tracerProvider)
 			}
 		})
 	}
@@ -453,9 +453,9 @@ func TestFlagsChanged_TraceSamplingRate(t *testing.T) { //nolint:paralleltest
 			require.Equal(t, tt.newTraceSamplingRate, traceExporter.traceSamplingRate, "trace sampling rate value not updated")
 
 			if tt.shouldReplaceProvider {
-				require.NotNil(t, traceExporter.provider)
+				require.NotNil(t, traceExporter.tracerProvider)
 			} else {
-				require.Nil(t, traceExporter.provider)
+				require.Nil(t, traceExporter.tracerProvider)
 			}
 		})
 	}
@@ -521,9 +521,9 @@ func TestFlagsChanged_TraceIngestServerURL(t *testing.T) { //nolint:paralleltest
 			require.Equal(t, tt.newObservabilityIngestServerURL, traceExporter.ingestUrl, "ingest url value not updated")
 
 			if tt.shouldReplaceProvider {
-				require.NotNil(t, traceExporter.provider)
+				require.NotNil(t, traceExporter.tracerProvider)
 			} else {
-				require.Nil(t, traceExporter.provider)
+				require.Nil(t, traceExporter.tracerProvider)
 			}
 		})
 	}
@@ -595,9 +595,9 @@ func TestFlagsChanged_DisableTraceIngestTLS(t *testing.T) { //nolint:paralleltes
 			require.Equal(t, tt.newDisableTraceIngestTLS, clientAuthenticator.disableTLS, "ingest TLS value not updated for client authenticator")
 
 			if tt.shouldReplaceProvider {
-				require.NotNil(t, traceExporter.provider)
+				require.NotNil(t, traceExporter.tracerProvider)
 			} else {
-				require.Nil(t, traceExporter.provider)
+				require.Nil(t, traceExporter.tracerProvider)
 			}
 		})
 	}
@@ -667,9 +667,9 @@ func TestFlagsChanged_TraceBatchTimeout(t *testing.T) { //nolint:paralleltest
 			require.Equal(t, tt.newBatchTimeout, traceExporter.batchTimeout, "batch timeout value not updated")
 
 			if tt.shouldReplaceProvider {
-				require.NotNil(t, traceExporter.provider)
+				require.NotNil(t, traceExporter.tracerProvider)
 			} else {
-				require.Nil(t, traceExporter.provider)
+				require.Nil(t, traceExporter.tracerProvider)
 			}
 		})
 	}


### PR DESCRIPTION
Following on from https://github.com/kolide/launcher/pull/2215 -- renames exporting structs/vars that are currently specific to traces so that they can also encompass metrics in the near future.