### PR TITLE
Dedupe flag

### DIFF
--- a/ee/agent/flags/flag_controller.go
+++ b/ee/agent/flags/flag_controller.go
@@ -816,3 +816,15 @@ func (fc *FlagController) PerformanceMonitoringEnabled() bool {
 		WithDefaultBool(false),
 	).get(fc.getControlServerValue(keys.PerformanceMonitoringEnabled))
 }
+
+func (fc *FlagController) SetDuplicateLogWindow(duration time.Duration) error {
+	return fc.setControlServerValue(keys.DuplicateLogWindow, durationToBytes(duration))
+}
+
+func (fc *FlagController) DuplicateLogWindow() time.Duration {
+	return NewDurationFlagValue(fc.slogger, keys.DuplicateLogWindow,
+		WithDefault(0*time.Second), // Default is 0 (disabled)
+		WithMin(0*time.Second),     // Allow 0 to disable deduplication
+		WithMax(24*time.Hour),      // Maximum of 24 hours seems reasonable
+	).get(fc.getControlServerValue(keys.DuplicateLogWindow))
+}

--- a/ee/agent/flags/keys/keys.go
+++ b/ee/agent/flags/keys/keys.go
@@ -66,6 +66,7 @@ const (
 	CachedQueryResultsTTL            FlagKey = "cached_query_results_ttl"
 	ResetOnHardwareChangeEnabled     FlagKey = "reset_on_hardware_change_enabled"
 	PerformanceMonitoringEnabled     FlagKey = "performance_monitoring_enabled"
+	DuplicateLogWindow               FlagKey = "duplicate_log_window"
 )
 
 func (key FlagKey) String() string {

--- a/ee/agent/types/flags.go
+++ b/ee/agent/types/flags.go
@@ -269,4 +269,8 @@ type Flags interface {
 	// PerformanceMonitoringEnabled controls whether launcher self-monitors for performance issues
 	SetPerformanceMonitoringEnabled(enabled bool) error
 	PerformanceMonitoringEnabled() bool
+
+	// DuplicateLogWindow is the time window for deduplicating duplicate log records
+	SetDuplicateLogWindow(duration time.Duration) error
+	DuplicateLogWindow() time.Duration
 }

--- a/ee/agent/types/mocks/flags.go
+++ b/ee/agent/types/mocks/flags.go
@@ -365,6 +365,24 @@ func (_m *Flags) DistributedForwardingInterval() time.Duration {
 	return r0
 }
 
+// DuplicateLogWindow provides a mock function with no fields
+func (_m *Flags) DuplicateLogWindow() time.Duration {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DuplicateLogWindow")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // EnableInitialRunner provides a mock function with no fields
 func (_m *Flags) EnableInitialRunner() bool {
 	ret := _m.Called()
@@ -1233,6 +1251,24 @@ func (_m *Flags) SetDistributedForwardingInterval(interval time.Duration) error 
 // SetDistributedForwardingIntervalOverride provides a mock function with given fields: value, duration
 func (_m *Flags) SetDistributedForwardingIntervalOverride(value time.Duration, duration time.Duration) {
 	_m.Called(value, duration)
+}
+
+// SetDuplicateLogWindow provides a mock function with given fields: duration
+func (_m *Flags) SetDuplicateLogWindow(duration time.Duration) error {
+	ret := _m.Called(duration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetDuplicateLogWindow")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
+		r0 = rf(duration)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SetExportTraces provides a mock function with given fields: enabled

--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -513,6 +513,24 @@ func (_m *Knapsack) Dt4aInfoStore() types.GetterSetterDeleterIteratorUpdaterCoun
 	return r0
 }
 
+// DuplicateLogWindow provides a mock function with no fields
+func (_m *Knapsack) DuplicateLogWindow() time.Duration {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DuplicateLogWindow")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // EnableInitialRunner provides a mock function with no fields
 func (_m *Knapsack) EnableInitialRunner() bool {
 	ret := _m.Called()
@@ -1733,6 +1751,24 @@ func (_m *Knapsack) SetDistributedForwardingInterval(interval time.Duration) err
 // SetDistributedForwardingIntervalOverride provides a mock function with given fields: value, duration
 func (_m *Knapsack) SetDistributedForwardingIntervalOverride(value time.Duration, duration time.Duration) {
 	_m.Called(value, duration)
+}
+
+// SetDuplicateLogWindow provides a mock function with given fields: duration
+func (_m *Knapsack) SetDuplicateLogWindow(duration time.Duration) error {
+	ret := _m.Called(duration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetDuplicateLogWindow")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
+		r0 = rf(duration)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SetEnrollmentDetails provides a mock function with given fields: details

--- a/pkg/log/multislogger/flag_observer_test.go
+++ b/pkg/log/multislogger/flag_observer_test.go
@@ -1,0 +1,214 @@
+package multislogger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/ee/agent/flags/keys"
+	"github.com/kolide/launcher/ee/agent/types/mocks"
+)
+
+func TestMultiSlogger_FlagsChanged_DuplicateLogWindow(t *testing.T) {
+	t.Parallel()
+
+	// Create a multislogger with dedup enabled
+	ms := NewWithDedup(50 * time.Millisecond)
+	ms.Start(context.Background())
+	defer ms.Stop()
+
+	// Create a mock flags interface
+	mockFlags := mocks.NewFlags(t)
+	mockFlags.On("DuplicateLogWindow").Return(100 * time.Millisecond)
+
+	// Set the flags on the multislogger
+	ms.SetFlags(mockFlags)
+
+	// Call FlagsChanged with DuplicateLogWindow flag
+	ctx := context.Background()
+	ms.FlagsChanged(ctx, keys.DuplicateLogWindow)
+
+	// Verify that the mock was called
+	mockFlags.AssertCalled(t, "DuplicateLogWindow")
+
+	// Verify that the dedup engine was updated by checking its behavior
+	// (This is an indirect test since getDuplicateLogWindow is not exported from the engine)
+	// We'll test by verifying dedup behavior changes
+}
+
+func TestMultiSlogger_FlagsChanged_OtherFlags(t *testing.T) {
+	t.Parallel()
+
+	// Create a multislogger with dedup enabled
+	ms := NewWithDedup(50 * time.Millisecond)
+	ms.Start(context.Background())
+	defer ms.Stop()
+
+	// Create a mock flags interface
+	mockFlags := mocks.NewFlags(t)
+
+	// Set the flags on the multislogger
+	ms.SetFlags(mockFlags)
+
+	// Call FlagsChanged with non-DuplicateLogWindow flags
+	ctx := context.Background()
+	ms.FlagsChanged(ctx, keys.Debug, keys.LoggingInterval)
+
+	// Verify that DuplicateLogWindow() was NOT called since we didn't pass that flag
+	mockFlags.AssertNotCalled(t, "DuplicateLogWindow")
+}
+
+func TestMultiSlogger_FlagsChanged_NilFlags(t *testing.T) {
+	t.Parallel()
+
+	// Create a multislogger without setting flags
+	ms := NewWithDedup(50 * time.Millisecond)
+	ms.Start(context.Background())
+	defer ms.Stop()
+
+	// Call FlagsChanged without setting flags - should not panic
+	ctx := context.Background()
+	ms.FlagsChanged(ctx, keys.DuplicateLogWindow)
+	// Test passes if no panic occurs
+}
+
+func TestMultiSlogger_SetFlags(t *testing.T) {
+	t.Parallel()
+
+	ms := NewWithDedup(50 * time.Millisecond)
+	mockFlags := mocks.NewFlags(t)
+
+	// Test setting flags
+	ms.SetFlags(mockFlags)
+
+	// Verify flags are set by testing FlagsChanged behavior
+	mockFlags.On("DuplicateLogWindow").Return(100 * time.Millisecond)
+
+	ctx := context.Background()
+	ms.FlagsChanged(ctx, keys.DuplicateLogWindow)
+
+	mockFlags.AssertCalled(t, "DuplicateLogWindow")
+}
+
+func TestMultiSlogger_SetFlags_Nil(t *testing.T) {
+	t.Parallel()
+
+	// Test setting nil multislogger - should not panic
+	var nilMs *MultiSlogger
+	nilMs.SetFlags(nil)
+	// Test passes if no panic occurs
+}
+
+func TestMultiSlogger_FlagsChanged_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	// Create a multislogger with dedup enabled
+	ms := NewWithDedup(50 * time.Millisecond)
+	ms.Start(context.Background())
+	defer ms.Stop()
+
+	// Create a mock flags interface with thread-safe mock
+	mockFlags := &mocks.Flags{}
+	mockFlags.On("DuplicateLogWindow").Return(100 * time.Millisecond).Maybe()
+
+	// Set the flags on the multislogger
+	ms.SetFlags(mockFlags)
+
+	// Start multiple goroutines that concurrently call FlagsChanged
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Goroutine 1: Continuously trigger flag changes
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx := context.Background()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				ms.FlagsChanged(ctx, keys.DuplicateLogWindow)
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Goroutine 2: Continuously update duplicate log window directly
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		windows := []time.Duration{0, 50 * time.Millisecond, 100 * time.Millisecond, 200 * time.Millisecond}
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				ms.UpdateDuplicateLogWindow(windows[i%len(windows)])
+				i++
+				time.Sleep(15 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Goroutine 3: Continuously process logs to exercise the dedup engine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				// Create a test log record and process it through the multislogger
+				ms.Log(context.Background(), slog.LevelInfo, "concurrent test", "iteration", i)
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Let the test run for a short duration
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	// Test passes if no race conditions occurred (detected by go test -race)
+}
+
+func TestMultiSlogger_UpdateDuplicateLogWindow(t *testing.T) {
+	t.Parallel()
+
+	ms := NewWithDedup(50 * time.Millisecond)
+	ms.Start(context.Background())
+	defer ms.Stop()
+
+	// Test updating the window
+	ms.UpdateDuplicateLogWindow(100 * time.Millisecond)
+
+	// We can't directly verify the internal state, but we can verify the method doesn't panic
+	// and that the multislogger continues to function
+	ms.Log(context.Background(), slog.LevelInfo, "test message after update")
+}
+
+func TestMultiSlogger_UpdateDuplicateLogWindow_NilEngine(t *testing.T) {
+	t.Parallel()
+
+	// Create a multislogger without dedup (nil engine)
+	ms := New()
+
+	// Test updating window on nil engine - should not panic
+	ms.UpdateDuplicateLogWindow(100 * time.Millisecond)
+	// Test passes if no panic occurs
+}
+
+func TestMultiSlogger_UpdateDuplicateLogWindow_NilMultiSlogger(t *testing.T) {
+	t.Parallel()
+
+	// Test updating window on nil multislogger - should not panic
+	var nilMs *MultiSlogger
+	nilMs.UpdateDuplicateLogWindow(100 * time.Millisecond)
+	// Test passes if no panic occurs
+}


### PR DESCRIPTION
This pull request introduces a configurable duplicate log suppression ("deduplication") window, allowing runtime adjustment of how long duplicate log records are suppressed. The changes add a new `DuplicateLogWindow` flag, update the deduplication engine to support dynamic updates, and integrate this feature into the multislogger and flag controller systems. Comprehensive unit tests are included to ensure thread safety and correct behavior during flag changes and concurrent access.

**Deduplication window configuration and runtime updates:**

* Added a new `DuplicateLogWindow` flag key (`ee/agent/flags/keys/keys.go`) and exposed getter/setter methods in the `Flags` interface and its mocks, enabling runtime configuration of the deduplication window. [[1]](diffhunk://#diff-1e73b05c8d4f4f0f1de6f0dda2310f332bc88b625f1fc48064f58c3e0abe0e27R69) [[2]](diffhunk://#diff-d4072ec5e95c96a74b54248830c08732d0ff7bd69e5c516be1541cee4b439430R272-R275) [[3]](diffhunk://#diff-73705c5a4d5b76f004593cbf1cb84a1fb6966ccef4f2a990e1fded7d453306f2R819-R830) [[4]](diffhunk://#diff-c0d4e1b9c036b43e815c7ab1c26f8bb4f14023b0606127751fed7f04a2940e34R368-R385) [[5]](diffhunk://#diff-c0d4e1b9c036b43e815c7ab1c26f8bb4f14023b0606127751fed7f04a2940e34R1256-R1273) [[6]](diffhunk://#diff-ba742f0ddc02b42b772f5c78fdd4ec47d1e623161dbfb07763f60d0804357fa1R516-R533) [[7]](diffhunk://#diff-ba742f0ddc02b42b772f5c78fdd4ec47d1e623161dbfb07763f60d0804357fa1R1756-R1773)
* Modified the deduplication engine (`pkg/log/dedup/dedup_middleware.go`) to store and atomically update the deduplication window, with new methods to get/set the window and logic to disable deduplication when the window is zero. [[1]](diffhunk://#diff-c12bdbfd62aefa2c1bb52da113c228d7611ebfc1edb9504719a0aacb80af9247R145-R148) [[2]](diffhunk://#diff-c12bdbfd62aefa2c1bb52da113c228d7611ebfc1edb9504719a0aacb80af9247R170-R171) [[3]](diffhunk://#diff-c12bdbfd62aefa2c1bb52da113c228d7611ebfc1edb9504719a0aacb80af9247L174-R180) [[4]](diffhunk://#diff-c12bdbfd62aefa2c1bb52da113c228d7611ebfc1edb9504719a0aacb80af9247L219-R225) [[5]](diffhunk://#diff-c12bdbfd62aefa2c1bb52da113c228d7611ebfc1edb9504719a0aacb80af9247R265-R284)

**Integration with multislogger and launcher:**

* Updated `MultiSlogger` to accept a deduplication window at construction, store a reference to the flags interface, and react to flag changes by updating the deduplication engine at runtime. Added helper methods for setting flags and updating the deduplication window. [[1]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaR8-R11) [[2]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaR46-R48) [[3]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaR57-R61) [[4]](diffhunk://#diff-8c990b07ab0b7c1c4922b94725cb79d6b3778c5b862c22649749977b769ebadaL60-R71)
* In the launcher setup (`cmd/launcher/launcher.go`), registered the multislogger as an observer for `DuplicateLogWindow` flag changes and ensured its deduplication window is initialized and updated as flags change.

**Testing and validation:**

* Added extensive unit tests for the deduplication engine and multislogger to verify correct behavior when updating the deduplication window, handling concurrent access, and responding to flag changes. These tests ensure thread safety and correct suppression/enabling of duplicate logs. [[1]](diffhunk://#diff-2ec5a87351595ffe2665913386778860f599963b6df2878be750c374b7ab8fd4R296-R437) [[2]](diffhunk://#diff-de9063dfaef7ce247e0826a2695de09e24ed2749604d5b7971c304b82821f375R1-R214)