### PR TITLE
Remove windows-2019 in preparation for deprecation; add windows-2025

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -255,8 +255,8 @@ jobs:
           - macos-13
           - macos-14
           - macos-15
-          - windows-2019
           - windows-2022
+          - windows-2025
     needs:
       - version_baseline # version_baseline implies build_linux
       - build # need the other builds too


### PR DESCRIPTION
windows-2019 will be EOL'ed at the end of this month: https://github.com/actions/runner-images/issues/12045

Accordingly, removing windows-2019 and adding windows-2025 for our exec test job.