### PR TITLE
osqueryinstance test fixes

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -60,7 +60,6 @@ func TestCreateOsqueryCommand(t *testing.T) {
 		extensionAutoloadPath: "/foo/bar/osquery.autoload",
 	}
 
-	osquerydPath := testOsqueryBinary
 	rootDir := t.TempDir()
 
 	k := typesMocks.NewKnapsack(t)
@@ -77,7 +76,7 @@ func TestCreateOsqueryCommand(t *testing.T) {
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
 	i.paths = paths
 
-	_, err := i.createOsquerydCommand(osquerydPath)
+	_, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
 	k.AssertExpectations(t)
@@ -101,7 +100,7 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
 	i.paths = &osqueryFilePaths{}
 
-	cmd, err := i.createOsquerydCommand(testOsqueryBinary)
+	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
 	// count of flags that cannot be overridden with this option
@@ -135,7 +134,7 @@ func TestCreateOsqueryCommand_SetsEnabledWatchdogSettingsAppropriately(t *testin
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
 	i.paths = &osqueryFilePaths{}
 
-	cmd, err := i.createOsquerydCommand(testOsqueryBinary)
+	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
 	watchdogMemoryLimitMBFound := false
@@ -185,7 +184,7 @@ func TestCreateOsqueryCommand_SetsDisabledWatchdogSettingsAppropriately(t *testi
 	i := newInstance(types.DefaultRegistrationID, k, mockServiceClient(t), settingsstoremock.NewSettingsStoreWriter(t))
 	i.paths = &osqueryFilePaths{}
 
-	cmd, err := i.createOsquerydCommand(testOsqueryBinary)
+	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
 	disableWatchdogFound := false
@@ -254,6 +253,7 @@ func Test_healthcheckWithRetries(t *testing.T) {
 
 func TestHealthy(t *testing.T) {
 	t.Parallel()
+	downloadOnceFunc()
 
 	// Set up instance dependencies
 	logBytes, slogger := setUpTestSlogger()
@@ -347,6 +347,7 @@ func TestHealthy(t *testing.T) {
 
 func TestLaunch(t *testing.T) {
 	t.Parallel()
+	downloadOnceFunc()
 
 	logBytes, slogger := setUpTestSlogger()
 	rootDirectory := testRootDirectory(t)
@@ -433,6 +434,7 @@ func TestLaunch(t *testing.T) {
 
 func TestReloadKatcExtension(t *testing.T) {
 	t.Parallel()
+	downloadOnceFunc()
 
 	// Set up all million dependencies
 	logBytes, slogger := setUpTestSlogger()

--- a/pkg/osquery/runtime/osqueryinstance_windows_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_windows_test.go
@@ -17,8 +17,6 @@ import (
 func TestCreateOsqueryCommandEnvVars(t *testing.T) {
 	t.Parallel()
 
-	osquerydPath := testOsqueryBinary
-
 	k := typesMocks.NewKnapsack(t)
 	k.On("WatchdogEnabled").Return(true)
 	k.On("WatchdogMemoryLimitMB").Return(150)
@@ -38,7 +36,7 @@ func TestCreateOsqueryCommandEnvVars(t *testing.T) {
 		extensionAutoloadPath: "/foo/bar/osquery.autoload",
 	}
 
-	cmd, err := i.createOsquerydCommand(osquerydPath)
+	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
 	systemDriveEnvVarFound := false


### PR DESCRIPTION
I was seeing a bunch of flaky pipeline failures, e.g.:
- https://github.com/kolide/launcher/actions/runs/18478586521/job/52704713850?pr=2438
- https://github.com/kolide/launcher/actions/runs/18478586521/job/52649851350?pr=2438

indicating we were missing an osquery path- it looks like this was just flaky due to test ordering within the package (some tests still needed to call `downloadOnceFunc` explicitly to ensure `testOsqueryBinary` was set).
I quickly audited the rest of the osqueryinstance_tests and added the download call where needed, and pulled out potentially confusing references to the binary where no download was needed and it would be set to an empty string when running in isolation anyway