### PR TITLE
Add Dependency Updates section to release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,9 @@ changelog:
     - title: Tests, Docs, and Other No-op Changes
       labels:
         - "tests-docs"
+    - title: Dependency Updates
+      labels:
+        - "dependencies"
     - title: General # Non-code changes like tests, CI, documentation
       labels:
         - "*"


### PR DESCRIPTION
Adds `dependencies` label to our release.yml so that that section will be autogenerated in our releases too.