### PR TITLE
Link traces and metrics, where possible

### DIFF
--- a/ee/debug/checkups/checkpoint.go
+++ b/ee/debug/checkups/checkpoint.go
@@ -93,6 +93,9 @@ func (c *logCheckPointer) LogCheckupsOnStartup(ctx context.Context) {
 // based on those statuses; it logs the score and reports it as a metric. Once allows us to see a snapshot
 // of launcher health.
 func (c *logCheckPointer) Once(ctx context.Context) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	checkups := checkupsFor(c.knapsack, logSupported)
 
 	warningCheckups := make([]string, 0)

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -52,11 +52,17 @@ type PerformanceStats struct {
 // do the work of collecting these stats, we want to emit measurements to our
 // metrics instruments.)
 func CurrentProcessStats(ctx context.Context) (*PerformanceStats, error) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	pid := os.Getpid()
 	return ProcessStatsForPid(ctx, pid)
 }
 
 func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	proc, err := process.NewProcessWithContext(ctx, int32(pid))
 	if err != nil {
 		return nil, fmt.Errorf("getting process handle for pid %d: %w", pid, err)
@@ -89,11 +95,17 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 // do the work of collecting these stats, we want to emit measurements to our
 // metrics instruments.)
 func CurrentProcessChildStats(ctx context.Context) ([]*PerformanceStats, error) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	pid := os.Getpid()
 	return ChildProcessStatsForPid(ctx, int32(pid))
 }
 
 func ChildProcessStatsForPid(ctx context.Context, pid int32) ([]*PerformanceStats, error) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	proc, err := process.NewProcessWithContext(ctx, pid)
 	if err != nil {
 		return nil, fmt.Errorf("getting process handle for pid %d: %w", pid, err)
@@ -140,6 +152,9 @@ func ChildProcessStatsForPid(ctx context.Context, pid int32) ([]*PerformanceStat
 }
 
 func statsForProcess(ctx context.Context, proc *process.Process) (*PerformanceStats, *process.MemoryInfoStat, error) {
+	ctx, span := observability.StartSpan(ctx)
+	defer span.End()
+
 	ps := &PerformanceStats{
 		Pid:     int(proc.Pid),
 		MemInfo: &MemInfo{},


### PR DESCRIPTION
We can link traces and metrics through the use of [exemplars](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars).

In practice, this just means starting a span, then using the returned ctx when recording a metric.

For our particular frontend that we use for viewing metrics, the link only shows up for histogram-type metrics, so those are the ones that I've updated with span ctxs in this PR.