### PR TITLE
Add Microsoft Defender ATP health tables

### DIFF
--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -79,6 +79,10 @@ func Mdmclient(ctx context.Context, arg ...string) (*TracedCmd, error) {
 	return validatedCommand(ctx, "/usr/libexec/mdmclient", arg...)
 }
 
+func MicrosoftDefenderATP(ctx context.Context, arg ...string) (*TracedCmd, error) {
+	return validatedCommand(ctx, "/usr/local/bin/mdatp", arg...)
+}
+
 func Netstat(ctx context.Context, arg ...string) (*TracedCmd, error) {
 	return validatedCommand(ctx, "/usr/sbin/netstat", arg...)
 }

--- a/ee/allowedcmd/cmd_linux.go
+++ b/ee/allowedcmd/cmd_linux.go
@@ -105,6 +105,10 @@ func Lsof(ctx context.Context, arg ...string) (*TracedCmd, error) {
 	return validatedCommand(ctx, "/usr/bin/lsof", arg...)
 }
 
+func MicrosoftDefenderATP(ctx context.Context, arg ...string) (*TracedCmd, error) {
+	return validatedCommand(ctx, "/usr/bin/mdatp", arg...)
+}
+
 func NixEnv(ctx context.Context, arg ...string) (*TracedCmd, error) {
 	return validatedCommand(ctx, "/run/current-system/sw/bin/nix-env", arg...)
 }

--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -100,8 +100,9 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 	},
 	"microsoft_defender_atp": {
 		allowedOpts: map[string]struct{}{
-			"health":        {},
-			"--output json": {},
+			"health":   {},
+			"--output": {},
+			"json":     {},
 		},
 		generate: allowedcmd.MicrosoftDefenderATP,
 	},

--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -98,6 +98,13 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 		},
 		generate: allowedcmd.Zscli,
 	},
+	"microsoft_defender_atp": {
+		allowedOpts: map[string]struct{}{
+			"health":        {},
+			"--output json": {},
+		},
+		generate: allowedcmd.MicrosoftDefenderATP,
+	},
 }
 
 func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -129,5 +129,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}),
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "microsoft_defender_atp", "health", "--output json"}),
 	}
 }

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -129,6 +129,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}),
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "microsoft_defender_atp", "health", "--output json"}),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "microsoft_defender_atp", "health", "--output", "json"}),
 	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -73,5 +73,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_nftables", json.Parser, allowedcmd.Nftables, []string{"-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.MicrosoftDefenderATP, []string{"health", "--output json"}),
 	}
 }

--- a/pkg/osquery/table/platform_tables_linux.go
+++ b/pkg/osquery/table/platform_tables_linux.go
@@ -73,6 +73,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_nftables", json.Parser, allowedcmd.Nftables, []string{"-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.MicrosoftDefenderATP, []string{"health", "--output json"}),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_microsoft_defender_atp_health", json.Parser, allowedcmd.MicrosoftDefenderATP, []string{"health", "--output", "json"}),
 	}
 }


### PR DESCRIPTION
We've got some prospection around having checks for Microsoft Defender ATP on MacOS and Linux. This small PR is to add the health stats of devices through Microsoft Defender.