### PR TITLE
Remove extra logging when we hit db lock issue

### DIFF
--- a/ee/log/osquerylogs/log.go
+++ b/ee/log/osquerylogs/log.go
@@ -32,9 +32,8 @@ func WithLevel(level slog.Level) Option {
 }
 
 var (
-	callerRegexp  = regexp.MustCompile(`[\w.]+:\d+]`)
-	pidRegex      = regexp.MustCompile(`Refusing to kill non-osqueryd process (\d+)`)
-	lockfileRegex = regexp.MustCompile(`lock file: ([a-zA-Z0-9_\.\s\\\/\-:]*LOCK):`)
+	callerRegexp = regexp.MustCompile(`[\w.]+:\d+]`)
+	pidRegex     = regexp.MustCompile(`Refusing to kill non-osqueryd process (\d+)`)
 )
 
 func extractOsqueryCaller(msg string) string {

--- a/ee/log/osquerylogs/log.go
+++ b/ee/log/osquerylogs/log.go
@@ -199,29 +199,3 @@ func getSliceStat(getFunc func() ([]uint32, error)) string {
 	}
 	return fmt.Sprintf("%+v", stat)
 }
-
-func processStr(ctx context.Context, p *process.Process) string {
-	name := "unknown"
-	processOwner := "unknown"
-	runningStatus := "unknown"
-	cmdline := "unknown"
-
-	if gotName, err := p.NameWithContext(ctx); err == nil {
-		name = gotName
-	}
-	if gotUsername, err := p.UsernameWithContext(ctx); err == nil {
-		processOwner = gotUsername
-	}
-	if gotIsRunning, err := p.IsRunningWithContext(ctx); err == nil {
-		if gotIsRunning {
-			runningStatus = "running"
-		} else {
-			runningStatus = "not running"
-		}
-	}
-	if gotCmdline, err := p.CmdlineWithContext(ctx); err == nil {
-		cmdline = gotCmdline
-	}
-
-	return fmt.Sprintf("process with name `%s` and PID %d belonging to user `%s` has current status `%s` (%s)", name, p.Pid, processOwner, runningStatus, cmdline)
-}

