### PR TITLE
Fixing failing unit tests

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -254,6 +254,7 @@ func Test_healthcheckWithRetries(t *testing.T) {
 func TestHealthy(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	setupOnceFunc()
 
 	// Set up instance dependencies
 	logBytes, slogger := setUpTestSlogger()
@@ -276,6 +277,7 @@ func TestHealthy(t *testing.T) {
 	k.On("OsqueryHealthcheckStartupDelay").Return(10 * time.Second)
 	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
+	k.On("InModernStandby").Return(false).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()
 	k.On("UpdateChannel").Return("stable").Maybe()
 	k.On("PinnedLauncherVersion").Return("").Maybe()
@@ -348,6 +350,7 @@ func TestHealthy(t *testing.T) {
 func TestLaunch(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	setupOnceFunc()
 
 	logBytes, slogger := setUpTestSlogger()
 	rootDirectory := testRootDirectory(t)
@@ -368,6 +371,7 @@ func TestLaunch(t *testing.T) {
 	k.On("ReadEnrollSecret").Return("", nil)
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinary)
 	k.On("OsqueryHealthcheckStartupDelay").Return(10 * time.Second)
+	k.On("InModernStandby").Return(false).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()


### PR DESCRIPTION
This pull request makes minor improvements to the unit tests in `osqueryinstance_test.go` by ensuring consistent test setup and mocking additional dependencies. The main changes are:

Test setup consistency:

* Added calls to `setupOnceFunc()` at the start of both `TestHealthy` and `TestLaunch` to ensure consistent environment setup for each test. [[1]](diffhunk://#diff-3ab1c1b1cd2231bb7a48e503c830ff22f6d3d87b2b594f00f16c5733527dab4dR257) [[2]](diffhunk://#diff-3ab1c1b1cd2231bb7a48e503c830ff22f6d3d87b2b594f00f16c5733527dab4dR353)


Test failing before changes:

>    settings_store_writer.go:39: FAIL:  WriteSettings()
>                         at: [/Users/cesar.araujo/repos/launcher/pkg/osquery/runtime/runtime_posix_test.go:150]
>     settings_store_writer.go:39: FAIL: 0 out of 1 expectation(s) were met.
>                 The code you are testing needs to make 1 more call(s).
>                 at: [/Users/cesar.araujo/repos/launcher/pkg/osquery/mocks/settings_store_writer.go:39 /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1211 /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1445 /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1786 /opt/homebrew/Cellar/go/1.24.0/libexec/src/runtime/panic.go:631 /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1041 /Users/cesar.araujo/repos/launcher/pkg/osquery/runtime/runtime_test.go:568 /Users/cesar.araujo/repos/launcher/pkg/osquery/runtime/runtime_posix_test.go:158]
>     testing.go:1490: race detected during execution of test
> FAIL
> coverage: 46.2% of statements
> FAIL    github.com/kolide/launcher/pkg/osquery/runtime  30.194s

Passing after changes:

> ok      github.com/kolide/launcher/pkg/osquery/runsimple        3.801s  coverage: 65.5% of statements
> ok      github.com/kolide/launcher/pkg/osquery/runtime  14.225s coverage: 81.9% of statements
> ok      github.com/kolide/launcher/pkg/osquery/runtime/history  2.922s  coverage: 87.5% of statements
>         github.com/kolide/launcher/pkg/osquery/runtime/history/mocks            coverage: 0.0% of statements
> ok      github.com/kolide/launcher/pkg/osquery/table    1.536s  coverage: 23.3% of statements