### PR TITLE
Parse and ship desktop logs

### DIFF
--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kolide/launcher/ee/desktop/user/menu"
 	"github.com/kolide/launcher/ee/desktop/user/notify"
 	"github.com/kolide/launcher/ee/gowrapper"
+	"github.com/kolide/launcher/ee/log"
 	"github.com/kolide/launcher/ee/observability"
 	"github.com/kolide/launcher/ee/presencedetection"
 	"github.com/kolide/launcher/ee/ui/assets"
@@ -1032,15 +1033,13 @@ func (r *DesktopUsersProcessesRunner) processLogs(uid string, stdErr io.ReadClos
 	combined := io.MultiReader(stdErr, stdOut)
 	scanner := bufio.NewScanner(combined)
 
+	slogger := r.slogger.With("uid", uid, "subprocess", "desktop")
+
 	for scanner.Scan() {
 		logLine := scanner.Text()
 
 		// First, log the incoming log.
-		r.slogger.Log(context.TODO(), slog.LevelDebug, // nolint:sloglint // it's fine to not have a constant or literal here
-			logLine,
-			"uid", uid,
-			"subprocess", "desktop",
-		)
+		log.LogRawLogRecord(context.TODO(), []byte(logLine), slogger)
 
 		// Now, check log to see if we need to restart systray.
 		// Only perform the restart if the feature flag is enabled.

--- a/ee/desktop/user/universallink/handler_darwin.go
+++ b/ee/desktop/user/universallink/handler_darwin.go
@@ -69,7 +69,7 @@ func (u *universalLinkHandler) Execute() error {
 }
 
 func (u *universalLinkHandler) Interrupt(_ error) {
-	u.slogger.Log(context.TODO(), slog.LevelInfo,
+	u.slogger.Log(context.TODO(), slog.LevelDebug,
 		"received interrupt",
 	)
 

--- a/ee/log/parser.go
+++ b/ee/log/parser.go
@@ -1,0 +1,66 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+const keyFormatWithPrefix = "original.%s"
+
+// LogRawLogRecord parses the given `rawLogRecord`, which should be a JSON-encoded slog LogRecord,
+// and then logs it. We use this to process logs from related subprocesses (launcher watchdog,
+// launcher desktop) and log them at the correct level.
+func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Logger) {
+	logRecord := make(map[string]any)
+
+	if err := json.Unmarshal(rawLogRecord, &logRecord); err != nil {
+		// If we can't parse the log, then log the raw string.
+		slogger.Log(ctx, slog.LevelError,
+			"failed to unmarshal incoming log",
+			"log", string(rawLogRecord),
+			"err", err,
+		)
+		return
+	}
+
+	// Extract the fields that we know we care about (msg, level, and time) from the
+	// original log, so that we can set them correctly below. For any other fields that
+	// we may have duplicate values for, prepend "original." to the key -- most notably,
+	// we are handling potential duplicate `time` and `source` fields, and potentially
+	// `component` fields that could conflict with attributes set on our `slogger`.
+	// We do not prepend "original." to the error key, to make sure it's picked up correctly
+	// by our error reporting system.
+	logArgs := make([]slog.Attr, len(logRecord))
+	logLevel := slog.LevelInfo
+	logMsg := "original log message missing"
+	for k, v := range logRecord {
+		switch k {
+		case slog.MessageKey:
+			if logMsgStr, ok := v.(string); ok {
+				logMsg = logMsgStr
+			}
+		case slog.LevelKey:
+			if logLevelString, ok := v.(string); ok {
+				if err := logLevel.UnmarshalText([]byte(logLevelString)); err != nil {
+					// Log that we couldn't parse the level, but proceed with the rest of parsing.
+					slogger.Log(ctx, slog.LevelError,
+						"could not parse incoming log with invalid level",
+						"level", logLevelString,
+						"err", err,
+					)
+				}
+			}
+		case "err":
+			logArgs = append(logArgs, slog.Any(k, v))
+		default:
+			logArgs = append(logArgs, slog.Any(fmt.Sprintf(keyFormatWithPrefix, k), v))
+		}
+	}
+
+	// Re-issue the log using our slogger. Pulling out the existing log and
+	// re-adding all attributes like this will overwrite the automatic timestamp creation,
+	// as well as the msg and level set below.
+	slogger.LogAttrs(ctx, logLevel, logMsg, logArgs...)
+}

--- a/ee/log/parser.go
+++ b/ee/log/parser.go
@@ -30,8 +30,8 @@ func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Log
 	// we may have duplicate values for, prepend "original." to the key -- most notably,
 	// we are handling potential duplicate `time` and `source` fields, and potentially
 	// `component` fields that could conflict with attributes set on our `slogger`.
-	// We do not prepend "original." to the error key, to make sure it's picked up correctly
-	// by our error reporting system.
+	// We do not prepend "original." to keys relating to errors or panics, to make sure they're
+	// picked up correctly by our error reporting system.
 	logArgs := make([]slog.Attr, len(logRecord))
 	logLevel := slog.LevelInfo
 	logMsg := "original log message missing"
@@ -52,7 +52,7 @@ func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Log
 					)
 				}
 			}
