### PR TITLE
Increase test interval from 250ms to 2s to avoid client timeouts

### DIFF
--- a/cmd/launcher/desktop_test.go
+++ b/cmd/launcher/desktop_test.go
@@ -21,7 +21,7 @@ func Test_desktopMonitorParentProcess(t *testing.T) { //nolint:paralleltest
 	// register client and get token
 	token := runnerServer.RegisterClient("0")
 
-	monitorInterval := 250 * time.Millisecond
+	monitorInterval := 2 * time.Second
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{


### PR DESCRIPTION
Noticed an error where desktop server requests timed out for this test; increased interval from 250ms to the standard interval that desktop actually uses, 2s.