### PR TITLE
Fix control service Fetch deadlock (hopefully)

### DIFF
--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -135,6 +135,10 @@ func (fc *FlagController) notifyObservers(ctx context.Context, flagKeys ...keys.
 	ctx, span := observability.StartSpan(ctx)
 	defer span.End()
 
+	// If we hold `fc.observersMutex` for the duration of this function, we can have a deadlock
+	// if any `observer.FlagsChanged` function results in calling `fc.RegisterChangeObserver`,
+	// which uses the same `fc.observersMutex`. Therefore, we create a copy of the current
+	// observers map here and release `fc.observersMutex` preemptively.
 	fc.observersMutex.RLock()
 	span.AddEvent("observers_lock_acquired")
 	currentObservers := make(map[types.FlagsChangeObserver][]keys.FlagKey)


### PR DESCRIPTION
VERY MUCH HOPING THAT THIS closes https://github.com/kolide/launcher/issues/2224.

The explanation I have for the deadlock:

1. A control request interval override is set
2. At the configured time later, the control request interval override expires; the FlagController calls notifyObservers
3. notifyObservers holds **observersMutex**
4. Since the control request interval has changed, notifyObservers calls ControlService.FlagsChanged
5. ControlService.FlagsChanged calls ControlService.requestIntervalChanged, which calls ControlService.Fetch
6. ControlService.Fetch holds **fetchMutex**
7. ControlService.Fetch receives updated for the KATC subsystem
8. ControlService.Fetch calls subscribers.Ping, which for the KATC subsystem is the osquery runner
9. The KATC config must be rebuilt, which means initializing new tablewrapper tables
10. When creating a tablewrapper table, the constructor calls FlagController.RegisterChangeObserver so the table can respond to changes in TableGenerateTimeout; this call can never finish because FlagController.RegisterChangeObserver cannot acquire **observersMutex**
11. Creating the table never completes, so Fetch never completes

The deadlock is between 3 and 10, and the fetch mutex is held indefinitely by 6 and 11.