### PR TITLE
Replace debian:10 with debian:12 in pipeline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -305,7 +305,7 @@ jobs:
           #- centos:7 # Unsupported by actions/cache/restore GLIBC Issues
           - centos:8
           - debian:11
-          - debian:10
+          - debian:12
     needs:
       - version_baseline # version_baseline implies build_linux
       - build # need the other builds too


### PR DESCRIPTION
https://github.com/kolide/launcher/actions/runs/16305265947/job/46049992305?pr=2360

Looks like buster is no longer available via our mirror, so we should stop using debian:10. I replaced it with debian:12.