### PR TITLE
add launchd logs to flares

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -87,7 +87,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&Logs{k: k}, doctorSupported | flareSupported},
 		{&InitLogs{}, flareSupported},
 		{&BinaryDirectory{}, doctorSupported | flareSupported},
-		{&launchdCheckup{}, doctorSupported | flareSupported},
+		{&launchdCheckup{k: k}, doctorSupported | flareSupported},
 		{&runtimeCheckup{}, flareSupported},
 		{&enrollSecretCheckup{k: k}, doctorSupported | flareSupported},
 		{&bboltdbCheckup{k: k}, flareSupported},

--- a/ee/debug/checkups/launchd_darwin.go
+++ b/ee/debug/checkups/launchd_darwin.go
@@ -132,6 +132,7 @@ func gatherLaunchdLogs() ([]byte, error) {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			line := scanner.Text()
+			// our logs should all contain something like 'system/com.kolide-k2.launcher'
 			if strings.Contains(line, "kolide") {
 				logBuffer.WriteString(line + "\n")
 			}

--- a/ee/debug/checkups/launchd_other.go
+++ b/ee/debug/checkups/launchd_other.go
@@ -6,9 +6,12 @@ package checkups
 import (
 	"context"
 	"io"
+
+	"github.com/kolide/launcher/ee/agent/types"
 )
 
 type launchdCheckup struct {
+	k types.Knapsack
 }
 
 func (c *launchdCheckup) Name() string {


### PR DESCRIPTION
Adds launchd logs for kolide to our launchd checkup, we've had a few cases recently where this may have been useful.

the launchd.zip will also now contain a launchd-kolide-logs.txt with the following format:
```
2025-05-23 11:22:29.834516 (system/com.kolide-k2.launcher [820]) <Notice>: booting out service: caller = launchctl[93563]<-sudo[93562]<-zsh[23553]<-tmux[23387], value = 0x0
2025-05-23 11:22:29.834646 (system/com.kolide-k2.launcher [820]) <Notice>: signaled service: Terminated: 15
2025-05-23 11:22:29.834648 (system/com.kolide-k2.launcher [820]) <Notice>: service state: SIGTERMed
2025-05-23 11:22:29.834650 (system/com.kolide-k2.launcher [820]) <Notice>: scheduling cleanup in 5 sec after sending Terminated: 15
...
```

resolves https://github.com/kolide/launcher/issues/2114