### PR TITLE
remove processes checkup from log checkpoints

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -81,7 +81,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&Platform{}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&hostInfoCheckup{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&Version{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
-		{&Processes{}, doctorSupported | flareSupported | logSupported}, // Not startupLogSupported because processes may not have started up yet
+		{&Processes{}, doctorSupported | flareSupported},
 		{&RootDirectory{k: k}, doctorSupported | flareSupported},
 		{&Connectivity{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&Logs{k: k}, doctorSupported | flareSupported},


### PR DESCRIPTION
We now check the count of child processes within our performance checkup when generating the checkup scores. We wouldn't want to count this twice in score generation, and since the processes check can be expensive we should remove this from hourly checks