### PR TITLE
Upgrade to golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Note that multistage builds can leverage the tag applied (at build
 # time) to this container
 
-FROM --platform=linux/amd64 golang:1.25 AS golauncherbuild
+FROM --platform=linux/amd64 golang:1.26 AS golauncherbuild
 LABEL maintainer="engineering@kolide.co"
 
 # fake data or not?

--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -293,8 +293,8 @@ func (c *chain) validate(trustedKeys map[string]*ecdsa.PublicKey) error {
 	// make a copy of the root key so that we can reassign it
 	parentEcdsa := &ecdsa.PublicKey{
 		Curve: rootKey.Curve,
-		X:     rootKey.X,
-		Y:     rootKey.Y,
+		X:     rootKey.X, //nolint:staticcheck
+		Y:     rootKey.Y, //nolint:staticcheck
 	}
 
 	var currentPayload payload

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -470,8 +470,8 @@ func toJWK(key any, kid string) (*jwk, error) {
 		}
 
 		// Encode x and y coordinates using base64 URL encoding (unpadded).
-		xStr := base64.RawURLEncoding.EncodeToString(k.X.Bytes())
-		yStr := base64.RawURLEncoding.EncodeToString(k.Y.Bytes())
+		xStr := base64.RawURLEncoding.EncodeToString(k.X.Bytes()) //nolint:staticcheck
+		yStr := base64.RawURLEncoding.EncodeToString(k.Y.Bytes()) //nolint:staticcheck
 
 		return &jwk{
 			Curve: crv,

--- a/go.mod
+++ b/go.mod
@@ -174,6 +174,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.9
+go 1.26.2
 
 replace github.com/go-ole/go-ole v1.3.0 => github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767


### PR DESCRIPTION
The four ignored staticcheck errors are all the same:

> SA1019: rootKey.X|k.X|rootKey.Y|k.Y has been deprecated since Go 1.26 and an alternative has been available since Go 1.25: modifying the raw coordinates can produce invalid keys, and may invalidate internal optimizations; moreover, [big.Int] methods are not suitable for operating on cryptographic values. To encode and decode PublicKey values, use [PublicKey.Bytes] and [ParseUncompressedPublicKey] or [crypto/x509.MarshalPKIXPublicKey] and [crypto/x509.ParsePKIXPublicKey]. For ECDH, use [crypto/ecdh]. For lower-level elliptic curve operations, use a third-party module like filippo.io/nistec.

Since we aren't actually modifying the raw coordinates in the production code (just creating a copy that we can re-point), I don't think we have to worry particularly much here. I think we could swap to something like this in the future, but I wanted to minimize the testing surface for a major version upgrade.

```golang
rootKeyBytes, err := rootKey.Bytes()
if err != nil {
	return fmt.Errorf("getting root key bytes: %w", err)
}
parentEcdsa, err := ecdsa.ParseUncompressedPublicKey(rootKey.Curve, rootKeyBytes)
if err != nil {
	return fmt.Errorf("creating copy of root key: %w", err)
}
```