### PR TITLE
Kick off cache attempt when exiting modern standby

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -355,7 +355,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		runGroup.Add("powerEventWatcher", powerEventWatcher.Execute, powerEventWatcher.Interrupt)
 	}
 
-	windowsUpdatesCacher := windowsupdatetable.NewWindowsUpdatesCacher(k.WindowsUpdatesCacheStore(), 1*time.Hour, slogger)
+	windowsUpdatesCacher := windowsupdatetable.NewWindowsUpdatesCacher(k, k.WindowsUpdatesCacheStore(), 1*time.Hour, slogger)
 	runGroup.Add("windowsUpdatesCacher", windowsUpdatesCacher.Execute, windowsUpdatesCacher.Interrupt)
 
 	var client service.KolideService

--- a/ee/tables/windowsupdatetable/cache_other.go
+++ b/ee/tables/windowsupdatetable/cache_other.go
@@ -16,7 +16,7 @@ type noOpWindowsUpdatesCacher struct {
 	interrupted atomic.Bool
 }
 
-func NewWindowsUpdatesCacher(_ types.GetterSetter, _ time.Duration, _ *slog.Logger) *noOpWindowsUpdatesCacher {
+func NewWindowsUpdatesCacher(_ types.Flags, _ types.GetterSetter, _ time.Duration, _ *slog.Logger) *noOpWindowsUpdatesCacher {
 	return &noOpWindowsUpdatesCacher{
 		interrupt: make(chan struct{}),
 	}

--- a/ee/tables/windowsupdatetable/cache_test.go
+++ b/ee/tables/windowsupdatetable/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
+	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	testStore, err := storageci.NewStore(t, slogger, "test_cache_bucket")
 	require.NoError(t, err)
 
-	cacher := NewWindowsUpdatesCacher(testStore, 1*time.Minute, slogger)
+	cacher := NewWindowsUpdatesCacher(typesmocks.NewFlags(t), testStore, 1*time.Minute, slogger)
 
 	// Start and then interrupt
 	go cacher.Execute()

--- a/ee/tables/windowsupdatetable/cache_test.go
+++ b/ee/tables/windowsupdatetable/cache_test.go
@@ -21,7 +21,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	testFlags := typesmocks.NewFlags(t)
 	testFlags.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 
-	cacher := NewWindowsUpdatesCacher(typesmocks.NewFlags(t), testStore, 1*time.Minute, slogger)
+	cacher := NewWindowsUpdatesCacher(testFlags, testStore, 1*time.Minute, slogger)
 
 	// Start and then interrupt
 	go cacher.Execute()

--- a/ee/tables/windowsupdatetable/cache_test.go
+++ b/ee/tables/windowsupdatetable/cache_test.go
@@ -20,6 +20,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 	require.NoError(t, err)
 	testFlags := typesmocks.NewFlags(t)
 	testFlags.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
+	testFlags.On("InModernStandby").Maybe().Return(false)
 
 	cacher := NewWindowsUpdatesCacher(testFlags, testStore, 1*time.Minute, slogger)
 

--- a/ee/tables/windowsupdatetable/cache_test.go
+++ b/ee/tables/windowsupdatetable/cache_test.go
@@ -8,6 +8,7 @@ import (
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,6 +18,8 @@ func TestInterrupt_Multiple(t *testing.T) {
 	slogger := multislogger.NewNopLogger()
 	testStore, err := storageci.NewStore(t, slogger, "test_cache_bucket")
 	require.NoError(t, err)
+	testFlags := typesmocks.NewFlags(t)
+	testFlags.On("RegisterChangeObserver", mock.Anything, mock.Anything).Maybe().Return()
 
 	cacher := NewWindowsUpdatesCacher(typesmocks.NewFlags(t), testStore, 1*time.Minute, slogger)
 

--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -10,10 +10,13 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/observability"
 )
@@ -22,8 +25,10 @@ type (
 	// windowsUpdatesCacher queries for fresh Windows updates data every `cacheInterval`,
 	// and stores it in the `cacheStore`.
 	windowsUpdatesCacher struct {
+		flags         types.Flags
 		cacheStore    types.GetterSetter
 		cacheInterval time.Duration
+		cacheLock     *sync.Mutex
 		queryCancel   context.CancelFunc
 		slogger       *slog.Logger
 		interrupt     chan struct{}
@@ -38,13 +43,18 @@ type (
 	}
 )
 
-func NewWindowsUpdatesCacher(cacheStore types.GetterSetter, cacheInterval time.Duration, slogger *slog.Logger) *windowsUpdatesCacher {
-	return &windowsUpdatesCacher{
+func NewWindowsUpdatesCacher(flags types.Flags, cacheStore types.GetterSetter, cacheInterval time.Duration, slogger *slog.Logger) *windowsUpdatesCacher {
+	w := &windowsUpdatesCacher{
+		flags:         flags,
 		cacheStore:    cacheStore,
 		cacheInterval: cacheInterval,
+		cacheLock:     &sync.Mutex{},
 		slogger:       slogger.With("component", "windows_updates_cacher"),
 		interrupt:     make(chan struct{}, 1), // provide a buffer for the channel so that Interrupt can send to it and return immediately
 	}
+	flags.RegisterChangeObserver(w, keys.InModernStandby)
+
+	return w
 }
 
 func (w *windowsUpdatesCacher) Execute() (err error) {
@@ -52,23 +62,19 @@ func (w *windowsUpdatesCacher) Execute() (err error) {
 	defer cacheTicker.Stop()
 
 	for {
-		// Since this query happens in the background and will not block auth, we can use
-		// a much longer timeout than we use for our tables.
-		var ctx context.Context
-		ctx, w.queryCancel = context.WithTimeout(context.Background(), 20*time.Minute)
-		if err := w.queryAndStoreData(ctx); err != nil {
-			w.slogger.Log(ctx, slog.LevelError,
+
+		if err := w.queryAndStoreData(context.TODO()); err != nil {
+			w.slogger.Log(context.TODO(), slog.LevelError,
 				"error caching windows update data",
 				"err", err,
 			)
 			// Increment our counter tracking query failures/timeouts
-			observability.WindowsUpdatesQueryFailureCounter.Add(ctx, 1)
+			observability.WindowsUpdatesQueryFailureCounter.Add(context.TODO(), 1)
 		} else {
-			w.slogger.Log(ctx, slog.LevelDebug,
+			w.slogger.Log(context.TODO(), slog.LevelDebug,
 				"successfully cached windows updates data",
 			)
 		}
-		w.queryCancel()
 
 		select {
 		case <-cacheTicker.C:
@@ -95,12 +101,46 @@ func (w *windowsUpdatesCacher) Interrupt(_ error) {
 	w.interrupt <- struct{}{}
 }
 
+// FlagsChanged satisfies the types.FlagsChangeObserver interface. The cacher subscribes to changes to
+// InModernStandby.
+func (w *windowsUpdatesCacher) FlagsChanged(ctx context.Context, flagKeys ...keys.FlagKey) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
+	// If we've exited modern standby, kick off a query-and-cache attempt. We do this in a goroutine
+	// to avoid blocking notifying other observers of changed flags.
+	if slices.Contains(flagKeys, keys.InModernStandby) && !w.flags.InModernStandby() {
+		go func() {
+			if err := w.queryAndStoreData(ctx); err != nil {
+				w.slogger.Log(ctx, slog.LevelError,
+					"error caching windows update data after exiting modern standby",
+					"err", err,
+				)
+			} else {
+				w.slogger.Log(ctx, slog.LevelDebug,
+					"successfully cached windows updates data after exiting modern standby",
+				)
+			}
+		}()
+	}
+}
+
 // queryAndStoreData will query the Windows Update Agent API via the `launcher query-windowsupdates`
 // subcommand. If desired, a timeout can be created for the `ctx` arg; it will be respected by the
 // exec to `launcher query-windowsupdates`.
 func (w *windowsUpdatesCacher) queryAndStoreData(ctx context.Context) error {
 	ctx, span := observability.StartSpan(ctx)
 	defer span.End()
+
+	w.cacheLock.Lock()
+	defer w.cacheLock.Unlock()
+	span.AddEvent("cache_lock_acquired")
+
+	// Since this query happens in the background and will not block auth, we can use
+	// a much longer timeout than we use for our tables. We queryCancel on windowsUpdateCacher
+	// so that we can `Interrupt` ongoing query attempts on launcher shutdown if needed.
+	ctx, w.queryCancel = context.WithTimeout(ctx, 20*time.Minute)
+	defer w.queryCancel()
 
 	launcherPath, err := os.Executable()
 	if err != nil {

--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -143,6 +143,11 @@ func (w *windowsUpdatesCacher) queryAndStoreData(ctx context.Context) error {
 	defer w.cacheLock.Unlock()
 	span.AddEvent("cache_lock_acquired")
 
+	// Make sure that the rungroup was not interrupted while waiting for cache lock
+	if w.interrupted.Load() {
+		return nil
+	}
+
 	// Since this query happens in the background and will not block auth, we can use
 	// a much longer timeout than we use for our tables. We queryCancel on windowsUpdateCacher
 	// so that we can `Interrupt` ongoing query attempts on launcher shutdown if needed.

--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -149,7 +149,7 @@ func (w *windowsUpdatesCacher) queryAndStoreData(ctx context.Context) error {
 	}
 
 	// Since this query happens in the background and will not block auth, we can use
-	// a much longer timeout than we use for our tables. We queryCancel on windowsUpdateCacher
+	// a much longer timeout than we use for our tables. We set queryCancel on windowsUpdateCacher
 	// so that we can `Interrupt` ongoing query attempts on launcher shutdown if needed.
 	ctx, w.queryCancel = context.WithTimeout(ctx, 20*time.Minute)
 	defer w.queryCancel()

--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -6,6 +6,7 @@ package windowsupdatetable
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -145,7 +146,9 @@ func (w *windowsUpdatesCacher) queryAndStoreData(ctx context.Context) error {
 
 	// Make sure that the rungroup was not interrupted while waiting for cache lock
 	if w.interrupted.Load() {
-		return nil
+		err := errors.New("interrupted while waiting for cache lock, will not proceed with querying")
+		observability.SetError(span, err)
+		return err
 	}
 
 	// Since this query happens in the background and will not block auth, we can use

--- a/ee/tables/windowsupdatetable/windowsupdate.go
+++ b/ee/tables/windowsupdatetable/windowsupdate.go
@@ -161,16 +161,22 @@ func callQueryWindowsUpdatesSubcommand(ctx context.Context, launcherPath string,
 	cmd.Env = append(cmd.Env, "LAUNCHER_SKIP_UPDATES=TRUE")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("running query-windowsupdates: %w", err)
+		err = fmt.Errorf("running query-windowsupdates: %w", err)
+		observability.SetError(span, err)
+		return nil, err
 	}
 
 	var res QueryResults
 	if err := json.Unmarshal(out, &res); err != nil {
-		return nil, fmt.Errorf("unmarshalling results of running launcher query-windowsupdates: %w", err)
+		err = fmt.Errorf("unmarshalling results of running launcher query-windowsupdates: %w", err)
+		observability.SetError(span, err)
+		return nil, err
 	}
 
 	if res.ErrStr != "" {
-		return nil, fmt.Errorf("launcher query-windowsupdates returned error: %s", res.ErrStr)
+		err = fmt.Errorf("launcher query-windowsupdates returned error: %s", res.ErrStr)
+		observability.SetError(span, err)
+		return nil, err
 	}
 
 	return &res, nil


### PR DESCRIPTION
There are a handful of devices that time out even with the 20-minute timeout. Of the devices I spot-checked, all were in modern standby. This makes sense: querying the windows updates agent API requires network access, which is reduced/unavailable during modern standby.

I updated the cacher to respond to updates in `InModernStandby`, so that we can kick off an extra cache attempt right after exiting modern standby to hopefully keep this data fresh.

I also updated our traces to record any errors.