### PR TITLE
Run system time checkup in log checkpointer

### DIFF
--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -99,7 +99,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&launcherFlags{k: k}, doctorSupported | flareSupported},
 		{&gnomeExtensions{}, doctorSupported | flareSupported},
 		{&quarantine{}, doctorSupported | flareSupported},
-		{&systemTime{}, doctorSupported | flareSupported},
+		{&systemTime{}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&dnsCheckup{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
 		{&tufCheckup{k: k}, doctorSupported | flareSupported},
 		{&osqConfigConflictCheckup{}, doctorSupported | flareSupported},


### PR DESCRIPTION
When a device's system clock is off, it's not apparent until we get a localserver request and write a `timestamp is out of range` log. It would be helpful to know sooner when looking at a device's log if its system clock is off.