### PR TITLE
Add .exit command to input in TestProc to ensure that process will shut down

### DIFF
--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -109,7 +109,8 @@ func StartProcess(knapsack types.Knapsack, interactiveRootDir string, inFile, ou
 		"osquery socket file created",
 	)
 
-	extensionServer, err := loadExtensions(knapsack.Slogger(), socketPath, osqPlugins...)
+	// This call is blocking -- it will run the extension manager server until the user exits.
+	extensionServer, err := loadExtensionsAndStartServer(knapsack.Slogger(), socketPath, osqPlugins...)
 	if err != nil {
 		err = fmt.Errorf("error loading extensions: %w", err)
 
@@ -150,7 +151,9 @@ func buildOsqueryFlags(socketPath, augeasLensesPath string, osqueryFlags []strin
 	return flags
 }
 
-func loadExtensions(slogger *slog.Logger, socketPath string, plugins ...osquery.OsqueryPlugin) (*osquery.ExtensionManagerServer, error) {
+// loadExtensionsAndStartServer calls *osquery.ExtensionManagerServer.Start, which will block (while running the server)
+// until the user exits the process.
+func loadExtensionsAndStartServer(slogger *slog.Logger, socketPath string, plugins ...osquery.OsqueryPlugin) (*osquery.ExtensionManagerServer, error) {
 	client, err := osquery.NewClient(socketPath, 10*time.Second, osquery.MaxWaitTime(10*time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("error creating osquery client: %w", err)
@@ -180,13 +183,10 @@ func loadExtensions(slogger *slog.Logger, socketPath string, plugins ...osquery.
 		"registered plugins with server",
 	)
 
+	// Start will start and _run_ the server; it returns once the server is shut down.
 	if err := extensionManagerServer.Start(); err != nil {
 		return nil, fmt.Errorf("error starting extension manager server: %w", err)
 	}
-
-	slogger.Log(context.TODO(), slog.LevelDebug,
-		"started osquery extension server",
-	)
 
 	return extensionManagerServer, nil
 }

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -184,10 +184,11 @@ func TestProc(t *testing.T) {
 			require.NoError(t, err)
 			defer inFile.Close()
 
-			// For our stdin replacement, we want at least some data in the file so that interactive will actually do something
-			// instead of exiting immediately.
+			// For our stdin replacement, we want at least some data in the file  -- we want interactive to run a query,
+			// and then exit.
 			commandContents := `
 select * from osquery_info;
+.exit
 `
 			err = os.WriteFile(inFilePath, []byte(commandContents), 0755)
 			require.NoError(t, err)


### PR DESCRIPTION
New theory about test flakiness:

* `loadExtensions` is actually a blocking operation, since it calls `extensionManagerServer.Start()`
* This means that `StartProcess` doesn't actually return _until the process has shut down_
* My theory is that on Ubuntu, the process is actually running happily. This is supported by logs in recent failures (https://github.com/kolide/launcher/actions/runs/15878752198/job/44773402854?pr=2334), showing that the osquery process is responding to queries with results.

I added some documentation to interactive.go to make it clearer that `loadExtensions` isn't just loading extensions but also running the server until it is shut down.

To attempt to address the test flakiness, I have added a `.exit` command to our input, to ensure that the process will shut down so the test can proceed.