### PR TITLE
update goleveldb dependency to v0.0.0-20250731160947-c6b056c282de

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.16.2
 	github.com/golang/snappy v0.0.4
-	github.com/kolide/goleveldb v0.0.0-20250616200551-f51774e831fc
+	github.com/kolide/goleveldb v0.0.0-20250731160947-c6b056c282de
 	github.com/kolide/systray v1.10.5-0.20241021175748-13aef6380bdb
 	github.com/kolide/toast v1.0.2
 	github.com/saltosystems/winrt-go v0.0.0-20240510082706-db61b37f5877

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767 h1:kcLxfX6wdtztSwpgz
 github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/kolide/goleveldb v0.0.0-20250616200551-f51774e831fc h1:ubZk39hNWWTFW+66pFtH5OO+thR94hl1TPkw7qOq5GQ=
 github.com/kolide/goleveldb v0.0.0-20250616200551-f51774e831fc/go.mod h1:/ABgvSu1vZfgbLb1B9IwnFGv0xgoHSyCrTXiWX1UAQQ=
+github.com/kolide/goleveldb v0.0.0-20250731160947-c6b056c282de h1:uOqIPplWbS6Lf2VxMJqhkiJj9Z23U2oeR6tHKe/o7ss=
+github.com/kolide/goleveldb v0.0.0-20250731160947-c6b056c282de/go.mod h1:/ABgvSu1vZfgbLb1B9IwnFGv0xgoHSyCrTXiWX1UAQQ=
 github.com/kolide/kit v0.0.0-20250324140823-36d978ef488c h1:Bfea0JIcUHJ+r0+FHtOk/Q0pZa7VadkAKwV6zHc2JLw=
 github.com/kolide/kit v0.0.0-20250324140823-36d978ef488c/go.mod h1:TC+XiiSDeHCzs7upD67Z4AtoQUuISEyLyHFCQ6IHWP0=
 github.com/kolide/krypto v0.1.1-0.20250708213031-518c54eca90a h1:Z66UC5jlpCKOgA1vcffFY+6rFzxo1DyIcUkEGpinisQ=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc h1:g2S0GQ
 github.com/knightsc/system_policy v1.1.1-0.20211029142728-5f4c0d5419cc/go.mod h1:5e34JEkxWsOeAd9jvcxkz01tAY/JAGFuabGnNBJ6TT4=
 github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767 h1:kcLxfX6wdtztSwpgzgrjUaC9kfyihXBUNnOIfoN5u4Y=
 github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
-github.com/kolide/goleveldb v0.0.0-20250616200551-f51774e831fc h1:ubZk39hNWWTFW+66pFtH5OO+thR94hl1TPkw7qOq5GQ=
-github.com/kolide/goleveldb v0.0.0-20250616200551-f51774e831fc/go.mod h1:/ABgvSu1vZfgbLb1B9IwnFGv0xgoHSyCrTXiWX1UAQQ=
 github.com/kolide/goleveldb v0.0.0-20250731160947-c6b056c282de h1:uOqIPplWbS6Lf2VxMJqhkiJj9Z23U2oeR6tHKe/o7ss=
 github.com/kolide/goleveldb v0.0.0-20250731160947-c6b056c282de/go.mod h1:/ABgvSu1vZfgbLb1B9IwnFGv0xgoHSyCrTXiWX1UAQQ=
 github.com/kolide/kit v0.0.0-20250324140823-36d978ef488c h1:Bfea0JIcUHJ+r0+FHtOk/Q0pZa7VadkAKwV6zHc2JLw=


### PR DESCRIPTION
This pull request updates a dependency in the `go.mod` file to use a newer version of `github.com/kolide/goleveldb`.
Closes #2330 

Update to include: https://github.com/kolide/goleveldb/pull/9

Dependency update:

* Updated `github.com/kolide/goleveldb` from `v0.0.0-20250616200551-f51774e831fc` to `v0.0.0-20250731160947-c6b056c282de` in `go.mod` to include the latest changes and improvements.