### PR TITLE
Downgrade some log levels from error to warn

### DIFF
--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -345,7 +345,7 @@ func (cs *ControlService) fetchAndUpdate(ctx context.Context, subsystem, hash st
 	// Consumer and subscriber(s) notified now
 	if err := cs.update(ctx, subsystem, data); err != nil {
 		// Returning the error so we don't store the hash and we can try again next time
-		slogger.Log(ctx, slog.LevelError,
+		slogger.Log(ctx, slog.LevelWarn,
 			"failed to update consumers and subscribers",
 			"err", err,
 		)

--- a/ee/secureenclaverunner/secureenclaverunner.go
+++ b/ee/secureenclaverunner/secureenclaverunner.go
@@ -162,7 +162,7 @@ func (ser *secureEnclaveRunner) Interrupt(_ error) {
 func (ser *secureEnclaveRunner) Public() crypto.PublicKey {
 	k, err := ser.currentConsoleUserKey(context.TODO())
 	if err != nil {
-		ser.slogger.Log(context.TODO(), slog.LevelError,
+		ser.slogger.Log(context.TODO(), slog.LevelWarn,
 			"getting public key",
 			"err", err,
 		)

--- a/pkg/service/middleware.go
+++ b/pkg/service/middleware.go
@@ -30,7 +30,7 @@ type uuidmw struct {
 // levelForError returns slog.LevelError if err != nil, else slog.LevelDebug
 func levelForError(err error) slog.Level {
 	if err != nil {
-		return slog.LevelError
+		return slog.LevelWarn
 	}
 	return slog.LevelDebug
 }

--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -106,7 +106,7 @@ func (mw logmw) PublishLogs(ctx context.Context, nodeKey string, logType logger.
 			if err == nil {
 				message = "success"
 			} else {
-				message = "failure"
+				message = "failure publishing logs"
 			}
 		}
 

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -107,7 +107,7 @@ func (mw logmw) PublishResults(ctx context.Context, nodeKey string, results []di
 			if err == nil {
 				message = "success"
 			} else {
-				message = "failure"
+				message = "failure publishing results"
 			}
 		}
 

--- a/pkg/service/request_config.go
+++ b/pkg/service/request_config.go
@@ -103,7 +103,7 @@ func (mw logmw) RequestConfig(ctx context.Context, nodeKey string) (config strin
 
 		message := "success"
 		if err != nil {
-			message = "failure"
+			message = "failure requesting config"
 		}
 
 		mw.knapsack.Slogger().Log(ctx, levelForError(err), message, // nolint:sloglint // it's fine to not have a constant or literal here

--- a/pkg/service/request_enrollment.go
+++ b/pkg/service/request_enrollment.go
@@ -113,7 +113,7 @@ func (mw logmw) RequestEnrollment(ctx context.Context, enrollSecret, hostIdentif
 
 		message := "success"
 		if err != nil {
-			message = "failure"
+			message = "failure requesting enrollment"
 		}
 
 		keyvals := []interface{}{

--- a/pkg/service/request_queries.go
+++ b/pkg/service/request_queries.go
@@ -110,7 +110,7 @@ func (mw logmw) RequestQueries(ctx context.Context, nodeKey string) (res *distri
 
 		message := "success"
 		if err != nil {
-			message = "failure"
+			message = "failure requesting queries"
 		}
 
 		mw.knapsack.Slogger().Log(ctx, levelForError(err), // nolint:sloglint // it's fine to not have a constant or literal here


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/pull/2295, https://github.com/kolide/launcher/pull/2283, https://github.com/kolide/launcher/pull/2305, https://github.com/kolide/launcher/pull/2309

Now that we can see errors getting reported, downgrade the noisy ones that aren't actionable.