### PR TITLE
Add 1p origin pattern to allowlist

### DIFF
--- a/ee/localserver/dt4a.go
+++ b/ee/localserver/dt4a.go
@@ -33,16 +33,14 @@ func (ls *localServer) requestDt4aInfoHandlerFunc(w http.ResponseWriter, r *http
 	// unauthenticated endpoint that points directly to this handler, so we're leaving the check
 	// in both places for now. We can remove it once /zta is removed.
 	requestOrigin := r.Header.Get("Origin")
-	if requestOrigin != "" {
-		if _, ok := allowlistedDt4aOriginsLookup[requestOrigin]; !ok && !strings.HasPrefix(requestOrigin, safariWebExtensionScheme) {
-			escapedOrigin := strings.ReplaceAll(strings.ReplaceAll(requestOrigin, "\n", ""), "\r", "") // remove any newlines
-			ls.slogger.Log(r.Context(), slog.LevelInfo,
-				"received dt4a request with origin not in allowlist",
-				"req_origin", escapedOrigin,
-			)
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
+	if !originIsAllowlisted(requestOrigin) {
+		escapedOrigin := strings.ReplaceAll(strings.ReplaceAll(requestOrigin, "\n", ""), "\r", "") // remove any newlines
+		ls.slogger.Log(r.Context(), slog.LevelInfo,
+			"received dt4a request with origin not in allowlist",
+			"req_origin", escapedOrigin,
+		)
+		w.WriteHeader(http.StatusForbidden)
+		return
 	}
 
 	// We only allow acceleration via this endpoint if this testing flag is set.

--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -45,7 +45,7 @@ var (
 		"https://dev.sites.gitlab.1password.io": {},
 	}
 
-	allowlisted1POriginRegex = regexp.MustCompile(`https:\/\/.+\.1password\.com`)
+	allowlisted1POriginRegex = regexp.MustCompile(`https:\/\/.+\.1password\.(com|ca|eu)`)
 )
 
 const (

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -350,6 +350,16 @@ func Test_originIsAllowlisted(t *testing.T) {
 			expectAllowlisted: true,
 		},
 		{
+			testCaseName:      "1p with .ca",
+			requestOrigin:     "https://example2.1password.ca",
+			expectAllowlisted: true,
+		},
+		{
+			testCaseName:      "1p with .eu",
+			requestOrigin:     "https://example3.1password.eu",
+			expectAllowlisted: true,
+		},
+		{
 			testCaseName:      "origin not on allowlist",
 			requestOrigin:     "https://example.com",
 			expectAllowlisted: false,

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -324,6 +324,56 @@ func Test_ValidateCertChain(t *testing.T) {
 	})
 }
 
+func Test_originIsAllowlisted(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		testCaseName      string
+		requestOrigin     string
+		expectAllowlisted bool
+	}
+
+	testCases := []testCase{
+		{
+			testCaseName:      "empty origin",
+			requestOrigin:     "",
+			expectAllowlisted: true,
+		},
+		{
+			testCaseName:      "safari web extension",
+			requestOrigin:     "safari-web-extension://testtest",
+			expectAllowlisted: true,
+		},
+		{
+			testCaseName:      "1p prod",
+			requestOrigin:     "https://example.1password.com",
+			expectAllowlisted: true,
+		},
+		{
+			testCaseName:      "origin not on allowlist",
+			requestOrigin:     "https://example.com",
+			expectAllowlisted: false,
+		},
+	}
+
+	for allowlistedOrigin := range allowlistedDt4aOriginsLookup {
+		testCases = append(testCases, testCase{
+			testCaseName:      allowlistedOrigin,
+			requestOrigin:     allowlistedOrigin,
+			expectAllowlisted: true,
+		})
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expectAllowlisted, originIsAllowlisted(tt.requestOrigin))
+		})
+	}
+}
+
 // newChain creates a new chain of keys, where each key signs the next key in the chain
 // leaving this in the _test file since we will always be receiving a chain of keys
 // so this is only needed for testing


### PR DESCRIPTION
Closes https://github.com/kolide/launcher/issues/2348.

Since we now have two one-offs outside of our lookup map `allowlistedDt4aOriginsLookup` (the safari extension prefix, and the new regex for 1p URLs), I've refactored the origin check into its own function.