### PR TITLE
Add additional attributes to traces and metrics

### DIFF
--- a/ee/observability/exporter/exporter.go
+++ b/ee/observability/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"log/slog"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -131,7 +132,7 @@ func (t *TelemetryExporter) addDeviceIdentifyingAttributes() {
 
 	if deviceId, err := t.knapsack.ServerProvidedDataStore().Get([]byte("device_id")); err != nil {
 		t.slogger.Log(context.TODO(), slog.LevelWarn,
-			"could not get device id",
+			"could not get device id for attributes",
 			"err", err,
 		)
 	} else {
@@ -141,7 +142,7 @@ func (t *TelemetryExporter) addDeviceIdentifyingAttributes() {
 
 	if munemo, err := t.knapsack.ServerProvidedDataStore().Get([]byte("munemo")); err != nil {
 		t.slogger.Log(context.TODO(), slog.LevelWarn,
-			"could not get munemo",
+			"could not get munemo for attributes",
 			"err", err,
 		)
 	} else {
@@ -150,7 +151,7 @@ func (t *TelemetryExporter) addDeviceIdentifyingAttributes() {
 
 	if orgId, err := t.knapsack.ServerProvidedDataStore().Get([]byte("organization_id")); err != nil {
 		t.slogger.Log(context.TODO(), slog.LevelWarn,
-			"could not get organization id",
+			"could not get organization id for attributes",
 			"err", err,
 		)
 	} else {
@@ -159,11 +160,25 @@ func (t *TelemetryExporter) addDeviceIdentifyingAttributes() {
 
 	if serialNumber, err := t.knapsack.ServerProvidedDataStore().Get([]byte("serial_number")); err != nil {
 		t.slogger.Log(context.TODO(), slog.LevelWarn,
-			"could not get serial number",
+			"could not get serial number for attributes",
 			"err", err,
 		)
 	} else {
 		t.attrs = append(t.attrs, attribute.String("launcher.serial", string(serialNumber)))
+	}
+
+	t.attrs = append(t.attrs, attribute.String("launcher.update_channel", t.knapsack.UpdateChannel()))
+
+	// Add some attributes about the currently-running process, too
+	t.attrs = append(t.attrs, attribute.String("launcher.run_id", t.knapsack.GetRunID()))
+	t.attrs = append(t.attrs, semconv.ProcessPID(os.Getpid()))
+	if execPath, err := os.Executable(); err != nil {
+		t.slogger.Log(context.TODO(), slog.LevelWarn,
+			"could not get executable path for attributes",
+			"err", err,
+		)
+	} else {
+		t.attrs = append(t.attrs, semconv.ProcessExecutablePath(execPath))
 	}
 }
 

--- a/ee/observability/exporter/exporter_test.go
+++ b/ee/observability/exporter/exporter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/kit/version"
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/storage"
@@ -47,6 +48,8 @@ func TestNewTelemetryExporter(t *testing.T) { //nolint:paralleltest
 	mockKnapsack.On("TraceBatchTimeout").Return(1 * time.Minute)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+	mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+	mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 	mockKnapsack.On("GetEnrollmentDetails").Return(types.EnrollmentDetails{
 		OsqueryVersion: "5.8.0",
 		OSName:         runtime.GOOS,
@@ -63,7 +66,7 @@ func TestNewTelemetryExporter(t *testing.T) { //nolint:paralleltest
 	// We expect a total of 13 attributes: 4 initial attributes, 5 from the ServerProvidedDataStore, and 4 from osquery
 	telemetryExporter.attrLock.RLock()
 	defer telemetryExporter.attrLock.RUnlock()
-	require.Equal(t, 13, len(telemetryExporter.attrs))
+	require.Equal(t, 17, len(telemetryExporter.attrs))
 
 	// Confirm we set a provider
 	telemetryExporter.providerLock.Lock()
@@ -86,6 +89,8 @@ func TestNewTelemetryExporter_exportNotEnabled(t *testing.T) {
 	mockKnapsack.On("TraceSamplingRate").Return(0.0)
 	mockKnapsack.On("TraceBatchTimeout").Return(1 * time.Minute)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
+	mockKnapsack.On("UpdateChannel").Return("alpha").Maybe()
+	mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 
 	telemetryExporter, err := NewTelemetryExporter(context.Background(), mockKnapsack, nil)
@@ -126,6 +131,8 @@ func TestInterrupt_Multiple(t *testing.T) { //nolint:paralleltest
 	mockKnapsack.On("TraceSamplingRate").Return(0.0)
 	mockKnapsack.On("TraceBatchTimeout").Return(1 * time.Minute)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.ExportTraces, keys.TraceSamplingRate, keys.TraceIngestServerURL, keys.DisableTraceIngestTLS, keys.TraceBatchTimeout).Return(nil)
+	mockKnapsack.On("UpdateChannel").Return("beta").Maybe()
+	mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -190,6 +197,12 @@ func Test_addDeviceIdentifyingAttributes(t *testing.T) {
 	expectedSerialNumber := "abcd"
 	s.Set([]byte("serial_number"), []byte(expectedSerialNumber))
 
+	expectedUpdateChannel := "stable"
+	mockKnapsack.On("UpdateChannel").Return(expectedUpdateChannel)
+
+	expectedRunId := ulid.New()
+	mockKnapsack.On("GetRunID").Return(expectedRunId)
+
 	traceExporter := &TelemetryExporter{
 		knapsack:                  mockKnapsack,
 		slogger:                   multislogger.NewNopLogger(),
@@ -206,7 +219,7 @@ func Test_addDeviceIdentifyingAttributes(t *testing.T) {
 	traceExporter.addDeviceIdentifyingAttributes()
 
 	// Confirm all expected attributes were added
-	require.Equal(t, 5, len(traceExporter.attrs))
+	require.Equal(t, 9, len(traceExporter.attrs))
 	for _, actualAttr := range traceExporter.attrs {
 		switch actualAttr.Key {
 		case "service.instance.id", "k2.device_id":
@@ -217,6 +230,12 @@ func Test_addDeviceIdentifyingAttributes(t *testing.T) {
 			require.Equal(t, expectedOrganizationId, actualAttr.Value.AsString())
 		case "launcher.serial":
 			require.Equal(t, expectedSerialNumber, actualAttr.Value.AsString())
+		case "launcher.update_channel":
+			require.Equal(t, expectedUpdateChannel, actualAttr.Value.AsString())
+		case "launcher.run_id":
+			require.Equal(t, expectedRunId, actualAttr.Value.AsString())
+		case "process.pid", "process.executable.path":
+			// Not going to validate attr values, but we do expect to have them
 		default:
 			t.Fatalf("unexpected attr %s", actualAttr.Key)
 		}
@@ -285,6 +304,8 @@ func TestPing(t *testing.T) {
 	s := testTokenStore(t)
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("TokenStore").Return(s)
+	mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+	mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 	traceExporter := &TelemetryExporter{
 		knapsack:                  mockKnapsack,
@@ -355,6 +376,8 @@ func TestFlagsChanged_ExportTraces(t *testing.T) { //nolint:paralleltest
 			s := testServerProvidedDataStore(t)
 			mockKnapsack := typesmocks.NewKnapsack(t)
 			mockKnapsack.On("ExportTraces").Return(tt.newEnableValue)
+			mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+			mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 			if tt.shouldReplaceProvider {
 				mockKnapsack.On("TraceIngestServerURL").Return("https://example.com")
@@ -437,6 +460,8 @@ func TestFlagsChanged_TraceSamplingRate(t *testing.T) { //nolint:paralleltest
 		t.Run(tt.testName, func(t *testing.T) {
 			mockKnapsack := typesmocks.NewKnapsack(t)
 			mockKnapsack.On("TraceSamplingRate").Return(tt.newTraceSamplingRate)
+			mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+			mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 			if tt.shouldReplaceProvider {
 				mockKnapsack.On("TraceIngestServerURL").Return("https://example.com")
@@ -511,6 +536,8 @@ func TestFlagsChanged_TraceIngestServerURL(t *testing.T) { //nolint:paralleltest
 		t.Run(tt.testName, func(t *testing.T) {
 			mockKnapsack := typesmocks.NewKnapsack(t)
 			mockKnapsack.On("TraceIngestServerURL").Return(tt.newObservabilityIngestServerURL)
+			mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+			mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			traceExporter := &TelemetryExporter{
@@ -580,6 +607,8 @@ func TestFlagsChanged_DisableTraceIngestTLS(t *testing.T) { //nolint:paralleltes
 		t.Run(tt.testName, func(t *testing.T) {
 			mockKnapsack := typesmocks.NewKnapsack(t)
 			mockKnapsack.On("DisableTraceIngestTLS").Return(tt.newDisableTraceIngestTLS)
+			mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+			mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 			if tt.shouldReplaceProvider {
 				mockKnapsack.On("TraceIngestServerURL").Return("https://example.com")
@@ -656,6 +685,8 @@ func TestFlagsChanged_TraceBatchTimeout(t *testing.T) { //nolint:paralleltest
 		t.Run(tt.testName, func(t *testing.T) {
 			mockKnapsack := typesmocks.NewKnapsack(t)
 			mockKnapsack.On("TraceBatchTimeout").Return(tt.newBatchTimeout)
+			mockKnapsack.On("UpdateChannel").Return("nightly").Maybe()
+			mockKnapsack.On("GetRunID").Return(ulid.New()).Maybe()
 
 			if tt.shouldReplaceProvider {
 				mockKnapsack.On("TraceIngestServerURL").Return("https://example.com")


### PR DESCRIPTION
I thought it would be useful to be able to filter traces and metrics to exclude nightly/etc data more easily than doing regexes on the launcher version.

I also noticed that there were some process-related attrs we weren't setting but could, so I added those, plus the run ID as well.