### PR TITLE
Make windowsupdate error strings more verbose

### DIFF
--- a/pkg/windows/windowsupdate/icategory.go
+++ b/pkg/windows/windowsupdate/icategory.go
@@ -1,6 +1,8 @@
 package windowsupdate
 
 import (
+	"fmt"
+
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
 	"github.com/kolide/launcher/pkg/windows/oleconv"
@@ -24,19 +26,19 @@ type ICategory struct {
 func toICategories(categoriesDisp *ole.IDispatch) ([]*ICategory, error) {
 	count, err := oleconv.ToInt32Err(oleutil.GetProperty(categoriesDisp, "Count"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Count as int32: %w", err)
 	}
 
 	categories := make([]*ICategory, 0, count)
 	for i := 0; i < int(count); i++ {
 		categoryDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(categoriesDisp, "Item", i))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting property Item at index %d of %d as IDispatch: %w", i, count, err)
 		}
 
 		category, err := toICategory(categoryDisp)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("converting Item IDispatch at index %d of %d to ICategory: %w", i, count, err)
 		}
 
 		categories = append(categories, category)
@@ -51,39 +53,39 @@ func toICategory(categoryDisp *ole.IDispatch) (*ICategory, error) {
 	}
 
 	if iCategory.CategoryID, err = oleconv.ToStringErr(oleutil.GetProperty(categoryDisp, "CategoryID")); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property CategoryID as string: %w", err)
 	}
 
 	childrenDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(categoryDisp, "Children"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Children as IDispatch: %w", err)
 	}
 	if childrenDisp != nil {
 		if iCategory.Children, err = toICategories(childrenDisp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("converting Children IDispatch to ICategories: %w", err)
 		}
 	}
 
 	if iCategory.Description, err = oleconv.ToStringErr(oleutil.GetProperty(categoryDisp, "Description")); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Description as string: %w", err)
 	}
 
 	imageDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(categoryDisp, "Image"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Image as IDispatch: %w", err)
 	}
 	if imageDisp != nil {
 		if iCategory.Image, err = toIImageInformation(imageDisp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("converting Image IDispatch to IImageInformation: %w", err)
 		}
 	}
 
 	if iCategory.Name, err = oleconv.ToStringErr(oleutil.GetProperty(categoryDisp, "Name")); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Name as string: %w", err)
 	}
 
 	if iCategory.Order, err = oleconv.ToInt32Err(oleutil.GetProperty(categoryDisp, "Order")); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Order as int32: %w", err)
 	}
 
 	// parentDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(categoryDisp, "Parent"))
@@ -97,7 +99,7 @@ func toICategory(categoryDisp *ole.IDispatch) (*ICategory, error) {
 	// }
 
 	if iCategory.Type, err = oleconv.ToStringErr(oleutil.GetProperty(categoryDisp, "Type")); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Type as string: %w", err)
 	}
 
 	// updatesDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(categoryDisp, "Updates"))

