### PR TITLE
add osquerypublisher encryption metadata and AAD

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -457,7 +457,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		controlService.RegisterSubscriber(katcSubsystemName, osqueryRunner)
 		controlService.RegisterSubscriber(katcSubsystemName, startupSettingsWriter)
 		controlService.RegisterConsumer(serverReleaseTrackerDataSubsystemName, keyvalueconsumer.NewConfigConsumer(k.ServerReleaseTrackerDataStore()))
-
 		// Manage filewalkers and handle updates to filewalk configs
 		filewalkManager := filewalker.New(k, slogger)
 		runGroup.Add("filewalkManager", filewalkManager.Execute, filewalkManager.Interrupt)
@@ -545,7 +544,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			controlService.RegisterSubscriber(authTokensSubsystemName, telemetryExporter)
 		}
 
+		// logPublishClient handles refreshing it's own auth tokens and encryption keys from the token store
 		controlService.RegisterSubscriber(authTokensSubsystemName, logPublishClient)
+		// logPublishClient handles embedding device metadata into encrypted payloads, subscribe to any changes in e.g. device ID
+		controlService.RegisterSubscriber(serverDataSubsystemName, logPublishClient)
 
 		if metadataWriter := internal.NewMetadataWriter(slogger, k); metadataWriter == nil {
 			slogger.Log(ctx, slog.LevelError,

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -457,6 +457,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		controlService.RegisterSubscriber(katcSubsystemName, osqueryRunner)
 		controlService.RegisterSubscriber(katcSubsystemName, startupSettingsWriter)
 		controlService.RegisterConsumer(serverReleaseTrackerDataSubsystemName, keyvalueconsumer.NewConfigConsumer(k.ServerReleaseTrackerDataStore()))
+
 		// Manage filewalkers and handle updates to filewalk configs
 		filewalkManager := filewalker.New(k, slogger)
 		runGroup.Add("filewalkManager", filewalkManager.Execute, filewalkManager.Interrupt)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -544,7 +544,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			controlService.RegisterSubscriber(authTokensSubsystemName, telemetryExporter)
 		}
 
-		// logPublishClient handles refreshing it's own auth tokens and encryption keys from the token store
+		// logPublishClient handles refreshing its own auth tokens and encryption keys from the token store
 		controlService.RegisterSubscriber(authTokensSubsystemName, logPublishClient)
 		// logPublishClient handles embedding device metadata into encrypted payloads, subscribe to any changes in e.g. device ID
 		controlService.RegisterSubscriber(serverDataSubsystemName, logPublishClient)

--- a/ee/osquerypublisher/client.go
+++ b/ee/osquerypublisher/client.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kolide/kit/contexts/uuid"
@@ -36,29 +37,26 @@ type (
 	// LogPublisherClient adheres to the Publisher interface. It handles log publication
 	// to the agent-ingester microservice
 	LogPublisherClient struct {
-		slogger        *slog.Logger
-		knapsack       types.Knapsack
-		client         PublisherHTTPClient
-		authTokens     map[string]string
-		hpkeKeys       map[string]*KeyData
-		psks           map[string]*KeyData
-		tokensMutex    *sync.RWMutex // used to protect the authTokens, hpkeKeys, and psks maps
-		deviceID       string        // cached device id from server provided data store used for the encrypted blob
-		organizationID string        // cached organization id from server provided data store used for the encrypted blob
-		metadataMutex  *sync.RWMutex // used to protect the encrypted blob metadata fields (device id, org id)
+		slogger      *slog.Logger
+		knapsack     types.Knapsack
+		client       PublisherHTTPClient
+		authTokens   map[string]string
+		hpkeKeys     map[string]*KeyData
+		psks         map[string]*KeyData
+		tokensMutex  *sync.RWMutex          // used to protect the authTokens, hpkeKeys, and psks maps
+		metadataJSON atomic.Pointer[[]byte] // cached JSON for encrypted blob metadata (see refreshServerMetadata)
 	}
 )
 
 func NewLogPublisherClient(logger *slog.Logger, k types.Knapsack, client PublisherHTTPClient) types.OsqueryPublisher {
 	lpc := LogPublisherClient{
-		slogger:       logger.With("component", "osquery_log_publisher"),
-		knapsack:      k,
-		client:        client,
-		authTokens:    make(map[string]string),
-		tokensMutex:   &sync.RWMutex{},
-		hpkeKeys:      make(map[string]*KeyData),
-		psks:          make(map[string]*KeyData),
-		metadataMutex: &sync.RWMutex{},
+		slogger:     logger.With("component", "osquery_log_publisher"),
+		knapsack:    k,
+		client:      client,
+		authTokens:  make(map[string]string),
+		tokensMutex: &sync.RWMutex{},
+		hpkeKeys:    make(map[string]*KeyData),
+		psks:        make(map[string]*KeyData),
 	}
 
 	lpc.refreshTokenCache()
@@ -161,16 +159,11 @@ func (lpc *LogPublisherClient) PublishResults(ctx context.Context, results []dis
 // includes marshalling the payload, fetching the auth token, issuing the request, and handling the response/logging.
 func (lpc *LogPublisherClient) publish(ctx context.Context, slogger *slog.Logger, payload any, publicationPath string) (*types.OsqueryPublicationResponse, error) {
 	var err error
-	// copy over the cached metadata to avoid race conditions
-	lpc.metadataMutex.RLock()
-	deviceID := lpc.deviceID
-	organizationID := lpc.organizationID
-	lpc.metadataMutex.RUnlock()
-	// don't bother publishing the payloadif we don't have the device ID or organization ID,
-	// we wouldn't know how to handle the payload downstream anyway
-	if deviceID == "" || organizationID == "" {
-		return nil, errors.New("no device ID or organization ID found, skipping publication")
+	metaPtr := lpc.metadataJSON.Load()
+	if metaPtr == nil || len(*metaPtr) == 0 {
+		return nil, errors.New("no publication metadata available, skipping publication")
 	}
+	metadataJSON := *metaPtr
 	// in the future we will want to plumb an enrollment ID through here, for now just use the default
 	enrollmentID := types.DefaultEnrollmentID
 	authToken := lpc.getTokenForEnrollment(enrollmentID)
@@ -195,7 +188,7 @@ func (lpc *LogPublisherClient) publish(ctx context.Context, slogger *slog.Logger
 
 	// TODO: (upcoming PR) data should be compressed here prior to encryption
 	// encrypt the payload
-	encryptedBlob, err := encryptWithHPKE(jsonData, hpkeKey, psk, deviceID, organizationID)
+	encryptedBlob, err := encryptWithHPKE(jsonData, hpkeKey, psk, metadataJSON)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt payload with HPKE: %w", err)
 	}
@@ -268,15 +261,16 @@ func (lpc *LogPublisherClient) refreshServerMetadata() {
 
 	if store == nil { // should never happen but sanity check
 		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
-			"ServerProvidedDataStore is not set, skipping AAD metadata refresh",
+			"ServerProvidedDataStore is not set, skipping metadata refresh",
 		)
 		return
 	}
 
+	// any errors encountered here are likely transient, don't clear the metadata cache on failure
 	deviceID, err := store.Get([]byte("device_id"))
 	if err != nil {
 		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
-			"failed to fetch device ID from ServerProvidedDataStore, skipping AAD metadata refresh",
+			"failed to fetch device ID from ServerProvidedDataStore, skipping metadata refresh",
 			"err", err,
 		)
 		return
@@ -285,16 +279,33 @@ func (lpc *LogPublisherClient) refreshServerMetadata() {
 	organizationID, err := store.Get([]byte("organization_id"))
 	if err != nil {
 		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
-			"failed to fetch organization ID from ServerProvidedDataStore, skipping AAD metadata refresh",
+			"failed to fetch organization ID from ServerProvidedDataStore, skipping metadata refresh",
 			"err", err,
 		)
 		return
 	}
 
-	lpc.metadataMutex.Lock()
-	defer lpc.metadataMutex.Unlock()
-	lpc.deviceID = string(deviceID)
-	lpc.organizationID = string(organizationID)
+	// if we legitimately don't have a device or organization ID, clear the metadata cache so we
+	// do not attempt to publish any logs/results. These would not be able to be routed or decrypted correctly
+	if len(deviceID) == 0 || len(organizationID) == 0 {
+		lpc.metadataJSON.Store(nil)
+		return
+	}
+
+	metadata := &Metadata{
+		DeviceID:       string(deviceID),
+		OrganizationID: string(organizationID),
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to marshal publication metadata, skipping metadata refresh",
+			"err", err,
+		)
+		return
+	}
+
+	lpc.metadataJSON.Store(&encoded)
 }
 
 // refreshTokenCache loads in the agent ingester auth token, HPKE keys, and PSKs from the TokenStore

--- a/ee/osquerypublisher/client.go
+++ b/ee/osquerypublisher/client.go
@@ -292,7 +292,7 @@ func (lpc *LogPublisherClient) refreshServerMetadata() {
 		return
 	}
 
-	metadata := &Metadata{
+	metadata := &blobMetadata{
 		DeviceID:       string(deviceID),
 		OrganizationID: string(organizationID),
 	}

--- a/ee/osquerypublisher/client.go
+++ b/ee/osquerypublisher/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -35,28 +36,33 @@ type (
 	// LogPublisherClient adheres to the Publisher interface. It handles log publication
 	// to the agent-ingester microservice
 	LogPublisherClient struct {
-		slogger     *slog.Logger
-		knapsack    types.Knapsack
-		client      PublisherHTTPClient
-		authTokens  map[string]string
-		hpkeKeys    map[string]*KeyData
-		psks        map[string]*KeyData
-		tokensMutex *sync.RWMutex // used to protect the authTokens, hpkeKeys, and psks maps
+		slogger        *slog.Logger
+		knapsack       types.Knapsack
+		client         PublisherHTTPClient
+		authTokens     map[string]string
+		hpkeKeys       map[string]*KeyData
+		psks           map[string]*KeyData
+		tokensMutex    *sync.RWMutex // used to protect the authTokens, hpkeKeys, and psks maps
+		deviceID       string        // cached device id from server provided data store used for the encrypted blob
+		organizationID string        // cached organization id from server provided data store used for the encrypted blob
+		metadataMutex  *sync.RWMutex // used to protect the encrypted blob metadata fields (device id, org id)
 	}
 )
 
 func NewLogPublisherClient(logger *slog.Logger, k types.Knapsack, client PublisherHTTPClient) types.OsqueryPublisher {
 	lpc := LogPublisherClient{
-		slogger:     logger.With("component", "osquery_log_publisher"),
-		knapsack:    k,
-		client:      client,
-		authTokens:  make(map[string]string),
-		tokensMutex: &sync.RWMutex{},
-		hpkeKeys:    make(map[string]*KeyData),
-		psks:        make(map[string]*KeyData),
+		slogger:       logger.With("component", "osquery_log_publisher"),
+		knapsack:      k,
+		client:        client,
+		authTokens:    make(map[string]string),
+		tokensMutex:   &sync.RWMutex{},
+		hpkeKeys:      make(map[string]*KeyData),
+		psks:          make(map[string]*KeyData),
+		metadataMutex: &sync.RWMutex{},
 	}
 
 	lpc.refreshTokenCache()
+	lpc.refreshServerMetadata()
 
 	return &lpc
 }
@@ -155,6 +161,16 @@ func (lpc *LogPublisherClient) PublishResults(ctx context.Context, results []dis
 // includes marshalling the payload, fetching the auth token, issuing the request, and handling the response/logging.
 func (lpc *LogPublisherClient) publish(ctx context.Context, slogger *slog.Logger, payload any, publicationPath string) (*types.OsqueryPublicationResponse, error) {
 	var err error
+	// copy over the cached metadata to avoid race conditions
+	lpc.metadataMutex.RLock()
+	deviceID := lpc.deviceID
+	organizationID := lpc.organizationID
+	lpc.metadataMutex.RUnlock()
+	// don't bother publishing the payloadif we don't have the device ID or organization ID,
+	// we wouldn't know how to handle the payload downstream anyway
+	if deviceID == "" || organizationID == "" {
+		return nil, errors.New("no device ID or organization ID found, skipping publication")
+	}
 	// in the future we will want to plumb an enrollment ID through here, for now just use the default
 	enrollmentID := types.DefaultEnrollmentID
 	authToken := lpc.getTokenForEnrollment(enrollmentID)
@@ -179,7 +195,7 @@ func (lpc *LogPublisherClient) publish(ctx context.Context, slogger *slog.Logger
 
 	// TODO: (upcoming PR) data should be compressed here prior to encryption
 	// encrypt the payload
-	encryptedBlob, err := encryptWithHPKE(jsonData, hpkeKey, psk)
+	encryptedBlob, err := encryptWithHPKE(jsonData, hpkeKey, psk, deviceID, organizationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt payload with HPKE: %w", err)
 	}
@@ -243,7 +259,42 @@ func (lpc *LogPublisherClient) publish(ctx context.Context, slogger *slog.Logger
 }
 
 func (lpc *LogPublisherClient) Ping() {
+	lpc.refreshServerMetadata()
 	lpc.refreshTokenCache()
+}
+
+func (lpc *LogPublisherClient) refreshServerMetadata() {
+	store := lpc.knapsack.ServerProvidedDataStore()
+
+	if store == nil { // should never happen but sanity check
+		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
+			"ServerProvidedDataStore is not set, skipping AAD metadata refresh",
+		)
+		return
+	}
+
+	deviceID, err := store.Get([]byte("device_id"))
+	if err != nil {
+		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to fetch device ID from ServerProvidedDataStore, skipping AAD metadata refresh",
+			"err", err,
+		)
+		return
+	}
+
+	organizationID, err := store.Get([]byte("organization_id"))
+	if err != nil {
+		lpc.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to fetch organization ID from ServerProvidedDataStore, skipping AAD metadata refresh",
+			"err", err,
+		)
+		return
+	}
+
+	lpc.metadataMutex.Lock()
+	defer lpc.metadataMutex.Unlock()
+	lpc.deviceID = string(deviceID)
+	lpc.organizationID = string(organizationID)
 }
 
 // refreshTokenCache loads in the agent ingester auth token, HPKE keys, and PSKs from the TokenStore

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -23,11 +23,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-const (
-	testDeviceID       string = "12345"
-	testOrganizationID string = "54321"
-)
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
@@ -41,12 +36,12 @@ func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 
-func testServerProvidedDataStore(t *testing.T) types.KVStore {
+func makeTestServerProvidedDataStore(t *testing.T) types.KVStore {
 	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
 	require.NoError(t, err)
-	err = store.Set([]byte("device_id"), []byte(testDeviceID))
+	err = store.Set([]byte("device_id"), []byte("12345"))
 	require.NoError(t, err)
-	err = store.Set([]byte("organization_id"), []byte(testOrganizationID))
+	err = store.Set([]byte("organization_id"), []byte("54321"))
 	require.NoError(t, err)
 	return store
 }
@@ -102,7 +97,7 @@ func TestLogPublisherClient_PublishLogs(t *testing.T) {
 			err = tokenStore.Set(storage.AgentIngesterHPKEPresharedKey, []byte("test-psk-id:"+base64.StdEncoding.EncodeToString([]byte("test-psk-key-data"))))
 			require.NoError(t, err)
 			mockKnapsack.On("TokenStore").Return(tokenStore).Maybe()
-			mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
+			mockKnapsack.On("ServerProvidedDataStore").Return(makeTestServerProvidedDataStore(t)).Maybe()
 
 			resp := &http.Response{
 				StatusCode: tt.responseStatus,
@@ -182,7 +177,7 @@ func TestLogPublisherClient_PublishResults(t *testing.T) {
 			err = tokenStore.Set(storage.AgentIngesterHPKEPresharedKey, []byte("test-psk-id:"+base64.StdEncoding.EncodeToString([]byte("test-psk-key-data"))))
 			require.NoError(t, err)
 			mockKnapsack.On("TokenStore").Return(tokenStore).Maybe()
-			mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
+			mockKnapsack.On("ServerProvidedDataStore").Return(makeTestServerProvidedDataStore(t)).Maybe()
 
 			resp := &http.Response{
 				StatusCode: tt.responseStatus,
@@ -676,7 +671,7 @@ func TestLogPublisherClient_refreshTokenCache_WithHPKEKeys(t *testing.T) {
 
 	mockKnapsack.On("OsqueryPublisherURL").Return("https://example.com").Maybe()
 	mockKnapsack.On("OsqueryPublisherPercentEnabled").Return(100).Maybe()
-	mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
+	mockKnapsack.On("ServerProvidedDataStore").Return(makeTestServerProvidedDataStore(t)).Maybe()
 
 	tokenStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.TokenStore.String())
 	require.NoError(t, err)

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -23,6 +23,11 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	testDeviceID       string = "12345"
+	testOrganizationID string = "54321"
+)
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
@@ -34,6 +39,16 @@ type mockHTTPClient struct {
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func testServerProvidedDataStore(t *testing.T) types.KVStore {
+	store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+	require.NoError(t, err)
+	err = store.Set([]byte("device_id"), []byte(testDeviceID))
+	require.NoError(t, err)
+	err = store.Set([]byte("organization_id"), []byte(testOrganizationID))
+	require.NoError(t, err)
+	return store
 }
 
 func TestLogPublisherClient_PublishLogs(t *testing.T) {
@@ -87,6 +102,7 @@ func TestLogPublisherClient_PublishLogs(t *testing.T) {
 			err = tokenStore.Set(storage.AgentIngesterHPKEPresharedKey, []byte("test-psk-id:"+base64.StdEncoding.EncodeToString([]byte("test-psk-key-data"))))
 			require.NoError(t, err)
 			mockKnapsack.On("TokenStore").Return(tokenStore).Maybe()
+			mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
 
 			resp := &http.Response{
 				StatusCode: tt.responseStatus,
@@ -166,6 +182,7 @@ func TestLogPublisherClient_PublishResults(t *testing.T) {
 			err = tokenStore.Set(storage.AgentIngesterHPKEPresharedKey, []byte("test-psk-id:"+base64.StdEncoding.EncodeToString([]byte("test-psk-key-data"))))
 			require.NoError(t, err)
 			mockKnapsack.On("TokenStore").Return(tokenStore).Maybe()
+			mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
 
 			resp := &http.Response{
 				StatusCode: tt.responseStatus,
@@ -659,6 +676,7 @@ func TestLogPublisherClient_refreshTokenCache_WithHPKEKeys(t *testing.T) {
 
 	mockKnapsack.On("OsqueryPublisherURL").Return("https://example.com").Maybe()
 	mockKnapsack.On("OsqueryPublisherPercentEnabled").Return(100).Maybe()
+	mockKnapsack.On("ServerProvidedDataStore").Return(testServerProvidedDataStore(t)).Maybe()
 
 	tokenStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.TokenStore.String())
 	require.NoError(t, err)

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cloudflare/circl/hpke"
@@ -44,6 +46,180 @@ func makeTestServerProvidedDataStore(t *testing.T) types.KVStore {
 	err = store.Set([]byte("organization_id"), []byte("54321"))
 	require.NoError(t, err)
 	return store
+}
+
+func TestLogPublisherClient_refreshServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setupKnapsack func(t *testing.T) *mocks.Knapsack
+		seed          func(lpc *LogPublisherClient)
+		assert        func(t *testing.T, lpc *LogPublisherClient)
+	}{
+		{
+			name: "nil ServerProvidedDataStore leaves cache unchanged",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(nil).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"12345","organization_id":"54321"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				p := lpc.metadataJSON.Load()
+				require.NotNil(t, p)
+				var got Metadata
+				require.NoError(t, json.Unmarshal(*p, &got))
+				require.Equal(t, "12345", got.DeviceID)
+				require.Equal(t, "54321", got.OrganizationID)
+			},
+		},
+		{
+			name: "device_id Get error leaves cache unchanged",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				kv := mocks.NewKVStore(t)
+				kv.On("Get", []byte("device_id")).Return(nil, errors.New("read error")).Once()
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(kv).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"keepmedeviceid","organization_id":"keepmeorganizationid"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				p := lpc.metadataJSON.Load()
+				require.NotNil(t, p)
+				var got Metadata
+				require.NoError(t, json.Unmarshal(*p, &got))
+				require.Equal(t, "keepmedeviceid", got.DeviceID)
+				require.Equal(t, "keepmeorganizationid", got.OrganizationID)
+			},
+		},
+		{
+			name: "organization_id Get error leaves cache unchanged",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				kv := mocks.NewKVStore(t)
+				kv.On("Get", []byte("device_id")).Return([]byte("originaldeviceid"), nil).Once()
+				kv.On("Get", []byte("organization_id")).Return(nil, errors.New("read error")).Once()
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(kv).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"originaldeviceid","organization_id":"originalorganizationid"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				p := lpc.metadataJSON.Load()
+				require.NotNil(t, p)
+				var got Metadata
+				require.NoError(t, json.Unmarshal(*p, &got))
+				require.Equal(t, "originaldeviceid", got.DeviceID)
+				require.Equal(t, "originalorganizationid", got.OrganizationID)
+			},
+		},
+		{
+			name: "valid device and organization IDs",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+				require.NoError(t, err)
+				require.NoError(t, store.Set([]byte("device_id"), []byte("12345")))
+				require.NoError(t, store.Set([]byte("organization_id"), []byte("54321")))
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(store).Once()
+				return k
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				p := lpc.metadataJSON.Load()
+				require.NotNil(t, p)
+				var got Metadata
+				require.NoError(t, json.Unmarshal(*p, &got))
+				require.Equal(t, "12345", got.DeviceID)
+				require.Equal(t, "54321", got.OrganizationID)
+			},
+		},
+		{
+			name: "empty device_id clears cache",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+				require.NoError(t, err)
+				require.NoError(t, store.Set([]byte("device_id"), []byte{}))
+				require.NoError(t, store.Set([]byte("organization_id"), []byte("org-only")))
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(store).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"stale","organization_id":"stale"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				require.Nil(t, lpc.metadataJSON.Load())
+			},
+		},
+		{
+			name: "empty organization_id clears cache",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+				require.NoError(t, err)
+				require.NoError(t, store.Set([]byte("device_id"), []byte("dev-only")))
+				require.NoError(t, store.Set([]byte("organization_id"), []byte{}))
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(store).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"stale","organization_id":"stale"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				require.Nil(t, lpc.metadataJSON.Load())
+			},
+		},
+		{
+			name: "missing device_id key clears cache",
+			setupKnapsack: func(t *testing.T) *mocks.Knapsack {
+				store, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+				require.NoError(t, err)
+				require.NoError(t, store.Set([]byte("organization_id"), []byte("org-1")))
+				k := mocks.NewKnapsack(t)
+				k.On("ServerProvidedDataStore").Return(store).Once()
+				return k
+			},
+			seed: func(lpc *LogPublisherClient) {
+				b := []byte(`{"device_id":"stale","organization_id":"stale"}`)
+				lpc.metadataJSON.Store(&b)
+			},
+			assert: func(t *testing.T, lpc *LogPublisherClient) {
+				require.Nil(t, lpc.metadataJSON.Load())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mk := tt.setupKnapsack(t)
+			lpc := &LogPublisherClient{
+				slogger:     multislogger.NewNopLogger().With("component", "osquery_log_publisher"),
+				knapsack:    mk,
+				client:      &mockHTTPClient{},
+				authTokens:  make(map[string]string),
+				tokensMutex: &sync.RWMutex{},
+				hpkeKeys:    make(map[string]*KeyData),
+				psks:        make(map[string]*KeyData),
+			}
+			if tt.seed != nil {
+				tt.seed(lpc)
+			}
+			lpc.refreshServerMetadata()
+			tt.assert(t, lpc)
+		})
+	}
 }
 
 func TestLogPublisherClient_PublishLogs(t *testing.T) {

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -71,7 +71,7 @@ func TestLogPublisherClient_refreshServerMetadata(t *testing.T) {
 			assert: func(t *testing.T, lpc *LogPublisherClient) {
 				p := lpc.metadataJSON.Load()
 				require.NotNil(t, p)
-				var got Metadata
+				var got blobMetadata
 				require.NoError(t, json.Unmarshal(*p, &got))
 				require.Equal(t, "12345", got.DeviceID)
 				require.Equal(t, "54321", got.OrganizationID)
@@ -93,7 +93,7 @@ func TestLogPublisherClient_refreshServerMetadata(t *testing.T) {
 			assert: func(t *testing.T, lpc *LogPublisherClient) {
 				p := lpc.metadataJSON.Load()
 				require.NotNil(t, p)
-				var got Metadata
+				var got blobMetadata
 				require.NoError(t, json.Unmarshal(*p, &got))
 				require.Equal(t, "keepmedeviceid", got.DeviceID)
 				require.Equal(t, "keepmeorganizationid", got.OrganizationID)
@@ -116,7 +116,7 @@ func TestLogPublisherClient_refreshServerMetadata(t *testing.T) {
 			assert: func(t *testing.T, lpc *LogPublisherClient) {
 				p := lpc.metadataJSON.Load()
 				require.NotNil(t, p)
-				var got Metadata
+				var got blobMetadata
 				require.NoError(t, json.Unmarshal(*p, &got))
 				require.Equal(t, "originaldeviceid", got.DeviceID)
 				require.Equal(t, "originalorganizationid", got.OrganizationID)
@@ -136,7 +136,7 @@ func TestLogPublisherClient_refreshServerMetadata(t *testing.T) {
 			assert: func(t *testing.T, lpc *LogPublisherClient) {
 				p := lpc.metadataJSON.Load()
 				require.NotNil(t, p)
-				var got Metadata
+				var got blobMetadata
 				require.NoError(t, json.Unmarshal(*p, &got))
 				require.Equal(t, "12345", got.DeviceID)
 				require.Equal(t, "54321", got.OrganizationID)

--- a/ee/osquerypublisher/encryption.go
+++ b/ee/osquerypublisher/encryption.go
@@ -20,7 +20,8 @@ const (
 	// Using the encryption suite is common practice for this type of data, but it is only important that whatever the value
 	// is cryptographically authenticated. If we chose to use a new suite and wanted to update this value, we should bump the
 	// EncryptedBlob version so that the receiver knows to utilize a newer AAD value.
-	// payloadAAD                  string = "HPKE-PSK-X25519-HKDF-SHA256-AES-256-GCM"
+	payloadAAD  string = "HPKE-PSK-X25519-HKDF-SHA256-AES-256-GCM"
+	metadataAAD string = "HPKE-BASE-X25519-HKDF-SHA256-AES-256-GCM"
 )
 
 // KeyData holds a key and it's corresponding identifier.
@@ -106,8 +107,8 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, metadataJ
 	}
 
 	// encrypt the plaintext with the associated data (aad). The aad should include any information
-	// that should be cryptographically authenticated but available in plaintext to the receiver.
-	ciphertext, err := sealer.Seal(plaintext, nil)
+	// that should be cryptographically authenticated but can be available in plaintext to the receiver.
+	ciphertext, err := sealer.Seal(plaintext, []byte(payloadAAD))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt plaintext: %w", err)
 	}
@@ -124,7 +125,7 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, metadataJ
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup HPKE base encryption for metadata: %w", err)
 	}
-	metadataCiphertext, err := metadataSealer.Seal(metadataJSON, nil)
+	metadataCiphertext, err := metadataSealer.Seal(metadataJSON, []byte(metadataAAD))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt metadata: %w", err)
 	}

--- a/ee/osquerypublisher/encryption.go
+++ b/ee/osquerypublisher/encryption.go
@@ -31,6 +31,8 @@ type EncryptedBlob struct {
 	PSKID           string `json:"psk_id"`
 	EncapsulatedKey string `json:"encapsulated_key"` // base64 encoded
 	Ciphertext      string `json:"ciphertext"`       // base64 encoded
+	DeviceID        string `json:"device_id"`
+	OrganizationID  string `json:"organization_id"`
 }
 
 // parseKeyData parses a concatenated string of "keyID:b64(keyMaterial)" into KeyData
@@ -65,7 +67,7 @@ func parseKeyData(concatenated string) (*KeyData, error) {
 
 // encryptWithHPKE encrypts plaintext using HPKE with PSK mode
 // Uses X25519 KEM, HKDF-SHA256 KDF, and AES-256-GCM AEAD
-func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData) (*EncryptedBlob, error) {
+func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, deviceID, organizationID string) (*EncryptedBlob, error) {
 	kemID := hpke.KEM_X25519_HKDF_SHA256
 	suite := hpke.NewSuite(kemID, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES256GCM)
 
@@ -89,7 +91,6 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData) (*Encrypt
 
 	// encrypt the plaintext with the associated data (aad). The aad should include any information
 	// that should be cryptographically authenticated but available in plaintext to the receiver.
-	// TODO: (upcoming PR) add metadata here for k2 (probably device id and encryption suite)
 	ciphertext, err := sealer.Seal(plaintext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt plaintext: %w", err)
@@ -105,5 +106,7 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData) (*Encrypt
 		PSKID:           psk.KeyID,
 		EncapsulatedKey: encapsulatedKeyB64,
 		Ciphertext:      ciphertextB64,
+		DeviceID:        deviceID,
+		OrganizationID:  organizationID,
 	}, nil
 }

--- a/ee/osquerypublisher/encryption.go
+++ b/ee/osquerypublisher/encryption.go
@@ -43,8 +43,8 @@ type EncryptedBlob struct {
 	MetadataCiphertext      string `json:"metadata_ciphertext"`       // base64 encoded
 }
 
-// Metadata represents the metadata required for data routing
-type Metadata struct {
+// blobMetadata represents the metadata required for data routing and server decryption
+type blobMetadata struct {
 	DeviceID       string `json:"device_id"`
 	OrganizationID string `json:"organization_id"`
 }

--- a/ee/osquerypublisher/encryption.go
+++ b/ee/osquerypublisher/encryption.go
@@ -3,6 +3,7 @@ package osquerypublisher
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,10 +30,17 @@ type EncryptedBlob struct {
 	Version         int    `json:"version"`
 	HPKEKeyID       string `json:"hpke_key_id"`
 	PSKID           string `json:"psk_id"`
-	EncapsulatedKey string `json:"encapsulated_key"` // base64 encoded
+	EncapsulatedKey string `json:"encapsulated_key"` // base64 encoded (PSK-mode HPKE for payload)
 	Ciphertext      string `json:"ciphertext"`       // base64 encoded
-	DeviceID        string `json:"device_id"`
-	OrganizationID  string `json:"organization_id"`
+	// Metadata uses HPKE base mode (separate handshake from the PSK payload)
+	MetadataEncapsulatedKey string `json:"metadata_encapsulated_key"` // base64 encoded
+	MetadataCiphertext      string `json:"metadata_ciphertext"`       // base64 encoded
+}
+
+// Metadata represents the metadata required for data routing
+type Metadata struct {
+	DeviceID       string `json:"device_id"`
+	OrganizationID string `json:"organization_id"`
 }
 
 // parseKeyData parses a concatenated string of "keyID:b64(keyMaterial)" into KeyData
@@ -65,8 +73,8 @@ func parseKeyData(concatenated string) (*KeyData, error) {
 	}, nil
 }
 
-// encryptWithHPKE encrypts plaintext using HPKE with PSK mode
-// Uses X25519 KEM, HKDF-SHA256 KDF, and AES-256-GCM AEAD
+// encryptWithHPKE encrypts plaintext in HPKE PSK mode and metadata in a separate HPKE base-mode
+// handshake (same KEM/KDF/AEAD: X25519, HKDF-SHA256, AES-256-GCM).
 func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, deviceID, organizationID string) (*EncryptedBlob, error) {
 	kemID := hpke.KEM_X25519_HKDF_SHA256
 	suite := hpke.NewSuite(kemID, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES256GCM)
@@ -99,14 +107,37 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, deviceID,
 	// b64 encode the outputs
 	encapsulatedKeyB64 := base64.StdEncoding.EncodeToString(encapsulatedKey)
 	ciphertextB64 := base64.StdEncoding.EncodeToString(ciphertext)
+	metadata := &Metadata{
+		DeviceID:       deviceID,
+		OrganizationID: organizationID,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	metaSender, err := suite.NewSender(pkR, []byte(hpkeDomain))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HPKE sender for metadata: %w", err)
+	}
+	metadataEncapsulatedKey, metadataSealer, err := metaSender.Setup(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup HPKE base encryption for metadata: %w", err)
+	}
+	metadataCiphertext, err := metadataSealer.Seal(metadataJSON, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt metadata: %w", err)
+	}
+	metadataEncapsulatedKeyB64 := base64.StdEncoding.EncodeToString(metadataEncapsulatedKey)
+	metadataCiphertextB64 := base64.StdEncoding.EncodeToString(metadataCiphertext)
 
 	return &EncryptedBlob{
-		Version:         currentEncryptedBlobVersion,
-		HPKEKeyID:       hpkeKey.KeyID,
-		PSKID:           psk.KeyID,
-		EncapsulatedKey: encapsulatedKeyB64,
-		Ciphertext:      ciphertextB64,
-		DeviceID:        deviceID,
-		OrganizationID:  organizationID,
+		Version:                 currentEncryptedBlobVersion,
+		HPKEKeyID:               hpkeKey.KeyID,
+		PSKID:                   psk.KeyID,
+		EncapsulatedKey:         encapsulatedKeyB64,
+		Ciphertext:              ciphertextB64,
+		MetadataEncapsulatedKey: metadataEncapsulatedKeyB64,
+		MetadataCiphertext:      metadataCiphertextB64,
 	}, nil
 }

--- a/ee/osquerypublisher/encryption.go
+++ b/ee/osquerypublisher/encryption.go
@@ -3,7 +3,6 @@ package osquerypublisher
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -16,6 +15,12 @@ const (
 	keyDelimiter                string = ":"
 	currentEncryptedBlobVersion int    = 1
 	hpkeDomain                  string = "AGENT_INGESTER_UPLOAD_ENC_V1"
+	// the payloadAAD stays unencrypted and is used to authenticate the payload to ensure the message hasn't
+	// been tampered with in transit. The receiver/decrypter must provide the same value in their decryption flow.
+	// Using the encryption suite is common practice for this type of data, but it is only important that whatever the value
+	// is cryptographically authenticated. If we chose to use a new suite and wanted to update this value, we should bump the
+	// EncryptedBlob version so that the receiver knows to utilize a newer AAD value.
+	// payloadAAD                  string = "HPKE-PSK-X25519-HKDF-SHA256-AES-256-GCM"
 )
 
 // KeyData holds a key and it's corresponding identifier.
@@ -73,9 +78,12 @@ func parseKeyData(concatenated string) (*KeyData, error) {
 	}, nil
 }
 
-// encryptWithHPKE encrypts plaintext in HPKE PSK mode and metadata in a separate HPKE base-mode
-// handshake (same KEM/KDF/AEAD: X25519, HKDF-SHA256, AES-256-GCM).
-func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, deviceID, organizationID string) (*EncryptedBlob, error) {
+// encryptWithHPKE encrypts plaintext in HPKE PSK mode and metadataJSON in a separate HPKE base-mode
+// handshake (same KEM/KDF/AEAD: X25519, HKDF-SHA256, AES-256-GCM). metadataJSON must be non-empty.
+func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, metadataJSON []byte) (*EncryptedBlob, error) {
+	if len(metadataJSON) == 0 {
+		return nil, errors.New("metadata JSON is empty")
+	}
 	kemID := hpke.KEM_X25519_HKDF_SHA256
 	suite := hpke.NewSuite(kemID, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES256GCM)
 
@@ -107,14 +115,6 @@ func encryptWithHPKE(plaintext []byte, hpkeKey *KeyData, psk *KeyData, deviceID,
 	// b64 encode the outputs
 	encapsulatedKeyB64 := base64.StdEncoding.EncodeToString(encapsulatedKey)
 	ciphertextB64 := base64.StdEncoding.EncodeToString(ciphertext)
-	metadata := &Metadata{
-		DeviceID:       deviceID,
-		OrganizationID: organizationID,
-	}
-	metadataJSON, err := json.Marshal(metadata)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
-	}
 
 	metaSender, err := suite.NewSender(pkR, []byte(hpkeDomain))
 	if err != nil {

--- a/ee/osquerypublisher/encryption_test.go
+++ b/ee/osquerypublisher/encryption_test.go
@@ -88,9 +88,10 @@ func TestEncryptWithHPKE(t *testing.T) {
 	}
 
 	plaintext := []byte("test plaintext message")
-
+	expectedDeviceID := "12345"
+	expectedOrganizationID := "54321"
 	// Encrypt
-	encryptedBlob, err := encryptWithHPKE(plaintext, hpkeKey, psk)
+	encryptedBlob, err := encryptWithHPKE(plaintext, hpkeKey, psk, expectedDeviceID, expectedOrganizationID)
 	require.NoError(t, err)
 	require.NotNil(t, encryptedBlob)
 
@@ -100,7 +101,8 @@ func TestEncryptWithHPKE(t *testing.T) {
 	require.Equal(t, psk.KeyID, encryptedBlob.PSKID)
 	require.NotEmpty(t, encryptedBlob.EncapsulatedKey)
 	require.NotEmpty(t, encryptedBlob.Ciphertext)
-
+	require.Equal(t, expectedDeviceID, encryptedBlob.DeviceID)
+	require.Equal(t, expectedOrganizationID, encryptedBlob.OrganizationID)
 	// Decrypt to verify round-trip (using the private key we generated)
 	encapsulatedKeyBytes, err := base64.StdEncoding.DecodeString(encryptedBlob.EncapsulatedKey)
 	require.NoError(t, err, "encapsulated key should be valid base64")

--- a/ee/osquerypublisher/encryption_test.go
+++ b/ee/osquerypublisher/encryption_test.go
@@ -91,8 +91,13 @@ func TestEncryptWithHPKE(t *testing.T) {
 	plaintext := []byte("test plaintext message")
 	expectedDeviceID := "12345"
 	expectedOrganizationID := "54321"
-	// Encrypt
-	encryptedBlob, err := encryptWithHPKE(plaintext, hpkeKey, psk, expectedDeviceID, expectedOrganizationID)
+	metadataJSON, err := json.Marshal(&Metadata{
+		DeviceID:       expectedDeviceID,
+		OrganizationID: expectedOrganizationID,
+	})
+	require.NoError(t, err)
+
+	encryptedBlob, err := encryptWithHPKE(plaintext, hpkeKey, psk, metadataJSON)
 	require.NoError(t, err)
 	require.NotNil(t, encryptedBlob)
 

--- a/ee/osquerypublisher/encryption_test.go
+++ b/ee/osquerypublisher/encryption_test.go
@@ -2,6 +2,7 @@ package osquerypublisher
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudflare/circl/hpke"
@@ -101,8 +102,8 @@ func TestEncryptWithHPKE(t *testing.T) {
 	require.Equal(t, psk.KeyID, encryptedBlob.PSKID)
 	require.NotEmpty(t, encryptedBlob.EncapsulatedKey)
 	require.NotEmpty(t, encryptedBlob.Ciphertext)
-	require.Equal(t, expectedDeviceID, encryptedBlob.DeviceID)
-	require.Equal(t, expectedOrganizationID, encryptedBlob.OrganizationID)
+	require.NotEmpty(t, encryptedBlob.MetadataEncapsulatedKey)
+	require.NotEmpty(t, encryptedBlob.MetadataCiphertext)
 	// Decrypt to verify round-trip (using the private key we generated)
 	encapsulatedKeyBytes, err := base64.StdEncoding.DecodeString(encryptedBlob.EncapsulatedKey)
 	require.NoError(t, err, "encapsulated key should be valid base64")
@@ -119,4 +120,20 @@ func TestEncryptWithHPKE(t *testing.T) {
 	decrypted, err := opener.Open(ciphertextBytes, nil)
 	require.NoError(t, err)
 	require.Equal(t, plaintext, decrypted, "decrypted plaintext should match original")
+
+	metaEncBytes, err := base64.StdEncoding.DecodeString(encryptedBlob.MetadataEncapsulatedKey)
+	require.NoError(t, err)
+	metaCipherBytes, err := base64.StdEncoding.DecodeString(encryptedBlob.MetadataCiphertext)
+	require.NoError(t, err)
+
+	metaReceiver, err := suite.NewReceiver(skR, []byte(hpkeDomain))
+	require.NoError(t, err)
+	metaOpener, err := metaReceiver.Setup(metaEncBytes)
+	require.NoError(t, err)
+	metadataPlain, err := metaOpener.Open(metaCipherBytes, nil)
+	require.NoError(t, err)
+	var gotMeta Metadata
+	require.NoError(t, json.Unmarshal(metadataPlain, &gotMeta))
+	require.Equal(t, expectedDeviceID, gotMeta.DeviceID)
+	require.Equal(t, expectedOrganizationID, gotMeta.OrganizationID)
 }

--- a/ee/osquerypublisher/encryption_test.go
+++ b/ee/osquerypublisher/encryption_test.go
@@ -91,7 +91,7 @@ func TestEncryptWithHPKE(t *testing.T) {
 	plaintext := []byte("test plaintext message")
 	expectedDeviceID := "12345"
 	expectedOrganizationID := "54321"
-	metadataJSON, err := json.Marshal(&Metadata{
+	metadataJSON, err := json.Marshal(&blobMetadata{
 		DeviceID:       expectedDeviceID,
 		OrganizationID: expectedOrganizationID,
 	})
@@ -137,7 +137,7 @@ func TestEncryptWithHPKE(t *testing.T) {
 	require.NoError(t, err)
 	metadataPlain, err := metaOpener.Open(metaCipherBytes, []byte(metadataAAD))
 	require.NoError(t, err)
-	var gotMeta Metadata
+	var gotMeta blobMetadata
 	require.NoError(t, json.Unmarshal(metadataPlain, &gotMeta))
 	require.Equal(t, expectedDeviceID, gotMeta.DeviceID)
 	require.Equal(t, expectedOrganizationID, gotMeta.OrganizationID)

--- a/ee/osquerypublisher/encryption_test.go
+++ b/ee/osquerypublisher/encryption_test.go
@@ -122,7 +122,7 @@ func TestEncryptWithHPKE(t *testing.T) {
 	opener, err := receiver.SetupPSK(encapsulatedKeyBytes, psk.Key, []byte(psk.KeyID))
 	require.NoError(t, err)
 
-	decrypted, err := opener.Open(ciphertextBytes, nil)
+	decrypted, err := opener.Open(ciphertextBytes, []byte(payloadAAD))
 	require.NoError(t, err)
 	require.Equal(t, plaintext, decrypted, "decrypted plaintext should match original")
 
@@ -135,7 +135,7 @@ func TestEncryptWithHPKE(t *testing.T) {
 	require.NoError(t, err)
 	metaOpener, err := metaReceiver.Setup(metaEncBytes)
 	require.NoError(t, err)
-	metadataPlain, err := metaOpener.Open(metaCipherBytes, nil)
+	metadataPlain, err := metaOpener.Open(metaCipherBytes, []byte(metadataAAD))
 	require.NoError(t, err)
 	var gotMeta Metadata
 	require.NoError(t, json.Unmarshal(metadataPlain, &gotMeta))

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -77,6 +77,13 @@ func makeKnapsack(t *testing.T) *mocks.Knapsack {
 	m.On("OsqueryPublisherPercentEnabled").Return(0).Maybe()
 	m.On("OsqueryPublisherURL").Return("").Maybe()
 	m.On("PersistAgentIngesterKeys", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return().Maybe()
+	serverProvidedDataStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+	require.NoError(t, err)
+	err = serverProvidedDataStore.Set([]byte("device_id"), []byte("12345"))
+	require.NoError(t, err)
+	err = serverProvidedDataStore.Set([]byte("organization_id"), []byte("54321"))
+	require.NoError(t, err)
+	m.On("ServerProvidedDataStore").Return(serverProvidedDataStore).Maybe()
 
 	return m
 }

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -74,6 +74,13 @@ func makeTestOsqLogPublisher(t *testing.T, mk *typesMocks.Knapsack) types.Osquer
 	tokenStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.TokenStore.String())
 	require.NoError(t, err)
 	mk.On("TokenStore").Return(tokenStore).Maybe()
+	serverProvidedDataStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
+	require.NoError(t, err)
+	err = serverProvidedDataStore.Set([]byte("device_id"), []byte("12345"))
+	require.NoError(t, err)
+	err = serverProvidedDataStore.Set([]byte("organization_id"), []byte("54321"))
+	require.NoError(t, err)
+	mk.On("ServerProvidedDataStore").Return(serverProvidedDataStore).Maybe()
 	slogger := multislogger.NewNopLogger()
 	client := &http.Client{}
 	t.Cleanup(func() {


### PR DESCRIPTION
- adds in AAD strings to osquery publisher encryption flows
- registers osquery publisher to subscribe to server provided data store changes
- caches device and org id as metadataJSON
- embeds encrypted metadata with EncryptedBlob payload