### PR TITLE
Make timestamps UTC for consistency with launcher log timestamps

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -808,9 +808,9 @@ func (ta *TufAutoupdater) shouldDelayDownload(binary autoupdatableBinary, target
 	delayCutoffTime := time.Unix(releasePromotedAt+splayDelaySeconds, 0)
 	slogger.Log(context.TODO(), slog.LevelInfo,
 		"release promoted within splay time, determining download eligibility",
-		"promote_start", promoteStart,
+		"promote_start", promoteStart.UTC(),
 		"delay_seconds", splayDelaySeconds,
-		"delay_cutoff", delayCutoffTime,
+		"delay_cutoff", delayCutoffTime.UTC(),
 		"delay_minutes_from_now", time.Until(delayCutoffTime).Minutes(),
 		"will_delay", time.Now().Before(delayCutoffTime),
 	)


### PR DESCRIPTION
Log currently looks something like this:

```json
{
    "time":"2025-07-22T14:20:10.030797Z",
    "level":"INFO",
    "msg":"release promoted within splay time, determining download eligibility",
    "component":"tuf_autoupdater",
    "download_splay_minutes":480,
    "binary":"launcher",
    "update_channel":"nightly",
    "promote_start":"2025-07-22T09:43:46-04:00",
    "delay_seconds":13972,
    "delay_cutoff":"2025-07-22T13:36:38-04:00",
    "delay_minutes_from_now":196.46615343333335,
    "will_delay":true
}
```

It will be easier for us to read this log if `promote_start` and `delay_cutoff` are in UTC, like `time` is. This PR makes that change.