-		case "err":
+		case "err", "stack_trace":
 			logArgs = append(logArgs, slog.Any(k, v))
 		default:
 			logArgs = append(logArgs, slog.Any(fmt.Sprintf(keyFormatWithPrefix, k), v))

--- a/ee/log/parser_test.go
+++ b/ee/log/parser_test.go
@@ -1,0 +1,196 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogRawLogRecord(t *testing.T) {
+	t.Parallel()
+
+	logTimeString := "2025-07-24T19:34:15.741622Z"
+
+	// Need to explicitly make it a float64 because of JSON number processing
+	fileLineInt := 238
+	var fileLineAsFloat float64 = 238
+
+	for _, tt := range []struct {
+		testCaseName          string
+		rawLogRecord          []byte
+		expectedLogMessage    string
+		expectedLogLevel      slog.Level
+		expectedLogAttributes []slog.Attr
+	}{
+		{
+			testCaseName:       "valid debug-level log",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"DEBUG","source":{"function":"github.com/kolide/launcher/ee/observability/exporter.(*TelemetryExporter).addAttributesFromEnrollmentDetails","file":"/Users/runner/work/launcher/launcher/ee/observability/exporter/exporter.go","line":%d},"msg":"added attributes from enrollment details"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "added attributes from enrollment details",
+			expectedLogLevel:   slog.LevelDebug,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "/Users/runner/work/launcher/launcher/ee/observability/exporter/exporter.go",
+					"function": "github.com/kolide/launcher/ee/observability/exporter.(*TelemetryExporter).addAttributesFromEnrollmentDetails",
+					"line":     fileLineAsFloat,
+				}),
+			},
+		},
+		{
+			testCaseName:       "valid info-level log",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"INFO","source":{"function":"github.com/kolide/launcher/ee/log/osquerylogs.(*OsqueryLogAdapter).Write","file":"/Users/runner/work/launcher/launcher/ee/log/osquerylogs/log.go","line":%d},"msg":"I0725 09:58:21.866813 1883975680 scheduler.cpp:201] Found results for query: pack:kolide_log_pipeline:example_noisy_pack:current_time","component":"osquery","osqlevel":"stderr","registration_id":"default","instance_run_id":"01K10511D8DCCGW37X8SR5WKC3","caller":"scheduler.cpp:201"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "I0725 09:58:21.866813 1883975680 scheduler.cpp:201] Found results for query: pack:kolide_log_pipeline:example_noisy_pack:current_time",
+			expectedLogLevel:   slog.LevelInfo,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "/Users/runner/work/launcher/launcher/ee/log/osquerylogs/log.go",
+					"function": "github.com/kolide/launcher/ee/log/osquerylogs.(*OsqueryLogAdapter).Write",
+					"line":     fileLineAsFloat,
+				}),
+				slog.String("original.component", "osquery"),
+				slog.String("original.osqlevel", "stderr"),
+				slog.String("original.registration_id", "default"),
+				slog.String("original.instance_run_id", "01K10511D8DCCGW37X8SR5WKC3"),
+				slog.String("original.caller", "scheduler.cpp:201"),
+			},
+		},
+		{
+			testCaseName:       "valid warn-level log",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"WARN","source":{"function":"github.com/kolide/launcher/pkg/osquery/runtime.(*OsqueryInstance).Launch.func4","file":"/Users/runner/work/launcher/launcher/pkg/osquery/runtime/osqueryinstance.go","line":%d},"msg":"error running osquery command","component":"osquery_instance","registration_id":"default","instance_run_id":"01K0YYVJK0G5A33RSC8VCKMK26","path":"/usr/local/kolide-nababe-k2/bin/osqueryd","err":"signal: killed"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "error running osquery command",
+			expectedLogLevel:   slog.LevelWarn,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "/Users/runner/work/launcher/launcher/pkg/osquery/runtime/osqueryinstance.go",
+					"function": "github.com/kolide/launcher/pkg/osquery/runtime.(*OsqueryInstance).Launch.func4",
+					"line":     fileLineAsFloat,
+				}),
+				slog.String("original.component", "osquery_instance"),
+				slog.String("original.registration_id", "default"),
+				slog.String("original.instance_run_id", "01K0YYVJK0G5A33RSC8VCKMK26"),
+				slog.String("original.path", "/usr/local/kolide-nababe-k2/bin/osqueryd"),
+				slog.String("err", "signal: killed"),
+			},
+		},
+		{
+			testCaseName:       "valid error-level log",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"ERROR","uid":"test","pid":968,"source":{"line":%d,"function":"github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).refreshMenu","file":"D:/a/launcher/launcher/ee/desktop/runner/runner.go"},"msg":"sending refresh command to user desktop process","err":"making request: Get \"http://unix/refresh\": open \\\\.\\pipe\\kolide_desktop_01K0ZRX5V7C2JK4S019TQ8GBB3: The system cannot find the file specified.","path":"C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\1.23.1\\launcher.exe","component":"desktop_runner"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "sending refresh command to user desktop process",
+			expectedLogLevel:   slog.LevelError,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "D:/a/launcher/launcher/ee/desktop/runner/runner.go",
+					"function": "github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).refreshMenu",
+					"line":     fileLineAsFloat,
+				}),
+				slog.String("original.component", "desktop_runner"),
+				slog.String("original.uid", "test"),
+				slog.Float64("original.pid", 968),
+				slog.String("err", "making request: Get \"http://unix/refresh\": open \\\\.\\pipe\\kolide_desktop_01K0ZRX5V7C2JK4S019TQ8GBB3: The system cannot find the file specified."),
+				slog.String("original.path", "C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\1.23.1\\launcher.exe"),
+			},
+		},
+		{
+			testCaseName:       "valid runner log",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"INFO","source":{"function":"github.com/kolide/launcher/pkg/rungroup.(*Group).Run","file":"/Users/runner/work/launcher/launcher/pkg/rungroup/rungroup.go","line":%d},"msg":"received interrupt error from first actor -- shutting down other actors","subprocess":"desktop","session_pid":57974,"uid":"501","component":"run_group","err":null,"error_source":"desktopServerShutdownListener"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "received interrupt error from first actor -- shutting down other actors",
+			expectedLogLevel:   slog.LevelInfo,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "/Users/runner/work/launcher/launcher/pkg/rungroup/rungroup.go",
+					"function": "github.com/kolide/launcher/pkg/rungroup.(*Group).Run",
+					"line":     fileLineAsFloat,
+				}),
+				slog.String("original.subprocess", "desktop"),
+				slog.Float64("original.session_pid", 57974),
+				slog.String("original.uid", "501"),
+				slog.String("original.component", "run_group"),
+				slog.String("original.error_source", "desktopServerShutdownListener"),
+			},
+		},
+		{
+			testCaseName:       "invalid JSON",
+			rawLogRecord:       []byte("not a log"),
+			expectedLogMessage: "failed to unmarshal incoming log",
+			expectedLogLevel:   slog.LevelError,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("log", "not a log"),
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			// The test handler will receive the incoming log record and assert our expectations against it.
+			slogger := slog.New(newTestHandler(t, tt.expectedLogMessage, tt.expectedLogLevel, tt.expectedLogAttributes))
+
+			// Process raw log record and allow the test handler to validate the outcome.
+			LogRawLogRecord(context.TODO(), tt.rawLogRecord, slogger)
+		})
+	}
+}
+
+type testHandler struct {
+	t                       *testing.T
+	expectedLogMessage      string
+	expectedLogLevel        slog.Level
+	expectedLogAttributeMap map[string]any
+}
+
+func newTestHandler(t *testing.T, expectedLogMessage string, expectedLogLevel slog.Level, expectedLogAttributes []slog.Attr) *testHandler {
+	logAttrMap := make(map[string]any)
+	for _, attr := range expectedLogAttributes {
+		logAttrMap[attr.Key] = attr.Value.Any()
+	}
+	return &testHandler{
+		t:                       t,
+		expectedLogMessage:      expectedLogMessage,
+		expectedLogLevel:        expectedLogLevel,
+		expectedLogAttributeMap: logAttrMap,
+	}
+}
+
+func (th *testHandler) Enabled(context.Context, slog.Level) bool {
+	// Test handler handles all levels for simplicity's sake
+	return true
+}
+
+func (th *testHandler) Handle(ctx context.Context, r slog.Record) error {
+	require.Equal(th.t, th.expectedLogMessage, r.Message, "msg is incorrect")
+	require.Equal(th.t, th.expectedLogLevel, r.Level, "level is incorrect")
+
+	// Check our attrs -- original.time plus everything in th.expectedLogAttributeMap
+	foundExpectedAttrs := make([]string, 0)
+	r.Attrs(func(a slog.Attr) bool {
+		expectedVal, ok := th.expectedLogAttributeMap[a.Key]
+		if !ok {
+			// Not an attr we were expecting (maybe a slogger attr), no need to check it
+			return true
+		}
+		foundExpectedAttrs = append(foundExpectedAttrs, a.Key)
+		require.Equal(th.t, expectedVal, a.Value.Any())
+		return true
+	})
+
+	require.Equal(th.t, len(th.expectedLogAttributeMap), len(foundExpectedAttrs), fmt.Sprintf("did not find all expected attrs: found: %+v; expected: %+v", foundExpectedAttrs, th.expectedLogAttributeMap))
+
+	return nil
+}
+
+func (th *testHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// No-op for test
+	return th
+}
+
+func (th *testHandler) WithGroup(name string) slog.Handler {
+	// No-op for test
+	return th
+}

