### PR TITLE
Add .kolide.test to list of kolide servers that localserver should use the localhost ecc server cert with

### DIFF
--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -182,7 +182,7 @@ func (ls *localServer) LoadDefaultKeyIfNotSet() error {
 	slogLevel := slog.LevelDebug
 
 	switch {
-	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.Contains(ls.kolideServer, ".ngrok."):
+	case strings.HasPrefix(ls.kolideServer, "localhost"), strings.HasPrefix(ls.kolideServer, "127.0.0.1"), strings.Contains(ls.kolideServer, ".ngrok."), strings.Contains(ls.kolideServer, ".kolide.test"):
 		ls.slogger.Log(ctx, slogLevel,
 			"using developer certificates",
 		)


### PR DESCRIPTION
We often test with a kolide server that looks like `*.kolide.test`; localserver should acknowledge that this is a test environment and use the local certs.