### PR TITLE
Fix potential panic during osquery instance shutdown

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -367,7 +367,7 @@ func (i *OsqueryInstance) Launch() error {
 	// Register as many of our shutdown functions ahead of time as we can, so that we can make sure
 	// we fully clean up after any partially-launched erroring instances.
 	i.errgroup.AddShutdownGoroutine(ctx, "kill_osquery_process", func() error {
-		if i.cmd.Process == nil {
+		if i.cmd == nil || i.cmd.Process == nil {
 			return nil
 		}
 


### PR DESCRIPTION
Fixes e.g.

```
runtime error: invalid memory address or nil pointer dereference
github.com/kolide/launcher/pkg/osquery/runtime.(*OsqueryInstance).Launch.(*LoggedErrgroup).AddShutdownGoroutine.func6.1
	/Users/runner/work/launcher/launcher/ee/errgroup/errgroup.go:140
runtime.gopanic
	/Users/runner/hostedtoolcache/go/1.23.0/x64/src/runtime/panic.go:785
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1
	/Users/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.30.0/trace/span.go:398
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End
	/Users/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.30.0/trace/span.go:436
runtime.gopanic
	/Users/runner/hostedtoolcache/go/1.23.0/x64/src/runtime/panic.go:785
runtime.panicmem
	/Users/runner/hostedtoolcache/go/1.23.0/x64/src/runtime/panic.go:262
runtime.sigpanic
	/Users/runner/hostedtoolcache/go/1.23.0/x64/src/runtime/signal_unix.go:900
github.com/kolide/launcher/pkg/osquery/runtime.(*OsqueryInstance).Launch.func1
	/Users/runner/work/launcher/launcher/pkg/osquery/runtime/osqueryinstance.go:370
github.com/kolide/launcher/pkg/osquery/runtime.(*OsqueryInstance).Launch.(*LoggedErrgroup).AddShutdownGoroutine.func6
	/Users/runner/work/launcher/launcher/ee/errgroup/errgroup.go:157
golang.org/x/sync/errgroup.(*Group).Go.func1
	/Users/runner/go/pkg/mod/golang.org/x/sync@v0.11.0/errgroup/errgroup.go:78
runtime.goexit
	/Users/runner/hostedtoolcache/go/1.23.0/x64/src/runtime/asm_arm64.s:1223
```