### PR TITLE
If we cannot look up a newer launcher path, continue running our current version

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -92,12 +92,15 @@ func runMain() int {
 		// not using the runNewerLauncherIfAvailable helper here because we need to distinguish between
 		// commands that are expected to exit (like subcommands) and those that are not (like the main launcher run / svc* commands)
 		lastestLauncherPath, err := latestLauncherPath(ctx, systemSlogger.Logger)
+
+		// If we can't get the latest version of launcher, this is probably a new install that doesn't yet
+		// have any TUF metadata downloaded. Log the error in case it's relevant, and then we'll proceed to
+		// continue running this version of launcher, rather than execing a new one.
 		if err != nil {
 			systemSlogger.Log(ctx, slog.LevelError,
-				"could not check out latest launcher",
+				"could not check out latest launcher (likely new install that has not yet downloaded any updates)",
 				"err", err,
 			)
-			return 1
 		}
 
 		if lastestLauncherPath != "" {


### PR DESCRIPTION
_This_ should hopefully fix:

```
Run binaries/Linux-build/linux.amd64/launcher --version
{"time":"2025-11-06T04:27:28.928490431Z","level":"INFO","msg":"launcher starting up","version":"1.28.2-8-g42c6d297","revision":"42c6d2971d722274c88ad5a656782abf4e4ecf3d"}
{"time":"2025-11-06T04:27:28.928602249Z","level":"ERROR","msg":"could not check out latest launcher","err":"checking out latest launcher: could not get autoupdate config: could not read config file because it does not exist at /etc/kolide-k2/launcher.flags: stat /etc/kolide-k2/launcher.flags: no such file or directory","@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","message":"could not check out latest launcher"}
Error: Process completed with exit code 1.
```