--- a/pkg/windows/windowsupdate/icategory.go
+++ b/pkg/windows/windowsupdate/icategory.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ICategory represents the category to which an update belongs.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-icategory
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-icategory
 type ICategory struct {
 	disp        *ole.IDispatch
 	CategoryID  string

--- a/pkg/windows/windowsupdate/iimageinformation.go
+++ b/pkg/windows/windowsupdate/iimageinformation.go
@@ -5,7 +5,7 @@ import (
 )
 
 // IImageInformation contains information about a localized image that is associated with an update or a category.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iimageinformation
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iimageinformation
 type IImageInformation struct {
 	disp    *ole.IDispatch //nolint:unused
 	AltText string

--- a/pkg/windows/windowsupdate/iinstallationbehavior.go
+++ b/pkg/windows/windowsupdate/iinstallationbehavior.go
@@ -5,12 +5,12 @@ import (
 )
 
 // IInstallationBehavior represents the installation and uninstallation options of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iinstallationbehavior
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iinstallationbehavior
 type IInstallationBehavior struct {
 	disp                        *ole.IDispatch //nolint:unused
 	CanRequestUserInput         bool
-	Impact                      int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationimpact
-	RebootBehavior              int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationrebootbehavior
+	Impact                      int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-installationimpact
+	RebootBehavior              int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-installationrebootbehavior
 	RequiresNetworkConnectivity bool
 }
 

--- a/pkg/windows/windowsupdate/isearchresult.go
+++ b/pkg/windows/windowsupdate/isearchresult.go
@@ -25,37 +25,37 @@ func toISearchResult(searchResultDisp *ole.IDispatch) (*ISearchResult, error) {
 	}
 
 	if iSearchResult.ResultCode, err = oleconv.ToInt32Err(oleutil.GetProperty(searchResultDisp, "ResultCode")); err != nil {
-		return nil, fmt.Errorf("ResultCode: %w", err)
+		return nil, fmt.Errorf("getting property ResultCode as int32: %w", err)
 	}
 
 	rootCategoriesDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(searchResultDisp, "RootCategories"))
 	if err != nil {
-		return nil, fmt.Errorf("RootCategories: %w", err)
+		return nil, fmt.Errorf("getting property RootCategories as IDispatch: %w", err)
 	}
 	if rootCategoriesDisp != nil {
 		if iSearchResult.RootCategories, err = toICategories(rootCategoriesDisp); err != nil {
-			return nil, fmt.Errorf("toICategories: %w", err)
+			return nil, fmt.Errorf("converting RootCategories IDispatch to ICategories: %w", err)
 		}
 	}
 
 	// Updates is a IUpdateCollection, and we want the full details. So cast it ia toIUpdates
 	updatesDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(searchResultDisp, "Updates"))
 	if err != nil {
-		return nil, fmt.Errorf("Updates: %w", err)
+		return nil, fmt.Errorf("getting property Updates as IDispatch: %w", err)
 	}
 	if updatesDisp != nil {
 		if iSearchResult.Updates, err = toIUpdates(updatesDisp); err != nil {
-			return nil, fmt.Errorf("toIUpdates: %w", err)
+			return nil, fmt.Errorf("converting Updates IDispatch to IUpdates: %w", err)
 		}
 	}
 
 	warningsDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(searchResultDisp, "Warnings"))
 	if err != nil {
-		return nil, fmt.Errorf("Warnings: %w", err)
+		return nil, fmt.Errorf("getting property Warnings as IDispatch: %w", err)
 	}
 	if warningsDisp != nil {
 		if iSearchResult.Warnings, err = toIUpdateExceptions(warningsDisp); err != nil {
-			return nil, fmt.Errorf("toIUpdateExceptions: %w", err)
+			return nil, fmt.Errorf("converting Warnings IDispatch to IUpdateExceptions: %w", err)
 		}
 	}
 

