### PR TITLE
Make processes checkup "logSupported" so that it will count towards the checkup score

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -81,7 +81,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&Platform{}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&hostInfoCheckup{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&Version{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
-		{&Processes{}, doctorSupported | flareSupported},
+		{&Processes{}, doctorSupported | flareSupported | logSupported}, // Not startupLogSupported because processes may not have started up yet
 		{&RootDirectory{k: k}, doctorSupported | flareSupported},
 		{&Connectivity{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&Logs{k: k}, doctorSupported | flareSupported},


### PR DESCRIPTION
The log checkpointer will now also run the processes checkup, and count its status toward its checkup score.