### PR TITLE
Add feature-flagged performance monitoring to automatically upload flares

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kolide/launcher/ee/control/consumers/notificationconsumer"
 	"github.com/kolide/launcher/ee/control/consumers/remoterestartconsumer"
 	"github.com/kolide/launcher/ee/control/consumers/uninstallconsumer"
+	performancedebug "github.com/kolide/launcher/ee/debug"
 	"github.com/kolide/launcher/ee/debug/checkups"
 	desktopRunner "github.com/kolide/launcher/ee/desktop/runner"
 	"github.com/kolide/launcher/ee/gowrapper"
@@ -319,6 +320,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		checkpointer.LogCheckupsOnStartup(ctx)
 	})
 	runGroup.Add("logcheckpoint", checkpointer.Run, checkpointer.Interrupt)
+
+	// Periodically check launcher performance
+	performanceMonitor := performancedebug.NewPerformanceMonitor(k)
+	runGroup.Add("performanceMonitor", performanceMonitor.Execute, performanceMonitor.Interrupt)
 
 	watchdogController, err := watchdog.NewController(ctx, k, opts.ConfigFilePath)
 	if err != nil { // log any issues here but move on, watchdog is not critical path

--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -806,3 +806,13 @@ func (fc *FlagController) AutoupdateDownloadSplay() time.Duration {
 func (fc *FlagController) SetAutoupdateDownloadSplay(val time.Duration) error {
 	return fc.setControlServerValue(keys.AutoupdateDownloadSplay, durationToBytes(val))
 }
+
+func (fc *FlagController) SetPerformanceMonitoringEnabled(enabled bool) error {
+	return fc.setControlServerValue(keys.PerformanceMonitoringEnabled, boolToBytes(enabled))
+}
+
+func (fc *FlagController) PerformanceMonitoringEnabled() bool {
+	return NewBoolFlagValue(
+		WithDefaultBool(false),
+	).get(fc.getControlServerValue(keys.PerformanceMonitoringEnabled))
+}

--- a/ee/agent/flags/keys/keys.go
+++ b/ee/agent/flags/keys/keys.go
@@ -65,6 +65,7 @@ const (
 	UseCachedDataForScheduledQueries FlagKey = "use_cached_data_for_scheduled_queries"
 	CachedQueryResultsTTL            FlagKey = "cached_query_results_ttl"
 	ResetOnHardwareChangeEnabled     FlagKey = "reset_on_hardware_change_enabled"
+	PerformanceMonitoringEnabled     FlagKey = "performance_monitoring_enabled"
 )
 
 func (key FlagKey) String() string {

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -265,4 +265,8 @@ type Flags interface {
 
 	AutoupdateDownloadSplay() time.Duration
 	SetAutoupdateDownloadSplay(val time.Duration) error
+
+	// PerformanceMonitoringEnabled controls whether launcher self-monitors for performance issues
+	SetPerformanceMonitoringEnabled(enabled bool) error
+	PerformanceMonitoringEnabled() bool
 }

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -799,6 +799,24 @@ func (_m *Flags) OsquerydPath() string {
 	return r0
 }
 
+// PerformanceMonitoringEnabled provides a mock function with no fields
+func (_m *Flags) PerformanceMonitoringEnabled() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PerformanceMonitoringEnabled")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // PinnedLauncherVersion provides a mock function with no fields
 func (_m *Flags) PinnedLauncherVersion() string {
 	ret := _m.Called()
@@ -1472,6 +1490,24 @@ func (_m *Flags) SetOsqueryVerbose(verbose bool) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool) error); ok {
 		r0 = rf(verbose)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetPerformanceMonitoringEnabled provides a mock function with given fields: enabled
+func (_m *Flags) SetPerformanceMonitoringEnabled(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetPerformanceMonitoringEnabled")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -1121,6 +1121,24 @@ func (_m *Knapsack) OsquerydPath() string {
 	return r0
 }
 
+// PerformanceMonitoringEnabled provides a mock function with no fields
+func (_m *Knapsack) PerformanceMonitoringEnabled() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PerformanceMonitoringEnabled")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // PersistentHostDataStore provides a mock function with no fields
 func (_m *Knapsack) PersistentHostDataStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
 	ret := _m.Called()
@@ -1987,6 +2005,24 @@ func (_m *Knapsack) SetOsqueryVerbose(verbose bool) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool) error); ok {
 		r0 = rf(verbose)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetPerformanceMonitoringEnabled provides a mock function with given fields: enabled
+func (_m *Knapsack) SetPerformanceMonitoringEnabled(enabled bool) error {
+	ret := _m.Called(enabled)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetPerformanceMonitoringEnabled")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(enabled)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/ee/debug/performance_monitor.go
+++ b/ee/debug/performance_monitor.go
@@ -1,0 +1,150 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/kolide/launcher/ee/agent/types"
+	"github.com/kolide/launcher/ee/debug/checkups"
+	"github.com/kolide/launcher/ee/debug/shipper"
+	"github.com/kolide/launcher/ee/performance"
+)
+
+const (
+	performanceCheckInitialDelay      = 5 * time.Minute
+	performanceCheckInterval          = 15 * time.Minute
+	golangMemUsageThresholdForFlare   = 1000 * 1024 * 1024 // 1 GB in bytes
+	minimumFlareResendIntervalSeconds = 24 * 60 * 60       // 1 day
+	flareUploadRequestUrl             = "https://api.kolide.com/api/agent/flare"
+	notePrefix                        = "automated flare"
+)
+
+type performanceMonitor struct {
+	knapsack      types.Knapsack
+	slogger       *slog.Logger
+	lastFlareSent *atomic.Int64
+	interrupt     chan struct{}
+	interrupted   *atomic.Bool
+}
+
+func NewPerformanceMonitor(k types.Knapsack) *performanceMonitor {
+	return &performanceMonitor{
+		knapsack:      k,
+		slogger:       k.Slogger().With("component", "performance_monitor"),
+		lastFlareSent: &atomic.Int64{},
+		interrupt:     make(chan struct{}),
+		interrupted:   &atomic.Bool{},
+	}
+}
+
+func (p *performanceMonitor) Execute() error {
+	// Wait a bit before beginning monitoring
+	select {
+	case <-p.interrupt:
+		return nil
+	case <-time.After(performanceCheckInitialDelay):
+		break
+	}
+
+	ticker := time.NewTicker(performanceCheckInterval)
+	defer ticker.Stop()
+	for {
+		p.checkPerformance()
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-p.interrupt:
+			return nil
+		}
+	}
+}
+
+// checkPerformance gathers stats for the current process and assesses them. If performance
+// seems egregiously bad, it triggers a flare upload.
+func (p *performanceMonitor) checkPerformance() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	stats, err := performance.CurrentProcessStats(ctx)
+	if err != nil {
+		p.slogger.Log(ctx, slog.LevelWarn,
+			"could not get current process stats",
+			"err", err,
+		)
+		return
+	}
+
+	// Check if we should trigger a flare
+	if stats.MemInfo.GoMemUsage < golangMemUsageThresholdForFlare {
+		return
+	}
+
+	// Make sure we haven't sent a flare too recently
+	nextAllowableFlareTimestamp := p.lastFlareSent.Load() + minimumFlareResendIntervalSeconds
+	if nextAllowableFlareTimestamp > time.Now().Unix() {
+		p.slogger.Log(ctx, slog.LevelWarn,
+			"noticed abnormally high Golang memory usage while monitoring, but triggered flare too recently",
+			"golang_memory_usage", stats.MemInfo.GoMemUsage,
+			"non_golang_memory_usage", stats.MemInfo.NonGoMemUsage,
+			"rss", stats.MemInfo.RSS,
+		)
+		return
+	}
+
+	// If we've noticed extraordinarily high Golang memory usage, trigger a flare.
+	// Since we're looking at Golang memory here, the flare's memprofile will be useful
+	// in understanding what's using memory.
+	p.slogger.Log(ctx, slog.LevelWarn,
+		"noticed abnormally high Golang memory usage while monitoring, triggering flare",
+		"golang_memory_usage", stats.MemInfo.GoMemUsage,
+		"non_golang_memory_usage", stats.MemInfo.NonGoMemUsage,
+		"rss", stats.MemInfo.RSS,
+	)
+
+	flareShipper, err := shipper.New(p.knapsack, shipper.WithUploadRequestURL(flareUploadRequestUrl), shipper.WithNote(p.uploadNote("high Golang memory usage")))
+	if err != nil {
+		p.slogger.Log(ctx, slog.LevelError,
+			"could not create flare shipper to capture high Golang memory usage",
+			"err", err,
+		)
+		return
+	}
+
+	if err := checkups.RunFlare(ctx, p.knapsack, flareShipper, checkups.InSituEnvironment); err != nil {
+		p.slogger.Log(ctx, slog.LevelError,
+			"could not run and ship flare to capture high Golang memory usage",
+			"err", err,
+		)
+		return
+	}
+
+	p.slogger.Log(ctx, slog.LevelInfo,
+		"successfully triggered flare to capture abnormally high Golang memory usage",
+		"flare_id", flareShipper.Name(),
+	)
+
+	p.lastFlareSent.Store(time.Now().Unix())
+}
+
+// uploadNote creates a flare note, identifying that this is a) an automated flare, b) the reason
+// the flare is being created, and c) the device via the serial, if available.
+func (p *performanceMonitor) uploadNote(reason string) string {
+	deviceDetails := p.knapsack.GetEnrollmentDetails()
+	if deviceDetails.HardwareSerial != "" {
+		return fmt.Sprintf("%s: %s (%s)", notePrefix, reason, deviceDetails.HardwareSerial)
+	}
+	return fmt.Sprintf("%s: %s (unknown serial)", notePrefix, reason)
+}
+
+func (p *performanceMonitor) Interrupt(_ error) {
+	// Only perform shutdown tasks on first call to interrupt -- no need to repeat on potential extra calls.
+	if p.interrupted.Swap(true) {
+		return
+	}
+
+	p.interrupt <- struct{}{}
+}

