### PR TITLE
Throw more time at query-windowsupdates

### DIFF
--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -55,7 +55,7 @@ func (w *windowsUpdatesCacher) Execute() (err error) {
 		// Since this query happens in the background and will not block auth, we can use
 		// a much longer timeout than we use for our tables.
 		var ctx context.Context
-		ctx, w.queryCancel = context.WithTimeout(context.Background(), 10*time.Minute)
+		ctx, w.queryCancel = context.WithTimeout(context.Background(), 20*time.Minute)
 		if err := w.queryAndStoreData(ctx); err != nil {
 			w.slogger.Log(ctx, slog.LevelError,
 				"error caching windows update data",


### PR DESCRIPTION
We really want `kolide_windows_updates_cached` to be successfully populated with data -- so, throw even more time at the timeout.

After alpha/beta release we can look at tracing data to see how long it takes on devices that are struggling with this check currently.