### PR TITLE
Gather performance stats for launcher child processes

### DIFF
--- a/ee/debug/checkups/performance.go
+++ b/ee/debug/checkups/performance.go
@@ -32,6 +32,12 @@ func (p *perfCheckup) Run(ctx context.Context, _ io.Writer) error {
 		return fmt.Errorf("gathering performance stats: %w", err)
 	}
 
+	childStats, err := performance.CurrentProcessChildStats(ctx)
+	if err != nil {
+		p.status = Erroring
+		return fmt.Errorf("gathering child performance stats: %w", err)
+	}
+
 	memOver := stats.MemInfo.GoMemUsage > golangMemUsageThreshold || stats.MemInfo.NonGoMemUsage > nonGolangMemUsageThreshold
 	cpuOver := stats.CPUPercent > cpuPercentThreshold
 	if cpuOver || memOver {
@@ -49,6 +55,7 @@ func (p *perfCheckup) Run(ctx context.Context, _ io.Writer) error {
 	)
 
 	p.data["stats"] = stats
+	p.data["child_stats"] = childStats
 
 	return nil
 }

--- a/ee/debug/checkups/performance.go
+++ b/ee/debug/checkups/performance.go
@@ -43,7 +43,8 @@ func (p *perfCheckup) Run(ctx context.Context, _ io.Writer) error {
 	// We don't have access to runtime stats for the child processes, so we only check against the launcher process here.
 	launcherMemOver := stats.MemInfo.GoMemUsage > golangMemUsageThreshold || stats.MemInfo.NonGoMemUsage > nonGolangMemUsageThreshold
 
-	// We have access to CPU percent for the children, so sum those up too.
+	// We have access to CPU percent for the children, so sum those up too -- they are not accounted
+	// for in the launcher process `stats.CPUPercent` automatically.
 	totalCpu := stats.CPUPercent
 	for _, c := range childStats {
 		totalCpu += c.CPUPercent

--- a/ee/observability/exporter/exporter.go
+++ b/ee/observability/exporter/exporter.go
@@ -345,7 +345,7 @@ func (t *TelemetryExporter) setNewGlobalMeterProvider(launcherResource *resource
 	// Create new meter provider and let otel set it globally
 	newMeterProvider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(launcherResource),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricsExporter, sdkmetric.WithInterval(10*time.Minute))),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricsExporter, sdkmetric.WithInterval(15*time.Minute))),
 	)
 	otel.SetMeterProvider(newMeterProvider)
 

