### PR TITLE
Print logs and interrupt start time when interrupt test fails

### DIFF
--- a/cmd/launcher/signal_listener_test.go
+++ b/cmd/launcher/signal_listener_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,11 +17,16 @@ func TestInterrupt_Multiple(t *testing.T) {
 
 	sigChannel := make(chan os.Signal, 1)
 	_, cancel := context.WithCancel(context.TODO())
-	sigListener := newSignalListener(sigChannel, cancel, multislogger.NewNopLogger())
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	sigListener := newSignalListener(sigChannel, cancel, slogger)
 
 	// Let the signal listener run for a bit
 	go sigListener.Execute()
 	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
 	sigListener.Interrupt(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
@@ -44,7 +50,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 			receivedInterrupts += 1
 			continue
 		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 			t.FailNow()
 		}
 	}

--- a/ee/control/actionqueue/actionqueue_test.go
+++ b/ee/control/actionqueue/actionqueue_test.go
@@ -272,7 +272,11 @@ func TestStopCleanup_Multiple(t *testing.T) {
 	mockActor := mocks.NewActor(t)
 	store := setupStorage(t)
 	mockKnapsack := typesmocks.NewKnapsack(t)
-	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	mockKnapsack.On("Slogger").Return(slogger)
 	actionQueue := New(
 		mockKnapsack,
 		WithStore(store),
@@ -284,6 +288,7 @@ func TestStopCleanup_Multiple(t *testing.T) {
 	// start clean up
 	go actionQueue.StartCleanup()
 	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
 	actionQueue.StopCleanup(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
@@ -307,7 +312,7 @@ func TestStopCleanup_Multiple(t *testing.T) {
 			receivedInterrupts += 1
 			continue
 		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 			t.FailNow()
 		}
 	}

--- a/ee/control/control_test.go
+++ b/ee/control/control_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"strconv"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	typesMocks "github.com/kolide/launcher/ee/agent/types/mocks"
 	"github.com/kolide/launcher/ee/control/consumers/keyvalueconsumer"
 	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -570,13 +572,18 @@ func TestInterrupt_Multiple(t *testing.T) {
 	k := typesMocks.NewKnapsack(t)
 	k.On("ControlRequestInterval").Return(24 * time.Hour)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything).Return()
-	k.On("Slogger").Return(multislogger.NewNopLogger())
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	k.On("Slogger").Return(slogger)
 	data := &TestClient{}
 	control := New(k, data)
 
 	go control.ExecuteWithContext(ctx)
 
 	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
 	control.Interrupt(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
@@ -600,7 +607,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 			receivedInterrupts += 1
 			continue
 		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 			t.FailNow()
 		}
 	}

--- a/ee/debug/checkups/checkpoint_test.go
+++ b/ee/debug/checkups/checkpoint_test.go
@@ -2,13 +2,14 @@ package checkups
 
 import (
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	storageci "github.com/kolide/launcher/ee/agent/storage/ci"
 	"github.com/kolide/launcher/ee/agent/types"
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
-	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,11 +33,17 @@ func TestInterrupt_Multiple(t *testing.T) {
 	mockKnapsack.On("ServerProvidedDataStore").Return(nil).Maybe()
 	mockKnapsack.On("CurrentEnrollmentStatus").Return(types.Enrolled, nil).Maybe()
 	mockKnapsack.On("LauncherHistoryStore").Return(nil).Maybe()
-	checkupLogger := NewCheckupLogger(multislogger.NewNopLogger(), mockKnapsack)
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	checkupLogger := NewCheckupLogger(slogger, mockKnapsack)
 	mockKnapsack.AssertExpectations(t)
 
 	// Start and then interrupt
 	go checkupLogger.Run()
+	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
 	checkupLogger.Interrupt(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
@@ -60,7 +67,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 			receivedInterrupts += 1
 			continue
 		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 			t.FailNow()
 		}
 	}

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -167,6 +167,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 
 			// let it run a few intervals
 			time.Sleep(r.updateInterval * 6)
+			interruptStart := time.Now()
 			r.Interrupt(nil)
 
 			user, err := user.Current()
@@ -233,7 +234,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 					receivedInterrupts += 1
 					continue
 				case <-time.After(5 * time.Second):
-					t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+					t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 					t.FailNow()
 				}
 			}

--- a/ee/powereventwatcher/power_event_watcher_other_test.go
+++ b/ee/powereventwatcher/power_event_watcher_other_test.go
@@ -6,23 +6,30 @@ package powereventwatcher
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
-	"github.com/kolide/launcher/pkg/log/multislogger"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInterrupt_Multiple(t *testing.T) {
 	t.Parallel()
 
-	ksubscriber := NewKnapsackSleepStateUpdater(multislogger.NewNopLogger(), typesmocks.NewKnapsack(t))
-	p, err := New(context.TODO(), multislogger.NewNopLogger(), ksubscriber)
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	ksubscriber := NewKnapsackSleepStateUpdater(slogger, typesmocks.NewKnapsack(t))
+	p, err := New(context.TODO(), slogger, ksubscriber)
 	require.NoError(t, err)
 
 	// Start and then interrupt
 	go p.Execute()
+	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
 	p.Interrupt(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
@@ -46,7 +53,7 @@ func TestInterrupt_Multiple(t *testing.T) {
 			receivedInterrupts += 1
 			continue
 		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- received %d interrupts before timeout", receivedInterrupts)
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
 			t.FailNow()
 		}
 	}


### PR DESCRIPTION
I've seen this failure more recently lately: https://github.com/kolide/launcher/actions/runs/15163639023/job/42635887237

The "interrupt multiple times" test is useful because it's really important that we know we can shut down any rungroup actor with 1-2 calls to the interrupt function, without blocking. But, because it's a timing-based test, it's also frequently flaky.

I've updated _all_ of these tests to print logs from the actor on failure, as well as the timestamp corresponding with the first interrupt, to be able to understand better what's happening when interrupt fails to return.