### PR TITLE
Updates to auto triggered flares

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,15 @@
-version: "2"
+run:
+  timeout: 5m
+
 linters:
   enable:
     - bodyclose
     - containedctx
     - exhaustive
     - forbidigo
+    - gofmt
+    - govet
+    - ineffassign
     - misspell
     - nakedret
     - noctx
@@ -15,111 +20,89 @@ linters:
     - rowserrcheck
     - sloglint
     - sqlclosecheck
+    - staticcheck
     - unconvert
+    - unused
     - usetesting
   disable:
     - errcheck
     - gosec
-  settings:
-    errcheck:
-      exclude-functions:
-        - github.com/go-kit/kit/log:Log
-    forbidigo:
-      forbid:
-        - pattern: ^exec\.Command.*$
-          msg: use ee/allowedcmd functions instead
-        - pattern: ^os\.Exit.*$
-          msg: do not use os.Exit so that launcher can shut down gracefully
-        - pattern: ^logutil\.Fatal.*$
-          msg: do not use logutil.Fatal so that launcher can shut down gracefully
-        - pattern: ^panic.*$
-          msg: do not use panic so that launcher can shut down gracefully
-        - pattern: ^go func.*$
-          msg: use gowrapper.Go() instead of raw goroutines for proper panic handling
-        - pattern: \.Cmd\.(Run|Start|Output|CombinedOutput)
-          msg: Do not call embedded exec.Cmd methods directly on TracedCmd; call TracedCmd.Run(), TracedCmd.Start(), etc. instead
-        - pattern: ^table\.NewPlugin.*$
-          msg: use ee/tables/tablewrapper to enforce timeouts on table queries
-    revive:
-      rules:
-        - name: superfluous-else
-          arguments:
-            - preserveScope
-          severity: warning
-          disabled: false
-        - name: package-comments
-          disabled: false
-        - name: context-as-argument
-          disabled: false
-        - name: context-keys-type
-          disabled: false
-        - name: error-return
-          disabled: false
-        - name: errorf
-          disabled: false
-        - name: unreachable-code
-          disabled: false
-        - name: early-return
-          disabled: false
-        - name: confusing-naming
-          disabled: false
-        - name: defer
-          disabled: false
-    sloglint:
-      kv-only: true
-      context: all
-      static-msg: true
-      key-naming-case: snake
-    staticcheck:
-      checks:
-        - all
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
+    - gosimple
+
+linters-settings:
+  errcheck:
+    exclude-functions: [github.com/go-kit/kit/log:Log]
+  gofmt:
+    simplify: false
+  forbidigo:
+    forbid:
+      - p: ^exec\.Command.*$
+        msg: use ee/allowedcmd functions instead
+      - p: ^os\.Exit.*$
+        msg: do not use os.Exit so that launcher can shut down gracefully
+      - p: ^logutil\.Fatal.*$
+        msg: do not use logutil.Fatal so that launcher can shut down gracefully
+      - p: ^panic.*$
+        msg: do not use panic so that launcher can shut down gracefully
+      - p: ^go func.*$
+        msg: use gowrapper.Go() instead of raw goroutines for proper panic handling
+      - p: \.Cmd\.(Run|Start|Output|CombinedOutput)
+        msg: "Do not call embedded exec.Cmd methods directly on TracedCmd; call TracedCmd.Run(), TracedCmd.Start(), etc. instead"
+      - p: ^table\.NewPlugin.*$
+        msg: use ee/tables/tablewrapper to enforce timeouts on table queries
+  sloglint:
+    kv-only: true
+    context: "all"
+    key-naming-case: snake
+    static-msg: true
+  revive:
     rules:
-      - linters:
-          - paralleltest
-        text: does not use range value in test Run
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with string concatenation
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with faster hex.EncodeToString
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with faster strconv.FormatBool
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with faster strconv.FormatInt
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with faster strconv.FormatUint
-      - linters:
-          - perfsprint
-        text: fmt.Sprintf can be replaced with faster strconv.Itoa
-      - linters:
-          - perfsprint
-        text: fmt.Sprint can be replaced with faster strconv.Itoa
-    paths:
-      - test-cmds
-      - third_party$
-      - builtin$
-      - examples$
-formatters:
-  enable:
-    - gofmt
-  settings:
-    gofmt:
-      simplify: false
-  exclusions:
-    generated: lax
-    paths:
-      - test-cmds
-      - third_party$
-      - builtin$
-      - examples$
+      - name: superfluous-else
+        severity: warning
+        disabled: false
+        arguments:
+          - "preserveScope"
+      - name: package-comments
+        disabled: false
+      - name: context-as-argument
+        disabled: false
+      - name: context-keys-type
+        disabled: false
+      - name: error-return
+        disabled: false
+      - name: errorf
+        disabled: false
+      - name: unreachable-code
+        disabled: false
+      - name: early-return
+        disabled: false
+      - name: confusing-naming
+        disabled: false
+      - name: defer
+        disabled: false
+  staticcheck:
+    checks: ["all"]
+
+issues:
+  exclude-rules:
+    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
+    - linters:
+        - paralleltest
+      text: "does not use range value in test Run"
+    # We prefer fmt.Sprintf over string concatenation for readability
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with string concatenation"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatInt"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+    - linters: [perfsprint]
+      text: "fmt.Sprintf can be replaced with faster strconv.Itoa"
+    - linters: [perfsprint]
+      text: "fmt.Sprint can be replaced with faster strconv.Itoa"
+  exclude-dirs:
+    - test-cmds

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,10 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
     - bodyclose
     - containedctx
     - exhaustive
     - forbidigo
-    - gofmt
-    - govet
-    - ineffassign
     - misspell
     - nakedret
     - noctx
@@ -20,89 +15,111 @@ linters:
     - rowserrcheck
     - sloglint
     - sqlclosecheck
-    - staticcheck
     - unconvert
-    - unused
     - usetesting
   disable:
     - errcheck
     - gosec
