### PR TITLE
rundisclaimed test and docs

### DIFF
--- a/ee/disclaim/run_disclaimed_darwin.go
+++ b/ee/disclaim/run_disclaimed_darwin.go
@@ -70,6 +70,12 @@ type allowedCmdGenerator struct {
 	generate    func(ctx context.Context, args ...string) (*allowedcmd.TracedCmd, error)
 }
 
+// allowedCmdGenerators maps command names to their allowed options and generator functions.
+// Each entry defines which command-line options are permitted for a given command when
+// running in disclaimed mode, along with the function to generate the TracedCmd.
+// in most cases you should be able to set generator to the corresponding allowedcmd,
+// but you may need to add a helper for additional setup if your command
+// requires it (see generateBrewCommand)
 var allowedCmdGenerators = map[string]allowedCmdGenerator{
 	"brew": {
 		allowedOpts: map[string]struct{}{
@@ -109,6 +115,13 @@ var allowedCmdGenerators = map[string]allowedCmdGenerator{
 	},
 }
 
+// RunDisclaimed executes a command using posix_spawn with disclaimed privileges.
+// It validates the command and arguments against our allowedCmdGenerators, then spawns the process
+// using C bindings to spawn_disclaimed. If the target binary is not found, it writes a
+// message to stderr and returns nil to allow callers to handle missing binaries gracefully.
+// An error is returned if any command validation fails, or if spawn_disclaimed is unsuccessful-
+// in these cases the subcommand itself will return a non-zero exit status, meaning that the
+// corresponding table Run command will see an error here as a failure to run
 func RunDisclaimed(_ *multislogger.MultiSlogger, args []string) error {
 	ctx := context.Background()
 	cmd, err := commandToDisclaim(ctx, args)

--- a/ee/disclaim/run_disclaimed_darwin_test.go
+++ b/ee/disclaim/run_disclaimed_darwin_test.go
@@ -6,6 +6,7 @@ package disclaim
 import (
 	"testing"
 
+	"github.com/kolide/launcher/ee/allowedcmd"
 	"github.com/kolide/launcher/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
@@ -26,4 +27,21 @@ func TestRunDisclaimedDoesNotRunArbitraryOptions(t *testing.T) {
 	err := RunDisclaimed(slogger, []string{"brew", "outdated", "--json", "&&", "reboot"})
 	require.Error(t, err, "expected rundisclaimed to err for unknown command options")
 	require.Contains(t, err.Error(), "invalid argument provided")
+}
+
+// TestRunDisclaimedDoesNotErr tests only the happy path of running a basic command (echo)
+// through our C bindings for spawn_disclaimed. This is meant as a basic sanity test that it works.
+// It does not test that the disclaim itself works, but we are hoping to figure out a test for that
+// in the future
+func TestRunDisclaimedDoesNotErr(t *testing.T) { // nolint:paralleltest // writes to package level var allowedCmdGenerators
+	allowedCmdGenerators["echo"] = allowedCmdGenerator{
+		allowedOpts: map[string]struct{}{
+			"hello": {},
+		},
+		generate: allowedcmd.Echo,
+	}
+
+	slogger := multislogger.New()
+	err := RunDisclaimed(slogger, []string{"echo", "hello"})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
- adds some comments/docs to make RunDisclaimed a little more friendly
- adds a happy path test to just verify that RunDIsclaimed can run without error

Still hoping to be able to add a test which actually verifies the responsible PID changes/disclaim happens but that is proving trickier than I had hoped