### PR TITLE
Only log instance shutdown error if it's not nil or ctx cancel

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -130,11 +130,12 @@ func (r *Runner) runInstance(registrationId string) error {
 
 		// The osquery instance either exited on its own, or we called `Restart`.
 		// Either way, we wait for exit to complete, and then restart the instance.
-		err := instance.WaitShutdown(ctx)
-		slogger.Log(context.TODO(), slog.LevelError,
-			"unexpected restart of instance",
-			"err", err,
-		)
+		if err := instance.WaitShutdown(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			slogger.Log(context.TODO(), slog.LevelError,
+				"received error on instance shutdown after instance exit or instance restart",
+				"err", err,
+			)
+		}
 
 		var launchErr error
 		instance, launchErr = r.launchInstanceWithRetries(ctx, registrationId)


### PR DESCRIPTION
We see a lot of `unexpected restart of instance` logs, but often they're just because we shut down the instance to restart it. This PR updates to only log the error if it's a truly unexpected restart.