### PR TITLE
Add flag `use_cached_data_for_scheduled_queries`, and rewrite osquery config accordingly when set

### DIFF
--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -758,3 +758,12 @@ func (fc *FlagController) TableGenerateTimeout() time.Duration {
 		WithMax(10*time.Minute),
 	).get(fc.getControlServerValue(keys.TableGenerateTimeout))
 }
+
+func (fc *FlagController) SetUseCachedDataForScheduledQueries(enabled bool) error {
+	return fc.setControlServerValue(keys.UseCachedDataForScheduledQueries, boolToBytes(enabled))
+}
+func (fc *FlagController) UseCachedDataForScheduledQueries() bool {
+	return NewBoolFlagValue(
+		WithDefaultBool(false),
+	).get(fc.getControlServerValue(keys.UseCachedDataForScheduledQueries))
+}

--- a/ee/agent/flags/keys/keys.go
+++ b/ee/agent/flags/keys/keys.go
@@ -61,6 +61,7 @@ const (
 	SystrayRestartEnabled            FlagKey = "systray_restart_enabled"
 	CurrentRunningOsqueryVersion     FlagKey = "osquery_version"
 	TableGenerateTimeout             FlagKey = "table_generate_timeout"
+	UseCachedDataForScheduledQueries FlagKey = "use_cached_data_for_scheduled_queries"
 )
 
 func (key FlagKey) String() string {

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -248,4 +248,10 @@ type Flags interface {
 	// TableGenerateTimeout is the maximum time a Kolide extension table is permitted to take
 	SetTableGenerateTimeout(interval time.Duration) error
 	TableGenerateTimeout() time.Duration
+
+	// UseCachedDataForScheduledQueries controls whether launcher uses cached data for scheduled queries.
+	// Currently, we do this only for the kolide_windows_updates table, since that table can time out when
+	// querying for fresh data.
+	SetUseCachedDataForScheduledQueries(enabled bool) error
+	UseCachedDataForScheduledQueries() bool
 }

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -1574,6 +1574,24 @@ func (_m *Flags) SetUpdateDirectory(directory string) error {
 	return r0
 }
 
+// SetUseCachedDataForScheduledQueries provides a mock function with given fields: enabled
+func (_m *Flags) SetUseCachedDataForScheduledQueries(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetUseCachedDataForScheduledQueries")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetWatchdogDelaySec provides a mock function with given fields: sec
 func (_m *Flags) SetWatchdogDelaySec(sec int) error {
 	ret := _m.Called(sec)
@@ -1803,6 +1821,24 @@ func (_m *Flags) UpdateDirectory() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// UseCachedDataForScheduledQueries provides a mock function with no fields
+func (_m *Flags) UseCachedDataForScheduledQueries() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UseCachedDataForScheduledQueries")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -2059,6 +2059,24 @@ func (_m *Knapsack) SetUpdateDirectory(directory string) error {
 	return r0
 }
 
+// SetUseCachedDataForScheduledQueries provides a mock function with given fields: enabled
+func (_m *Knapsack) SetUseCachedDataForScheduledQueries(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetUseCachedDataForScheduledQueries")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetWatchdogDelaySec provides a mock function with given fields: sec
 func (_m *Knapsack) SetWatchdogDelaySec(sec int) error {
 	ret := _m.Called(sec)
@@ -2388,6 +2406,24 @@ func (_m *Knapsack) UpdateDirectory() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// UseCachedDataForScheduledQueries provides a mock function with no fields
+func (_m *Knapsack) UseCachedDataForScheduledQueries() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UseCachedDataForScheduledQueries")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -555,6 +556,13 @@ func (e *Extension) generateConfigsWithReenroll(ctx context.Context, reenroll bo
 	}
 
 	config = e.setOsqueryOptions(config, configOptsToSet)
+
+	// If this feature flag is set, we want to use cached data for scheduled queries that might otherwise
+	// time out. We achieve this by updating the config to point to the tables holding the cached data.
+	if e.knapsack.UseCachedDataForScheduledQueries() {
+		// The kolide_windows_updates table is currently the only table we use this feature for.
+		config = strings.ReplaceAll(config, "kolide_windows_updates", "kolide_windows_updates_cached")
+	}
 
 	return config, nil
 }

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -70,6 +70,7 @@ func makeKnapsack(t *testing.T, db *bbolt.DB) types.Knapsack {
 	osqHistory, err := history.InitHistory(store)
 	require.NoError(t, err)
 	m.On("OsqueryHistory").Return(osqHistory).Maybe()
+	m.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	m.On("GetEnrollmentDetails").Return(types.EnrollmentDetails{OSVersion: "1", Hostname: "test"}, nil).Maybe()
 	return m
 }

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -283,6 +283,7 @@ func TestHealthy(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	s := settingsstoremock.NewSettingsStoreWriter(t)
 	s.On("WriteSettings").Return(nil)
 	setupHistory(t, k)
@@ -375,6 +376,7 @@ func TestLaunch(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 
 	s := settingsstoremock.NewSettingsStoreWriter(t)
 	s.On("WriteSettings").Return(nil)
@@ -472,6 +474,7 @@ func TestReloadKatcExtension(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	s := settingsstoremock.NewSettingsStoreWriter(t)
 	s.On("WriteSettings").Return(nil)
 	osqHistory := setupHistory(t, k)

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -70,6 +70,7 @@ func TestOsquerySlowStart(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -135,6 +136,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -197,6 +197,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -247,6 +248,7 @@ func TestFlagsChanged(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -367,6 +369,7 @@ func TestPing(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 
 	// Start the runner
 	runner := New(k, mockServiceClient(t), s)
@@ -616,6 +619,7 @@ func TestSimplePath(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -666,6 +670,7 @@ func TestMultipleInstances(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 	serviceClient := mockServiceClient(t)
@@ -749,6 +754,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 	serviceClient := mockServiceClient(t)
@@ -827,6 +833,7 @@ func TestMultipleShutdowns(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -877,6 +884,7 @@ func TestOsqueryDies(t *testing.T) {
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory := setupHistory(t, k)
 
@@ -1049,6 +1057,7 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
+	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
 	setUpMockStores(t, k)
 	osqHistory = setupHistory(t, k)
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/pull/2229 and https://github.com/kolide/launcher/pull/2230.

This PR adds a new agent flag `use_cached_data_for_scheduled_queries`. When it is set, we rewrite the osquery config (at the same time that we perform other config modifications) to query `kolide_windows_updates_cached` instead of `kolide_windows_updates`. This should prevent timeouts when scheduled queries need Windows Update Agent API data, therefore preventing relevant checks from going stale.