### PR TITLE
fix: skip blank lines in data_table and simple_array parsers

### DIFF
--- a/ee/tables/execparsers/data_table/parser.go
+++ b/ee/tables/execparsers/data_table/parser.go
@@ -73,8 +73,11 @@ func (p parser) parseLines(reader io.Reader) ([]map[string]string, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// headers weren't provided, so retrieve them from the first available line.
+		// headers weren't provided, so retrieve them from the first non-blank line.
 		if headerCount == 0 {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
 			p.headers = p.lineSplit(line, headerCount)
 			headerCount = len(p.headers)
 			continue

--- a/ee/tables/execparsers/data_table/parser_test.go
+++ b/ee/tables/execparsers/data_table/parser_test.go
@@ -191,6 +191,14 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "blank first line with explicit delimiter is skipped",
+			input:     []byte("\nname,age\nalice,30\n"),
+			delimiter: ",",
+			expected: []map[string]string{
+				{"name": "alice", "age": "30"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/ee/tables/execparsers/simple_array/parser.go
+++ b/ee/tables/execparsers/simple_array/parser.go
@@ -34,6 +34,10 @@ func parse(reader io.Reader) (any, error) {
 			chunk = strings.TrimSpace(chunk)
 			chunk = strings.Trim(chunk, `"`)
 
+			if chunk == "" {
+				continue
+			}
+
 			// If a chunk has a space in the middle, it's malformed and we should error out
 			if strings.Contains(chunk, " ") {
 				return nil, fmt.Errorf("malformed chunk: %s in line %s", chunk, line)


### PR DESCRIPTION
data_table used a blank line as its header row when auto-detecting headers with an explicit delimiter set, producing empty column names. simple_array emitted empty-string entries for blank lines and trailing commas.

- data_table: skip blank lines during header auto-detection
- simple_array: skip chunks that are empty after trimming