### PR TITLE
Handle near-simultaneous calls to Interrupt in secureenclaverunner

### DIFF
--- a/cmd/launcher/signal_listener.go
+++ b/cmd/launcher/signal_listener.go
@@ -37,11 +37,10 @@ func (s *signalListener) Execute() error {
 
 func (s *signalListener) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if s.interrupted.Load() {
+	if s.interrupted.Swap(true) {
 		return
 	}
 
-	s.interrupted.Store(true)
 	s.cancel()
 	close(s.sigChannel)
 }

--- a/ee/agent/storage/bbolt/backup.go
+++ b/ee/agent/storage/bbolt/backup.go
@@ -72,10 +72,9 @@ func (d *databaseBackupSaver) Execute() error {
 
 func (d *databaseBackupSaver) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if d.interrupted.Load() {
+	if d.interrupted.Swap(true) {
 		return
 	}
-	d.interrupted.Store(true)
 
 	d.interrupt <- struct{}{}
 }

--- a/ee/control/consumers/remoterestartconsumer/remoterestartconsumer.go
+++ b/ee/control/consumers/remoterestartconsumer/remoterestartconsumer.go
@@ -123,10 +123,9 @@ func (r *RemoteRestartConsumer) Execute() (err error) {
 // and be shut down when the rungroup shuts down.
 func (r *RemoteRestartConsumer) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if r.interrupted.Load() {
+	if r.interrupted.Swap(true) {
 		return
 	}
-	r.interrupted.Store(true)
 
 	r.interrupt <- struct{}{}
 }

--- a/ee/debug/checkups/checkpoint.go
+++ b/ee/debug/checkups/checkpoint.go
@@ -63,11 +63,9 @@ func (c *logCheckPointer) Run() error {
 
 func (c *logCheckPointer) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if c.interrupted.Load() {
+	if c.interrupted.Swap(true) {
 		return
 	}
-
-	c.interrupted.Store(true)
 
 	c.interrupt <- struct{}{}
 }

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -252,11 +252,9 @@ func (r *DesktopUsersProcessesRunner) Execute() error {
 // It also signals the execute loop to exit, so new desktop processes cease to spawn.
 func (r *DesktopUsersProcessesRunner) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if r.interrupted.Load() {
+	if r.interrupted.Swap(true) {
 		return
 	}
-
-	r.interrupted.Store(true)
 
 	// Tell the execute loop to stop checking, and exit
 	r.interrupt <- struct{}{}

--- a/ee/desktop/user/notify/notify_darwin.go
+++ b/ee/desktop/user/notify/notify_darwin.go
@@ -41,11 +41,9 @@ func (m *macNotifier) Execute() error {
 }
 
 func (m *macNotifier) Interrupt(err error) {
-	if m.interrupted.Load() {
+	if m.interrupted.Swap(true) {
 		return
 	}
-
-	m.interrupted.Store(true)
 
 	m.interrupt <- struct{}{}
 }

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -128,10 +128,9 @@ func (d *dbusNotifier) Execute() error {
 }
 
 func (d *dbusNotifier) Interrupt(err error) {
-	if d.interrupted.Load() {
+	if d.interrupted.Swap(true) {
 		return
 	}
-	d.interrupted.Store(true)
 
 	d.interrupt <- struct{}{}
 

--- a/ee/desktop/user/notify/notify_windows.go
+++ b/ee/desktop/user/notify/notify_windows.go
@@ -34,10 +34,9 @@ func (w *windowsNotifier) Execute() error {
 func (w *windowsNotifier) Listen() {}
 
 func (w *windowsNotifier) Interrupt(err error) {
-	if w.interrupted.Load() {
+	if w.interrupted.Swap(true) {
 		return
 	}
-	w.interrupted.Store(true)
 
 	w.interrupt <- struct{}{}
 }

--- a/ee/desktop/user/universallink/handler_darwin.go
+++ b/ee/desktop/user/universallink/handler_darwin.go
@@ -74,10 +74,9 @@ func (u *universalLinkHandler) Interrupt(_ error) {
 	)
 
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if u.interrupted.Load() {
+	if u.interrupted.Swap(true) {
 		return
 	}
-	u.interrupted.Store(true)
 
 	u.interrupt <- struct{}{}
 	close(u.urlInput)

--- a/ee/desktop/user/universallink/handler_other.go
+++ b/ee/desktop/user/universallink/handler_other.go
@@ -30,10 +30,9 @@ func (n *noopUniversalLinkHandler) Execute() error {
 
 func (n *noopUniversalLinkHandler) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if n.interrupted.Load() {
+	if n.interrupted.Swap(true) {
 		return
 	}
-	n.interrupted.Store(true)
 
 	n.interrupt <- struct{}{}
 	close(n.unusedInput)

--- a/ee/observability/exporter/exporter.go
+++ b/ee/observability/exporter/exporter.go
@@ -378,11 +378,9 @@ func (t *TelemetryExporter) Execute() error {
 
 func (t *TelemetryExporter) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if t.interrupted.Load() {
+	if t.interrupted.Swap(true) {
 		return
 	}
-
-	t.interrupted.Store(true)
 
 	// We must use context.Background here, not t.ctx -- if we use t.ctx, the restart metric won't ship,
 	// and calls to Shutdown will time out.

--- a/ee/powereventwatcher/power_event_watcher_other.go
+++ b/ee/powereventwatcher/power_event_watcher_other.go
@@ -39,11 +39,9 @@ func (n *noOpPowerEventWatcher) Execute() error {
 
 func (n *noOpPowerEventWatcher) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if n.interrupted.Load() {
+	if n.interrupted.Swap(true) {
 		return
 	}
-
-	n.interrupted.Store(true)
 
 	n.interrupt <- struct{}{}
 }

--- a/ee/powereventwatcher/power_event_watcher_windows.go
+++ b/ee/powereventwatcher/power_event_watcher_windows.go
@@ -235,11 +235,9 @@ func (p *powerEventWatcher) Execute() error {
 
 func (p *powerEventWatcher) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if p.interrupted.Load() {
+	if p.interrupted.Swap(true) {
 		return
 	}
-
-	p.interrupted.Store(true)
 
 	// EvtClose: https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclose
 	ret, _, err := p.unsubscribeProcedure.Call(p.subscriptionHandle)

--- a/ee/tables/windowsupdatetable/cache_other.go
+++ b/ee/tables/windowsupdatetable/cache_other.go
@@ -29,11 +29,9 @@ func (n *noOpWindowsUpdatesCacher) Execute() error {
 
 func (n *noOpWindowsUpdatesCacher) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if n.interrupted.Load() {
+	if n.interrupted.Swap(true) {
 		return
 	}
-
-	n.interrupted.Store(true)
 
 	n.interrupt <- struct{}{}
 }

--- a/ee/tables/windowsupdatetable/cache_windows.go
+++ b/ee/tables/windowsupdatetable/cache_windows.go
@@ -95,10 +95,9 @@ func (w *windowsUpdatesCacher) Execute() (err error) {
 
 func (w *windowsUpdatesCacher) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if w.interrupted.Load() {
+	if w.interrupted.Swap(true) {
 		return
 	}
-	w.interrupted.Store(true)
 
 	// If we have a long-running query going right now, cancel it so that it doesn't prevent
 	// shutdown.

--- a/ee/tpmrunner/tpmrunner.go
+++ b/ee/tpmrunner/tpmrunner.go
@@ -132,11 +132,9 @@ func (tr *tpmRunner) Execute() error {
 
 func (tr *tpmRunner) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if tr.interrupted.Load() {
+	if tr.interrupted.Swap(true) {
 		return
 	}
-
-	tr.interrupted.Store(true)
 
 	// Tell the execute loop to stop checking, and exit
 	tr.interrupt <- struct{}{}

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -278,10 +278,9 @@ func (ta *TufAutoupdater) Execute() (err error) {
 
 func (ta *TufAutoupdater) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if ta.interrupted.Load() {
+	if ta.interrupted.Swap(true) {
 		return
 	}
-	ta.interrupted.Store(true)
 
 	ta.interrupt <- struct{}{}
 }

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -154,12 +154,11 @@ func (wc *WatchdogController) publishLogs(ctx context.Context) {
 
 func (wc *WatchdogController) Interrupt(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if wc.interrupted.Load() {
+	if wc.interrupted.Swap(true) {
 		return
 	}
 
 	wc.logPublisher.Close()
-	wc.interrupted.Store(true)
 	wc.interrupt <- struct{}{}
 }
 

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -213,10 +213,9 @@ func (e *Extension) Execute() error {
 // with this extension.
 func (e *Extension) Shutdown(_ error) {
 	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
-	if e.interrupted.Load() {
+	if e.interrupted.Swap(true) {
 		return
 	}
-	e.interrupted.Store(true)
 
 	e.knapsack.DeregisterChangeObserver(e)
 	close(e.done)


### PR DESCRIPTION
With the troubleshooting in https://github.com/kolide/launcher/pull/2267 plus the new log added in this PR, I discovered that the runner occasionally gets near-simultaneous calls to `Interrupt` in the tests -- the `interrupted atomic.Bool` doesn't appear to get set in time to prevent the two simultaneous calls.

This PR updates to use the atomic `Swap` in a single operation to avoid this issue -- see comment thread [here](https://github.com/kolide/launcher/pull/2268#discussion_r2100758355) from @James-Pickett for more details.