### PR TITLE
Reset RecoveryActions during uninstall to ensure manual start will be respected

### DIFF
--- a/ee/uninstall/uninstall_windows.go
+++ b/ee/uninstall/uninstall_windows.go
@@ -3,6 +3,7 @@ package uninstall
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/watchdog"
@@ -32,6 +33,17 @@ func disableAutoStart(ctx context.Context, k types.Knapsack) error {
 	cfg.StartType = mgr.StartManual
 	if err := launcherSvc.UpdateConfig(cfg); err != nil {
 		return fmt.Errorf("updating launcher service config: %w", err)
+	}
+
+	// Recovery actions happen even when we have StartManual set, so we need to clear
+	// those as well and replace with a NoAction action.
+	if err := launcherSvc.SetRecoveryActions([]mgr.RecoveryAction{
+		{
+			Type:  mgr.NoAction,
+			Delay: 5 * time.Second,
+		},
+	}, 24*60*60); err != nil {
+		return fmt.Errorf("resetting recovery actions: %w", err)
 	}
 
 	// attempt to remove watchdog service in case it is installed to prevent startups later on


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2190.

I tested and our original data race theory didn't bear out -- I updated the uninstall function to confirm that the launcher service's start type was set to manual start, and even with backoff and a fresh service handle, the behavior didn't change. I looked in the event logs, and those confirmed that the service's start type was set to demand start (manual) before the service shut down. I also saw in the event logs immediately afterwards that the service manager noted that the launcher svc had terminated unexpectedly _and that it would restart in 5 seconds_.

Updating the uninstall function to also remove our recovery actions fixed the issue. Now, launcher remains stopped after remote uninstall.