### PR TITLE
ensure crt file cleanup in tests

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -61,6 +61,7 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	}
 
 	osquerydPath := testOsqueryBinary
+	rootDir := t.TempDir()
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(true)
@@ -70,7 +71,7 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
 	k.On("Slogger").Return(multislogger.NewNopLogger())
-	k.On("RootDirectory").Return("")
+	k.On("RootDirectory").Return(rootDir)
 	setupHistory(t, k)
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
@@ -85,6 +86,7 @@ func TestCreateOsqueryCommand(t *testing.T) {
 func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	t.Parallel()
 
+	rootDir := t.TempDir()
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(true)
 	k.On("WatchdogMemoryLimitMB").Return(150)
@@ -93,7 +95,7 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	k.On("OsqueryFlags").Return([]string{"verbose=false", "windows_event_channels=foo,bar"})
 	k.On("OsqueryVerbose").Return(true)
 	k.On("Slogger").Return(multislogger.NewNopLogger())
-	k.On("RootDirectory").Return("")
+	k.On("RootDirectory").Return(rootDir)
 	setupHistory(t, k)
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
@@ -118,6 +120,7 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testing.T) {
 	t.Parallel()
 
+	rootDir := t.TempDir()
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(true)
 	k.On("WatchdogMemoryLimitMB").Return(150)
@@ -126,7 +129,7 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
-	k.On("RootDirectory").Return("")
+	k.On("RootDirectory").Return(rootDir)
 	setupHistory(t, k)
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
@@ -170,12 +173,13 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 func TestCreateOsqueryCommand_SetsDisabledWatchdogSettingsAppropriately(t *testing.T) {
 	t.Parallel()
 
+	rootDir := t.TempDir()
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(false)
 	k.On("Slogger").Return(multislogger.NewNopLogger())
 	k.On("OsqueryVerbose").Return(true)
 	k.On("OsqueryFlags").Return([]string{})
-	k.On("RootDirectory").Return("")
+	k.On("RootDirectory").Return(rootDir)
 	setupHistory(t, k)
 
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))


### PR DESCRIPTION
when running `make test` locally i was repeatedly seeing `ca-certs-9dae8d76e55cb08991f2b672d58999ea15560d910759c16b544f843bdffbb994.crt` get regenerated inside `pkg/osquery/runtime/`.

This was happening where osqueryinstance_test.go tests were not mocking out root dir with a valid temp directory, meaning the crt file was being written to the current directory. This prevents that from happening and ensures cleanup after the test