### PR TITLE
Use arm64 as arch when building deb

### DIFF
--- a/pkg/packagekit/package_fpm.go
+++ b/pkg/packagekit/package_fpm.go
@@ -100,12 +100,9 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 	}
 	defer os.RemoveAll(outputPathDir)
 
-	// Set arch correctly when invoking fpm. Allowable values are amd64 (does not require update) and
-	// aarch64 (requires update from "arm64").
-	arch := f.arch
-	if arch == "arm64" {
-		arch = "aarch64"
-	}
+	// Set arch correctly when invoking fpm. Allowable values are amd64 (does not require update),
+	// arm64 (for deb, also does not require update) and aarch64 (for RPM, requires update from "arm64").
+	arch := fpmArch(f)
 
 	fpmCommand := []string{
 		"fpm",
@@ -190,4 +187,15 @@ func PackageFPM(ctx context.Context, w io.Writer, po *PackageOptions, fpmOpts ..
 	SetInContext(ctx, ContextLauncherVersionKey, po.Version)
 
 	return nil
+}
+
+func fpmArch(f fpmOptions) string {
+	// Set arch correctly when invoking fpm. Allowable values are amd64 (does not require update),
+	// arm64 (for deb, also does not require update) and aarch64 (for RPM, requires update from "arm64").
+	arch := f.arch
+	if arch == "arm64" && f.outputType == RPM {
+		arch = "aarch64"
+	}
+
+	return arch
 }

--- a/pkg/packagekit/package_fpm_test.go
+++ b/pkg/packagekit/package_fpm_test.go
@@ -1,0 +1,64 @@
+package packagekit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_fpmArch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName string
+		f            fpmOptions
+		expectedArch string
+	}{
+		{
+			testCaseName: "amd64",
+			f: fpmOptions{
+				arch: "amd64",
+			},
+			expectedArch: "amd64",
+		},
+		{
+			testCaseName: "arm64 - deb",
+			f: fpmOptions{
+				arch:       "arm64",
+				outputType: Deb,
+			},
+			expectedArch: "arm64",
+		},
+		{
+			testCaseName: "arm64 - rpm",
+			f: fpmOptions{
+				arch:       "arm64",
+				outputType: RPM,
+			},
+			expectedArch: "aarch64",
+		},
+		{
+			testCaseName: "arm64 - tar",
+			f: fpmOptions{
+				arch:       "arm64",
+				outputType: Tar,
+			},
+			expectedArch: "arm64",
+		},
+		{
+			testCaseName: "arm64 - pacman",
+			f: fpmOptions{
+				arch:       "arm64",
+				outputType: Pacman,
+			},
+			expectedArch: "arm64",
+		},
+	} {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expectedArch, fpmArch(tt.f))
+		})
+	}
+}


### PR DESCRIPTION
Corrects an overcorrection from https://github.com/kolide/launcher/pull/2360: the docs indicate that `valid values are: x86_64/amd64, aarch64, native (current architecture), all/noarch/any`, but in practice it appears that we do still want `arm64` when building debs. I have updated to _only_ use aarch64 when building RPMs, since that's the only one that we actually know requires aarch64.