### PR TITLE
Replace debian 10 test container with debian 12

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -305,7 +305,7 @@ jobs:
           #- centos:7 # Unsupported by actions/cache/restore GLIBC Issues
           - centos:8
           - debian:11
-          - debian:10
+          - debian:12
     needs:
       - version_baseline # version_baseline implies build_linux
       - build # need the other builds too

--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -100,13 +100,20 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 	}
 	defer os.RemoveAll(outputPathDir)
 
+	// Set arch correctly when invoking fpm. Allowable values are amd64 (does not require update) and
+	// aarch64 (requires update from "arm64").
+	arch := f.arch
+	if arch == "arm64" {
+		arch = "aarch64"
+	}
+
 	fpmCommand := []string{
 		"fpm",
 		"-s", "dir",
 		"-t", string(f.outputType),
 		"-n", fmt.Sprintf("%s-%s", po.Name, po.Identifier),
 		"-v", po.Version,
-		"-a", f.arch,
+		"-a", arch,
 		"-p", filepath.Join("/out", outputFilename),
 		"-C", "/pkgsrc",
 	}


### PR DESCRIPTION
https://github.com/kolide/launcher/actions/runs/16305265947/job/46049992305?pr=2360

Looks like buster is no longer available via our mirror, so we should stop using debian:10. I replaced it with debian:12.