### PR TITLE
Close files after opening

### DIFF
--- a/ee/dataflatten/xml.go
+++ b/ee/dataflatten/xml.go
@@ -12,6 +12,7 @@ func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rdr.Close()
 
 	mv, err := mxj.NewMapXmlReader(rdr)
 	if err != nil {

--- a/ee/debug/checkups/desktop_menu.go
+++ b/ee/debug/checkups/desktop_menu.go
@@ -37,6 +37,7 @@ func (d *desktopMenu) Run(_ context.Context, fullFH io.Writer) error {
 		d.summary = fmt.Sprintf("failed to open %s: %s", menuJsonPath, err)
 		return nil
 	}
+	defer file.Close()
 
 	menuJson, err := io.ReadAll(file)
 	if err != nil {

--- a/ee/debug/checkups/launcher_flags.go
+++ b/ee/debug/checkups/launcher_flags.go
@@ -41,6 +41,7 @@ func (lf *launcherFlags) Run(_ context.Context, extraFh io.Writer) error {
 		lf.summary = fmt.Sprintf("failed to open %s: %s", configFilePath, err)
 		return nil
 	}
+	defer file.Close()
 
 	fmt.Fprint(extraFh, "\nlauncher.flags contents:\n\n")
 

--- a/ee/tables/gsettings/gsettings_test.go
+++ b/ee/tables/gsettings/gsettings_test.go
@@ -53,6 +53,7 @@ func TestGsettingsValues(t *testing.T) {
 			getBytes: func(ctx context.Context, slogger *slog.Logger, username string, buf *bytes.Buffer) error {
 				f, err := os.Open(filepath.Join("testdata", tt.filename))
 				require.NoError(t, err, "opening file %s", tt.filename)
+				defer f.Close()
 				_, err = buf.ReadFrom(f)
 				require.NoError(t, err, "read file %s", tt.filename)
 
@@ -176,6 +177,7 @@ func TestListKeys(t *testing.T) {
 			cmdRunner: func(ctx context.Context, args []string, tmpdir string, buf *bytes.Buffer) error {
 				f, err := os.Open(filepath.Join("testdata", tt.filename))
 				require.NoError(t, err, "opening file %s", tt.filename)
+				defer f.Close()
 				_, err = buf.ReadFrom(f)
 				require.NoError(t, err, "read file %s", tt.filename)
 

--- a/ee/tables/xfconf/parser.go
+++ b/ee/tables/xfconf/parser.go
@@ -45,6 +45,7 @@ func readChannelXml(file string) (ChannelXML, error) {
 	if err != nil {
 		return ChannelXML{}, err
 	}
+	defer rdr.Close()
 
 	xmlDecoder := xml.NewDecoder(rdr)
 

--- a/ee/tables/xrdb/xrdb_test.go
+++ b/ee/tables/xrdb/xrdb_test.go
@@ -90,6 +90,7 @@ func TestXrdbParse(t *testing.T) {
 			getBytes: func(ctx context.Context, display, username string, buf *bytes.Buffer) error {
 				f, err := os.Open(filepath.Join("testdata", tt.filename))
 				require.NoError(t, err, "opening file %s", tt.filename)
+				defer f.Close()
 				_, err = buf.ReadFrom(f)
 				require.NoError(t, err, "read file %s", tt.filename)
 

--- a/pkg/osquery/table/program_icons_windows.go
+++ b/pkg/osquery/table/program_icons_windows.go
@@ -181,20 +181,20 @@ func parseIcoFile(ctx context.Context, fullPath string) (icon, error) {
 	var programIcon icon
 	expandedPath, err := registry.ExpandString(fullPath)
 	if err != nil {
-		return programIcon, err
+		return programIcon, fmt.Errorf("expanding path: %w", err)
 	}
 	icoReader, err := os.Open(expandedPath)
 	if err != nil {
-		return programIcon, err
+		return programIcon, fmt.Errorf("opening path: %w", err)
 	}
 	img, err := ico.Decode(icoReader)
 	if err != nil {
-		return programIcon, err
+		return programIcon, fmt.Errorf("decoding image: %w", err)
 	}
 	buf := new(bytes.Buffer)
 	img = resize.Resize(128, 128, img, resize.Bilinear)
 	if err := png.Encode(buf, img); err != nil {
-		return programIcon, err
+		return programIcon, fmt.Errorf("encoding image: %w", err)
 	}
 
 	checksum := crc64.Checksum(buf.Bytes(), crcTable)

--- a/pkg/osquery/table/program_icons_windows.go
+++ b/pkg/osquery/table/program_icons_windows.go
@@ -187,6 +187,7 @@ func parseIcoFile(ctx context.Context, fullPath string) (icon, error) {
 	if err != nil {
 		return programIcon, fmt.Errorf("opening path: %w", err)
 	}
+	defer icoReader.Close()
 	img, err := ico.Decode(icoReader)
 	if err != nil {
 		return programIcon, fmt.Errorf("decoding image: %w", err)


### PR DESCRIPTION
While investigating https://github.com/kolide/launcher/issues/2271, I noticed we have a handful of places where we're opening a file but not closing it afterward. This PR updates those locations to close the file when we're done with it.

I took a brief look for golangci-linters or revive rules that could have caught this issue, but did not find any.

I also added more verbose error messages to the kolide_program_icons `parseIcoFile`, which will not help with the panic but seemed useful.