### PR TITLE
Fix possible TUF deadlock

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -265,10 +265,6 @@ func (ta *TufAutoupdater) Execute() (err error) {
 		}
 
 		select {
-		case <-checkTicker.C:
-			continue
-		case <-cleanupTicker.C:
-			ta.cleanUpOldErrors()
 		case <-ta.interrupt:
 			ta.slogger.Log(context.TODO(), slog.LevelDebug,
 				"received external interrupt, stopping",
@@ -279,6 +275,10 @@ func (ta *TufAutoupdater) Execute() (err error) {
 				"received interrupt to restart launcher after update, stopping",
 			)
 			return signalRestartErr
+		case <-checkTicker.C:
+			continue
+		case <-cleanupTicker.C:
+			ta.cleanUpOldErrors()
 		}
 	}
 }


### PR DESCRIPTION
A deadlock can occur in the following scenario:

* The execute loop checks for an update
* During this update check, the execute loop receives a tick from `cleanupTicker`
* After the update check, we enter the select block and due to ordering, perform a cleanup (since we have a tick from the cleanup ticker) instead of exiting because we've received a restart signal
* The execute loop continue to the next loop iteration, and checks for an update again
* Now, the update check happens again, and indicates a restart is needed -- but it is blocked trying to send on the restart signal channel since that channel has a buffer size of 1

This PR provides an immediate fix by reordering the select cases -- receiving an interrupt/restart signal takes precedence over recheck or cleaning up old errors.