### PR TITLE
bug fix for duration flag value

### DIFF
--- a/ee/agent/flags/flag_value_duration.go
+++ b/ee/agent/flags/flag_value_duration.go
@@ -62,19 +62,9 @@ func NewDurationFlagValue(slogger *slog.Logger, key keys.FlagKey, opts ...durati
 
 func (d *durationFlagValue) get(controlServerValue []byte) time.Duration {
 	int64Value := d.defaultVal
+
 	if controlServerValue != nil {
-		// Control server provided integers are stored as strings and need to be converted back
-		var err error
-		parsedInt, err := strconv.ParseInt(string(controlServerValue), 10, 64)
-		if err == nil {
-			int64Value = parsedInt
-		} else {
-			d.slogger.Log(context.TODO(), slog.LevelDebug,
-				"failed to convert stored duration flag value",
-				"key", d.key,
-				"err", err,
-			)
-		}
+		int64Value = d.parseControlServerValue(controlServerValue, int64Value)
 	}
 
 	if d.override != nil && d.override.Value() != nil {
@@ -88,6 +78,29 @@ func (d *durationFlagValue) get(controlServerValue []byte) time.Duration {
 	// Integers are sanitized to avoid unreasonable values
 	int64Value = clampValue(int64Value, d.min, d.max)
 	return time.Duration(int64Value)
+}
+
+// parseControlServerValue attempts to parse the control server value as either a duration string or nanoseconds
+func (d *durationFlagValue) parseControlServerValue(controlServerValue []byte, defaultValue int64) int64 {
+	valueStr := string(controlServerValue)
+
+	// First try to parse as a duration string (e.g., "4s", "10m")
+	if parsedDuration, err := time.ParseDuration(valueStr); err == nil {
+		return int64(parsedDuration)
+	}
+
+	// Fall back to parsing as nanoseconds for backward compatibility
+	if parsedInt, err := strconv.ParseInt(valueStr, 10, 64); err == nil {
+		return parsedInt
+	}
+
+	// Both parsing attempts failed, log and return default
+	d.slogger.Log(context.TODO(), slog.LevelDebug,
+		"failed to convert stored duration flag value",
+		"key", d.key,
+		"value", valueStr,
+	)
+	return defaultValue
 }
 
 // clampValue returns a value that is clamped to be within the range defined by min and max.

--- a/ee/agent/flags/flag_value_duration_test.go
+++ b/ee/agent/flags/flag_value_duration_test.go
@@ -67,6 +67,45 @@ func TestFlagValueDuration(t *testing.T) {
 			controlServerValue: []byte("30000000000"),
 			expectedValue:      25 * time.Second,
 		},
+		// New tests for duration string support
+		{
+			name:               "duration string seconds",
+			controlServerValue: []byte("4s"),
+			expectedValue:      4 * time.Second,
+		},
+		{
+			name:               "duration string minutes",
+			controlServerValue: []byte("10m"),
+			expectedValue:      10 * time.Minute,
+		},
+		{
+			name:               "duration string hours",
+			controlServerValue: []byte("2h"),
+			expectedValue:      2 * time.Hour,
+		},
+		{
+			name:               "duration string complex",
+			controlServerValue: []byte("1h30m45s"),
+			expectedValue:      1*time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		{
+			name:               "duration string with default fallback",
+			options:            []durationOption{WithDefault(5 * time.Second)},
+			controlServerValue: []byte("30s"),
+			expectedValue:      30 * time.Second,
+		},
+		{
+			name:               "legacy nanoseconds still work",
+			options:            []durationOption{WithDefault(5 * time.Second)},
+			controlServerValue: []byte("300000000000"), // 5 minutes in nanoseconds
+			expectedValue:      5 * time.Minute,
+		},
+		{
+			name:               "invalid duration string falls back to default",
+			options:            []durationOption{WithDefault(5 * time.Second)},
+			controlServerValue: []byte("invalid-duration"),
+			expectedValue:      5 * time.Second,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
This pull request enhances the handling of duration flag values by allowing support for both human-readable duration strings (like "4s", "10m") and legacy nanosecond integer formats. It refactors the parsing logic into a dedicated helper method and adds comprehensive tests to ensure correct behavior and backward compatibility.

Closes #2175 

### Improved duration flag parsing

* Added a new helper method `parseControlServerValue` to handle parsing of control server values as either duration strings or nanoseconds, improving code clarity and maintainability.
* Updated the main parsing logic in `get` to use the new helper method, ensuring that both formats are supported and errors are handled consistently.

### Expanded test coverage

* Added multiple new test cases to `TestFlagValueDuration` to verify support for duration strings, fallback to defaults, and continued compatibility with legacy nanosecond values.