--- a/ee/debug/performance_monitor.go
+++ b/ee/debug/performance_monitor.go
@@ -66,6 +66,11 @@ func (p *performanceMonitor) Execute() error {
 // checkPerformance gathers stats for the current process and assesses them. If performance
 // seems egregiously bad, it triggers a flare upload.
 func (p *performanceMonitor) checkPerformance() {
+	// Only gather stats if performance monitoring is enabled
+	if !p.knapsack.PerformanceMonitoringEnabled() {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 

--- a/ee/debug/performance_monitor_test.go
+++ b/ee/debug/performance_monitor_test.go
@@ -1,0 +1,59 @@
+package debug
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	typesmocks "github.com/kolide/launcher/ee/agent/types/mocks"
+	"github.com/kolide/launcher/pkg/threadsafebuffer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterrupt_Multiple(t *testing.T) {
+	t.Parallel()
+
+	testKnapsack := typesmocks.NewKnapsack(t)
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	testKnapsack.On("Slogger").Return(slogger)
+
+	p := NewPerformanceMonitor(testKnapsack)
+
+	// Start and then interrupt
+	go p.Execute()
+	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
+	p.Interrupt(errors.New("test error"))
+
+	// Confirm we can call Interrupt multiple times without blocking
+	interruptComplete := make(chan struct{})
+	expectedInterrupts := 3
+	for i := 0; i < expectedInterrupts; i += 1 {
+		go func() {
+			p.Interrupt(nil)
+			interruptComplete <- struct{}{}
+		}()
+	}
+
+	receivedInterrupts := 0
+	for {
+		if receivedInterrupts >= expectedInterrupts {
+			break
+		}
+
+		select {
+		case <-interruptComplete:
+			receivedInterrupts += 1
+			continue
+		case <-time.After(5 * time.Second):
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
+			t.FailNow()
+		}
+	}
+
+	require.Equal(t, expectedInterrupts, receivedInterrupts)
+}


### PR DESCRIPTION
If the new feature flag is enabled, then launcher will check its performance stats every fifteen minutes. If it notices egregiously high Golang memory usage, then it will trigger a flare upload. Launcher will do this at most once a day.

For now, this only triggers on high Golang memory, but we could trigger on high CPU in the future as well.