### PR TITLE
Only log new table_generate_timeout if it did actually change

### DIFF
--- a/ee/tables/tablewrapper/tablewrapper.go
+++ b/ee/tables/tablewrapper/tablewrapper.go
@@ -89,6 +89,9 @@ func (wt *wrappedTable) FlagsChanged(ctx context.Context, flagKeys ...keys.FlagK
 	defer wt.genTimeoutLock.Unlock()
 
 	newGenTimeout := wt.flagsController.TableGenerateTimeout()
+	if newGenTimeout == wt.genTimeout {
+		return
+	}
 
 	wt.slogger.Log(ctx, slog.LevelInfo,
 		"received changed value for table_generate_timeout",


### PR DESCRIPTION
Right now, logs look like this:

> {"time":"2025-05-07T13:22:58.501273Z","level":"INFO","source":{"function":"github.com/kolide/launcher/ee/tables/tablewrapper.(*wrappedTable).FlagsChanged","file":"/Users/runner/work/launcher/launcher/ee/tables/tablewrapper/tablewrapper.go","line":93},"msg":"received changed value for table_generate_timeout","component":"launcher_tables","table_name":"kolide_tuf_release_version","old_timeout":"7m30s","new_timeout":"7m30s","span_id":"a25c89fb305b0574","trace_id":"948db33bc380825b55cf7f8f9c0c844f","trace_sampled":false}

This is because we receive `FlagsChanged` when any flag changes -- not sure what's up with that. In any case, this change isn't a big deal, but I wanted to make the logs less verbose and only log when we actually have a change.