### PR TITLE
Track known invalid usernames and ignore them

### DIFF
--- a/ee/consoleuser/consoleuser_windows_test.go
+++ b/ee/consoleuser/consoleuser_windows_test.go
@@ -175,6 +175,6 @@ func Test_updateInvalidUsernameMaps_RequiresFailuresWithinWindow(t *testing.T) {
 	// Confirm that we do still have some timestamps recorded
 	potentialInvalidUsernamesMapLock.Lock()
 	require.Contains(t, potentialInvalidUsernamesMap, invalidTestUsername)
-	require.Greater(t, len(potentialInvalidUsernamesMap[invalidTestUsername]), 0)
+	require.Equal(t, maxUsernameLookupFailureCount, len(potentialInvalidUsernamesMap[invalidTestUsername]))
 	potentialInvalidUsernamesMapLock.Unlock()
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/2463; implements suggestion from here: https://github.com/kolide/launcher/pull/2468#issuecomment-3474896699.

https://github.com/kolide/launcher/pull/2465 excluded some known usernames, but wasn't enough to cover all usernames that we aren't able to find explorer.exe processes for. This PR adds a lookup map to track usernames that we know we are unable to find explorer.exe processes for. Once we've failed to find an explorer.exe process for a username 3 times within 1 minute, we assume that this is a username we should not be starting a desktop process for.