### PR TITLE
Wait before remediating systray error, and retry remediation if it fails

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -1091,7 +1091,7 @@ func (r *DesktopUsersProcessesRunner) processLogs(uid string, stdErr io.ReadClos
 			return nil
 		}, 3*time.Minute, 35*time.Second); err != nil {
 			r.slogger.Log(context.TODO(), slog.LevelError,
-				"could not kill desktop process",
+				"could not kill desktop process after detecting systray initialization error",
 				"err", err,
 				"uid", uid,
 			)

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -1063,14 +1063,34 @@ func (r *DesktopUsersProcessesRunner) processLogs(uid string, stdErr io.ReadClos
 			continue
 		}
 
-		// Kill the desktop process for the given uid to force it to restart systray.
+		// We know that systray needs to restart, which means we need to kill this desktop
+		// process in order to restart it fully. However, this process is still starting up --
+		// we may not have a record for it yet in r.uidProcs. We want to delay slightly before
+		// attempting to kill the process. We usually see the process show up in under a second
+		// after we detect that systray needs a restart, so delaying five seconds should be sufficient.
+		time.Sleep(5 * time.Second)
+
 		r.slogger.Log(context.TODO(), slog.LevelInfo,
 			"noticed systray error -- shutting down and restarting desktop processes",
 			"systray_log", logLine,
 			"uid", uid,
 		)
-		if err := r.killDesktopProcess(context.Background(), uid); err != nil {
-			r.slogger.Log(context.TODO(), slog.LevelInfo,
+
+		// We want to perform some retries if we can't kill the process -- we aren't likely to get
+		// another log indicating that systray needs to restart, so we really want to fix this now.
+		// The call to `Shutdown` has a 30-second timeout, so we have a 35-second retry interval.
+		if err := backoff.WaitFor(func() error {
+			if err := r.killDesktopProcess(context.Background(), uid); err != nil {
+				r.slogger.Log(context.TODO(), slog.LevelWarn,
+					"could not kill desktop process, will retry",
+					"err", err,
+					"uid", uid,
+				)
+			}
+
+			return nil
+		}, 3*time.Minute, 35*time.Second); err != nil {
+			r.slogger.Log(context.TODO(), slog.LevelError,
 				"could not kill desktop process",
 				"err", err,
 				"uid", uid,


### PR DESCRIPTION
Hopefully addresses https://github.com/kolide/launcher/issues/2332.

When looking at logs, I noticed that our attempts to restart systray largely weren't working because we weren't actually successfully restarting the desktop process yet -- we didn't have a record for it. This PR introduces a delay before we attempt to restart the process.

 I also added a retry. If we see the log indicating that systray needs to restart, this is basically our one chance to catch and fix the error, so I think it's worth the extra time and attempts.

Finally, I upgraded the log when we fail to restart to an error level, so that it will be reported in our error groups for further investigation if we _still_ can't fix this issue.