### PR TITLE
Log when server metadata changes

### DIFF
--- a/cmd/launcher/internal/record_metadata.go
+++ b/cmd/launcher/internal/record_metadata.go
@@ -57,7 +57,8 @@ func (mw *metadataWriter) Ping() {
 		)
 	}
 
-	if preUpdateMetadata == nil {
+	if preUpdateMetadata == nil ||
+		(preUpdateMetadata.DeviceId == "" && preUpdateMetadata.OrganizationId == "" && preUpdateMetadata.OrganizationMunemo == "") {
 		// No prior metadata to compare to, nothing more to do here
 		return
 	}

--- a/cmd/launcher/internal/record_metadata_test.go
+++ b/cmd/launcher/internal/record_metadata_test.go
@@ -102,6 +102,9 @@ func TestPing(t *testing.T) {
 			_, err = os.Stat(metadataFile)
 			require.True(t, errors.Is(err, os.ErrNotExist), "metadata file should not exist yet")
 
+			// Set blank data in file
+			testMetadataWriter.Ping()
+
 			// Set up existing metadata file, if required
 			if tt.startingMetadata != nil {
 				// Set starting data in store


### PR DESCRIPTION
If a device's ID or organization changes, that is a noteworthy event and we should log it. This PR adds logging to our metadata writer for that purpose.