### PR TITLE
fix(actionqueue): guard cancel nil in StopCleanup

### DIFF
--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -175,7 +175,9 @@ func (aq *ActionQueue) runCleanup() {
 }
 
 func (aq *ActionQueue) StopCleanup(err error) {
-	aq.cancel()
+	if aq.cancel != nil {
+		aq.cancel()
+	}
 }
 
 func (aq *ActionQueue) storeActionRecord(actionToStore action) {


### PR DESCRIPTION
cancel is only set when StartCleanup is called. If StopCleanup is called first (e.g. during failed startup), cancel is nil and panics.