-    - gosimple
-
-linters-settings:
-  errcheck:
-    exclude-functions: [github.com/go-kit/kit/log:Log]
-  gofmt:
-    simplify: false
-  forbidigo:
-    forbid:
-      - p: ^exec\.Command.*$
-        msg: use ee/allowedcmd functions instead
-      - p: ^os\.Exit.*$
-        msg: do not use os.Exit so that launcher can shut down gracefully
-      - p: ^logutil\.Fatal.*$
-        msg: do not use logutil.Fatal so that launcher can shut down gracefully
-      - p: ^panic.*$
-        msg: do not use panic so that launcher can shut down gracefully
-      - p: ^go func.*$
-        msg: use gowrapper.Go() instead of raw goroutines for proper panic handling
-      - p: \.Cmd\.(Run|Start|Output|CombinedOutput)
-        msg: "Do not call embedded exec.Cmd methods directly on TracedCmd; call TracedCmd.Run(), TracedCmd.Start(), etc. instead"
-      - p: ^table\.NewPlugin.*$
-        msg: use ee/tables/tablewrapper to enforce timeouts on table queries
-  sloglint:
-    kv-only: true
-    context: "all"
-    key-naming-case: snake
-    static-msg: true
-  revive:
+  settings:
+    errcheck:
+      exclude-functions:
+        - github.com/go-kit/kit/log:Log
+    forbidigo:
+      forbid:
+        - pattern: ^exec\.Command.*$
+          msg: use ee/allowedcmd functions instead
+        - pattern: ^os\.Exit.*$
+          msg: do not use os.Exit so that launcher can shut down gracefully
+        - pattern: ^logutil\.Fatal.*$
+          msg: do not use logutil.Fatal so that launcher can shut down gracefully
+        - pattern: ^panic.*$
+          msg: do not use panic so that launcher can shut down gracefully
+        - pattern: ^go func.*$
+          msg: use gowrapper.Go() instead of raw goroutines for proper panic handling
+        - pattern: \.Cmd\.(Run|Start|Output|CombinedOutput)
+          msg: Do not call embedded exec.Cmd methods directly on TracedCmd; call TracedCmd.Run(), TracedCmd.Start(), etc. instead
+        - pattern: ^table\.NewPlugin.*$
+          msg: use ee/tables/tablewrapper to enforce timeouts on table queries
+    revive:
+      rules:
+        - name: superfluous-else
+          arguments:
+            - preserveScope
+          severity: warning
+          disabled: false
+        - name: package-comments
+          disabled: false
+        - name: context-as-argument
+          disabled: false
+        - name: context-keys-type
+          disabled: false
+        - name: error-return
+          disabled: false
+        - name: errorf
+          disabled: false
+        - name: unreachable-code
+          disabled: false
+        - name: early-return
+          disabled: false
+        - name: confusing-naming
+          disabled: false
+        - name: defer
+          disabled: false
+    sloglint:
+      kv-only: true
+      context: all
+      static-msg: true
+      key-naming-case: snake
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: superfluous-else
-        severity: warning
-        disabled: false
-        arguments:
-          - "preserveScope"
-      - name: package-comments
-        disabled: false
-      - name: context-as-argument
-        disabled: false
-      - name: context-keys-type
-        disabled: false
-      - name: error-return
-        disabled: false
-      - name: errorf
-        disabled: false
-      - name: unreachable-code
-        disabled: false
-      - name: early-return
-        disabled: false
-      - name: confusing-naming
-        disabled: false
-      - name: defer
-        disabled: false
-  staticcheck:
-    checks: ["all"]
-
-issues:
-  exclude-rules:
-    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
-    - linters:
-        - paralleltest
-      text: "does not use range value in test Run"
-    # We prefer fmt.Sprintf over string concatenation for readability
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with string concatenation"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster hex.EncodeToString"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatBool"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.Itoa"
-    - linters: [perfsprint]
-      text: "fmt.Sprint can be replaced with faster strconv.Itoa"
-  exclude-dirs:
-    - test-cmds
+      - linters:
+          - paralleltest
+        text: does not use range value in test Run
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with string concatenation
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster hex.EncodeToString
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatBool
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatInt
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatUint
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.Itoa
+      - linters:
+          - perfsprint
+        text: fmt.Sprint can be replaced with faster strconv.Itoa
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -304,7 +304,7 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 
 	for _, c := range checkupsFor(k, flareType) {
 		// Log that we're doing this, because sometimes we seem to hang, and we want to debug it.
-		k.Slogger().Log(ctx, slog.LevelDebug,
+		k.Slogger().Log(ctx, slog.LevelInfo,
 			"running flare checkup",
 			"name", c.Name(),
 			"runtime_environment", runtimeEnvironment,

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -75,7 +75,7 @@ const (
 func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 	// This encodes what checkups run in which contexts. This could be pushed down into the checkups directly,
 	// but it seems nice to have it here. TBD
-	  	var runEverywhere targetBits = 255
+	var runEverywhere targetBits = 255
 
 	var potentialCheckups = []struct {
 		c       checkupInt
@@ -91,7 +91,7 @@ func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 		{&InitLogs{}, flareSupported},
 		{&BinaryDirectory{k: k}, doctorSupported | flareSupported},
 		{&launchdCheckup{k: k}, doctorSupported | flareSupported},
-		{&runtimeCheckup{k: k}, flareSupported | flarePerformanceSupported },
+		{&runtimeCheckup{k: k}, flareSupported | flarePerformanceSupported},
 		{&enrollSecretCheckup{k: k}, doctorSupported | flareSupported},
 		{&bboltdbCheckup{k: k}, flareSupported},
 		{&networkCheckup{}, doctorSupported | flareSupported},
@@ -263,8 +263,8 @@ func runDoctorCheckup(ctx context.Context, c checkupInt, w io.Writer) Status {
 type runtimeEnvironmentType string
 
 const (
-	StandaloneEnviroment runtimeEnvironmentType = "standalone"
-	InSituEnvironment    runtimeEnvironmentType = "in situ"
+	StandaloneEnviroment         runtimeEnvironmentType = "standalone"
+	InSituEnvironment            runtimeEnvironmentType = "in situ"
 	InSituPerformanceEnvironment runtimeEnvironmentType = "in situ performance"
 )
 
@@ -304,11 +304,11 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 
 	for _, c := range checkupsFor(k, flareType) {
 		// Log that we're doing this, because sometimes we seem to hang, and we want to debug it.
-		k.Slogger().Log(ctx, slog.LevelDebug, 
+		k.Slogger().Log(ctx, slog.LevelDebug,
 			"running flare checkup",
-			 "name", c.Name(),
-			 "runtimeEnvironment", runtimeEnvironment,
-			)
+			"name", c.Name(),
+			"runtimeEnvironment", runtimeEnvironment,
+		)
 		flareCheckup(ctx, c, &combinedSummary, flare)
 		if err := flare.Flush(); err != nil {
 			return errors.Join(fmt.Errorf("writing flare zip: %w", err), finalize())

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -307,7 +307,7 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 		k.Slogger().Log(ctx, slog.LevelDebug,
 			"running flare checkup",
 			"name", c.Name(),
-			"runtimeEnvironment", runtimeEnvironment,
+			"runtime_environment", runtimeEnvironment,
 		)
 		flareCheckup(ctx, c, &combinedSummary, flare)
 		if err := flare.Flush(); err != nil {

--- a/ee/debug/checkups/checkups.go
+++ b/ee/debug/checkups/checkups.go
@@ -65,6 +65,7 @@ type targetBits uint8
 const (
 	doctorSupported targetBits = 1 << iota
 	flareSupported
+	flarePerformanceSupported
 	logSupported
 	startupLogSupported
 )
@@ -74,21 +75,23 @@ const (
 func checkupsFor(k types.Knapsack, target targetBits) []checkupInt {
 	// This encodes what checkups run in which contexts. This could be pushed down into the checkups directly,
 	// but it seems nice to have it here. TBD
+	  	var runEverywhere targetBits = 255
+
 	var potentialCheckups = []struct {
 		c       checkupInt
 		targets targetBits
 	}{
-		{&Platform{}, doctorSupported | flareSupported | logSupported | startupLogSupported},
+		{&Platform{}, runEverywhere},
 		{&hostInfoCheckup{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
-		{&Version{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
+		{&Version{k: k}, runEverywhere},
 		{&Processes{}, doctorSupported | flareSupported},
 		{&RootDirectory{k: k}, doctorSupported | flareSupported},
 		{&Connectivity{k: k}, doctorSupported | flareSupported | logSupported | startupLogSupported},
-		{&Logs{k: k}, doctorSupported | flareSupported},
+		{&Logs{k: k}, doctorSupported | flareSupported | flarePerformanceSupported},
 		{&InitLogs{}, flareSupported},
 		{&BinaryDirectory{k: k}, doctorSupported | flareSupported},
 		{&launchdCheckup{k: k}, doctorSupported | flareSupported},
-		{&runtimeCheckup{k: k}, flareSupported},
+		{&runtimeCheckup{k: k}, flareSupported | flarePerformanceSupported },
 		{&enrollSecretCheckup{k: k}, doctorSupported | flareSupported},
 		{&bboltdbCheckup{k: k}, flareSupported},
 		{&networkCheckup{}, doctorSupported | flareSupported},
@@ -262,11 +265,18 @@ type runtimeEnvironmentType string
 const (
 	StandaloneEnviroment runtimeEnvironmentType = "standalone"
 	InSituEnvironment    runtimeEnvironmentType = "in situ"
+	InSituPerformanceEnvironment runtimeEnvironmentType = "in situ performance"
 )
 
 func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser, runtimeEnvironment runtimeEnvironmentType) error {
 	flare := zip.NewWriter(flareStream)
 	combinedSummary := bytes.Buffer{}
+
+	// If this is trigger for performance reasons, we run a limited set of checkups
+	flareType := flareSupported
+	if runtimeEnvironment == InSituPerformanceEnvironment {
+		flareType = flarePerformanceSupported
+	}
 
 	finalize := func() error {
 		closeFlares := func() error {
@@ -292,7 +302,13 @@ func RunFlare(ctx context.Context, k types.Knapsack, flareStream io.WriteCloser,
 		return errors.Join(fmt.Errorf("writing flare environment: %w", err), finalize())
 	}
 
-	for _, c := range checkupsFor(k, flareSupported) {
+	for _, c := range checkupsFor(k, flareType) {
+		// Log that we're doing this, because sometimes we seem to hang, and we want to debug it.
+		k.Slogger().Log(ctx, slog.LevelDebug, 
+			"running flare checkup",
+			 "name", c.Name(),
+			 "runtimeEnvironment", runtimeEnvironment,
+			)
 		flareCheckup(ctx, c, &combinedSummary, flare)
 		if err := flare.Flush(); err != nil {
 			return errors.Join(fmt.Errorf("writing flare zip: %w", err), finalize())

--- a/ee/debug/checkups/runtime.go
+++ b/ee/debug/checkups/runtime.go
@@ -118,11 +118,25 @@ func gatherPprofCpu(z *zip.Writer) error {
 		return fmt.Errorf("creating cpuprofile: %w", err)
 	}
 
-	// Increase the CPU profiling rate, in the hopes we can capture more / better detail. This
-	// is quite unclear, there's a long discussion at https://github.com/golang/go/issues/40094 and
-	// linked issues. But my takeaway is that in _some_ cases, there's value in raising this. But it
-	// does produce a spurious error -- "runtime: cannot set cpu profile rate until previous profile has finished"
-	runtime.SetCPUProfileRate(200)
+	// A digression on CPU profiling in Go...
+	//
+	// We are not experts, and this might be wrong. But as I understand it, go will sample what the
+	// CPU is doing N times per second. The default value is 100Hz, but it is very unclear if this
+	// is correct.
+	//
+	// One theory, is that this is too low on modern CPUs, and it's easy to miss things. There is
+	// a lot of discussion on this in https://github.com/golang/go/issues/40094 and
+	// linked issues.
+	//
+	// However, there is another school of thought, that, at least on windows, it's too high. The windows
+	// default timer is 15.6ms (about 64Hz) which is well below that 100Hz. See discussion in https://github.com/golang/go/issues/61665#issuecomment-1659714314
+	// However that also links to a CL where go starts using the high resolution timers -- https://go-review.googlesource.com/c/go/+/514375
+	//
+	// Because we don't understand, we are leaving it alone for now. If we do choose to change it, we
+	// can use the `runtime.SetCPUProfileRate(rate int)` function to do so.
+	//
+	// Also, note that changing this will cause profiling to produce a spurious
+	// error -- "runtime: cannot set cpu profile rate until previous profile has finished"
 
 	if err := pprof.StartCPUProfile(out); err != nil {
 		return fmt.Errorf("starting CPU profile: %w", err)

--- a/ee/debug/performance_monitor.go
+++ b/ee/debug/performance_monitor.go
@@ -109,7 +109,7 @@ func (p *performanceMonitor) checkPerformance() {
 		return
 	}
 
-	if err := checkups.RunFlare(ctx, p.knapsack, flareShipper, checkups.InSituEnvironment); err != nil {
+	if err := checkups.RunFlare(ctx, p.knapsack, flareShipper, checkups.InSituPerformanceEnvironment); err != nil {
 		p.slogger.Log(ctx, slog.LevelError,
 			"could not run and ship flare to capture high Golang memory and/or CPU usage",
 			"err", err,


### PR DESCRIPTION
When the autoflares trigger in a high CPU environment, sometimes they don't complete. This is a couple of attempts at improving that. And in generally trying to get better CPU profiling

1. Create a separate flare environment for perf triggers. Having written this, I think the environment and type are overlapping, and it's messy
2. Limit which flares run in the perf environment
3. Add some logging in the hopes that we see _something_
4. tweak the cpu profiling