### PR TITLE
Increase log file size and number of backups

### DIFF
--- a/pkg/log/locallogger/locallogger.go
+++ b/pkg/log/locallogger/locallogger.go
@@ -22,9 +22,9 @@ func NewKitLogger(logFilePath string) localLogger {
 	// This is meant as an always available debug tool. Thus we hardcode these options
 	lj := &lumberjack.Logger{
 		Filename:   logFilePath,
-		MaxSize:    3, // megabytes
+		MaxSize:    5, // megabytes
 		Compress:   true,
-		MaxBackups: 5,
+		MaxBackups: 8,
 	}
 
 	writer := log.NewSyncWriter(lj)


### PR DESCRIPTION
Sometimes we want to debug an issue that happened a week ago or even more recently, but the logs have already been rotated out. This PR increases our retention to an amount we feel is reasonable.