### PR TITLE
Guard against missing name/query keys in scheduled query results

### DIFF
--- a/ee/localserver/request-query.go
+++ b/ee/localserver/request-query.go
@@ -101,17 +101,28 @@ func (ls *localServer) requestScheduledQueryHandlerFunc(w http.ResponseWriter, r
 	results := make([]distributed.Result, len(scheduledQueriesQueryResults))
 
 	for i, scheduledQuery := range scheduledQueriesQueryResults {
-		results[i] = distributed.Result{
-			QueryName: scheduledQuery["name"],
+		name, nameOk := scheduledQuery["name"]
+		query, queryOk := scheduledQuery["query"]
+		if !nameOk || name == "" || !queryOk || query == "" {
+			ls.slogger.Log(r.Context(), slog.LevelError,
+				"scheduled query result missing name or query field",
+				"query_name", name,
+			)
+			results[i].Status = 1
+			continue
 		}
 
-		scheduledQueryResult, err := queryWithRetries(ls.querier, scheduledQuery["query"])
+		results[i] = distributed.Result{
+			QueryName: name,
+		}
+
+		scheduledQueryResult, err := queryWithRetries(ls.querier, query)
 		if err != nil {
 			ls.slogger.Log(r.Context(), slog.LevelError,
 				"running scheduled query on demand",
 				"err", err,
-				"query", scheduledQuery["query"],
-				"query_name", scheduledQuery["name"],
+				"query", query,
+				"query_name", name,
 			)
 
 			results[i].Status = 1


### PR DESCRIPTION
osquery_schedule rows are map[string]string; accessing a missing key returns empty string rather than panicking, but passing an empty string as a SQL query to the querier would cause a confusing error. Add explicit presence and emptiness checks before using each value.