--- a/pkg/windows/windowsupdate/isearchresult.go
+++ b/pkg/windows/windowsupdate/isearchresult.go
@@ -12,7 +12,7 @@ import (
 // https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-isearchresult
 type ISearchResult struct {
 	disp           *ole.IDispatch
-	ResultCode     int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-operationresultcode
+	ResultCode     int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-operationresultcode
 	RootCategories []*ICategory
 	Updates        []*IUpdate
 	Warnings       []*IUpdateException

--- a/pkg/windows/windowsupdate/istringcollection.go
+++ b/pkg/windows/windowsupdate/istringcollection.go
@@ -1,6 +1,8 @@
 package windowsupdate
 
 import (
+	"fmt"
+
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
 	"github.com/kolide/launcher/pkg/windows/oleconv"
@@ -20,7 +22,7 @@ func iStringCollectionToStringArrayErr(disp *ole.IDispatch, err error) ([]string
 
 	count, err := oleconv.ToInt32Err(oleutil.GetProperty(disp, "Count"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Count as int32: %w", err)
 	}
 
 	stringCollection := make([]string, count)
@@ -28,7 +30,7 @@ func iStringCollectionToStringArrayErr(disp *ole.IDispatch, err error) ([]string
 	for i := 0; i < int(count); i++ {
 		str, err := oleconv.ToStringErr(oleutil.GetProperty(disp, "Item", i))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting property Item at index %d of %d as string: %w", i, count, err)
 		}
 
 		stringCollection[i] = str

--- a/pkg/windows/windowsupdate/iupdate.go
+++ b/pkg/windows/windowsupdate/iupdate.go
@@ -24,10 +24,10 @@ type IUpdate struct {
 	Deadline                        *time.Time
 	DeltaCompressedContentAvailable bool
 	DeltaCompressedContentPreferred bool
-	DeploymentAction                int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-deploymentaction
+	DeploymentAction                int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-deploymentaction
 	Description                     string
 	DownloadContents                []*IUpdateDownloadContent
-	DownloadPriority                int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-downloadpriority
+	DownloadPriority                int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-downloadpriority
 	EulaAccepted                    bool
 	EulaText                        string
 	HandlerID                       string

--- a/pkg/windows/windowsupdate/iupdate.go
+++ b/pkg/windows/windowsupdate/iupdate.go
@@ -1,6 +1,7 @@
 package windowsupdate
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-ole/go-ole"
@@ -66,19 +67,19 @@ type IUpdate struct {
 func toIUpdates(updatesDisp *ole.IDispatch) ([]*IUpdate, error) {
 	count, err := oleconv.ToInt32Err(oleutil.GetProperty(updatesDisp, "Count"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Count as int32: %w", err)
 	}
 
 	updates := make([]*IUpdate, count)
 	for i := 0; i < int(count); i++ {
 		updateDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(updatesDisp, "Item", i))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting property Item at index %d of %d as IDispatch: %w", i, count, err)
 		}
 
 		update, err := toIUpdate(updateDisp)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("converting Item IDispatch at index %d of %d to IUpdate: %w", i, count, err)
 		}
 
 		updates[i] = update
@@ -95,23 +96,23 @@ func toIUpdatesIdentities(updatesDisp *ole.IDispatch) ([]*IUpdateIdentity, error
 
 	count, err := oleconv.ToInt32Err(oleutil.GetProperty(updatesDisp, "Count"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting property Count as int32: %w", err)
 	}
 
 	identities := make([]*IUpdateIdentity, count)
 	for i := 0; i < int(count); i++ {
 		updateDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(updatesDisp, "Item", i))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting property Item at index %d of %d as IDispatch: %w", i, count, err)
 		}
 
 		identityDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(updateDisp, "Identity"))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting property Identity at index %d of %d as IDispatch: %w", i, count, err)
 		}
 		if identityDisp != nil {
 			if identities[i], err = toIUpdateIdentity(identityDisp); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("converting Identity IDispatch at index %d of %d to IUpdateIdentity: %w", i, count, err)
 			}
 		}
 	}

--- a/pkg/windows/windowsupdate/iupdatedownloadcontent.go
+++ b/pkg/windows/windowsupdate/iupdatedownloadcontent.go
@@ -5,7 +5,7 @@ import (
 )
 
 // IUpdateDownloadContent represents the download content of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatedownloadcontent
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdatedownloadcontent
 type IUpdateDownloadContent struct {
 	disp        *ole.IDispatch //nolint:unused
 	DownloadUrl string

--- a/pkg/windows/windowsupdate/iupdateexception.go
+++ b/pkg/windows/windowsupdate/iupdateexception.go
@@ -5,10 +5,10 @@ import (
 )
 
 // IUpdateException represents info about the aspects of search results returned in the ISearchResult object that were incomplete. For more info, see Remarks.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdateexception
+// https://learn.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdateexception
 type IUpdateException struct {
 	disp    *ole.IDispatch //nolint:unused
-	Context int32          // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
+	Context int32          // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
 	HResult int64
 	Message string
 }

--- a/pkg/windows/windowsupdate/iupdatehistoryentry.go
+++ b/pkg/windows/windowsupdate/iupdatehistoryentry.go
@@ -32,19 +32,19 @@ type IUpdateHistoryEntry struct {
 func toIUpdateHistoryEntries(updateHistoryEntriesDisp *ole.IDispatch) ([]*IUpdateHistoryEntry, error) {
 	count, err := oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntriesDisp, "Count"))
 	if err != nil {
-		return nil, fmt.Errorf("Count: %w", err)
+		return nil, fmt.Errorf("getting property Count as int32: %w", err)
 	}
 
 	updateHistoryEntries := make([]*IUpdateHistoryEntry, count)
 	for i := 0; i < int(count); i++ {
 		updateHistoryEntryDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(updateHistoryEntriesDisp, "Item", i))
 		if err != nil {
-			return nil, fmt.Errorf("item %d: %w", i, err)
+			return nil, fmt.Errorf("getting property Item at index %d of %d as IDispatch: %w", i, count, err)
 		}
 
 		updateHistoryEntry, err := toIUpdateHistoryEntry(updateHistoryEntryDisp)
 		if err != nil {
-			return nil, fmt.Errorf("toIUpdateHistoryEntry: %w", err)
+			return nil, fmt.Errorf("converting Item IDispatch at index %d of %d to IUpdateHistoryEntry: %w", i, count, err)
 		}
 
 		updateHistoryEntries[i] = updateHistoryEntry
@@ -59,64 +59,64 @@ func toIUpdateHistoryEntry(updateHistoryEntryDisp *ole.IDispatch) (*IUpdateHisto
 	}
 
 	if iUpdateHistoryEntry.ClientApplicationID, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "ClientApplicationID")); err != nil {
-		return nil, fmt.Errorf("ClientApplicationID: %w", err)
+		return nil, fmt.Errorf("getting property ClientApplicationID as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.Date, err = oleconv.ToTimeErr(oleutil.GetProperty(updateHistoryEntryDisp, "Date")); err != nil {
-		return nil, fmt.Errorf("Date: %w", err)
+		return nil, fmt.Errorf("getting property Date as time: %w", err)
 	}
 
 	if iUpdateHistoryEntry.Description, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "Description")); err != nil {
-		return nil, fmt.Errorf("Description: %w", err)
+		return nil, fmt.Errorf("getting property Description as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.HResult, err = oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntryDisp, "HResult")); err != nil {
-		return nil, fmt.Errorf("HResult: %w", err)
+		return nil, fmt.Errorf("getting property HResult as int32: %w", err)
 	}
 
 	if iUpdateHistoryEntry.Operation, err = oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntryDisp, "Operation")); err != nil {
-		return nil, fmt.Errorf("Operation: %w", err)
+		return nil, fmt.Errorf("getting property Operation as int32: %w", err)
 	}
 
 	if iUpdateHistoryEntry.ResultCode, err = oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntryDisp, "ResultCode")); err != nil {
-		return nil, fmt.Errorf("ResultCode: %w", err)
+		return nil, fmt.Errorf("getting property ResultCode as int32: %w", err)
 	}
 
 	if iUpdateHistoryEntry.ServerSelection, err = oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntryDisp, "ServerSelection")); err != nil {
-		return nil, fmt.Errorf("ServerSelection: %w", err)
+		return nil, fmt.Errorf("getting property ServerSelection as int32: %w", err)
 	}
 
 	if iUpdateHistoryEntry.ServiceID, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "ServiceID")); err != nil {
-		return nil, fmt.Errorf("ServiceID: %w", err)
+		return nil, fmt.Errorf("getting property ServiceID as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.SupportUrl, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "SupportUrl")); err != nil {
-		return nil, fmt.Errorf("SupportUrl: %w", err)
+		return nil, fmt.Errorf("getting property SupportUrl as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.Title, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "Title")); err != nil {
-		return nil, fmt.Errorf("Title: %w", err)
+		return nil, fmt.Errorf("getting property Title as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.UninstallationNotes, err = oleconv.ToStringErr(oleutil.GetProperty(updateHistoryEntryDisp, "UninstallationNotes")); err != nil {
-		return nil, fmt.Errorf("UninstallationNotes: %w", err)
+		return nil, fmt.Errorf("getting property UninstallationNotes as string: %w", err)
 	}
 
 	if iUpdateHistoryEntry.UninstallationSteps, err = oleconv.ToStringSliceErr(oleutil.GetProperty(updateHistoryEntryDisp, "UninstallationSteps")); err != nil {
-		return nil, fmt.Errorf("UninstallationSteps: %w", err)
+		return nil, fmt.Errorf("getting property UninstallationSteps as string slice: %w", err)
 	}
 
 	if iUpdateHistoryEntry.UnmappedResultCode, err = oleconv.ToInt32Err(oleutil.GetProperty(updateHistoryEntryDisp, "UnmappedResultCode")); err != nil {
-		return nil, fmt.Errorf("UnmappedResultCode: %w", err)
+		return nil, fmt.Errorf("getting property UnmappedResultCode as int32: %w", err)
 	}
 
 	updateIdentityDisp, err := oleconv.ToIDispatchErr(oleutil.GetProperty(updateHistoryEntryDisp, "UpdateIdentity"))
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIdentity: %w", err)
+		return nil, fmt.Errorf("getting property UpdateIdentity as IDispatch: %w", err)
 	}
 	if updateIdentityDisp != nil {
 		if iUpdateHistoryEntry.UpdateIdentity, err = toIUpdateIdentity(updateIdentityDisp); err != nil {
-			return nil, fmt.Errorf("toIUpdateIdentity: %w", err)
+			return nil, fmt.Errorf("converting UpdateIdentity IDispatch to IUpdateIdentity: %w", err)
 		}
 	}
 

--- a/pkg/windows/windowsupdate/iupdateidentity.go
+++ b/pkg/windows/windowsupdate/iupdateidentity.go
@@ -23,11 +23,11 @@ func toIUpdateIdentity(updateIdentityDisp *ole.IDispatch) (*IUpdateIdentity, err
 	}
 
 	if iUpdateIdentity.RevisionNumber, err = oleconv.ToInt32Err(oleutil.GetProperty(updateIdentityDisp, "RevisionNumber")); err != nil {
-		return nil, fmt.Errorf("RevisionNumber: %w", err)
+		return nil, fmt.Errorf("getting property RevisionNumber as int32: %w", err)
 	}
 
 	if iUpdateIdentity.UpdateID, err = oleconv.ToStringErr(oleutil.GetProperty(updateIdentityDisp, "UpdateID")); err != nil {
-		return nil, fmt.Errorf("UpdateID: %w", err)
+		return nil, fmt.Errorf("getting property UpdateID as string: %w", err)
 	}
 
 	return iUpdateIdentity, nil

--- a/pkg/windows/windowsupdate/iupdatesearcher.go
+++ b/pkg/windows/windowsupdate/iupdatesearcher.go
@@ -64,7 +64,7 @@ func (iUpdateSearcher *IUpdateSearcher) Search(criteria string) (*ISearchResult,
 }
 
 // QueryHistory synchronously queries the computer for the history of the update events.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-queryhistory
+// https://learn.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-queryhistory
 func (iUpdateSearcher *IUpdateSearcher) QueryHistory(startIndex int32, count int32) ([]*IUpdateHistoryEntry, error) {
 	updateHistoryEntriesDisp, err := oleconv.ToIDispatchErr(oleutil.CallMethod(iUpdateSearcher.disp, "QueryHistory", startIndex, count))
 	if err != nil {

--- a/pkg/windows/windowsupdate/iupdatesearcher.go
+++ b/pkg/windows/windowsupdate/iupdatesearcher.go
@@ -27,27 +27,27 @@ func toIUpdateSearcher(updateSearcherDisp *ole.IDispatch) (*IUpdateSearcher, err
 	}
 
 	if iUpdateSearcher.CanAutomaticallyUpgradeService, err = oleconv.ToBoolErr(oleutil.GetProperty(updateSearcherDisp, "CanAutomaticallyUpgradeService")); err != nil {
-		return nil, fmt.Errorf("CanAutomaticallyUpgradeService: %w", err)
+		return nil, fmt.Errorf("getting property CanAutomaticallyUpgradeService as bool: %w", err)
 	}
 
 	if iUpdateSearcher.ClientApplicationID, err = oleconv.ToStringErr(oleutil.GetProperty(updateSearcherDisp, "ClientApplicationID")); err != nil {
-		return nil, fmt.Errorf("ClientApplicationID: %w", err)
+		return nil, fmt.Errorf("getting property ClientApplicationID as string: %w", err)
 	}
 
 	if iUpdateSearcher.IncludePotentiallySupersededUpdates, err = oleconv.ToBoolErr(oleutil.GetProperty(updateSearcherDisp, "IncludePotentiallySupersededUpdates")); err != nil {
-		return nil, fmt.Errorf("IncludePotentiallySupersededUpdates: %w", err)
+		return nil, fmt.Errorf("getting property IncludePotentiallySupersededUpdates as bool: %w", err)
 	}
 
 	if iUpdateSearcher.Online, err = oleconv.ToBoolErr(oleutil.GetProperty(updateSearcherDisp, "Online")); err != nil {
-		return nil, fmt.Errorf("Online: %w", err)
+		return nil, fmt.Errorf("getting property Online as bool: %w", err)
 	}
 
 	if iUpdateSearcher.ServerSelection, err = oleconv.ToInt32Err(oleutil.GetProperty(updateSearcherDisp, "ServerSelection")); err != nil {
-		return nil, fmt.Errorf("ServerSelection: %w", err)
+		return nil, fmt.Errorf("getting property ServerSelection as int32: %w", err)
 	}
 
 	if iUpdateSearcher.ServiceID, err = oleconv.ToStringErr(oleutil.GetProperty(updateSearcherDisp, "ServiceID")); err != nil {
-		return nil, fmt.Errorf("ServiceID: %w", err)
+		return nil, fmt.Errorf("getting property ServiceID as string: %w", err)
 	}
 
 	return iUpdateSearcher, nil
@@ -58,7 +58,7 @@ func toIUpdateSearcher(updateSearcherDisp *ole.IDispatch) (*IUpdateSearcher, err
 func (iUpdateSearcher *IUpdateSearcher) Search(criteria string) (*ISearchResult, error) {
 	searchResultDisp, err := oleconv.ToIDispatchErr(oleutil.CallMethod(iUpdateSearcher.disp, "Search", criteria))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("calling Search: %w", err)
 	}
 	return toISearchResult(searchResultDisp)
 }
@@ -68,7 +68,7 @@ func (iUpdateSearcher *IUpdateSearcher) Search(criteria string) (*ISearchResult,
 func (iUpdateSearcher *IUpdateSearcher) QueryHistory(startIndex int32, count int32) ([]*IUpdateHistoryEntry, error) {
 	updateHistoryEntriesDisp, err := oleconv.ToIDispatchErr(oleutil.CallMethod(iUpdateSearcher.disp, "QueryHistory", startIndex, count))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("calling QueryHistory: %w", err)
 	}
 	return toIUpdateHistoryEntries(updateHistoryEntriesDisp)
 }
@@ -83,7 +83,7 @@ func (iUpdateSearcher *IUpdateSearcher) GetTotalHistoryCount() (int32, error) {
 func (iUpdateSearcher *IUpdateSearcher) QueryHistoryAll() ([]*IUpdateHistoryEntry, error) {
 	count, err := iUpdateSearcher.GetTotalHistoryCount()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting total history count: %w", err)
 	}
 	return iUpdateSearcher.QueryHistory(0, count)
 }

--- a/pkg/windows/windowsupdate/session.go
+++ b/pkg/windows/windowsupdate/session.go
@@ -23,11 +23,11 @@ type IUpdateSession struct {
 func NewUpdateSession() (*IUpdateSession, error) {
 	unknown, err := oleutil.CreateObject("Microsoft.Update.Session")
 	if err != nil {
-		return nil, fmt.Errorf("create Microsoft.Update.Session: %w", err)
+		return nil, fmt.Errorf("creating Microsoft.Update.Session: %w", err)
 	}
 	disp, err := unknown.QueryInterface(ole.IID_IDispatch)
 	if err != nil {
-		return nil, fmt.Errorf("IID_IDispatch: %w", err)
+		return nil, fmt.Errorf("querying IID_IDispatch: %w", err)
 	}
 	return toIUpdateSession(disp)
 }
@@ -40,11 +40,11 @@ func toIUpdateSession(updateSessionDisp *ole.IDispatch) (*IUpdateSession, error)
 	}
 
 	if iUpdateSession.ClientApplicationID, err = oleconv.ToStringErr(oleutil.GetProperty(updateSessionDisp, "ClientApplicationID")); err != nil {
-		return nil, fmt.Errorf("ClientApplicationID: %w", err)
+		return nil, fmt.Errorf("getting property ClientApplicationID as string: %w", err)
 	}
 
 	if iUpdateSession.ReadOnly, err = oleconv.ToBoolErr(oleutil.GetProperty(updateSessionDisp, "ReadOnly")); err != nil {
-		return nil, fmt.Errorf("ReadOnly: %w", err)
+		return nil, fmt.Errorf("getting property ReadOnly as bool: %w", err)
 	}
 
 	return iUpdateSession, nil
@@ -66,7 +66,7 @@ func (iUpdateSession *IUpdateSession) SetLocal(locale uint32) error {
 func (iUpdateSession *IUpdateSession) CreateUpdateSearcher() (*IUpdateSearcher, error) {
 	updateSearcherDisp, err := oleconv.ToIDispatchErr(oleutil.CallMethod(iUpdateSession.disp, "CreateUpdateSearcher"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("calling CreateUpdateSearcher: %w", err)
 	}
 
 	return toIUpdateSearcher(updateSearcherDisp)

--- a/pkg/windows/windowsupdate/session.go
+++ b/pkg/windows/windowsupdate/session.go
@@ -62,7 +62,7 @@ func (iUpdateSession *IUpdateSession) SetLocal(locale uint32) error {
 }
 
 // CreateUpdateSearcher returns an IUpdateSearcher interface for this session.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher
 func (iUpdateSession *IUpdateSession) CreateUpdateSearcher() (*IUpdateSearcher, error) {
 	updateSearcherDisp, err := oleconv.ToIDispatchErr(oleutil.CallMethod(iUpdateSession.disp, "CreateUpdateSearcher"))
 	if err != nil {


### PR DESCRIPTION
I noticed some of our error messages end up pretty terse, like `querying: Exception occurred. (<nil>)`, or  `querying: toIUpdates: Element not found.` This PR updates the error messages to add more context.

I also noticed we were linking to the incorrect documentation in a few places, so I updated to point to the English-language documentation as well.