### PR TITLE
fix(repcli): fix two panics in parser

### DIFF
--- a/ee/tables/execparsers/repcli/parser.go
+++ b/ee/tables/execparsers/repcli/parser.go
@@ -82,6 +82,9 @@ func updatedKeyPaths(currentPaths []*repcliLine, newSection *repcliLine) []*repc
 
 		// we've gone too far and need to replace the previous key
 		if newSection.indentLevel < sectionLine.indentLevel {
+			if idx == 0 {
+				return []*repcliLine{newSection}
+			}
 			return append(currentPaths[:idx-1], newSection)
 		}
 
@@ -117,11 +120,14 @@ func setNestedValue(results resultMap, lines []*repcliLine) resultMap {
 		return results
 	}
 
-	if _, ok := results[key]; !ok {
-		results[key] = make(resultMap, 0)
+	existing, ok := results[key].(resultMap)
+	if !ok {
+		// Key was previously set to a non-map value (e.g. string or []string).
+		// A section header now claims this path — create a fresh map.
+		existing = make(resultMap)
 	}
 
-	results[key] = setNestedValue(results[key].(resultMap), lines[1:])
+	results[key] = setNestedValue(existing, lines[1:])
 
 	return results
 }

--- a/ee/tables/execparsers/repcli/parser_test.go
+++ b/ee/tables/execparsers/repcli/parser_test.go
@@ -91,6 +91,32 @@ You Should Not See this erroneous L1n3
 			},
 		},
 		{
+			name: "deeper-indented first line followed by top-level line does not panic",
+			input: []byte(`    Nested Key: deeply indented value
+Top Level Key: value
+`),
+			expected: resultMap{
+				"nested_key":    "deeply indented value",
+				"top_level_key": "value",
+			},
+		},
+		{
+			name: "key reused as section header after leaf value does not panic",
+			input: []byte(`Section:
+    Key: leaf value
+Section:
+    Key:
+        Nested: nested value
+`),
+			expected: resultMap{
+				"section": resultMap{
+					"key": resultMap{
+						"nested": "nested value",
+					},
+				},
+			},
+		},
+		{
 			name:  "repcli mac status",
 			input: repcli_mac_status,
 			expected: resultMap{


### PR DESCRIPTION
updatedKeyPaths computed idx-1 without checking idx==0, panicking when transitioning to a shallower indent level at the first element. setNestedValue used an unchecked type assertion on results[key], panicking when a key previously held a string value.

- updatedKeyPaths: return early when idx==0 to avoid negative slice index
- setNestedValue: use comma-ok type assertion and fall back to a new map