### PR TITLE
Switch to non-deprecated setup-zig action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -136,7 +136,7 @@ jobs:
       run: make deps
 
     - name: Set up zig
-      uses: goto-bus-stop/setup-zig@v2
+      uses: mlugg/setup-zig@v1
 
     - name: Build
       run: make -j2 github-build


### PR DESCRIPTION
Per https://github.com/goto-bus-stop/setup-zig/issues/88, the setup-zig action we're using is deprecated; this PR updates to use a new action.