--- a/ee/log/osquerylogs/log.go
+++ b/ee/log/osquerylogs/log.go
@@ -7,10 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/shirou/gopsutil/v4/host"
@@ -20,10 +18,9 @@ import (
 // OsqueryLogAdapater creates an io.Writer implementation useful for attaching
 // to the osquery stdout/stderr
 type OsqueryLogAdapter struct {
-	slogger             *slog.Logger
-	level               slog.Level
-	rootDirectory       string
-	lastLockfileLogTime time.Time
+	slogger       *slog.Logger
+	level         slog.Level
+	rootDirectory string
 }
 
 type Option func(*OsqueryLogAdapter)
@@ -77,24 +74,6 @@ func (l *OsqueryLogAdapter) Write(p []byte) (int, error) {
 		gowrapper.Go(context.TODO(), l.slogger, func() {
 			l.logInfoAboutUnrecognizedProcessLockingPidfile(p)
 		})
-	}
-
-	// We have noticed the lock file occasionally locked when it shouldn't be -- we think this can happen
-	// when osquery doesn't get adequate time to shut down gracefully. The held lockfile will prevent
-	// osquery from starting up entirely.
-	// See: https://github.com/kolide/launcher/issues/2004.
-	if bytes.Contains(p, []byte("Rocksdb open failed")) {
-		// We can get spammed with this log, but we don't want to do all the work to look up info about the process
-		// using the lockfile each time we see this log -- make sure we only log once every 10 minutes at most.
-		if time.Since(l.lastLockfileLogTime) > 10*time.Minute {
-			l.lastLockfileLogTime = time.Now()
-			l.slogger.Log(context.TODO(), slog.LevelError,
-				"detected stale lockfile, logging info about file",
-			)
-			gowrapper.Go(context.TODO(), l.slogger, func() {
-				l.logInfoAboutProcessHoldingLockfile(context.TODO(), p)
-			})
-		}
 	}
 
 	msg := strings.TrimSpace(string(p))
@@ -220,60 +199,6 @@ func getSliceStat(getFunc func() ([]uint32, error)) string {
 		return fmt.Sprintf("could not get stat: %v", err)
 	}
 	return fmt.Sprintf("%+v", stat)
-}
-
-// logInfoAboutProcessHoldingLockfile logs information about the osquery database's lock file.
-func (l *OsqueryLogAdapter) logInfoAboutProcessHoldingLockfile(ctx context.Context, p []byte) {
-	executable, err := os.Executable()
-	if err == nil && strings.Contains(executable, "__debug_bin") {
-		return
-	}
-
-	matches := lockfileRegex.FindAllStringSubmatch(string(p), -1)
-	if len(matches) < 1 || len(matches[0]) < 2 {
-		l.slogger.Log(context.TODO(), slog.LevelError,
-			"could not extract lockfile path from log line",
-			"log_line", string(p),
-		)
-
-		return
-	}
-
-	lockFilePath := strings.TrimSpace(matches[0][1]) // We want the group, not the full match
-	if runtime.GOOS == "windows" {
-		// for some reason the last separator in the path that we see from the logs is a forward slash even on windows.
-		// this causes it to fail to match the open files we check later. so if we see that suffix on windows,
-		// just flip that part of the path to correctly match the open file paths we'll check against
-		lockSuffix := "/LOCK"
-		if strings.HasSuffix(lockFilePath, lockSuffix) {
-			lockFilePath = lockFilePath[:len(lockFilePath)-len(lockSuffix)] + "\\LOCK"
-		}
-	}
-
-	infoToLog := []any{
-		"lockfile_path", lockFilePath,
-	}
-
-	defer func() {
-		l.slogger.Log(ctx, slog.LevelInfo,
-			"detected stale osquery db lock file",
-			infoToLog...,
-		)
-	}()
-
-	// Check to see whether the process holding the file still exists
-	processes, err := getProcessesHoldingFile(ctx, lockFilePath)
-	if err != nil {
-		infoToLog = append(infoToLog, "err", err)
-		return
-	}
-
-	// Grab more info to log from the processes using the lockfile
-	processStrs := make([]string, len(processes))
-	for i, p := range processes {
-		processStrs[i] = processStr(ctx, p)
-	}
-	infoToLog = append(infoToLog, "processes", processStrs)
 }
 
 func processStr(ctx context.Context, p *process.Process) string {

--- a/ee/log/osquerylogs/log_windows.go
+++ b/ee/log/osquerylogs/log_windows.go
@@ -3,15 +3,6 @@
 
 package osquerylogs
 
-import (
-	"context"
-	"errors"
-	"fmt"
-	"strings"
-
-	"github.com/shirou/gopsutil/v4/process"
-)
-
 func (l *OsqueryLogAdapter) runAndLogPs(_ string) {
 	return
 }
@@ -22,40 +13,4 @@ func (l *OsqueryLogAdapter) runAndLogLsofByPID(_ string) {
 
 func (l *OsqueryLogAdapter) runAndLogLsofOnPidfile() {
 	return
-}
-
-func getProcessesHoldingFile(ctx context.Context, pathToFile string) ([]*process.Process, error) {
-	allProcesses, err := process.ProcessesWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting process list: %w", err)
-	}
-	if len(allProcesses) == 0 {
-		return nil, errors.New("could not get any processes")
-	}
-
-	processes := make([]*process.Process, 0)
-	for _, p := range allProcesses {
-		openFiles, err := p.OpenFilesWithContext(ctx)
-		if err != nil {
-			continue
-		}
-
-		// Check the process's open files to see if this process is the one using the lockfile
-		for _, f := range openFiles {
-			// We check for strings.Contains rather than equals because the open file's path contains
-			// a `\\?\` prefix.
-			if !strings.Contains(f.Path, pathToFile) {
-				continue
-			}
-
-			processes = append(processes, p)
-			break
-		}
-	}
-
-	if len(processes) == 0 {
-		return nil, fmt.Errorf("no processes found using file %s", pathToFile)
-	}
-
-	return processes, nil
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/2004.

Removing the logging for the following reasons:

1. We now know why we are running into the lockfile issue -- osquery not properly terminating in time -- so we don't actually need the info in this log anymore.
2. I suspect that this extra information gathering is a little onerous on Windows performance-wise.
3. I have seen at least some panics in the logs that trace to this log collection (see example below). My best guess is that the process has gone away while we're performing the logging, and that triggers the panic.

```
runtime error: invalid memory address or nil pointer dereference
github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1
	D:/a/launcher/launcher/ee/gowrapper/goroutine.go:31
runtime.gopanic
	C:/hostedtoolcache/windows/go/1.23.0/x64/src/runtime/panic.go:785
runtime.panicmem
	C:/hostedtoolcache/windows/go/1.23.0/x64/src/runtime/panic.go:262
runtime.sigpanic
	C:/hostedtoolcache/windows/go/1.23.0/x64/src/runtime/signal_windows.go:401
github.com/shirou/gopsutil/v4/process.(*Process).OpenFilesWithContext
	C:/Users/runneradmin/go/pkg/mod/github.com/shirou/gopsutil/v4@v4.24.8/process/process_windows.go:688
github.com/kolide/launcher/ee/log/osquerylogs.getProcessesHoldingFile
	D:/a/launcher/launcher/ee/log/osquerylogs/log_windows.go:38
github.com/kolide/launcher/ee/log/osquerylogs.(*OsqueryLogAdapter).logInfoAboutProcessHoldingLockfile
	D:/a/launcher/launcher/ee/log/osquerylogs/log.go:265
github.com/kolide/launcher/ee/log/osquerylogs.(*OsqueryLogAdapter).Write.func2
	D:/a/launcher/launcher/ee/log/osquerylogs/log.go:95
github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1
	D:/a/launcher/launcher/ee/gowrapper/goroutine.go:39
runtime.goexit
	C:/hostedtoolcache/windows/go/1.23.0/x64/src/runtime/asm_amd64.s:1700
```

We could consider adding a counter metric to this area instead.