### PR TITLE
add table options for reporting errors

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -47,6 +47,14 @@ func runMain() int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// these systemslogger logs will go to stderr, which will dirty the results of our
+	// rundisclaimed operations (some specifically collect stderr for reporting).
+	// the only log we would see before running the subcommand
+	// should be "launcher starting up", so override here with a no-op logger
+	if len(os.Args) > 1 && os.Args[1] == "rundisclaimed" {
+		systemSlogger = multislogger.New()
+	}
+
 	systemSlogger.Log(ctx, slog.LevelInfo,
 		"launcher starting up",
 		"version", version.Version().Version,

--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -152,6 +152,5 @@ func Zpool(ctx context.Context, arg ...string) (*TracedCmd, error) {
 }
 
 func Zscli(ctx context.Context, arg ...string) (*TracedCmd, error) {
-	// return validatedCommand(ctx, "/Applications/Zscaler/Zscaler.app/Contents/PlugIns/zscli", arg...)
-	return validatedCommand(ctx, "/tmp/zscaler", arg...)
+	return validatedCommand(ctx, "/Applications/Zscaler/Zscaler.app/Contents/PlugIns/zscli", arg...)
 }

--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -152,5 +152,6 @@ func Zpool(ctx context.Context, arg ...string) (*TracedCmd, error) {
 }
 
 func Zscli(ctx context.Context, arg ...string) (*TracedCmd, error) {
-	return validatedCommand(ctx, "/Applications/Zscaler/Zscaler.app/Contents/PlugIns/zscli", arg...)
+	// return validatedCommand(ctx, "/Applications/Zscaler/Zscaler.app/Contents/PlugIns/zscli", arg...)
+	return validatedCommand(ctx, "/tmp/zscaler", arg...)
 }

--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -57,6 +57,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/user"
 	"unsafe"
 
@@ -105,6 +106,8 @@ func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {
 	cmd, err := commandToDisclaim(ctx, args)
 	// this command is used to generate table data, do not error if the target binary is not found
 	if err != nil && errors.Is(err, allowedcmd.ErrCommandNotFound) {
+		// write that we haven't found the binary to stderr so callers can report on this if needed
+		fmt.Fprintln(os.Stderr, "binary is not present on device")
 		return nil
 	}
 

--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -107,7 +107,7 @@ func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {
 	// this command is used to generate table data, do not error if the target binary is not found
 	if err != nil && errors.Is(err, allowedcmd.ErrCommandNotFound) {
 		// write that we haven't found the binary to stderr so callers can report on this if needed
-		fmt.Fprintln(os.Stderr, "binary is not present on device")
+		fmt.Fprint(os.Stderr, "binary is not present on device")
 		return nil
 	}
 

--- a/ee/tables/dataflattentable/exec_and_parse.go
+++ b/ee/tables/dataflattentable/exec_and_parse.go
@@ -103,8 +103,6 @@ func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryCont
 
 	// historically, callers expect that includeStderr implies stdout == stderr, so we do that here.
 	// callers are free to ignore stdErr if not needed in other cases.
-	// we cannot declare stdErr as io.Discard and then overwrite it conditionally because there
-	// will be no way to read from it later if needed (e.g. for WithReportStderr).
 	if t.includeStderr {
 		stdErr = stdout
 	}

--- a/ee/tables/dataflattentable/exec_and_parse.go
+++ b/ee/tables/dataflattentable/exec_and_parse.go
@@ -112,16 +112,16 @@ func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryCont
 	if err := tablehelpers.Run(ctx, t.slogger, t.timeoutSeconds, t.cmd, t.execArgs, &stdout, &stdErr); err != nil {
 		// exec will error if there's no binary, don't record that unless configured to do so
 		if os.IsNotExist(errors.Cause(err)) || errors.Is(err, allowedcmd.ErrCommandNotFound) {
-			if !t.reportMissingBinary {
-				return nil, nil
+			if t.reportMissingBinary {
+				return append(results, ToMap([]dataflatten.Row{
+					{
+						Path:  []string{"error"},
+						Value: "binary is not present on device",
+					},
+				}, "*", nil)...), nil
 			}
 
-			return append(results, ToMap([]dataflatten.Row{
-				{
-					Path:  []string{"error"},
-					Value: "binary is not present on device",
-				},
-			}, "*", nil)...), nil
+			return nil, nil
 		}
 
 		observability.SetError(span, err)
@@ -129,6 +129,17 @@ func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryCont
 			"exec failed",
 			"err", err,
 		)
+
+		// Run failed, but we may have stderr to report with results anyway
+		if t.reportStderr && stdErr.Len() > 0 {
+			return append(results, ToMap([]dataflatten.Row{
+				{
+					Path:  []string{"error"},
+					Value: stdErr.String(),
+				},
+			}, "*", nil)...), nil
+		}
+
 		return nil, nil
 	}
 
@@ -154,6 +165,8 @@ func (t *execTableV2) generate(ctx context.Context, queryContext table.QueryCont
 		results = append(results, ToMap(flattened, dataQuery, nil)...)
 	}
 
+	// we could have made it through tablehelpers.Run above but still have seen error messaging
+	// to stderr- ensure we include that here if configured to do so
 	if t.reportStderr && stdErr.Len() > 0 {
 		results = append(results, ToMap([]dataflatten.Row{
 			{

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -126,7 +126,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "carbonblack_repcli", "status"}),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}, dataflattentable.WithReportStderr()),
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
 	}

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -126,7 +126,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`, `--no-scan`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_softwareupdate_scan", softwareupdate.Parser, allowedcmd.Softwareupdate, []string{`--list`}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_carbonblack_repcli_status", repcli.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "carbonblack_repcli", "status"}),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}, dataflattentable.WithReportStderr()),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Launcher, []string{"rundisclaimed", "zscaler", "status", "-s", "all"}, dataflattentable.WithReportStderr(), dataflattentable.WithReportMissingBinary()),
 		zfs.ZfsPropertiesPlugin(k, slogger),
 		zfs.ZpoolPropertiesPlugin(k, slogger),
 	}

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -31,6 +31,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		windowsupdatetable.CachedWindowsUpdatesTablePlugin(k, slogger, k.WindowsUpdatesCacheStore()),
 		wmitable.TablePlugin(k, slogger),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_dsregcmd", dsregcmd.Parser, allowedcmd.Dsregcmd, []string{`/status`}),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}, , dataflattentable.WithReportStderr()),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}, dataflattentable.WithReportStderr()),
 	}
 }

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -31,6 +31,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		windowsupdatetable.CachedWindowsUpdatesTablePlugin(k, slogger, k.WindowsUpdatesCacheStore()),
 		wmitable.TablePlugin(k, slogger),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_dsregcmd", dsregcmd.Parser, allowedcmd.Dsregcmd, []string{`/status`}),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}, , dataflattentable.WithReportStderr()),
 	}
 }

--- a/pkg/osquery/table/platform_tables_windows.go
+++ b/pkg/osquery/table/platform_tables_windows.go
@@ -31,6 +31,6 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		windowsupdatetable.CachedWindowsUpdatesTablePlugin(k, slogger, k.WindowsUpdatesCacheStore()),
 		wmitable.TablePlugin(k, slogger),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_dsregcmd", dsregcmd.Parser, allowedcmd.Dsregcmd, []string{`/status`}),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}, dataflattentable.WithReportStderr()),
+		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_zscaler", json.Parser, allowedcmd.Zscli, []string{"status", "-s", "all"}, dataflattentable.WithReportStderr(), dataflattentable.WithReportMissingBinary()),
 	}
 }


### PR DESCRIPTION
this adds 2 new `execTableV2Opts`:
- `WithReportStderr` to allow configuration of tables where we want to see stderr reported separately from stdout. see inline comments for additional details
- `WithReportMissingBinary` to allow configuration of tables where we want to report that the device is missing the target binary, instead of our typical empty response

```
[*]osquery> select fullkey, value from kolide_zscaler;
+---------+---------------------------------+
| fullkey | value                           |
+---------+---------------------------------+
| error   | binary is not present on device |
+---------+---------------------------------+
[*]osquery> select fullkey, value from kolide_zscaler;
+---------+----------------------------------------------------+
| fullkey | value                                              |
+---------+----------------------------------------------------+
| error   | Please log into ZCC to enable CLI usage by policy. |
+---------+----------------------------------------------------+
```

This got a little messy with RunDisclaimed on macos, and we did need to revisit the choice made [here](https://github.com/kolide/launcher/pull/2196/files/6baf22278f32e11f33c1d4d26ad31ba0bf2f3da7#r2035680933) in order to keep stderr clean for reporting in results.

resolves https://github.com/kolide/launcher/issues/2302