### PR TITLE
Add meter for autoupdate failures

### DIFF
--- a/ee/observability/meter.go
+++ b/ee/observability/meter.go
@@ -32,6 +32,8 @@ const (
 	windowsUpdatesQueryFailureCounterDescription = "The number of failures when querying the Windows Update Agent API"
 	tablewrapperTimeoutCounterName               = "launcher.tablewrapper.timeout"
 	tablewrapperTimeoutCounterDescription        = "The number of timeouts when querying a Kolide extension table"
+	autoupdateFailureCounterName                 = "launcher.autoupdate.failed"
+	autoupdateFailureCounterDescription          = "The number of TUF autoupdate failures"
 )
 
 var (
@@ -46,6 +48,7 @@ var (
 	OsqueryRestartCounter             metric.Int64Counter
 	WindowsUpdatesQueryFailureCounter metric.Int64Counter
 	TablewrapperTimeoutCounter        metric.Int64Counter
+	AutoupdateFailureCounter          metric.Int64Counter
 )
 
 // Initialize all of our meters. All meter names should have "launcher." prepended,
@@ -84,8 +87,10 @@ func ReinitializeMetrics() {
 		metric.WithUnit(unitFailure))
 	TablewrapperTimeoutCounter = int64CounterOrNoop(tablewrapperTimeoutCounterName,
 		metric.WithDescription(tablewrapperTimeoutCounterDescription),
-		metric.WithUnit(unitFailure),
-	)
+		metric.WithUnit(unitFailure))
+	AutoupdateFailureCounter = int64CounterOrNoop(autoupdateFailureCounterName,
+		metric.WithDescription(autoupdateFailureCounterDescription),
+		metric.WithUnit(unitFailure))
 }
 
 // int64GaugeOrNoop is guaranteed to return an Int64Gauge -- if we cannot create

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -253,6 +253,7 @@ func (ta *TufAutoupdater) Execute() (err error) {
 			"checking for updates",
 		)
 		if err := ta.checkForUpdate(context.TODO(), binaries); err != nil {
+			observability.AutoupdateFailureCounter.Add(context.TODO(), 1)
 			ta.slogger.Log(context.TODO(), slog.LevelError,
 				"error checking for update",
 				"err", err,
@@ -341,6 +342,7 @@ func (ta *TufAutoupdater) Do(data io.Reader) error {
 	)
 
 	if err := ta.checkForUpdate(ctx, binariesToUpdate); err != nil {
+		observability.AutoupdateFailureCounter.Add(ctx, 1)
 		ta.slogger.Log(ctx, slog.LevelError,
 			"error checking for update per control server request",
 			"binaries_to_update", fmt.Sprintf("%+v", binariesToUpdate),
@@ -401,6 +403,7 @@ func (ta *TufAutoupdater) FlagsChanged(ctx context.Context, flagKeys ...keys.Fla
 
 	// At least one binary requires a recheck -- perform that now
 	if err := ta.checkForUpdate(ctx, binariesToCheckForUpdate); err != nil {
+		observability.AutoupdateFailureCounter.Add(ctx, 1)
 		ta.slogger.Log(ctx, slog.LevelError,
 			"error checking for update after autoupdate setting changed",
 			"update_channel", ta.updateChannel,


### PR DESCRIPTION
I pulled out use of the autoupdater error store in https://github.com/kolide/launcher/pull/2244 -- but I think it _would_ be nice to add autoupdater errors to our metrics. So, here they are!