### PR TITLE
Add histogram meter to track RSS in bytes for launcher process

### DIFF
--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -98,6 +98,7 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 	observability.NonGoMemoryUsageGauge.Record(ctx, int64(ps.MemInfo.NonGoMemUsage))
 	observability.MemoryPercentGauge.Record(ctx, int64(ps.MemInfo.MemPercent))
 	observability.CpuPercentGauge.Record(ctx, int64(ps.CPUPercent))
+	observability.RSSHistogram.Record(ctx, int64(ps.MemInfo.RSS))
 
 	return ps, nil
 }


### PR DESCRIPTION
Did a histogram, rather than a gauge, because I think histograms would have actually been a better choice than _all_ of the gauges I added. (If we take multiple measurements between metric exports, the gauge meters appear to only report the most recent value, but the histogram will account for all of the data points.)