### PR TITLE
Log failures to send notifications at the notifier level

### DIFF
--- a/ee/desktop/user/notify/notify_darwin.go
+++ b/ee/desktop/user/notify/notify_darwin.go
@@ -70,6 +70,8 @@ func (m *macNotifier) SendNotification(n Notification) error {
 
 	success := C.sendNotification(titleCStr, bodyCStr, actionUriCStr)
 	if !success {
+		// We don't need to log the lack of success here -- `C.sendNotification`
+		// performs an NSLog with the actual error in it.
 		return fmt.Errorf("could not send notification: %s", n.Title)
 	}
 

--- a/ee/desktop/user/server/server.go
+++ b/ee/desktop/user/server/server.go
@@ -161,10 +161,7 @@ func (s *UserServer) notificationHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	if err := s.notifier.SendNotification(notificationToSend); err != nil {
-		s.slogger.Log(context.TODO(), slog.LevelError,
-			"could not send notification",
-			"err", err,
-		)
+		// This error has already been logged appropriately by the notifier
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Logging these errors in the desktop server was effectively double-logging them -- the macOS notifier emits NSLogs on error already, and the Linux notifier logs as appropriate. I deduplicated logging by removing the log from the desktop server, because we will likely want to set error levels for these logs per-OS in the future. (For example, all the macOS notifier logs are logged at the warn level because they indicate permissions issues that we can't address.) I added logging to the Windows notifier to ensure errors are logged there.