--- a/ee/observability/meter.go
+++ b/ee/observability/meter.go
@@ -28,6 +28,10 @@ const (
 	checkupScoreGaugeDescription                 = "Computed checkup score"
 	rssHistogramName                             = "launcher.memory.rss"
 	rssHistogramDescription                      = "launcher process RSS bytes"
+	osqueryCpuHistogramName                      = "launcher.osquery.cpu.percent"
+	osqueryCpuHistogramDescription               = "osquery process CPU percent"
+	osqueryRssHistogramName                      = "launcher.osquery.memory.rss"
+	osqueryRssHistogramDescription               = "osquery process RSS bytes"
 	launcherRestartCounterName                   = "launcher.restart"
 	launcherRestartCounterDescription            = "The number of launcher restarts"
 	osqueryRestartCounterName                    = "launcher.osquery.restart"
@@ -51,7 +55,9 @@ var (
 	CheckupScoreGauge     metric.Float64Gauge
 
 	// Histograms
-	RSSHistogram metric.Int64Histogram
+	RSSHistogram               metric.Int64Histogram
+	OsqueryCpuPercentHistogram metric.Float64Histogram
+	OsqueryRssHistogram        metric.Int64Histogram
 
 	// Counters
 	LauncherRestartCounter            metric.Int64Counter
@@ -92,6 +98,12 @@ func ReinitializeMetrics() {
 	// Histograms
 	RSSHistogram = int64HistogramOrNoop(rssHistogramName,
 		metric.WithDescription(rssHistogramDescription),
+		metric.WithUnit(unitByte))
+	OsqueryCpuPercentHistogram = float64HistogramOrNoop(osqueryCpuHistogramName,
+		metric.WithDescription(osqueryCpuHistogramDescription),
+		metric.WithUnit(unitPercent))
+	OsqueryRssHistogram = int64HistogramOrNoop(osqueryRssHistogramName,
+		metric.WithDescription(osqueryRssHistogramDescription),
 		metric.WithUnit(unitByte))
 
 	// Counters
@@ -141,6 +153,16 @@ func int64HistogramOrNoop(name string, options ...metric.Int64HistogramOption) m
 	hist, err := otel.Meter(instrumentationPkg).Int64Histogram(name, options...)
 	if err != nil {
 		return noop.Int64Histogram{}
+	}
+	return hist
+}
+
+// int64HistogramOrNoop is guaranteed to return an Float64Histogram -- if we cannot create
+// a real Float64Histogram, we return a noop version instead.
+func float64HistogramOrNoop(name string, options ...metric.Float64HistogramOption) metric.Float64Histogram {
+	hist, err := otel.Meter(instrumentationPkg).Float64Histogram(name, options...)
+	if err != nil {
+		return noop.Float64Histogram{}
 	}
 	return hist
 }

--- a/ee/observability/meter_test.go
+++ b/ee/observability/meter_test.go
@@ -166,6 +166,34 @@ func Test_int64HistogramOrNoop(t *testing.T) { //nolint:paralleltest
 	require.Greater(t, len(meterOutBytes.String()), 0)
 }
 
+// Test_float64HistogramOrNoop does not run in parallel to avoid setting a global meter provider
+// too early during the test run.
+func Test_float64HistogramOrNoop(t *testing.T) { //nolint:paralleltest
+	// Before we set up the meter provider, we should still get a usable int64 gauge
+	testHist := float64HistogramOrNoop("launcher.test.histogram", metric.WithUnit(unitByte))
+	require.NotNil(t, testHist)
+	testHist.Record(context.TODO(), 5)
+
+	// Set up a meter provider that writes to a buffer every 100 milliseconds
+	writeInterval := 100 * time.Millisecond
+	meterOutBytes := &threadsafebuffer.ThreadSafeBuffer{}
+	testExporter, err := stdoutmetric.New(stdoutmetric.WithWriter(meterOutBytes))
+	require.NoError(t, err)
+	testProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(testExporter, sdkmetric.WithInterval(writeInterval))))
+	otel.SetMeterProvider(testProvider)
+
+	// We should still be able to use our test gauge -- write data and wait
+	// for it to be written to our exporter.
+	for i := 0; i < 3; i++ {
+		time.Sleep(writeInterval)
+		testHist.Record(context.TODO(), float64(i))
+	}
+	time.Sleep(writeInterval)
+
+	// Confirm we exported data
+	require.Greater(t, len(meterOutBytes.String()), 0)
+}
+
 // Test_int64CounterOrNoop does not run in parallel to avoid setting a global meter provider
 // too early during the test run.
 func Test_int64CounterOrNoop(t *testing.T) { //nolint:paralleltest

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/kolide/launcher/ee/observability"
 	"github.com/shirou/gopsutil/v4/process"
@@ -102,6 +103,11 @@ func ChildProcessStatsForPid(ctx context.Context, pid int32) ([]*PerformanceStat
 			continue
 		}
 		stats = append(stats, ps)
+
+		if strings.Contains(ps.Cmdline, "osquery") {
+			observability.OsqueryRssHistogram.Record(ctx, int64(ps.MemInfo.RSS))
+			observability.OsqueryCpuPercentHistogram.Record(ctx, ps.CPUPercent)
+		}
 
 		// We want to grab one more level of child processes, to account for the desktop process
 		// being invoked with sudo first on posix.

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -48,7 +48,9 @@ type PerformanceStats struct {
 }
 
 // CurrentProcessStats gets memory and CPU stats for the current process;
-// it has the side effect of recording those metrics.
+// it has the side effect of recording those metrics. (Pretty much any time we
+// do the work of collecting these stats, we want to emit measurements to our
+// metrics instruments.)
 func CurrentProcessStats(ctx context.Context) (*PerformanceStats, error) {
 	pid := os.Getpid()
 	return ProcessStatsForPid(ctx, pid)
@@ -83,7 +85,9 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 }
 
 // CurrentProcessChildStats gets memory and CPU stats for the current process's child processes;
-// it has the side effect of recording those metrics.
+// it has the side effect of recording those metrics. (Pretty much any time we
+// do the work of collecting these stats, we want to emit measurements to our
+// metrics instruments.)
 func CurrentProcessChildStats(ctx context.Context) ([]*PerformanceStats, error) {
 	pid := os.Getpid()
 	return ChildProcessStatsForPid(ctx, int32(pid))

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -41,6 +41,7 @@ type MemInfo struct {
 type PerformanceStats struct {
 	Pid        int      `json:"pid"`
 	Exe        string   `json:"exe"`
+	Cmdline    string   `json:"cmdline"`
 	MemInfo    *MemInfo `json:"mem_info"`
 	CPUPercent float64  `json:"cpu_percent"`
 }
@@ -56,40 +57,15 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 		return nil, fmt.Errorf("getting process handle for pid %d: %w", pid, err)
 	}
 
-	ps := &PerformanceStats{
-		Pid:     pid,
-		MemInfo: &MemInfo{},
-	}
-
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	if exe, err := proc.ExeWithContext(ctx); err != nil {
-		return nil, fmt.Errorf("gathering exe: %w", err)
-	} else {
-		ps.Exe = exe
+	ps, memInfo, err := statsForProcess(ctx, proc)
+	if err != nil {
+		return nil, fmt.Errorf("gathering stats for process: %w", err)
 	}
 
-	if memInfo, err := proc.MemoryInfoWithContext(ctx); err != nil {
-		return nil, fmt.Errorf("gathering mem info: %w", err)
-	} else {
-		ps.MemInfo.RSS = memInfo.RSS
-		ps.MemInfo.VMS = memInfo.VMS
-		ps.MemInfo.NonGoMemUsage = nonGoMemUsage(memInfo, &memStats)
-	}
-
-	if memPercent, err := proc.MemoryPercentWithContext(ctx); err != nil {
-		return nil, fmt.Errorf("gathering mem percent: %w", err)
-	} else {
-		ps.MemInfo.MemPercent = memPercent
-	}
-
-	if cpuPercent, err := proc.CPUPercentWithContext(ctx); err != nil {
-		return nil, fmt.Errorf("gathering cpu percent: %w", err)
-	} else {
-		ps.CPUPercent = cpuPercent
-	}
-
+	ps.MemInfo.NonGoMemUsage = nonGoMemUsage(memInfo, &memStats)
 	ps.MemInfo.GoMemUsage = goMemUsage(&memStats)
 	ps.MemInfo.HeapTotal = heapTotal(&memStats)
 
@@ -101,6 +77,88 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 	observability.RSSHistogram.Record(ctx, int64(ps.MemInfo.RSS))
 
 	return ps, nil
+}
+
+func CurrentProcessChildStats(ctx context.Context) ([]*PerformanceStats, error) {
+	pid := os.Getpid()
+	return ChildProcessStatsForPid(ctx, int32(pid))
+}
+
+func ChildProcessStatsForPid(ctx context.Context, pid int32) ([]*PerformanceStats, error) {
+	proc, err := process.NewProcessWithContext(ctx, pid)
+	if err != nil {
+		return nil, fmt.Errorf("getting process handle for pid %d: %w", pid, err)
+	}
+
+	childProcesses, err := proc.ChildrenWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting child processes for pid %d: %w", pid, err)
+	}
+
+	stats := make([]*PerformanceStats, 0)
+	for _, childProcess := range childProcesses {
+		ps, _, err := statsForProcess(ctx, childProcess)
+		if err != nil {
+			continue
+		}
+		stats = append(stats, ps)
+
+		// We want to grab one more level of child processes, to account for the desktop process
+		// being invoked with sudo first on posix.
+		grandchildProcesses, err := childProcess.ChildrenWithContext(ctx)
+		if err != nil {
+			continue
+		}
+		for _, grandchildProcess := range grandchildProcesses {
+			ps, _, err := statsForProcess(ctx, grandchildProcess)
+			if err != nil {
+				continue
+			}
+			stats = append(stats, ps)
+		}
+	}
+
+	return stats, nil
+}
+
+func statsForProcess(ctx context.Context, proc *process.Process) (*PerformanceStats, *process.MemoryInfoStat, error) {
+	ps := &PerformanceStats{
+		Pid:     int(proc.Pid),
+		MemInfo: &MemInfo{},
+	}
+
+	if exe, err := proc.ExeWithContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("gathering exe: %w", err)
+	} else {
+		ps.Exe = exe
+	}
+
+	if cmdline, err := proc.CmdlineWithContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("gathering cmdline: %w", err)
+	} else {
+		ps.Cmdline = cmdline
+	}
+
+	memInfo, err := proc.MemoryInfoWithContext(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gathering mem info: %w", err)
+	}
+	ps.MemInfo.RSS = memInfo.RSS
+	ps.MemInfo.VMS = memInfo.VMS
+
+	if memPercent, err := proc.MemoryPercentWithContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("gathering mem percent: %w", err)
+	} else {
+		ps.MemInfo.MemPercent = memPercent
+	}
+
+	if cpuPercent, err := proc.CPUPercentWithContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("gathering cpu percent: %w", err)
+	} else {
+		ps.CPUPercent = cpuPercent
+	}
+
+	return ps, memInfo, nil
 }
 
 func heapTotal(ms *runtime.MemStats) uint64 {

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -47,6 +47,8 @@ type PerformanceStats struct {
 	CPUPercent float64  `json:"cpu_percent"`
 }
 
+// CurrentProcessStats gets memory and CPU stats for the current process;
+// it has the side effect of recording those metrics.
 func CurrentProcessStats(ctx context.Context) (*PerformanceStats, error) {
 	pid := os.Getpid()
 	return ProcessStatsForPid(ctx, pid)
@@ -80,6 +82,8 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 	return ps, nil
 }
 
+// CurrentProcessChildStats gets memory and CPU stats for the current process's child processes;
+// it has the side effect of recording those metrics.
 func CurrentProcessChildStats(ctx context.Context) ([]*PerformanceStats, error) {
 	pid := os.Getpid()
 	return ChildProcessStatsForPid(ctx, int32(pid))


### PR DESCRIPTION
* Gather and log performance stats for osquery; additionally, report these metrics via our metrics exporter
* Gather and log performance stats for launcher desktop -- not doing metrics yet
* Increase metrics exporting interval to 15m

Keeping this in the performance, rather than process, checkup, so that we can ultimately remove the process checkup from the log checkpointer, since the process checkpoint is more performance-intensive to run.