### PR TITLE
prevent comshim panics

### DIFF
--- a/cmd/launcher/query_windowsupdates_windows.go
+++ b/cmd/launcher/query_windowsupdates_windows.go
@@ -10,11 +10,11 @@ import (
 	"os"
 	"strconv"
 
+	comshim "github.com/NozomiNetworks/go-comshim"
 	"github.com/kolide/launcher/ee/tables/windowsupdatetable"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/windows/windowsupdate"
 	"github.com/peterbourgon/ff/v3"
-	"github.com/scjalliance/comshim"
 )
 
 // runQueryWindowsUpdates is a subcommand allowing us to call the Windows Update Agent
@@ -54,7 +54,10 @@ func runQueryWindowsUpdates(systemMultiSlogger *multislogger.MultiSlogger, args 
 }
 
 func searchLocale(locale string, tableMode int) ([]byte, string, int, error) {
-	comshim.Add(1)
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return nil, "", 0, fmt.Errorf("unable to init comshim: %w", err)
+	}
 	defer comshim.Done()
 
 	searcher, setLocale, isDefaultLocale, err := getSearcher(locale)

--- a/ee/tables/windowsupdatetable/windowsupdate.go
+++ b/ee/tables/windowsupdatetable/windowsupdate.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	comshim "github.com/NozomiNetworks/go-comshim"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/dataflatten"
 	"github.com/kolide/launcher/ee/observability"
@@ -22,7 +23,6 @@ import (
 	"github.com/kolide/launcher/ee/tables/tablewrapper"
 	"github.com/kolide/launcher/pkg/windows/windowsupdate"
 	"github.com/osquery/osquery-go/plugin/table"
-	"github.com/scjalliance/comshim"
 )
 
 // QueryResults is the data returned by execing `launcher.exe query-windowsupdates`.
@@ -212,7 +212,10 @@ func (t *Table) searchLocale(ctx context.Context, locale string, queryContext ta
 	ctx, span := observability.StartSpan(ctx)
 	defer span.End()
 
-	comshim.Add(1)
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return nil, fmt.Errorf("unable to init comshim: %w", err)
+	}
 	defer comshim.Done()
 
 	var results []map[string]string

--- a/ee/watchdog/controller_windows.go
+++ b/ee/watchdog/controller_windows.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/NozomiNetworks/go-comshim"
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
@@ -225,10 +226,11 @@ func installWatchdogTask(identifier, configFilePath string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
-	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
-	defer ole.CoUninitialize()
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return fmt.Errorf("unable to init comshim: %w", err)
+	}
+	defer comshim.Done()
 
 	// create our scheduler object
 	schedService, err := oleutil.CreateObject("Schedule.Service")
@@ -555,10 +557,11 @@ func RemoveWatchdogTask(identifier string) error {
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
-	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
-	defer ole.CoUninitialize()
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return fmt.Errorf("unable to init comshim: %w", err)
+	}
+	defer comshim.Done()
 
 	// create our scheduler object
 	schedService, err := oleutil.CreateObject("Schedule.Service")
@@ -606,10 +609,11 @@ func watchdogTaskExists(identifier string) (bool, error) { // nolint:unused
 	}
 
 	taskName := launcher.TaskName(identifier, watchdogTaskType)
-	// init COM - we discard the error returned by CoInitialize because it
-	// harmlessly returns S_FALSE if we call it more than once
-	ole.CoInitialize(0)
-	defer ole.CoUninitialize()
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return false, fmt.Errorf("unable to init comshim: %w", err)
+	}
+	defer comshim.Done()
 
 	// create our scheduler object
 	schedService, err := oleutil.CreateObject("Schedule.Service")

--- a/ee/wmi/wmi.go
+++ b/ee/wmi/wmi.go
@@ -37,9 +37,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	comshim "github.com/NozomiNetworks/go-comshim"
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
-	"github.com/scjalliance/comshim"
 )
 
 const (
@@ -134,7 +134,10 @@ func Query(ctx context.Context, slogger *slog.Logger, className string, properti
 	queryString := fmt.Sprintf("SELECT * FROM %s%s", className, whereClause)
 
 	// Initialize the COM system.
-	comshim.Add(1)
+	if err := comshim.TryAdd(1); err != nil {
+		comshim.Done() // ensure we decrement the global shim counter that TryAdd increments immediately
+		return nil, fmt.Errorf("unable to init comshim: %w", err)
+	}
 	defer comshim.Done()
 
 	unknown, err := oleutil.CreateObject("WbemScripting.SWbemLocator")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kolide/launcher
 require (
 	github.com/Masterminds/semver v1.4.2
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/NozomiNetworks/go-comshim v0.0.0-20241023091934-f8db5c9d85e0
 	github.com/clbanning/mxj v1.8.4
 	github.com/go-ini/ini v1.61.0
 	github.com/go-kit/kit v0.9.0
@@ -21,7 +22,6 @@ require (
 	github.com/osquery/osquery-go v0.0.0-20250131154556-629f995b6947
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/pkg/errors v0.9.1
-	github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
 	github.com/stretchr/testify v1.10.0
 	github.com/theupdateframework/go-tuf v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Microsoft/go-winio v0.4.9/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/NozomiNetworks/go-comshim v0.0.0-20241023091934-f8db5c9d85e0 h1:WOKXri7votvtRMpp0llnIGdb39eiMsPdT2EJUrT//YY=
+github.com/NozomiNetworks/go-comshim v0.0.0-20241023091934-f8db5c9d85e0/go.mod h1:eGli7SHrXxlN5RGaX3oYaCdB7q3/6+1xLb3EOiPym5c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -227,8 +229,6 @@ github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/samber/slog-multi v1.0.2 h1:6BVH9uHGAsiGkbbtQgAOQJMpKgV8unMrHhhJaw+X1EQ=
 github.com/samber/slog-multi v1.0.2/go.mod h1:uLAvHpGqbYgX4FSL0p1ZwoLuveIAJvBECtE07XmYvFo=
-github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e h1:+/AzLkOdIXEPrAQtwAeWOBnPQ0BnYlBW0aCZmSb47u4=
-github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e/go.mod h1:9Tc1SKnfACJb9N7cw2eyuI6xzy845G7uZONBsi5uPEA=
 github.com/secure-systems-lab/go-securesystemslib v0.5.0 h1:oTiNu0QnulMQgN/hLK124wJD/r2f9ZhIUuKIeBsCBT8=
 github.com/secure-systems-lab/go-securesystemslib v0.5.0/go.mod h1:uoCqUC0Ap7jrBSEanxT+SdACYJTVplRXWLkGMuDjXqk=
 github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 h1:ofR1ZdrNSkiWcMsRrubK9tb2/SlZVWttAfqUjJi6QYc=


### PR DESCRIPTION
- brings in new fork of comshim package which has already addressed the exact use case we were looking at with an additional `comshim.TryAdd` method
- updates existing comshim usages to utilize `TryAdd` with error handling
- updates watchdog controller's direct CoInitialize invocations to use comshim

I looked through the changes between the new and old fork and don't see anything we wouldn't want, this is pretty similar to how I was going to approach this with our own fork (+ some nice unrelated updates and tests)

fixes https://github.com/kolide/launcher/issues/2181