### PR TITLE
fix(service): add missing nil guard in publish encode functions

### DIFF
--- a/pkg/service/publish_logs.go
+++ b/pkg/service/publish_logs.go
@@ -50,7 +50,11 @@ func encodeJSONRPCPublishLogsResponse(_ context.Context, obj any) (json.RawMessa
 	}
 
 	b, err := json.Marshal(res)
-	return encodeJSONResponse(b, fmt.Errorf("marshal json response: %w", err))
+	if err != nil {
+		return encodeJSONResponse(b, fmt.Errorf("marshal json response: %w", err))
+	}
+
+	return encodeJSONResponse(b, nil)
 }
 
 func decodeJSONRPCPublishLogsResponse(_ context.Context, res jsonrpc.Response) (any, error) {

--- a/pkg/service/publish_results.go
+++ b/pkg/service/publish_results.go
@@ -58,7 +58,11 @@ func encodeJSONRPCPublishResultsResponse(_ context.Context, obj any) (json.RawMe
 	}
 
 	b, err := json.Marshal(res)
-	return encodeJSONResponse(b, fmt.Errorf("marshal json response: %w", err))
+	if err != nil {
+		return encodeJSONResponse(b, fmt.Errorf("marshal json response: %w", err))
+	}
+
+	return encodeJSONResponse(b, nil)
 }
 
 // PublishResults implements KolideService.PublishResults


### PR DESCRIPTION
fmt.Errorf always returns a non-nil error even when its argument is nil, so every successful PublishLogs and PublishResults response was being transmitted as a failure. Add the if err \!= nil guard that the other encode functions in this package already use.