### PR TITLE
Report all error-level logs to Error Reporting

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -263,7 +263,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 		telemetryExporter, err = exporter.NewTelemetryExporter(ctx, k, initialTraceBuffer)
 		if err != nil {
-			slogger.Log(ctx, multislogger.LevelReportedError,
+			slogger.Log(ctx, slog.LevelError,
 				"could not set up telemetry exporter",
 				"err", err,
 			)
@@ -349,7 +349,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	powerEventSubscriber := powereventwatcher.NewKnapsackSleepStateUpdater(slogger, k)
 	powerEventWatcher, err := powereventwatcher.New(ctx, slogger, powerEventSubscriber)
 	if err != nil {
-		slogger.Log(ctx, multislogger.LevelReportedError,
+		slogger.Log(ctx, slog.LevelError,
 			"could not init power event watcher",
 			"err", err,
 		)
@@ -496,7 +496,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		}
 
 		if metadataWriter := internal.NewMetadataWriter(slogger, k); metadataWriter == nil {
-			slogger.Log(ctx, multislogger.LevelReportedError,
+			slogger.Log(ctx, slog.LevelError,
 				"unable to set up metadata writer",
 				"err", err,
 			)
@@ -533,7 +533,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 		if err != nil {
 			// For now, log this and move on. It might be a fatal error
-			slogger.Log(ctx, multislogger.LevelReportedError,
+			slogger.Log(ctx, slog.LevelError,
 				"failed to setup local server",
 				"err", err,
 			)

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -83,12 +83,12 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 	// Log panics from the windows service
 	defer func() {
 		if r := recover(); r != nil {
-			systemSlogger.Log(context.TODO(), multislogger.LevelReportedError,
+			systemSlogger.Log(context.TODO(), slog.LevelError,
 				"panic occurred in windows service",
 				"err", r,
 			)
 			if err, ok := r.(error); ok {
-				systemSlogger.Log(context.TODO(), multislogger.LevelReportedError,
+				systemSlogger.Log(context.TODO(), slog.LevelError,
 					"panic stack trace",
 					"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 				)

--- a/ee/control/consumers/flareconsumer/flareconsumer.go
+++ b/ee/control/consumers/flareconsumer/flareconsumer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/debug/checkups"
 	"github.com/kolide/launcher/ee/debug/shipper"
-	"github.com/kolide/launcher/pkg/log/multislogger"
 )
 
 const (
@@ -103,7 +102,7 @@ func (fc *FlareConsumer) Do(data io.Reader) error {
 	}
 
 	if err := fc.flarer.RunFlare(context.Background(), fc.knapsack, flareStream); err != nil {
-		fc.slogger.Log(ctx, multislogger.LevelReportedError,
+		fc.slogger.Log(ctx, slog.LevelError,
 			"failed to run flare, not retrying",
 			"err", err,
 			"note", flareData.Note,

--- a/ee/errgroup/errgroup.go
+++ b/ee/errgroup/errgroup.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kolide/launcher/ee/gowrapper"
 	"github.com/kolide/launcher/ee/observability"
-	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -46,12 +45,12 @@ func (l *LoggedErrgroup) StartGoroutine(ctx context.Context, goroutineName strin
 		// we return an error from this goroutine overall if it panics.
 		defer func() {
 			if r := recover(); r != nil {
-				slogger.Log(ctx, multislogger.LevelReportedError,
+				slogger.Log(ctx, slog.LevelError,
 					"panic occurred in goroutine",
 					"err", r,
 				)
 				if recoveredErr, ok := r.(error); ok {
-					slogger.Log(ctx, multislogger.LevelReportedError,
+					slogger.Log(ctx, slog.LevelError,
 						"panic stack trace",
 						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(recoveredErr)),
 					)
@@ -131,12 +130,12 @@ func (l *LoggedErrgroup) AddShutdownGoroutine(ctx context.Context, goroutineName
 		// shutdown goroutines should not return an error besides the errgroup's initial error.
 		defer func() {
 			if r := recover(); r != nil {
-				slogger.Log(ctx, multislogger.LevelReportedError,
+				slogger.Log(ctx, slog.LevelError,
 					"panic occurred in shutdown goroutine",
 					"err", r,
 				)
 				if err, ok := r.(error); ok {
-					slogger.Log(ctx, multislogger.LevelReportedError,
+					slogger.Log(ctx, slog.LevelError,
 						"panic stack trace",
 						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 					)

--- a/ee/gowrapper/goroutine.go
+++ b/ee/gowrapper/goroutine.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/pkg/errors"
 )
 
@@ -22,12 +21,12 @@ func GoWithRecoveryAction(ctx context.Context, slogger *slog.Logger, goroutine f
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slogger.Log(ctx, multislogger.LevelReportedError,
+				slogger.Log(ctx, slog.LevelError,
 					"panic occurred in goroutine",
 					"err", r,
 				)
 				if err, ok := r.(error); ok {
-					slogger.Log(ctx, multislogger.LevelReportedError,
+					slogger.Log(ctx, slog.LevelError,
 						"panic stack trace",
 						"stack_trace", fmt.Sprintf("%+v", errors.WithStack(err)),
 					)

--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -20,9 +20,6 @@ const (
 	SpanIdKey          contextKey = "span_id"
 	TraceIdKey         contextKey = "trace_id"
 	TraceSampledKey    contextKey = "trace_sampled"
-
-	// Custom slog level for errors we want to group in our error reporting service
-	LevelReportedError slog.Level = slog.LevelError + 4
 )
 
 // ctxValueKeysToAdd is a list of context keys that will be
@@ -92,13 +89,12 @@ func ctxValuesMiddleWare(ctx context.Context, record slog.Record, next func(cont
 }
 
 func reportedErrorMiddleware(ctx context.Context, record slog.Record, next func(context.Context, slog.Record) error) error {
-	if record.Level != LevelReportedError {
+	if record.Level != slog.LevelError {
 		return next(ctx, record)
 	}
 
-	// We re-level "ReportedError" errors to the Error level, and then tag them for GCP.
+	// We tag LevelError logs for GCP.
 	// See: https://cloud.google.com/error-reporting/docs/formatting-error-messages
-	record.Level = slog.LevelError
 	record.AddAttrs(
 		// We must set @type so that GCP knows it's a ReportedError
 		slog.Attr{

--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kolide/launcher/ee/agent/flags/keys"
 	"github.com/kolide/launcher/ee/agent/types"
 	"github.com/kolide/launcher/ee/observability"
-	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/kolide/launcher/pkg/service"
 	"golang.org/x/sync/errgroup"
 )
@@ -68,7 +67,7 @@ func (r *Runner) Run() error {
 		id := registrationId
 		wg.Go(func() error {
 			if err := r.runInstance(id); err != nil {
-				r.slogger.Log(ctx, multislogger.LevelReportedError,
+				r.slogger.Log(ctx, slog.LevelError,
 					"runner terminated running osquery instance unexpectedly, shutting down runner",
 					"err", err,
 				)
@@ -279,7 +278,7 @@ func (r *Runner) FlagsChanged(ctx context.Context, flagKeys ...keys.FlagKey) {
 	)
 
 	if err := r.Restart(ctx); err != nil {
-		r.slogger.Log(ctx, multislogger.LevelReportedError,
+		r.slogger.Log(ctx, slog.LevelError,
 			"could not restart osquery instance after flag change",
 			"err", err,
 		)
@@ -318,7 +317,7 @@ func (r *Runner) Ping() {
 	)
 
 	if err := r.Restart(ctx); err != nil {
-		r.slogger.Log(ctx, multislogger.LevelReportedError,
+		r.slogger.Log(ctx, slog.LevelError,
 			"could not restart osquery instance after KATC configuration changed",
 			"err", err,
 		)


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/pull/2295, https://github.com/kolide/launcher/pull/2283, https://github.com/kolide/launcher/pull/2305.

This PR adjusts to report _all_ our error-level logs to `Error Reporting`, with the understanding that error-level logs are actionable in some way. There will definitely be one or more follow-up PRs to adjust some current `LevelError` logs to `LevelWarn`.