### PR TITLE
Get munemo for header checks from registration store

### DIFF
--- a/ee/localserver/dt4a_test.go
+++ b/ee/localserver/dt4a_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/ee/agent/storage"
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
+	"github.com/kolide/launcher/ee/agent/types"
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/mock"
@@ -37,7 +38,12 @@ func Test_requestDt4aInfoHandler(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -86,7 +92,12 @@ func Test_requestDt4aInfoHandlerWithDt4aIds(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -125,7 +136,12 @@ func Test_requestDt4aInfoHandlerWithDt4aIdsNoData(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -180,7 +196,12 @@ func Test_requestDt4aInfoHandler_allowsAllSafariWebExtensionOrigins(t *testing.T
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -219,7 +240,12 @@ func Test_requestDt4aInfoHandler_allowsMissingOrigin(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -257,7 +283,12 @@ func Test_requestDt4aInfoHandler_allowsEmptyOrigin(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -305,7 +336,12 @@ func Test_requestDt4aInfoHandler_badRequest(t *testing.T) {
 			k.On("KolideServerURL").Return("localserver")
 			k.On("Slogger").Return(slogger)
 			k.On("AllowOverlyBroadDt4aAcceleration").Maybe().Return(false)
-			k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+			k.On("Registrations").Return([]types.Registration{
+				{
+					RegistrationID: types.DefaultRegistrationID,
+					Munemo:         "test-munemo",
+				},
+			}, nil)
 
 			// Set up localserver
 			ls, err := New(context.TODO(), k, nil)
@@ -339,7 +375,12 @@ func Test_requestDt4aInfoHandler_noDataAvailable(t *testing.T) {
 	k.On("Slogger").Return(slogger)
 	k.On("Dt4aInfoStore").Return(dt4aInfoStore)
 	k.On("AllowOverlyBroadDt4aAcceleration").Return(false)
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)
@@ -368,7 +409,12 @@ func Test_requestDt4aAccelerationHandler(t *testing.T) {
 	k.On("SetControlRequestIntervalOverride", mock.Anything, mock.Anything).Return()
 	// Validate that we accelerate osquery distributed requests
 	k.On("SetDistributedForwardingIntervalOverride", mock.Anything, mock.Anything).Return()
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Set up localserver
 	ls, err := New(context.TODO(), k, nil)

--- a/ee/localserver/request-controlservice_test.go
+++ b/ee/localserver/request-controlservice_test.go
@@ -23,7 +23,9 @@ func Test_localServer_requestAccelerateControlFunc(t *testing.T) {
 		m := mocks.NewKnapsack(t)
 		m.On("KolideServerURL").Return("localhost")
 		m.On("Slogger").Return(slogger)
-		m.On("ReadEnrollSecret").Return("enroll_secret", nil)
+		m.On("Registrations").Return([]types.Registration{
+			{Munemo: "test-munemo"},
+		}, nil)
 		return m
 	}
 
@@ -49,7 +51,9 @@ func Test_localServer_requestAccelerateControlFunc(t *testing.T) {
 				m.On("SetControlRequestIntervalOverride", 250*time.Millisecond, 1*time.Second)
 				m.On("SetDistributedForwardingIntervalOverride", 250*time.Millisecond, 1*time.Second)
 				m.On("Slogger").Return(slogger)
-				m.On("ReadEnrollSecret").Return("enroll_secret", nil)
+				m.On("Registrations").Return([]types.Registration{
+					{Munemo: "test-munemo"},
+				}, nil)
 				return m
 			},
 		},

--- a/ee/localserver/request-id_test.go
+++ b/ee/localserver/request-id_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/kolide/launcher/ee/agent/types"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/stretchr/testify/assert"
@@ -24,11 +23,12 @@ func Test_localServer_requestIdHandler(t *testing.T) {
 	mockKnapsack.On("KolideServerURL").Return("localhost")
 	mockKnapsack.On("CurrentEnrollmentStatus").Return(types.Enrolled, nil)
 	mockKnapsack.On("GetEnrollmentDetails").Return(types.EnrollmentDetails{OSVersion: "1", Hostname: "test"}, nil)
-
-	enrollSecret, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"organization": "test-munemo"}).SignedString([]byte("test"))
-	require.NoError(t, err)
-
-	mockKnapsack.On("ReadEnrollSecret").Return(enrollSecret, nil)
+	mockKnapsack.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	var logBytes bytes.Buffer
 	slogger := slog.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{

--- a/ee/localserver/request-query_test.go
+++ b/ee/localserver/request-query_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/kolide/launcher/ee/agent/types"
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/localserver/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
@@ -55,7 +56,12 @@ func Test_localServer_requestQueryHandler(t *testing.T) {
 			mockKnapsack := typesMocks.NewKnapsack(t)
 			mockKnapsack.On("KolideServerURL").Return("localhost")
 			mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
-			mockKnapsack.On("ReadEnrollSecret").Return("enroll_secret", nil)
+			mockKnapsack.On("Registrations").Return([]types.Registration{
+				{
+					RegistrationID: types.DefaultRegistrationID,
+					Munemo:         "test-munemo",
+				},
+			}, nil)
 
 			//go:generate mockery --name Querier
 			// https://github.com/vektra/mockery <-- cli tool to generate mocks for usage with testify
@@ -221,7 +227,12 @@ func Test_localServer_requestRunScheduledQueryHandler(t *testing.T) {
 			mockKnapsack := typesMocks.NewKnapsack(t)
 			mockKnapsack.On("KolideServerURL").Return("localhost")
 			mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
-			mockKnapsack.On("ReadEnrollSecret").Return("enroll_secret", nil)
+			mockKnapsack.On("Registrations").Return([]types.Registration{
+				{
+					RegistrationID: types.DefaultRegistrationID,
+					Munemo:         "test-munemo",
+				},
+			}, nil)
 
 			// set up mock querier
 			mockQuerier := mocks.NewQuerier(t)

--- a/ee/localserver/server_test.go
+++ b/ee/localserver/server_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/launcher/ee/agent/types"
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/localserver/mocks"
 	"github.com/kolide/launcher/pkg/log/multislogger"
@@ -19,7 +20,12 @@ func TestInterrupt_Multiple(t *testing.T) {
 	k := typesmocks.NewKnapsack(t)
 	k.On("KolideServerURL").Return("localserver")
 	k.On("Slogger").Return(multislogger.NewNopLogger())
-	k.On("ReadEnrollSecret").Return("enroll_secret", nil)
+	k.On("Registrations").Return([]types.Registration{
+		{
+			RegistrationID: types.DefaultRegistrationID,
+			Munemo:         "test-munemo",
+		},
+	}, nil)
 
 	// Override the poll and recalculate interval for the test so we can be sure that the async workers
 	// do run, but then stop running on shutdown


### PR DESCRIPTION
Like https://github.com/kolide/launcher/pull/2263, this PR also uses the new registration store to get the munemo associated with the launcher installation, rather than reading and parsing the enrollment secret.

This means that there's the possibility that localserver will attempt to read from the store before the registration exists in it. To address this, I added a goroutine in the localserver similar to the async workers one, which will periodically check for registrations in the store until enrollment is complete, and then store the munemo in the middleware and exit when done. I liked this a little better than the alternative (injecting the knapsack into the middleware and having the middleware handle periodically checking instead) because this option allows us to keep the middleware more focused/lightweight, and fits better with our existing patterns.

Since this means the munemo can be altered in the middleware now, I opted for `atomic.String` to avoid data races. I chose `atomic.String` over a mutex to avoid the possibility of a lock holding up localserver requests.

Builds on https://github.com/kolide/launcher/pull/2262 -- tackles part of the second bullet point. Relates to https://github.com/kolide/launcher/issues/1473.