### PR TITLE
fix(keyidentifier): use io.ReadFull and check error in readSizedString

### DIFF
--- a/ee/keyidentifier/helpers.go
+++ b/ee/keyidentifier/helpers.go
@@ -19,7 +19,9 @@ func boolPtr(b bool) *bool {
 // read. It returns as string. (This is used by the ssh.com format.)
 func readSizedString(r *bytes.Reader) (string, error) {
 	strLenBytes := make([]uint8, 4)
-	r.Read(strLenBytes)
+	if _, err := io.ReadFull(r, strLenBytes); err != nil {
+		return "", fmt.Errorf("reading string length: %w", err)
+	}
 
 	strLen := binary.BigEndian.Uint32(strLenBytes)
 


### PR DESCRIPTION
r.Read() was called without checking the error. If the read failed, strLen would be computed from garbage bytes, corrupting all subsequent parsing. Use io.ReadFull to ensure the full buffer is read and propagate any error.