### PR TITLE
Add bounds checks in airport scan parser and mdmclient byte transformer

### DIFF
--- a/ee/tables/airport/table_darwin.go
+++ b/ee/tables/airport/table_darwin.go
@@ -203,6 +203,9 @@ func unmarshallScanOuput(reader io.Reader) []map[string]any {
 		rowData := make(map[string]any, len(headers))
 
 		for i, value := range splitAtIndexes(line, headerSeparatorIndexes) {
+			if i >= len(headers) {
+				break
+			}
 			rowData[headers[i]] = value
 		}
 

--- a/ee/tables/mdmclient/mdmclient.go
+++ b/ee/tables/mdmclient/mdmclient.go
@@ -202,7 +202,9 @@ func transformLengthByteEntriesInOutput(out []byte) []byte {
 
 		// Replace comma with semicolon for first capture group (e.g. transforming `length = 32,` to `length = 32;`)
 		lengthEndIndex := match[3]
-		out[lengthEndIndex-1] = ';'
+		if lengthEndIndex > 0 && lengthEndIndex <= len(out) {
+			out[lengthEndIndex-1] = ';'
+		}
 
 		// Quote second capture group and append a semicolon (e.g., transforming
 		// `bytes = 0x068b4535 172f7bd3 851facee c98e0d88 ... 38625271 61731ac3 ` to
@@ -224,6 +226,9 @@ func transformLengthByteEntriesInOutput(out []byte) []byte {
 }
 
 func insertAt(original []byte, insertIndex int, value byte) []byte {
+	if insertIndex < 0 || insertIndex > len(original) {
+		return original
+	}
 	original = append(original[:insertIndex+1], original[insertIndex:]...)
 	original[insertIndex] = value
 


### PR DESCRIPTION
airport: guard against splitAtIndexes returning more values than headers when a data row has more columns than the header row.

mdmclient: guard against out-of-bounds index in transformLengthByteEntriesInOutput and add early return for invalid insertIndex in insertAt.