### PR TITLE
Fix nil socket path when no recent socket file has stat info

### DIFF
--- a/ee/agent/listener/client.go
+++ b/ee/agent/listener/client.go
@@ -66,6 +66,10 @@ func NewLauncherClientConnection(ctx context.Context, rootDirectory string, sock
 		}
 	}
 
+	if socketPath == "" {
+		return nil, fmt.Errorf("no launcher socket found at %s", socketPattern)
+	}
+
 	d := net.Dialer{
 		Timeout: dialTimeout,
 	}


### PR DESCRIPTION
If all Stat calls fail in the selection loop, socketPath remains empty and the subsequent Dial would panic or fail with a confusing error. Add an explicit guard to return a clear error instead.