--- a/ee/log/parser_test.go
+++ b/ee/log/parser_test.go
@@ -116,6 +116,25 @@ func TestLogRawLogRecord(t *testing.T) {
 			},
 		},
 		{
+			testCaseName:       "stack trace preserved",
+			rawLogRecord:       fmt.Appendf(nil, `{"time":"%s","level":"ERROR","msg":"panic stack trace","source":{"file":"/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go","function":"github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1","line":%d},"subprocess":"desktop","uid":"501","stack_trace":"runtime error: index out of range [4] with length 0\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:31\nruntime.gopanic\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792\nruntime.goPanicIndex\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:115\nmain.runDesktop.func3\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/desktop.go:135\ngithub.com/kolide/launcher/pkg/rungroup.(*Group).Run.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/pkg/rungroup/rungroup.go:76\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:39\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/asm_arm64.s:1223","session_pid":46329,"component":"run_group"}`, logTimeString, fileLineInt),
+			expectedLogMessage: "panic stack trace",
+			expectedLogLevel:   slog.LevelError,
+			expectedLogAttributes: []slog.Attr{
+				slog.String("original.time", logTimeString),
+				slog.Any("original.source", map[string]any{
+					"file":     "/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go",
+					"function": "github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1",
+					"line":     fileLineAsFloat,
+				}),
+				slog.String("original.component", "run_group"),
+				slog.String("original.subprocess", "desktop"),
+				slog.Float64("original.session_pid", 46329),
+				slog.String("original.uid", "501"),
+				slog.String("stack_trace", "runtime error: index out of range [4] with length 0\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:31\nruntime.gopanic\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792\nruntime.goPanicIndex\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:115\nmain.runDesktop.func3\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/desktop.go:135\ngithub.com/kolide/launcher/pkg/rungroup.(*Group).Run.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/pkg/rungroup/rungroup.go:76\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:39\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/asm_arm64.s:1223"),
+			},
+		},
+		{
 			testCaseName:       "invalid JSON",
 			rawLogRecord:       []byte("not a log"),
 			expectedLogMessage: "failed to unmarshal incoming log",


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/2342.

This PR updates the log parsing from the launcher watchdog to additionally use it to parse desktop logs. Since we will now set the correct level on the logs instead of always logging them as debug, desktop logs at the info level and above will be shipped to the cloud. This means we'll also be able to take advantage of error reporting functionality for desktop logs.

### Log examples

<details><summary>"launcher starting up"</summary>

Before:

```json
{
  "time": "2025-07-25T14:43:41.794339Z",
  "level": "DEBUG",
  "source": {
    "function": "github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).processLogs",
    "file": "/Users/runner/work/launcher/launcher/ee/desktop/runner/runner.go",
    "line": 1039
  },
  "msg": "{\"time\":\"2025-07-25T14:43:41.794306Z\",\"level\":\"INFO\",\"msg\":\"launcher starting up\",\"version\":\"1.23.1-16-gf2750aae\",\"revision\":\"f2750aaeeb37e77ad19dd061766a96956cdb836d\"}",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop"
}
```

After:

```json
{
  "time": "2025-07-25T14:38:06.03199Z",
  "level": "INFO",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "launcher starting up",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.time": "2025-07-25T14:38:06.03189Z",
  "original.version": "1.23.1-16-gf2750aae-dirty",
  "original.revision": "f2750aaeeb37e77ad19dd061766a96956cdb836d"
}
```

</details>

<details><summary>"starting"</summary>

Before:

```json
{
  "time": "2025-07-25T14:43:41.794415Z",
  "level": "DEBUG",
  "source": {
    "function": "github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).processLogs",
    "file": "/Users/runner/work/launcher/launcher/ee/desktop/runner/runner.go",
    "line": 1039
  },
  "msg": "{\"time\":\"2025-07-25T10:43:41.794355-04:00\",\"level\":\"INFO\",\"source\":{\"function\":\"main.runDesktop\",\"file\":\"/Users/runner/work/launcher/launcher/cmd/launcher/desktop.go\",\"line\":109},\"msg\":\"starting\",\"subprocess\":\"desktop\",\"session_pid\":43482,\"uid\":\"501\"}",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop"
}
```

After:

```json
{
  "time": "2025-07-25T14:38:06.032066Z",
  "level": "INFO",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "starting",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.session_pid": 42756,
  "original.uid": "501",
  "original.time": "2025-07-25T10:38:06.03194-04:00",
  "original.source": {
    "file": "/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/desktop.go",
    "function": "main.runDesktop",
    "line": 109
  },
  "original.subprocess": "desktop"
}
```

</details>

<details><summary>"received interrupt error from first actor -- shutting down other actors"</summary>

Before:

```json
{
  "time": "2025-07-25T14:43:50.375691Z",
  "level": "DEBUG",
  "source": {
    "function": "github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).processLogs",
    "file": "/Users/runner/work/launcher/launcher/ee/desktop/runner/runner.go",
    "line": 1039
  },
  "msg": "{\"time\":\"2025-07-25T10:43:50.375558-04:00\",\"level\":\"INFO\",\"source\":{\"function\":\"github.com/kolide/launcher/pkg/rungroup.(*Group).Run\",\"file\":\"/Users/runner/work/launcher/launcher/pkg/rungroup/rungroup.go\",\"line\":99},\"msg\":\"received interrupt error from first actor -- shutting down other actors\",\"subprocess\":\"desktop\",\"session_pid\":43482,\"uid\":\"501\",\"component\":\"run_group\",\"err\":null,\"error_source\":\"desktopServerShutdownListener\"}",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop"
}
```

After:

```json
{
  "time": "2025-07-25T14:38:33.808803Z",
  "level": "INFO",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "received interrupt error from first actor -- shutting down other actors",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.time": "2025-07-25T10:38:33.808627-04:00",
  "original.source": {
    "file": "/Users/rebeccamahany-horton/Repos/launcher/pkg/rungroup/rungroup.go",
    "function": "github.com/kolide/launcher/pkg/rungroup.(*Group).Run",
    "line": 99
  },
  "original.subprocess": "desktop",
  "original.session_pid": 42756,
  "original.uid": "501",
  "original.component": "run_group",
  "err": null,
  "original.error_source": "desktopServerShutdownListener"
}
```

</details>

<details><summary>"received interrupt"</summary>

Before:

```json
{
  "time": "2025-07-25T14:43:50.37596Z",
  "level": "DEBUG",
  "source": {
    "function": "github.com/kolide/launcher/ee/desktop/runner.(*DesktopUsersProcessesRunner).processLogs",
    "file": "/Users/runner/work/launcher/launcher/ee/desktop/runner/runner.go",
    "line": 1039
  },
  "msg": "{\"time\":\"2025-07-25T10:43:50.375873-04:00\",\"level\":\"INFO\",\"source\":{\"function\":\"github.com/kolide/launcher/ee/desktop/user/universallink.(*universalLinkHandler).Interrupt\",\"file\":\"/Users/runner/work/launcher/launcher/ee/desktop/user/universallink/handler_darwin.go\",\"line\":72},\"msg\":\"received interrupt\",\"subprocess\":\"desktop\",\"session_pid\":43482,\"uid\":\"501\",\"component\":\"universal_link_handler\"}",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop"
}
```

After:

```json
{
  "time": "2025-07-25T14:38:33.809034Z",
  "level": "DEBUG",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "received interrupt",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.session_pid": 42756,
  "original.uid": "501",
  "original.component": "universal_link_handler",
  "original.time": "2025-07-25T10:38:33.808805-04:00",
  "original.source": {
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/desktop/user/universallink/handler_darwin.go",
    "function": "github.com/kolide/launcher/ee/desktop/user/universallink.(*universalLinkHandler).Interrupt",
    "line": 72
  },
  "original.subprocess": "desktop"
}
```

</details>

<details><summary>Desktop logs with manufactured panic</summary>

```json
{
  "time": "2025-07-25T14:56:05.363834Z",
  "level": "ERROR",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "panic occurred in goroutine",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.component": "run_group",
  "err": "runtime error: index out of range [4] with length 0",
  "original.subprocess": "desktop",
  "original.session_pid": 46329,
  "original.time": "2025-07-25T10:56:05.36361-04:00",
  "original.source": {
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go",
    "function": "github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1",
    "line": 24
  },
  "original.uid": "501",
  "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
  "message": "panic occurred in goroutine"
}
{
  "time": "2025-07-25T14:56:05.3641Z",
  "level": "ERROR",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 65
  },
  "msg": "panic stack trace",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop",
  "original.source": {
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go",
    "function": "github.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1",
    "line": 29
  },
  "original.subprocess": "desktop",
  "original.uid": "501",
  "stack_trace": "runtime error: index out of range [4] with length 0\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1.1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:31\nruntime.gopanic\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792\nruntime.goPanicIndex\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:115\nmain.runDesktop.func3\n\t/Users/rebeccamahany-horton/Repos/launcher/cmd/launcher/desktop.go:135\ngithub.com/kolide/launcher/pkg/rungroup.(*Group).Run.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/pkg/rungroup/rungroup.go:76\ngithub.com/kolide/launcher/ee/gowrapper.GoWithRecoveryAction.func1\n\t/Users/rebeccamahany-horton/Repos/launcher/ee/gowrapper/goroutine.go:39\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/asm_arm64.s:1223",
  "original.time": "2025-07-25T10:56:05.363786-04:00",
  "original.session_pid": 46329,
  "original.component": "run_group",
  "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
  "message": "panic stack trace"
}
```

</details>