### PR TITLE
Log known unprocessable logs at a lower level than error

### DIFF
--- a/ee/log/parser.go
+++ b/ee/log/parser.go
@@ -16,12 +16,11 @@ func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Log
 	logRecord := make(map[string]any)
 
 	if err := json.Unmarshal(rawLogRecord, &logRecord); err != nil {
-		// If we can't parse the log, then log the raw string.
-		slogger.Log(ctx, slog.LevelError,
-			"failed to unmarshal incoming log",
-			"log", string(rawLogRecord),
-			"err", err,
-		)
+		// If we can't parse the log, then log the raw string at the info level.
+		// Sometimes we get non-JSON logs when e.g. the process hasn't fully set up
+		// logging yet, or when we're interacting with systray or another library
+		// that emits its own logs.
+		slogger.Log(ctx, slog.LevelInfo, string(rawLogRecord)) // nolint:sloglint // it's fine to not have a constant or literal here
 		return
 	}
 

--- a/ee/log/parser.go
+++ b/ee/log/parser.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,9 @@ import (
 
 const keyFormatWithPrefix = "original.%s"
 
+// https://developer.apple.com/documentation/usernotifications/unerrordomain?language=objc
+var notificationErrorDomain = []byte("UNErrorDomain")
+
 // LogRawLogRecord parses the given `rawLogRecord`, which should be a JSON-encoded slog LogRecord,
 // and then logs it. We use this to process logs from related subprocesses (launcher watchdog,
 // launcher desktop) and log them at the correct level.
@@ -16,11 +20,7 @@ func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Log
 	logRecord := make(map[string]any)
 
 	if err := json.Unmarshal(rawLogRecord, &logRecord); err != nil {
-		// If we can't parse the log, then log the raw string at the info level.
-		// Sometimes we get non-JSON logs when e.g. the process hasn't fully set up
-		// logging yet, or when we're interacting with systray or another library
-		// that emits its own logs.
-		slogger.Log(ctx, slog.LevelInfo, string(rawLogRecord)) // nolint:sloglint // it's fine to not have a constant or literal here
+		logRawNonJsonLogRecord(ctx, rawLogRecord, slogger)
 		return
 	}
 
@@ -60,4 +60,23 @@ func LogRawLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Log
 
 	// Re-issue the log using our slogger and our updated args.
 	slogger.LogAttrs(ctx, logLevel, logMsg, logArgs...) // nolint:sloglint // it's fine to not have a constant or literal here
+}
+
+// logRawNonJsonLogRecord handles incoming log messages that we are unable
+// to parse further. For example, sometimes we get non-JSON logs when the
+// process hasn't fully set up logging yet, or when we're interacting with
+// systray or another library that emits its own logs. We check for the types
+// of logs that we're aware of and know are not errors to log those at a non-error
+// level, and log all others at the error level.
+func logRawNonJsonLogRecord(ctx context.Context, rawLogRecord []byte, slogger *slog.Logger) {
+	logLevel := slog.LevelError
+
+	// Check for macOS notification-related errors. We typically see these due to the user
+	// not granting us permission to send notifications, which we can't do anything about.
+	if bytes.Contains(rawLogRecord, notificationErrorDomain) {
+		logLevel = slog.LevelWarn
+	}
+
+	// Log the raw log at the appropriate level
+	slogger.Log(ctx, logLevel, string(rawLogRecord)) // nolint:sloglint // it's fine to not have a constant or literal here
 }

--- a/ee/log/parser_test.go
+++ b/ee/log/parser_test.go
@@ -135,10 +135,17 @@ func TestLogRawLogRecord(t *testing.T) {
 			},
 		},
 		{
-			testCaseName:          "invalid JSON",
+			testCaseName:          "invalid JSON, notification error",
 			rawLogRecord:          []byte(`2025-07-29 09:09:01.270 launcher[15047:189395675] Error asking for permission to send notifications Error Domain=UNErrorDomain Code=1 "Notifications are not allowed for this application" UserInfo={NSLocalizedDescription=Notifications are not allowed for this application}`),
 			expectedLogMessage:    `2025-07-29 09:09:01.270 launcher[15047:189395675] Error asking for permission to send notifications Error Domain=UNErrorDomain Code=1 "Notifications are not allowed for this application" UserInfo={NSLocalizedDescription=Notifications are not allowed for this application}`,
-			expectedLogLevel:      slog.LevelInfo,
+			expectedLogLevel:      slog.LevelWarn,
+			expectedLogAttributes: []slog.Attr{},
+		},
+		{
+			testCaseName:          "invalid JSON, unknown log",
+			rawLogRecord:          []byte(`sudo: unable to execute /some/path/to/launcher: Permission denied`),
+			expectedLogMessage:    `sudo: unable to execute /some/path/to/launcher: Permission denied`,
+			expectedLogLevel:      slog.LevelError,
 			expectedLogAttributes: []slog.Attr{},
 		},
 	} {

--- a/ee/log/parser_test.go
+++ b/ee/log/parser_test.go
@@ -135,13 +135,11 @@ func TestLogRawLogRecord(t *testing.T) {
 			},
 		},
 		{
-			testCaseName:       "invalid JSON",
-			rawLogRecord:       []byte("not a log"),
-			expectedLogMessage: "failed to unmarshal incoming log",
-			expectedLogLevel:   slog.LevelError,
-			expectedLogAttributes: []slog.Attr{
-				slog.String("log", "not a log"),
-			},
+			testCaseName:          "invalid JSON",
+			rawLogRecord:          []byte(`2025-07-29 09:09:01.270 launcher[15047:189395675] Error asking for permission to send notifications Error Domain=UNErrorDomain Code=1 "Notifications are not allowed for this application" UserInfo={NSLocalizedDescription=Notifications are not allowed for this application}`),
+			expectedLogMessage:    `2025-07-29 09:09:01.270 launcher[15047:189395675] Error asking for permission to send notifications Error Domain=UNErrorDomain Code=1 "Notifications are not allowed for this application" UserInfo={NSLocalizedDescription=Notifications are not allowed for this application}`,
+			expectedLogLevel:      slog.LevelInfo,
+			expectedLogAttributes: []slog.Attr{},
 		},
 	} {
 		tt := tt


### PR DESCRIPTION
I originally thought that unprocessable logs would be a useful error group -- but I realized that many of these logs are expected.

In this PR, I updated to check for expected logs first, to log at a lower level; the remaining we continue to log at the error level.

Example log:

```json
{
  "time": "2025-07-29T13:29:46.920514Z",
  "level": "WARN",
  "source": {
    "function": "github.com/kolide/launcher/ee/log.LogRawLogRecord",
    "file": "/Users/rebeccamahany-horton/Repos/launcher/ee/log/parser.go",
    "line": 23
  },
  "msg": "2025-07-29 09:29:46.920 launcher[98491:18403969] Error asking for permission to send notifications Error Domain=UNErrorDomain Code=1 \"(null)\"",
  "component": "desktop_runner",
  "uid": "501",
  "subprocess": "desktop"
}
```
