### PR TITLE
Ensure windows_updates_cacher logs are shipped to cloud

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -355,7 +355,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		runGroup.Add("powerEventWatcher", powerEventWatcher.Execute, powerEventWatcher.Interrupt)
 	}
 
-	windowsUpdatesCacher := windowsupdatetable.NewWindowsUpdatesCacher(k, k.WindowsUpdatesCacheStore(), 1*time.Hour, slogger)
+	windowsUpdatesCacher := windowsupdatetable.NewWindowsUpdatesCacher(k, k.WindowsUpdatesCacheStore(), 1*time.Hour, k.Slogger())
 	runGroup.Add("windowsUpdatesCacher", windowsUpdatesCacher.Execute, windowsUpdatesCacher.Interrupt)
 
 	var client service.KolideService


### PR DESCRIPTION
This change is required for `windows_updates_cacher` to be shipped to our ingest server.

I'm not quite sure why this is required -- maybe we have a regression somewhere after this fix https://github.com/kolide/launcher/pull/1578 from about a year ago?