### PR TITLE
Require machine GUID change when detecting hardware change on Windows

### DIFF
--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -165,6 +165,20 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 			expectDatabaseWipe:     true,
 		},
 		{
+			name:                   "hardware and serial changed, database wipe on non-Windows only",
+			serialSetInStore:       true,
+			serialChanged:          true,
+			hardwareUUIDSetInStore: true,
+			hardwareUUIDChanged:    true,
+			machineGUIDSetInStore:  true,
+			machineGUIDChanged:     false,
+			osquerySuccess:         true,
+			munemoSetInStore:       true,
+			munemoChanged:          true,
+			registrationsExist:     true,
+			expectDatabaseWipe:     runtime.GOOS != "windows",
+		},
+		{
 			name:                   "osquery failed and secret unchanged, no database wipe",
 			serialSetInStore:       true,
 			serialChanged:          false,
@@ -277,7 +291,7 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 			expectDatabaseWipe:     false,
 		},
 		{
-			name:                   "machine GUID previously stored, then changed, expect database wipe",
+			name:                   "machine GUID previously stored, then changed, expect database wipe on Windows only",
 			serialSetInStore:       true,
 			serialChanged:          false,
 			hardwareUUIDSetInStore: true,
@@ -288,7 +302,7 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 			munemoSetInStore:       true,
 			munemoChanged:          false,
 			registrationsExist:     true,
-			expectDatabaseWipe:     true,
+			expectDatabaseWipe:     runtime.GOOS == "windows",
 		},
 	}
 


### PR DESCRIPTION
We found that on Windows, both hardware UUID _and_ the serial can have flaky values -- we knew that the hardware UUID could change frequently without indicating a hardware change, but we also found recently that the serial can also change without indicating a hardware change. Therefore, when performing hardware change detection on Windows, we now _require_ that the machine GUID changed.

Added/updated tests accordingly.