### PR TITLE
Log when desktop shuts down due to not being able to monitor parent

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -281,7 +281,7 @@ func monitorParentProcess(slogger *slog.Logger, runnerServerUrl, runnerServerAut
 	for ; true; <-ticker.C {
 		// check to to ensure that the ppid is still legit
 		if os.Getppid() < 2 {
-			slogger.Log(context.TODO(), slog.LevelDebug,
+			slogger.Log(context.TODO(), slog.LevelError,
 				"ppid is 0 or 1, exiting",
 			)
 			break
@@ -309,7 +309,7 @@ func monitorParentProcess(slogger *slog.Logger, runnerServerUrl, runnerServerAut
 
 		// retry
 		if errCount < maxErrCount {
-			slogger.Log(context.TODO(), slog.LevelDebug,
+			slogger.Log(context.TODO(), slog.LevelWarn,
 				"could not connect to parent, will retry",
 				"err", err,
 				"attempts", errCount,
@@ -320,7 +320,7 @@ func monitorParentProcess(slogger *slog.Logger, runnerServerUrl, runnerServerAut
 		}
 
 		// errCount >= maxErrCount, exit
-		slogger.Log(context.TODO(), slog.LevelDebug,
+		slogger.Log(context.TODO(), slog.LevelError,
 			"could not connect to parent, max attempts reached, exiting",
 			"err", err,
 			"attempts", errCount,


### PR DESCRIPTION
We have seen at least one device's desktop process log that it was shutting down due to the `desktopMonitorParentProcess` actor exiting -- but we didn't have the corresponding logs from that actor to explain why, because desktop logs at the debug level don't get saved to `debug.json` unless the debug flag is set and which it usually isn't.

This PR updates the log level for those logs so that they will get written to debug.json.