### PR TITLE
Remove kolide_macos_software_update.app_updates_managed because data is not available on Tahoe

### DIFF
--- a/ee/tables/macos_software_update/SUSharedPrefs.h
+++ b/ee/tables/macos_software_update/SUSharedPrefs.h
@@ -107,6 +107,5 @@
 - (BOOL)isValidAnyUserPreference:(id)arg1;
 - (BOOL)useBackgroundNSURLSession;
 - (void)reloadPreferences;
-- (BOOL)isAppStoreAutoUpdatesManaged;
 
 @end

--- a/ee/tables/macos_software_update/software_update_table.go
+++ b/ee/tables/macos_software_update/software_update_table.go
@@ -32,7 +32,6 @@ func MacOSUpdate(flags types.Flags, slogger *slog.Logger) *table.Plugin {
 		table.IntegerColumn("autoupdate_enabled"),
 		table.IntegerColumn("download_managed"),
 		table.IntegerColumn("download"),
-		table.IntegerColumn("app_updates_managed"),
 		table.IntegerColumn("app_updates"),
 		table.IntegerColumn("os_updates_managed"),
 		table.IntegerColumn("os_updates"),
@@ -66,7 +65,6 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 		isAutomaticallyCheckForUpdatesEnabled             = C.int(0)
 		isdoBackgroundDownloadManaged                     = C.int(0)
 		doesBackgroundDownload                            = C.int(0)
-		isAppStoreAutoUpdatesManaged                      = C.int(0)
 		doesAppStoreAutoUpdates                           = C.int(0)
 		doesOSXAutoUpdatesManaged                         = C.int(0)
 		doesOSXAutoUpdates                                = C.int(0)
@@ -81,7 +79,6 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 		&isAutomaticallyCheckForUpdatesEnabled,
 		&isdoBackgroundDownloadManaged,
 		&doesBackgroundDownload,
-		&isAppStoreAutoUpdatesManaged,
 		&doesAppStoreAutoUpdates,
 		&doesOSXAutoUpdatesManaged,
 		&doesOSXAutoUpdates,
@@ -97,7 +94,6 @@ func (table *osUpdateTable) generateMacUpdate(ctx context.Context, queryContext 
 			"autoupdate_enabled":                   fmt.Sprintf("%d", isAutomaticallyCheckForUpdatesEnabled),
 			"download_managed":                     fmt.Sprintf("%d", isdoBackgroundDownloadManaged),
 			"download":                             fmt.Sprintf("%d", doesBackgroundDownload),
-			"app_updates_managed":                  fmt.Sprintf("%d", isAppStoreAutoUpdatesManaged),
 			"app_updates":                          fmt.Sprintf("%d", doesAppStoreAutoUpdates),
 			"os_updates_managed":                   fmt.Sprintf("%d", doesOSXAutoUpdatesManaged),
 			"os_updates":                           fmt.Sprintf("%d", doesOSXAutoUpdates),

--- a/ee/tables/macos_software_update/sus.h
+++ b/ee/tables/macos_software_update/sus.h
@@ -9,7 +9,6 @@ void getSoftwareUpdateConfiguration(
     int* isAutomaticallyCheckForUpdatesEnabled,
     int* isdoBackgroundDownloadManaged,
     int* doesBackgroundDownload,
-    int* isAppStoreAutoUpdatesManaged,
     int* doesAppStoreAutoUpdates,
     int* doesOSXAutoUpdatesManaged,
     int* doesOSXAutoUpdates,

--- a/ee/tables/macos_software_update/sus.m
+++ b/ee/tables/macos_software_update/sus.m
@@ -12,7 +12,6 @@ void getSoftwareUpdateConfiguration(
     int* isAutomaticallyCheckForUpdatesEnabled,
     int* isdoBackgroundDownloadManaged,
     int* doesBackgroundDownload,
-    int* isAppStoreAutoUpdatesManaged,
     int* doesAppStoreAutoUpdates,
     int* doesOSXAutoUpdatesManaged,
     int* doesOSXAutoUpdates,
@@ -57,8 +56,6 @@ void getSoftwareUpdateConfiguration(
                        : [manager doesBackgroundDownload];
   *doesBackgroundDownload = value ? 1 : 0;
 
-  *isAppStoreAutoUpdatesManaged =
-      [manager isAppStoreAutoUpdatesManaged] ? 1 : 0;
   *doesAppStoreAutoUpdates = [manager doesAppStoreAutoUpdates] ? 1 : 0;
 
   value = os_framework ? [settings automaticallyInstallOSUpdatesManaged]


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2323

I generated a new class dump (installed ipsw with `brew install blacktop/tap/ipsw`, then ran `ipsw class-dump /System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e SoftwareUpdate --headers`) and confirmed that `isAppStoreAutoUpdatesManaged` is no longer present. I didn't see a replacement field that we can use instead. After discussion with @iamharlie and @Micah-Kolide, we concluded we should remove this column.