### PR TITLE
fix: socketfilterfw fall-through and softwareupdate test structure

### DIFF
--- a/ee/tables/execparsers/socketfilterfw/parser.go
+++ b/ee/tables/execparsers/socketfilterfw/parser.go
@@ -38,9 +38,10 @@ func socketfilterfwParse(reader io.Reader) (any, error) {
 			appRow := parseAppList(line)
 			if appRow != nil {
 				results = append(results, appRow)
+				continue
 			}
-
-			continue
+			// Fall through to parseLine: feature-state lines (e.g. stealth, logging)
+			// can appear after the app list section.
 		}
 
 		k, v := parseLine(line)

--- a/ee/tables/execparsers/softwareupdate/parse_test.go
+++ b/ee/tables/execparsers/softwareupdate/parse_test.go
@@ -152,12 +152,12 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			p := New()
+			result, err := p.Parse(bytes.NewReader(tt.input))
+			require.NoError(t, err, "unexpected error parsing input")
+
+			require.ElementsMatch(t, tt.expected, result)
 		})
-
-		p := New()
-		result, err := p.Parse(bytes.NewReader(tt.input))
-		require.NoError(t, err, "unexpected error parsing input")
-
-		require.ElementsMatch(t, tt.expected, result)
 	}
 }


### PR DESCRIPTION
socketfilterfw's parseAppData flag was one-way: once set, every line went through parseAppList and non-matching lines (feature-state lines after the app list) were silently dropped. Fix: only continue when parseAppList returns a match; non-matches fall through to parseLine.

softwareupdate subtests called p.Parse() and require outside the t.Run closure, so all subtests evaluated the same result regardless of input. Fix: move the Parse call and assertions inside each t.Run.