### PR TITLE
Export metrics every 10 minutes instead of every minute

### DIFF
--- a/ee/observability/exporter/exporter.go
+++ b/ee/observability/exporter/exporter.go
@@ -345,7 +345,7 @@ func (t *TelemetryExporter) setNewGlobalMeterProvider(launcherResource *resource
 	// Create new meter provider and let otel set it globally
 	newMeterProvider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(launcherResource),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricsExporter)),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricsExporter, sdkmetric.WithInterval(10*time.Minute))),
 	)
 	otel.SetMeterProvider(newMeterProvider)
 


### PR DESCRIPTION
Our metrics exporter by default exports data points every minute. I had assumed that if no measurement had occurred during that minute, there would be nothing to export, so the export wouldn't happen. However, that appears to be incorrect -- the exporter will re-ship all meters with at least one data point every minute. I believe this behavior indicates that the latest data measurement is "unbroken", which seems reasonable and useful, but I also believe this is contributing to our higher metrics storage cost.

This PR changes the export interval to every 10 minutes instead of every minute. (I think we could comfortably bump this up to every 30 minutes or possibly every hour, but I'd like to confirm that this actually affects our billing data before making that change.) All metrics not yet exported will always be flushed and exported on launcher shutdown, so we don't risk losing data with this greater interval -- metrics will just take longer to show up. This seems like an acceptable tradeoff to me.