### PR TITLE
Desktop runner responds to update interval

### DIFF
--- a/ee/agent/types/mocks/knapsack.go
+++ b/ee/agent/types/mocks/knapsack.go
@@ -1177,26 +1177,6 @@ func (_m *Knapsack) OsqueryHistoryInstanceStore() types.GetterSetterDeleterItera
 	return r0
 }
 
-// ServerReleaseTrackerDataStore provides a mock function with no fields
-func (_m *Knapsack) ServerReleaseTrackerDataStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ServerReleaseTrackerDataStore")
-	}
-
-	var r0 types.GetterSetterDeleterIteratorUpdaterCounterAppender
-	if rf, ok := ret.Get(0).(func() types.GetterSetterDeleterIteratorUpdaterCounterAppender); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(types.GetterSetterDeleterIteratorUpdaterCounterAppender)
-		}
-	}
-
-	return r0
-}
-
 // OsqueryVerbose provides a mock function with no fields
 func (_m *Knapsack) OsqueryVerbose() bool {
 	ret := _m.Called()
@@ -1565,6 +1545,26 @@ func (_m *Knapsack) ServerProvidedDataStore() types.GetterSetterDeleterIteratorU
 
 	if len(ret) == 0 {
 		panic("no return value specified for ServerProvidedDataStore")
+	}
+
+	var r0 types.GetterSetterDeleterIteratorUpdaterCounterAppender
+	if rf, ok := ret.Get(0).(func() types.GetterSetterDeleterIteratorUpdaterCounterAppender); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.GetterSetterDeleterIteratorUpdaterCounterAppender)
+		}
+	}
+
+	return r0
+}
+
+// ServerReleaseTrackerDataStore provides a mock function with no fields
+func (_m *Knapsack) ServerReleaseTrackerDataStore() types.GetterSetterDeleterIteratorUpdaterCounterAppender {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServerReleaseTrackerDataStore")
 	}
 
 	var r0 types.GetterSetterDeleterIteratorUpdaterCounterAppender

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -129,6 +129,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			mockKnapsack := mocks.NewKnapsack(t)
 			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopEnabled)
 			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopGoMaxProcs)
+			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopUpdateInterval)
 			mockKnapsack.On("DesktopUpdateInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("DesktopGoMaxProcs").Return(2).Maybe()
@@ -168,7 +169,7 @@ func TestDesktopUserProcessRunner_Execute(t *testing.T) {
 			}()
 
 			// let it run a few intervals
-			time.Sleep(r.updateInterval * 6)
+			time.Sleep(r.updateInterval.Load() * 6)
 			interruptStart := time.Now()
 			r.Interrupt(nil)
 
@@ -376,6 +377,7 @@ func TestUpdate(t *testing.T) {
 			mockKnapsack := mocks.NewKnapsack(t)
 			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopEnabled)
 			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopGoMaxProcs)
+			mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopUpdateInterval)
 			mockKnapsack.On("DesktopUpdateInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 			mockKnapsack.On("DesktopGoMaxProcs").Return(2).Maybe()
@@ -412,6 +414,7 @@ func TestSendNotification_NoProcessesYet(t *testing.T) {
 	mockKnapsack := mocks.NewKnapsack(t)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopEnabled)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopGoMaxProcs)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopUpdateInterval)
 	mockKnapsack.On("DesktopUpdateInterval").Return(time.Millisecond * 250)
 	mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
 	mockKnapsack.On("DesktopGoMaxProcs").Return(2).Maybe()


### PR DESCRIPTION
This pull request introduces dynamic updating of the desktop process runner's update interval in response to configuration changes, improving flexibility and responsiveness. It achieves this by making the update interval atomic and resetting the ticker when the interval changes, and ensures that all relevant tests and mocks are updated accordingly.
Closes #2462 

**Dynamic update interval handling:**

* Refactored `DesktopUsersProcessesRunner` to store `updateInterval` as an `*atomic.Duration` and added an `updateTicker` field, allowing the update interval to be changed at runtime. The ticker is now reset when the interval changes, enabling immediate response to configuration updates. (`ee/desktop/runner/runner.go` [[1]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL112-R114) [[2]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL173-R175) [[3]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR195-R201) [[4]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL230-R237) [[5]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eL247-R253) [[6]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR575-R579) [[7]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR627-R654)
* Added observation of `DesktopUpdateInterval` changes via `RegisterChangeObserver`, and implemented the `updateIntervalChanged` method to handle interval updates and ticker resets. (`ee/desktop/runner/runner.go` [[1]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR195-R201) [[2]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR575-R579) [[3]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR627-R654)
