### PR TITLE
more log level cleanup

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -518,7 +518,7 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 		return fmt.Errorf("error reading control data: %w", err)
 	}
 	if err := r.writeSharedFile(r.menuTemplatePath(), dataBytes); err != nil {
-		r.slogger.Log(context.TODO(), slog.LevelError,
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
 			"menu template file did not exist, could not create it",
 			"err", err,
 		)
@@ -685,7 +685,7 @@ func (r *DesktopUsersProcessesRunner) writeDefaultMenuTemplateFile() {
 
 	if os.IsNotExist(err) {
 		if err := r.writeSharedFile(menuTemplatePath, menu.InitialMenu); err != nil {
-			r.slogger.Log(context.TODO(), slog.LevelError,
+			r.slogger.Log(context.TODO(), slog.LevelWarn,
 				"menu template file did not exist, could not create it",
 				"err", err,
 			)

--- a/ee/localserver/krypto-ec-middleware.go
+++ b/ee/localserver/krypto-ec-middleware.go
@@ -755,7 +755,7 @@ func (e *kryptoEcMiddleware) checkTimestamp(r *http.Request, challengeBox *chall
 	if timestampDelta > e.timestampValidityRange || timestampDelta < -e.timestampValidityRange {
 		span.SetAttributes(attribute.Int64("timestamp_delta", timestampDelta))
 		observability.SetError(span, errors.New("timestamp is out of range"))
-		e.slogger.Log(r.Context(), slog.LevelError,
+		e.slogger.Log(r.Context(), slog.LevelWarn,
 			"timestamp is out of range",
 			"delta", timestampDelta,
 		)

--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -370,7 +370,14 @@ func (e *Extension) ensureNodeKeyStored(nodeKey string) error {
 		// Grab the enroll secret, since we need that to create a new registration
 		enrollSecret, err := e.knapsack.ReadEnrollSecret()
 		if err != nil {
-			return fmt.Errorf("reading enroll secret to add new registration: %w", err)
+			e.slogger.Log(context.TODO(), slog.LevelWarn,
+				"unable to read enroll secret to add new registration",
+				"err", err,
+			)
+			// don't return an error here, there is nothing we can do. this is the
+			// result of a bad/manual installation (or uninstallation) and any errors
+			// returned here are reported
+			return nil
 		}
 		return e.addRegistration(nodeKey, enrollSecret)
 	}


### PR DESCRIPTION
downgrades error logging for the following scenarios where there is nothing we can do:
- menu template creation failures (no disk space)
- missing secret file (bad install)
- timestamp out of range