### PR TITLE
Check that osquery runner has not been interrupted before initiating instance launch

### DIFF
--- a/pkg/osquery/runtime/runner.go
+++ b/pkg/osquery/runtime/runner.go
@@ -161,6 +161,11 @@ func (r *Runner) launchInstanceWithRetries(ctx context.Context, registrationId s
 	defer span.End()
 
 	for {
+		// Never attempt to launch an instance if shutdown has already been initiated
+		if r.interrupted.Load() {
+			return nil, fmt.Errorf("runner received shutdown, halting before initiating launching instance for %s", registrationId)
+		}
+
 		// Add the instance to our instances map right away, so that if we receive a shutdown
 		// request during launch, we can shut down the instance.
 		r.instanceLock.Lock()


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/2446 -- at least one of the shutdowns I saw there was a race condition, where the osquery instance shut down and the runner began to launch a new one, right around when launcher received a shutdown request. The osquery instance began to launch, and the runner had to wait for it to launch before shutting down.

We can't do much to interrupt the instance launch once it's underway, but I've added one last check here prior to instance launch.

I tried to add tests for this, but the timing is very precise and it was looking like the tests would be _extremely_ flaky and impractical.