### PR TITLE
Remove IO counter meters

### DIFF
--- a/ee/observability/meter.go
+++ b/ee/observability/meter.go
@@ -15,8 +15,6 @@ const (
 	// Custom units
 	unitRestart = "{restart}"
 	unitFailure = "{failure}"
-	unitReads   = "{reads}"
-	unitWrites  = "{writes}"
 
 	// Define our meter names and descriptions. All meter names should have "launcher." prepended.
 	goMemoryUsageGaugeName                       = "launcher.memory.golang"
@@ -51,10 +49,6 @@ const (
 	autoupdateFailureCounterDescription          = "The number of TUF autoupdate failures"
 	checkupErrorCounterName                      = "launcher.checkup.error"
 	checkupErrorCounterDescription               = "The number of errors when running checkups"
-	ioReadsCounterName                           = "launcher.io.reads"
-	ioReadsCounterDescription                    = "IO read counter for launcher"
-	ioWritesCounterName                          = "launcher.io.writes"
-	ioWritesCounterDescription                   = "IO write counter for launcher"
 )
 
 var (
@@ -79,8 +73,6 @@ var (
 	TablewrapperTimeoutCounter        metric.Int64Counter
 	AutoupdateFailureCounter          metric.Int64Counter
 	CheckupErrorCounter               metric.Int64Counter
-	IOReadsCounter                    metric.Int64Counter
-	IOWritesCounter                   metric.Int64Counter
 )
 
 // Initialize all of our meters. All meter names should have "launcher." prepended,
@@ -146,12 +138,6 @@ func ReinitializeMetrics() {
 	CheckupErrorCounter = int64CounterOrNoop(checkupErrorCounterName,
 		metric.WithDescription(checkupErrorCounterDescription),
 		metric.WithUnit(unitFailure))
-	IOReadsCounter = int64CounterOrNoop(ioReadsCounterName,
-		metric.WithDescription(ioReadsCounterDescription),
-		metric.WithUnit(unitReads))
-	IOWritesCounter = int64CounterOrNoop(ioWritesCounterName,
-		metric.WithDescription(ioWritesCounterDescription),
-		metric.WithUnit(unitWrites))
 }
 
 // int64GaugeOrNoop is guaranteed to return an Int64Gauge -- if we cannot create

--- a/ee/performance/stats.go
+++ b/ee/performance/stats.go
@@ -94,10 +94,6 @@ func ProcessStatsForPid(ctx context.Context, pid int) (*PerformanceStats, error)
 	observability.MemoryPercentGauge.Record(ctx, int64(ps.MemInfo.MemPercent))
 	observability.CpuPercentGauge.Record(ctx, int64(ps.CPUPercent))
 	observability.RSSHistogram.Record(ctx, int64(ps.MemInfo.RSS))
-	if ps.IO != nil {
-		observability.IOReadsCounter.Add(ctx, int64(ps.IO.ReadCount))
-		observability.IOWritesCounter.Add(ctx, int64(ps.IO.WriteCount))
-	}
 
 	return ps, nil
 }


### PR DESCRIPTION
Removes a portion of what I added in https://github.com/kolide/launcher/pull/2425.

Not seeing a ton of value from the counters, so I'm pulling them out. However, leaving the IO stats in the performance package so that they'll still get logged by checkups, in case we want them.