### PR TITLE
Track checkups "score" and error count as metrics

### DIFF
--- a/ee/observability/meter.go
+++ b/ee/observability/meter.go
@@ -36,6 +36,8 @@ const (
 	tablewrapperTimeoutCounterDescription        = "The number of timeouts when querying a Kolide extension table"
 	autoupdateFailureCounterName                 = "launcher.autoupdate.failed"
 	autoupdateFailureCounterDescription          = "The number of TUF autoupdate failures"
+	checkupErrorCounterName                      = "launcher.checkup.error"
+	checkupErrorCounterDescription               = "The number of errors when running checkups"
 )
 
 var (
@@ -52,6 +54,7 @@ var (
 	WindowsUpdatesQueryFailureCounter metric.Int64Counter
 	TablewrapperTimeoutCounter        metric.Int64Counter
 	AutoupdateFailureCounter          metric.Int64Counter
+	CheckupErrorCounter               metric.Int64Counter
 )
 
 // Initialize all of our meters. All meter names should have "launcher." prepended,
@@ -96,6 +99,9 @@ func ReinitializeMetrics() {
 		metric.WithUnit(unitFailure))
 	AutoupdateFailureCounter = int64CounterOrNoop(autoupdateFailureCounterName,
 		metric.WithDescription(autoupdateFailureCounterDescription),
+		metric.WithUnit(unitFailure))
+	CheckupErrorCounter = int64CounterOrNoop(checkupErrorCounterName,
+		metric.WithDescription(checkupErrorCounterDescription),
 		metric.WithUnit(unitFailure))
 }
 

--- a/ee/observability/meter.go
+++ b/ee/observability/meter.go
@@ -24,6 +24,8 @@ const (
 	memoryPercentGaugeDescription                = "Process memory percent"
 	cpuPercentGaugeName                          = "launcher.cpu.percent"
 	cpuPercentGaugeDescription                   = "Process CPU percent"
+	checkupScoreGaugeName                        = "launcher.checkup.score"
+	checkupScoreGaugeDescription                 = "Computed checkup score"
 	launcherRestartCounterName                   = "launcher.restart"
 	launcherRestartCounterDescription            = "The number of launcher restarts"
 	osqueryRestartCounterName                    = "launcher.osquery.restart"
@@ -42,6 +44,7 @@ var (
 	NonGoMemoryUsageGauge metric.Int64Gauge
 	MemoryPercentGauge    metric.Int64Gauge
 	CpuPercentGauge       metric.Int64Gauge
+	CheckupScoreGauge     metric.Float64Gauge
 
 	// Counters
 	LauncherRestartCounter            metric.Int64Counter
@@ -74,6 +77,9 @@ func ReinitializeMetrics() {
 	CpuPercentGauge = int64GaugeOrNoop(cpuPercentGaugeName,
 		metric.WithDescription(cpuPercentGaugeDescription),
 		metric.WithUnit(unitPercent))
+	CheckupScoreGauge = float64GaugeOrNoop(checkupScoreGaugeName,
+		metric.WithDescription(checkupScoreGaugeDescription),
+		metric.WithUnit(unitPercent))
 
 	// Counters
 	LauncherRestartCounter = int64CounterOrNoop(launcherRestartCounterName,
@@ -99,6 +105,16 @@ func int64GaugeOrNoop(name string, options ...metric.Int64GaugeOption) metric.In
 	gauge, err := otel.Meter(instrumentationPkg).Int64Gauge(name, options...)
 	if err != nil {
 		return noop.Int64Gauge{}
+	}
+	return gauge
+}
+
+// float64GaugeOrNoop is guaranteed to return an Float64Gauge -- if we cannot create
+// a real Float64Gauge, we return a noop version instead.
+func float64GaugeOrNoop(name string, options ...metric.Float64GaugeOption) metric.Float64Gauge {
+	gauge, err := otel.Meter(instrumentationPkg).Float64Gauge(name, options...)
+	if err != nil {
+		return noop.Float64Gauge{}
 	}
 	return gauge
 }

--- a/ee/observability/meter_test.go
+++ b/ee/observability/meter_test.go
@@ -105,6 +105,34 @@ func Test_int64GaugeOrNoop(t *testing.T) { //nolint:paralleltest
 	require.Greater(t, len(meterOutBytes.String()), 0)
 }
 
+// Test_float64GaugeOrNoop does not run in parallel to avoid setting a global meter provider
+// too early during the test run.
+func Test_float64GaugeOrNoop(t *testing.T) { //nolint:paralleltest
+	// Before we set up the meter provider, we should still get a usable float64 gauge
+	testGauge := float64GaugeOrNoop("launcher.test.gauge", metric.WithUnit(unitPercent))
+	require.NotNil(t, testGauge)
+	testGauge.Record(context.TODO(), 5)
+
+	// Set up a meter provider that writes to a buffer every 100 milliseconds
+	writeInterval := 100 * time.Millisecond
+	meterOutBytes := &threadsafebuffer.ThreadSafeBuffer{}
+	testExporter, err := stdoutmetric.New(stdoutmetric.WithWriter(meterOutBytes))
+	require.NoError(t, err)
+	testProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(testExporter, sdkmetric.WithInterval(writeInterval))))
+	otel.SetMeterProvider(testProvider)
+
+	// We should still be able to use our test gauge -- write data and wait
+	// for it to be written to our exporter.
+	for i := range 3 {
+		time.Sleep(writeInterval)
+		testGauge.Record(context.TODO(), float64(i))
+	}
+	time.Sleep(writeInterval)
+
+	// Confirm we exported data
+	require.Greater(t, len(meterOutBytes.String()), 0)
+}
+
 // Test_int64CounterOrNoop does not run in parallel to avoid setting a global meter provider
 // too early during the test run.
 func Test_int64CounterOrNoop(t *testing.T) { //nolint:paralleltest


### PR DESCRIPTION
First pass at adding a "score" that launcher will report up during the log checkpoint, allowing us to assess launcher health over time.