### PR TITLE
Ensure arch is included in cache filename to avoid cross-arch cache hits

### DIFF
--- a/pkg/packaging/fetch.go
+++ b/pkg/packaging/fetch.go
@@ -44,8 +44,8 @@ func FetchBinary(ctx context.Context, localCacheDir, name, binaryName, channelOr
 		return "", fmt.Errorf("could not create cache directory: %w", err)
 	}
 
-	localBinaryPath := filepath.Join(localCacheDir, fmt.Sprintf("%s-%s-%s", name, target.Platform, channelOrVersion), binaryName)
-	localPackagePath := filepath.Join(localCacheDir, fmt.Sprintf("%s-%s-%s.tar.gz", name, target.Platform, channelOrVersion))
+	localBinaryPath := filepath.Join(localCacheDir, fmt.Sprintf("%s-%s-%s-%s", name, target.Platform, target.Arch, channelOrVersion), binaryName)
+	localPackagePath := filepath.Join(localCacheDir, fmt.Sprintf("%s-%s-%s-%s.tar.gz", name, target.Platform, target.Arch, channelOrVersion))
 
 	// See if a local package exists on disk already. If so, return the cached path
 	if _, err := os.Stat(localBinaryPath); err == nil {


### PR DESCRIPTION
Updates cache name for files from e.g. `launcher-linux-nightly` to `launcher-linux-arm64-nightly` to avoid using a `launcher-linux-nightly` download for both amd64 and arm64 packages.