### PR TITLE
Get munemo from registration store when performing db reset check

### DIFF
--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -28,7 +28,7 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 		)
 	}
 
-	if err := agent.ResetDatabase(ctx, k, resetReasonUninstallRequested); err != nil {
+	if err := agent.ResetDatabase(ctx, k, slogger, resetReasonUninstallRequested); err != nil {
 		slogger.Log(ctx, slog.LevelError,
 			"resetting database",
 			"err", err,


### PR DESCRIPTION
Also adds a "component" to the reset logs to make them easier to find.

Builds on https://github.com/kolide/launcher/pull/2262 -- tackles part of the second bullet point. Relates to https://github.com/kolide/launcher/issues/1473.