### PR TITLE
Group all logs about desktop process startup failures; make logs and errors more verbose

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -148,7 +148,11 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 
 	server, err := userserver.New(slogger, *flUserServerAuthToken, *flUserServerSocketPath, shutdownChan, showDesktopChan, notifier)
 	if err != nil {
-		return err
+		slogger.Log(context.TODO(), slog.LevelError,
+			"could not create user server",
+			"err", err,
+		)
+		return fmt.Errorf("creating server: %w", err)
 	}
 
 	universalLinkHandler, urlInput := universallink.NewUniversalLinkHandler(slogger)

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -780,6 +780,8 @@ func (r *DesktopUsersProcessesRunner) spawnForUser(ctx context.Context, uid stri
 
 	// If the process isn't responsive after 10 seconds, kill it and return an error
 	if err := backoff.WaitFor(pingFunc, 10*time.Second, 1*time.Second); err != nil {
+		observability.SetError(span, fmt.Errorf("pinging user desktop server after startup: pid %d: %w", cmd.Process.Pid, err))
+
 		// unregister proc from desktop server so server will not respond to its requests
 		r.runnerServer.DeRegisterClient(uid)
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -224,8 +224,8 @@ func (r *DesktopUsersProcessesRunner) Execute() error {
 	for {
 		// Check immediately on each iteration, avoiding the initial ticker delay
 		if err := r.runConsoleUserDesktop(); err != nil {
-			r.slogger.Log(context.TODO(), slog.LevelInfo,
-				"running console user desktop",
+			r.slogger.Log(context.TODO(), slog.LevelError,
+				"could not run console user desktop process",
 				"err", err,
 			)
 		}
@@ -778,23 +778,17 @@ func (r *DesktopUsersProcessesRunner) spawnForUser(ctx context.Context, uid stri
 		pingFunc = client.ShowDesktop
 	}
 
+	// If the process isn't responsive after 10 seconds, kill it (if it's not already gone) and return an error
 	if err := backoff.WaitFor(pingFunc, 10*time.Second, 1*time.Second); err != nil {
 		// unregister proc from desktop server so server will not respond to its requests
 		r.runnerServer.DeRegisterClient(uid)
 
-		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			r.slogger.Log(ctx, slog.LevelError,
-				"killing user desktop process after startup ping / show desktop failed",
-				"uid", uid,
-				"pid", cmd.Process.Pid,
-				"path", cmd.Path,
-				"err", err,
-			)
+		// Process may still exist -- try to kill it.
+		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) && err.Error() != "invalid argument" {
+			return fmt.Errorf("killing user desktop process after startup failed: %w", err)
 		}
 
-		observability.SetError(span, fmt.Errorf("pinging user desktop server after startup: pid %d: %w", cmd.Process.Pid, err))
-
-		return fmt.Errorf("pinging user desktop server after startup: pid %d: %w", cmd.Process.Pid, err)
+		return fmt.Errorf("user desktop server not responsive to ping after startup: pid %d: %w", cmd.Process.Pid, err)
 	}
 
 	r.slogger.Log(ctx, slog.LevelDebug,
@@ -849,7 +843,7 @@ func (r *DesktopUsersProcessesRunner) waitOnProcessAsync(uid string, proc *os.Pr
 		// waiting here gives the parent a chance to clean up
 		state, err := proc.Wait()
 		if err != nil {
-			r.slogger.Log(context.TODO(), slog.LevelInfo,
+			r.slogger.Log(context.TODO(), slog.LevelError,
 				"desktop process died",
 				"uid", uid,
 				"pid", proc.Pid,

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -130,7 +130,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("KolideServerURL").Return("somewhere-over-the-rainbow.example.com")
 
-			// if were not in CI, always exepect desktop enabled call
+			// if we're not in CI, always expect desktop enabled call
 			// if we are in CI only expect desktop enabled on windows and darwin
 			// since linux CI has no desktop user to make desktop process for
 			if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") || os.Getenv("CI") != "true" {

--- a/ee/desktop/user/server/server.go
+++ b/ee/desktop/user/server/server.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -80,12 +81,12 @@ func New(slogger *slog.Logger,
 
 	// remove existing socket
 	if err := userServer.removeSocket(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("removing existing socket: %w", err)
 	}
 
 	listener, err := listener(socketPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initializing socket listener at %s: %w", socketPath, err)
 	}
 	userServer.listener = listener
 
@@ -109,14 +110,14 @@ func (s *UserServer) Serve() error {
 func (s *UserServer) Shutdown(ctx context.Context) error {
 	err := s.server.Shutdown(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("shutting down server: %w", err)
 	}
 
 	// on windows we need to expliclty close the listener
 	// on non-windows this gives an error
 	if runtime.GOOS == "windows" {
 		if err := s.listener.Close(); err != nil {
-			return err
+			return fmt.Errorf("closing listener: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/2342

Ensures that desktop process startup failures are logged as error, so that we can see them in error reporting. Logs and wraps additional errors in the desktop process.