### PR TITLE
Update `commandExpectedToExit` to return true for `launcher --version`

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -355,5 +356,8 @@ func runVersion(_ *multislogger.MultiSlogger, args []string) error {
 // svc is used on windows to run as a service and we need a non-zero exit code for those no matter
 // the reason for the exit so the service manager will auto restart launcher
 func commandExpectedToExit(osArgs []string) bool {
-	return len(osArgs) > 1 && !strings.HasPrefix(osArgs[1], "-") && !strings.HasPrefix(osArgs[1], "svc")
+	return len(osArgs) > 1 &&
+		// Either first arg is not a flag, OR the flag is `--version` or `-version`
+		(!strings.HasPrefix(osArgs[1], "-") || slices.Contains(osArgs, "--version") || slices.Contains(osArgs, "-version")) &&
+		!strings.HasPrefix(osArgs[1], "svc")
 }

--- a/cmd/launcher/main_test.go
+++ b/cmd/launcher/main_test.go
@@ -66,11 +66,29 @@ func Test_commandExpectedToExit(t *testing.T) {
 			expectedExit: true,
 		},
 		{
+			testCaseName: "launcher subcommand version flag",
+			osArgs: []string{
+				"/some/path/to/launcher",
+				"--version",
+				"--config",
+				"/some/path/to/config",
+			},
+			expectedExit: true,
+		},
+		{
+			testCaseName: "launcher subcommand version flag, single dash",
+			osArgs: []string{
+				"/some/path/to/launcher",
+				"-version",
+			},
+			expectedExit: true,
+		},
+		{
 			testCaseName: "launcher subcommand interactive",
 			osArgs: []string{
 				"/some/path/to/launcher",
 				"interactive",
-				"-config",
+				"--config",
 				"/some/path/to/config",
 			},
 			expectedExit: true,


### PR DESCRIPTION
We can run the `runVersion` subcommand in two ways: via `launcher version` or `launcher --version` (`launcher -version`). This PR updates `commandExpectedToExit` to account for the latter as well.

Hopefully fixes e.g.

```
Run binaries/Linux-build/linux.amd64/launcher --version
{"time":"2025-11-06T04:27:28.928490431Z","level":"INFO","msg":"launcher starting up","version":"1.28.2-8-g42c6d297","revision":"42c6d2971d722274c88ad5a656782abf4e4ecf3d"}
{"time":"2025-11-06T04:27:28.928602249Z","level":"ERROR","msg":"could not check out latest launcher","err":"checking out latest launcher: could not get autoupdate config: could not read config file because it does not exist at /etc/kolide-k2/launcher.flags: stat /etc/kolide-k2/launcher.flags: no such file or directory","@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","message":"could not check out latest launcher"}
Error: Process completed with exit code 1.
```