### PR TITLE
We do not want a splay delay before rolling back to a version already available on disk

### DIFF
--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -283,7 +283,6 @@ func TestExecute_downgrade(t *testing.T) {
 	mockKnapsack.On("InModernStandby").Return(false)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay).Return()
 	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath)
-	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second)
 
 	// Set logger so that we can capture output
 	var logBytes threadsafebuffer.ThreadSafeBuffer
@@ -795,7 +794,6 @@ func TestDo_WillNotExecuteDuringInitialDelay(t *testing.T) {
 	mockKnapsack.On("InModernStandby").Return(false)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay).Return()
 	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath)
-	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second)
 
 	// Set up autoupdater
 	autoupdater, err := NewTufAutoupdater(context.TODO(), mockKnapsack, http.DefaultClient, http.DefaultClient, WithOsqueryRestart(func(context.Context) error { return nil }))


### PR DESCRIPTION
The autoupdate system maintains a small on-disk library of updates in order to be able to roll back as quickly as possible. Consequently, I'm moving the splay delay check until after the "available" check. This does mean that unfortunately in the case of a rollback we will experience more concentrated load on the cloud side, as before -- but I think the ability to roll back a bad release immediately is more important.