### PR TITLE
Ensure value returned by bbolt Get is valid after transaction completes

### DIFF
--- a/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
+++ b/ee/agent/storage/bbolt/keyvalue_store_bbolt.go
@@ -1,6 +1,7 @@
 package agentbbolt
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -73,7 +74,9 @@ func (s *bboltKeyValueStore) Get(key []byte) (value []byte, err error) {
 			return NewNoBucketError(s.bucketName)
 		}
 
-		value = b.Get(key)
+		// The value returned by b.Get is only valid for the lifetime of this transaction.
+		// Clone the returned value, so that we don't lose it if bbolt remaps.
+		value = bytes.Clone(b.Get(key))
 		return nil
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
Docs for `bucket.Get`:

```
// Get retrieves the value for a key in the bucket.
// Returns a nil value if the key does not exist or if the key is a nested bucket.
// The returned value is only valid for the life of the transaction.
```

If bbolt does any remapping, the byte slice returned by `bboltKeyValueStore.Get` can be modified. This can cause some occasional panics if we use this data after modification.