### PR TITLE
Increase buffer size to prevent deadlock on sending to channel

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -120,8 +120,8 @@ func NewTufAutoupdater(ctx context.Context, k types.Knapsack, metadataHttpClient
 
 	ta := &TufAutoupdater{
 		knapsack:      k,
-		interrupt:     make(chan struct{}, 1),
-		signalRestart: make(chan error, 1),
+		interrupt:     make(chan struct{}, 10), // We have a buffer so we don't block on sending to this channel
+		signalRestart: make(chan error, 10),    // We have a buffer so we don't block on sending to this channel
 		store:         k.AutoupdateErrorsStore(),
 		updateChannel: k.UpdateChannel(),
 		pinnedVersions: map[autoupdatableBinary]string{


### PR DESCRIPTION
See description of https://github.com/kolide/launcher/pull/2242 for explanation for how deadlock can occur during autoupdate.

This PR increases the buffer size so that we can send to the restart signal channel multiple times; it should additionally prevent deadlocks.