### PR TITLE
Make cached query results TTL cloud-configurable

### DIFF
--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -767,3 +767,14 @@ func (fc *FlagController) UseCachedDataForScheduledQueries() bool {
 		WithDefaultBool(false),
 	).get(fc.getControlServerValue(keys.UseCachedDataForScheduledQueries))
 }
+
+func (fc *FlagController) SetCachedQueryResultsTTL(ttl time.Duration) error {
+	return fc.setControlServerValue(keys.CachedQueryResultsTTL, durationToBytes(ttl))
+}
+func (fc *FlagController) CachedQueryResultsTTL() time.Duration {
+	return NewDurationFlagValue(fc.slogger, keys.CachedQueryResultsTTL,
+		WithDefault(6*time.Hour),
+		WithMin(90*time.Minute),
+		WithMax(72*time.Hour),
+	).get(fc.getControlServerValue(keys.CachedQueryResultsTTL))
+}

--- a/ee/agent/flags/keys/keys.go
+++ b/ee/agent/flags/keys/keys.go
@@ -62,6 +62,7 @@ const (
 	CurrentRunningOsqueryVersion     FlagKey = "osquery_version"
 	TableGenerateTimeout             FlagKey = "table_generate_timeout"
 	UseCachedDataForScheduledQueries FlagKey = "use_cached_data_for_scheduled_queries"
+	CachedQueryResultsTTL            FlagKey = "cached_query_results_ttl"
 )
 
 func (key FlagKey) String() string {

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -254,4 +254,8 @@ type Flags interface {
 	// querying for fresh data.
 	SetUseCachedDataForScheduledQueries(enabled bool) error
 	UseCachedDataForScheduledQueries() bool
+
+	// CachedQueryResultsTTL indicates how long cached query results are valid.
+	SetCachedQueryResultsTTL(ttl time.Duration) error
+	CachedQueryResultsTTL() time.Duration
 }

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -88,6 +88,24 @@ func (_m *Flags) AutoupdateInterval() time.Duration {
 	return r0
 }
 
+// CachedQueryResultsTTL provides a mock function with no fields
+func (_m *Flags) CachedQueryResultsTTL() time.Duration {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CachedQueryResultsTTL")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // CertPins provides a mock function with no fields
 func (_m *Flags) CertPins() [][]byte {
 	ret := _m.Called()
@@ -912,6 +930,24 @@ func (_m *Flags) SetAutoupdateInterval(interval time.Duration) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
 		r0 = rf(interval)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetCachedQueryResultsTTL provides a mock function with given fields: ttl
+func (_m *Flags) SetCachedQueryResultsTTL(ttl time.Duration) error {
+	ret := _m.Called(ttl)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetCachedQueryResultsTTL")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
+		r0 = rf(ttl)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -168,6 +168,24 @@ func (_m *Knapsack) BboltDB() *bbolt.DB {
 	return r0
 }
 
+// CachedQueryResultsTTL provides a mock function with no fields
+func (_m *Knapsack) CachedQueryResultsTTL() time.Duration {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CachedQueryResultsTTL")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // CertPins provides a mock function with no fields
 func (_m *Knapsack) CertPins() [][]byte {
 	ret := _m.Called()
@@ -1382,6 +1400,24 @@ func (_m *Knapsack) SetAutoupdateInterval(interval time.Duration) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
 		r0 = rf(interval)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetCachedQueryResultsTTL provides a mock function with given fields: ttl
+func (_m *Knapsack) SetCachedQueryResultsTTL(ttl time.Duration) error {
+	ret := _m.Called(ttl)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetCachedQueryResultsTTL")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
+		r0 = rf(ttl)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/ee/tables/windowsupdatetable/windowsupdate_cached.go
+++ b/ee/tables/windowsupdatetable/windowsupdate_cached.go
@@ -20,11 +20,8 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-const (
-	cachedDataTTL = 6 * time.Hour
-)
-
 type CachedWindowsUpdatesTable struct {
+	flags      types.Flags
 	slogger    *slog.Logger
 	cacheStore types.Getter
 	name       string
@@ -39,6 +36,7 @@ func CachedWindowsUpdatesTablePlugin(flags types.Flags, slogger *slog.Logger, ca
 	)
 
 	t := &CachedWindowsUpdatesTable{
+		flags:      flags,
 		slogger:    slogger.With("name", "kolide_windows_updates_cached"),
 		cacheStore: cacheStore,
 		name:       "kolide_windows_updates_cached",
@@ -81,7 +79,7 @@ func (c *CachedWindowsUpdatesTable) generateFromCachedData(ctx context.Context, 
 			continue
 		}
 
-		if res.QueryTime.Add(cachedDataTTL).Before(time.Now()) {
+		if res.QueryTime.Add(c.flags.CachedQueryResultsTTL()).Before(time.Now()) {
 			c.slogger.Log(ctx, slog.LevelWarn,
 				"cached data is expired, not using",
 				"locale", locale,


### PR DESCRIPTION
In case we don't like the 6-hour default TTL, this PR makes the TTL cloud-configurable.