### PR TITLE
fix: flush last record and clean whitespace in Linux parsers

### DIFF
--- a/ee/tables/execparsers/apt/parser.go
+++ b/ee/tables/execparsers/apt/parser.go
@@ -35,7 +35,7 @@ func aptParse(reader io.Reader) (any, error) {
 		row["package"] = packageName
 		row["sources"] = strings.TrimSpace(values[0])
 		row["update_version"] = strings.TrimSpace(values[1])
-		row["current_version"] = strings.TrimRight(values[5], "]")
+		row["current_version"] = strings.TrimRight(strings.TrimSpace(values[5]), "]")
 
 		results = append(results, row)
 	}

--- a/ee/tables/execparsers/apt/parser_test.go
+++ b/ee/tables/execparsers/apt/parser_test.go
@@ -41,6 +41,18 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "windows line endings",
+			input: []byte("base-files/jammy-updates 12ubuntu4.3 amd64 [upgradable from: 12ubuntu4.2]\r\n"),
+			expected: []map[string]string{
+				{
+					"package":         "base-files",
+					"sources":         "jammy-updates",
+					"update_version":  "12ubuntu4.3",
+					"current_version": "12ubuntu4.2",
+				},
+			},
+		},
+		{
 			name:  "apt_upgradeable",
 			input: apt_upgradeable,
 			expected: []map[string]string{

--- a/ee/tables/execparsers/dpkg/parser.go
+++ b/ee/tables/execparsers/dpkg/parser.go
@@ -50,5 +50,10 @@ func dpkgParse(reader io.Reader) (any, error) {
 		}
 	}
 
+	// Flush the last record if input ended without a trailing blank line.
+	if len(row) > 0 {
+		results = append(results, row)
+	}
+
 	return results, nil
 }

--- a/ee/tables/execparsers/dpkg/parser_test.go
+++ b/ee/tables/execparsers/dpkg/parser_test.go
@@ -155,6 +155,13 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "no trailing blank line",
+			input: []byte("Package: foo\nVersion: 1.0\nSection: admin\n"),
+			expected: []map[string]string{
+				{"package": "foo", "version": "1.0", "section": "admin"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/ee/tables/execparsers/pacman/group/parser.go
+++ b/ee/tables/execparsers/pacman/group/parser.go
@@ -12,6 +12,9 @@ func pacmanParse(reader io.Reader) (any, error) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		// We expect pacman to return lines in the following format:
 		// `base-devel autoconf`
 		// `gnome baobab`...

--- a/ee/tables/execparsers/pacman/group/parser_test.go
+++ b/ee/tables/execparsers/pacman/group/parser_test.go
@@ -124,6 +124,14 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "whitespace-only lines produce no rows",
+			input: []byte("base-devel autoconf\n   \n\t  \nbase-devel automake\n"),
+			expected: []map[string]string{
+				{"group": "base-devel", "package": "autoconf"},
+				{"group": "base-devel", "package": "automake"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/ee/tables/execparsers/pacman/info/parser.go
+++ b/ee/tables/execparsers/pacman/info/parser.go
@@ -50,5 +50,10 @@ func pacmanParse(reader io.Reader) (any, error) {
 		}
 	}
 
+	// Flush the last record if input ended without a trailing blank line.
+	if len(row) > 0 {
+		results = append(results, row)
+	}
+
 	return results, nil
 }


### PR DESCRIPTION
dpkg and pacman/info both silently dropped the last package record when the input lacked a trailing blank line. pacman/group emitted empty rows for whitespace-only lines. apt preserved \r in version strings on Windows-style input.

- dpkg: flush pending row after scan loop
- pacman/info: flush pending row after scan loop
- pacman/group: skip whitespace-only lines before splitting
- apt: TrimSpace before TrimRight so \r is stripped from version field