### PR TITLE
Move an existing secretscan exception into config.toml

### DIFF
--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -5,11 +5,15 @@ title = "Kolide secretscan config"
 [extend]
 useDefault = true
 
-# Ignore K8s Sealed Secrets
-# https://github.com/gitleaks/gitleaks/issues/1728
 [[rules]]
 id = "generic-api-key"
 [[rules.allowlists]]
+description = "Ignore K8s Sealed Secrets (https://github.com/gitleaks/gitleaks/issues/1728)"
 condition = "AND"
 regexes = ['''Ag[a-zA-Z0-9+/]{500,}={0,2}''']
 paths = ['''(?i).*\.ya?ml$''']
+[[rules.allowlists]]
+description = "Ignore variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
+condition = "AND"
+regex_target = "match"
+regexes = ['''^\s*\w[\w-]*=$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -16,4 +16,4 @@ paths = ['''(?i).*\.ya?ml$''']
 description = "Ignore variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
 condition = "AND"
 regex_target = "match"
-regexes = ['''^\s*\w[\w-]*=$''']
+regexes = ['''^\s*[A-Z\d][A-Z\d_-]*=$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -15,4 +15,6 @@ paths = ['''(?i).*\.ya?ml$''']
 [[rules.allowlists]]
 description = "Ignore variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
 condition = "AND"
-regexes = ['''^\s*[A-Z\d][A-Z\d_-]*=$''']
+# We limit length to 35 as a proxy for not allowlisting high-entropy values here.
+# Variable names are probably usually under that length.
+regexes = ['''^\s*[A-Z\d][A-Z\d_-]{0,35}=$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -18,3 +18,4 @@ condition = "AND"
 # We limit length to 35 as a proxy for not allowlisting high-entropy values here.
 # Variable names are probably usually under that length.
 regexes = ['''^\s*[A-Z\d][A-Z\d_-]{0,35}=$''']
+paths = ['''(?i).*\.env$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -19,7 +19,7 @@ condition = "AND"
 # Variable names are probably usually under that length. We restrict to all-caps
 # for the same reason.
 regexes = ['''^\s*[A-Z\d][A-Z\d_-]{0,35}=$''']
-paths = ['''(?i).*\.env$''']
+paths = ['''.*\.env(\..+)?$''']
 [[rules.allowlists]]
 description = "Ignore all-lowercase variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
 condition = "AND"
@@ -27,4 +27,4 @@ condition = "AND"
 # Variable names are probably usually under that length. We restrict to all-lowercase
 # for the same reason.
 regexes = ['''^\s*[a-z\d][a-z\d_-]{0,35}=$''']
-paths = ['''(?i).*\.env$''']
+paths = ['''.*\.env(\..+)?$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -13,9 +13,18 @@ condition = "AND"
 regexes = ['''Ag[a-zA-Z0-9+/]{500,}={0,2}''']
 paths = ['''(?i).*\.ya?ml$''']
 [[rules.allowlists]]
-description = "Ignore variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
+description = "Ignore all-caps variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
 condition = "AND"
 # We limit length to 35 as a proxy for not allowlisting high-entropy values here.
-# Variable names are probably usually under that length.
+# Variable names are probably usually under that length. We restrict to all-caps
+# for the same reason.
 regexes = ['''^\s*[A-Z\d][A-Z\d_-]{0,35}=$''']
+paths = ['''(?i).*\.env$''']
+[[rules.allowlists]]
+description = "Ignore all-lowercase variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
+condition = "AND"
+# We limit length to 35 as a proxy for not allowlisting high-entropy values here.
+# Variable names are probably usually under that length. We restrict to all-lowercase
+# for the same reason.
+regexes = ['''^\s*[a-z\d][a-z\d_-]{0,35}=$''']
 paths = ['''(?i).*\.env$''']

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -15,5 +15,4 @@ paths = ['''(?i).*\.ya?ml$''']
 [[rules.allowlists]]
 description = "Ignore variable names with empty values (https://github.com/gitleaks/gitleaks/issues/1828)"
 condition = "AND"
-regex_target = "match"
 regexes = ['''^\s*[A-Z\d][A-Z\d_-]*=$''']

--- a/ee/tables/secretscan/table.go
+++ b/ee/tables/secretscan/table.go
@@ -240,17 +240,12 @@ func (t *Table) findingsToRows(ctx context.Context, argon2idSalts []string, find
 
 	// Just for logging purposes -- we're curious how frequently we detect false positives
 	encryptedJwtFalsePositiveCount := 0
-	emptyVariableFalsePositiveCount := 0
 	for idx, f := range findings {
 		// We sometimes see false positives under the "generic-api-key" rule.
 		// Check for these.
 		if f.RuleID == "generic-api-key" {
 			if isEncryptedJWTFamilyValue(f) {
 				encryptedJwtFalsePositiveCount += 1
-				continue
-			}
-			if isEmptyVariable(f) {
-				emptyVariableFalsePositiveCount += 1
 				continue
 			}
 		}
@@ -287,11 +282,10 @@ func (t *Table) findingsToRows(ctx context.Context, argon2idSalts []string, find
 		results = append(results, row)
 	}
 
-	if encryptedJwtFalsePositiveCount > 0 || emptyVariableFalsePositiveCount > 0 {
+	if encryptedJwtFalsePositiveCount > 0 {
 		t.slogger.Log(ctx, slog.LevelInfo,
 			"detected and skipped false positive generic-api-key findings",
 			"jwt_family_count", encryptedJwtFalsePositiveCount,
-			"empty_variable", emptyVariableFalsePositiveCount,
 		)
 	}
 
@@ -338,46 +332,6 @@ func isEncryptedJWTFamilyValue(finding report.Finding) bool {
 	}
 
 	return false
-}
-
-// emptyVariableRegexp matches strings that start with a word char,
-// contain only word chars and underscores or hyphens, and end with a
-// singular equal sign -- for example, `MY_ENV_VAR=`.
-var emptyVariableRegexp = regexp.MustCompile(`^\w[\w-]*=$`)
-
-// isEmptyVariable inspects the given finding to determine if it is actually
-// an empty variable name instead.
-func isEmptyVariable(finding report.Finding) bool {
-	// This type of false positive typically has an entropy score around 3,
-	// so we exclude higher-entropy values right off the bat.
-	if finding.Entropy >= 4 {
-		return false
-	}
-
-	// Next, check for our regex match.
-	if !emptyVariableRegexp.MatchString(finding.Secret) {
-		return false
-	}
-
-	// We expect that this "secret" would be at the start of a line, with either nothing
-	// or whitespace in front of it. However, sometimes our finding.Line will contain
-	// multiple lines -- in this case, it looks like "\nMY_ENV_VAR1=\nMY_ENV_VAR2=".
-	// So first we isolate the actual line we're looking at, then check to see if there's
-	// anything besides whitespace in front of it.
-	lines := strings.Split(strings.ReplaceAll(finding.Line, "\r\n", "\n"), "\n")
-	var lineWithSecret string
-	for _, line := range lines {
-		if strings.Contains(line, finding.Secret) {
-			lineWithSecret = line
-			break
-		}
-	}
-	if lineWithSecret == "" {
-		return false
-	}
-	before, _, _ := strings.Cut(lineWithSecret, finding.Secret)
-	beforeTrimmed := strings.TrimSpace(before)
-	return beforeTrimmed == ""
 }
 
 // findingsToKeyNames attempts to extract the key names (eg: in an .env file) to help understand the context

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -483,10 +483,18 @@ spec:
 			expectedFinding: false,
 		},
 		{
-			testCaseName: "empty variable (true positive)",
+			testCaseName: "empty variable (true positive, variable is not empty)",
 			rawData: `
 123_S3_CREDS=9b065cc5-cf2e-4b3f-9a20-3422e060807a
 123_S3_IP_REGION=52b22b1e-2178-4a1e-bbba-50d0160ffab3
+`,
+			expectedFinding: true,
+		},
+		{
+			testCaseName: "empty variable (true positive, long variable with high entropy)",
+			rawData: `
+375E6860-39D4-11F1-B4AC-0800200C9A66-375E6861-39D4-11F1-B4AC-0800200C9A66_123_S3_CREDS=
+4DE613D1-39D4-11F1-B4AC-0800200C9A66_123_S3_IP_REGION_4DE613D0-39D4-11F1-B4AC-0800200C9A66=
 `,
 			expectedFinding: true,
 		},

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -470,7 +470,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with alphanumeric",
-			pathName:     ".env",
+			pathName:     ".env.local",
 			rawData: `
 123S3CREDS=
 123S3IPREGION=
@@ -479,7 +479,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with tab before empty variable",
-			pathName:     ".env",
+			pathName:     "aws.env",
 			rawData: `
 	123_S3_CREDS=
 	123_S3_IP_REGION=

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -414,90 +414,6 @@ func Test_isEncryptedJWTFamilyValue(t *testing.T) {
 	}
 }
 
-func Test_isEmptyVariable(t *testing.T) {
-	t.Parallel()
-
-	// Make sure config exists
-	newConfigOnce()
-	require.NoError(t, configErr)
-
-	for _, tt := range []struct {
-		testCaseName   string
-		rawData        string
-		expectedReturn bool
-	}{
-		{
-			testCaseName: "underscore",
-			rawData: `
-123_S3_CREDS=
-123_S3_IP_REGION=
-`,
-			expectedReturn: true,
-		},
-		{
-			testCaseName: "hyphen",
-			rawData: `
-123-S3-CREDS=
-123-S3-IP-REGION=
-`,
-			expectedReturn: true,
-		},
-		{
-			testCaseName: "alphanumeric",
-			rawData: `
-123S3CREDS=
-123S3IPREGION=
-`,
-			expectedReturn: true,
-		},
-		{
-			testCaseName: "tab before empty variable",
-			rawData: `
-	123_S3_CREDS=
-	123_S3_IP_REGION=
-`,
-			expectedReturn: true,
-		},
-		{
-			testCaseName: "non-empty",
-			rawData: `
-123_S3_CREDS=9b065cc5-cf2e-4b3f-9a20-3422e060807a
-123_S3_IP_REGION=52b22b1e-2178-4a1e-bbba-50d0160ffab3
-`,
-			expectedReturn: false,
-		},
-		{
-			testCaseName: "high entropy", // 4.19 entropy
-			rawData: `
-375E6860-39D4-11F1-B4AC-0800200C9A66-375E6861-39D4-11F1-B4AC-0800200C9A66_123_S3_CREDS=
-4DE613D1-39D4-11F1-B4AC-0800200C9A66_123_S3_IP_REGION_4DE613D0-39D4-11F1-B4AC-0800200C9A66=
-`,
-			expectedReturn: false,
-		},
-	} {
-		t.Run(tt.testCaseName, func(t *testing.T) {
-			t.Parallel()
-
-			detector := detect.NewDetector(*kolideConfig)
-			fileSource := &sources.File{
-				Content: strings.NewReader(tt.rawData),
-				Config:  &detector.Config,
-			}
-
-			findings, err := detector.DetectSource(t.Context(), fileSource)
-			require.NoError(t, err)
-			require.Greater(t, len(findings), 0)
-
-			for _, finding := range findings {
-				// Make sure the test finding we generated is the type we expected
-				require.Equal(t, "generic-api-key", finding.RuleID)
-				// Confirm that isEmptyVariable classifies the finding appropriately
-				require.Equal(t, tt.expectedReturn, isEmptyVariable(finding))
-			}
-		})
-	}
-}
-
 // Test_kolideConfig confirms that our overrides in config.toml work as expected
 func Test_kolideConfig(t *testing.T) {
 	t.Parallel()
@@ -530,6 +446,34 @@ spec:
       creationTimestamp: null
       name: basic-auth
       namespace: default
+`,
+		},
+		{
+			testCaseName: "empty variable, with underscore",
+			rawData: `
+123_S3_CREDS=
+123_S3_IP_REGION=
+`,
+		},
+		{
+			testCaseName: "empty variable, with hyphen",
+			rawData: `
+123-S3-CREDS=
+123-S3-IP-REGION=
+`,
+		},
+		{
+			testCaseName: "empty variable, with alphanumeric",
+			rawData: `
+123S3CREDS=
+123S3IPREGION=
+`,
+		},
+		{
+			testCaseName: "empty variable, with tab before empty variable",
+			rawData: `
+	123_S3_CREDS=
+	123_S3_IP_REGION=
 `,
 		},
 	} {

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -452,6 +452,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with underscore",
+			pathName:     ".env",
 			rawData: `
 123_S3_CREDS=
 123_S3_IP_REGION=
@@ -460,6 +461,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with hyphen",
+			pathName:     ".env",
 			rawData: `
 123-S3-CREDS=
 123-S3-IP-REGION=
@@ -468,6 +470,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with alphanumeric",
+			pathName:     ".env",
 			rawData: `
 123S3CREDS=
 123S3IPREGION=
@@ -476,6 +479,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable, with tab before empty variable",
+			pathName:     ".env",
 			rawData: `
 	123_S3_CREDS=
 	123_S3_IP_REGION=
@@ -484,6 +488,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable (true positive, variable is not empty)",
+			pathName:     ".env",
 			rawData: `
 123_S3_CREDS=9b065cc5-cf2e-4b3f-9a20-3422e060807a
 123_S3_IP_REGION=52b22b1e-2178-4a1e-bbba-50d0160ffab3
@@ -492,6 +497,7 @@ spec:
 		},
 		{
 			testCaseName: "empty variable (true positive, long variable with high entropy)",
+			pathName:     ".env",
 			rawData: `
 375E6860-39D4-11F1-B4AC-0800200C9A66-375E6861-39D4-11F1-B4AC-0800200C9A66_123_S3_CREDS=
 4DE613D1-39D4-11F1-B4AC-0800200C9A66_123_S3_IP_REGION_4DE613D0-39D4-11F1-B4AC-0800200C9A66=

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -487,6 +487,15 @@ spec:
 			expectedFinding: false,
 		},
 		{
+			testCaseName: "empty variable, all lowercase",
+			pathName:     ".env",
+			rawData: `
+123_s3_creds=
+123_s3_ip_region=
+`,
+			expectedFinding: false,
+		},
+		{
 			testCaseName: "empty variable (true positive, variable is not empty)",
 			pathName:     ".env",
 			rawData: `

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -423,9 +423,10 @@ func Test_kolideConfig(t *testing.T) {
 	require.NoError(t, configErr)
 
 	for _, tt := range []struct {
-		testCaseName string
-		pathName     string
-		rawData      string
+		testCaseName    string
+		pathName        string
+		rawData         string
+		expectedFinding bool
 	}{
 		{
 			testCaseName: "K8s sealed secrets",
@@ -447,6 +448,7 @@ spec:
       name: basic-auth
       namespace: default
 `,
+			expectedFinding: false,
 		},
 		{
 			testCaseName: "empty variable, with underscore",
@@ -454,6 +456,7 @@ spec:
 123_S3_CREDS=
 123_S3_IP_REGION=
 `,
+			expectedFinding: false,
 		},
 		{
 			testCaseName: "empty variable, with hyphen",
@@ -461,6 +464,7 @@ spec:
 123-S3-CREDS=
 123-S3-IP-REGION=
 `,
+			expectedFinding: false,
 		},
 		{
 			testCaseName: "empty variable, with alphanumeric",
@@ -468,6 +472,7 @@ spec:
 123S3CREDS=
 123S3IPREGION=
 `,
+			expectedFinding: false,
 		},
 		{
 			testCaseName: "empty variable, with tab before empty variable",
@@ -475,6 +480,15 @@ spec:
 	123_S3_CREDS=
 	123_S3_IP_REGION=
 `,
+			expectedFinding: false,
+		},
+		{
+			testCaseName: "empty variable (true positive)",
+			rawData: `
+123_S3_CREDS=9b065cc5-cf2e-4b3f-9a20-3422e060807a
+123_S3_IP_REGION=52b22b1e-2178-4a1e-bbba-50d0160ffab3
+`,
+			expectedFinding: true,
 		},
 	} {
 		t.Run(tt.testCaseName, func(t *testing.T) {
@@ -489,7 +503,11 @@ spec:
 
 			findings, err := detector.DetectSource(t.Context(), fileSource)
 			require.NoError(t, err)
-			require.Equal(t, 0, len(findings))
+			if tt.expectedFinding {
+				require.Less(t, 0, len(findings))
+			} else {
+				require.Equal(t, 0, len(findings))
+			}
 		})
 	}
 }


### PR DESCRIPTION
After updating to use our own override config here: https://github.com/kolide/launcher/pull/2701, we can now move the exceptions I previously added to config.toml.

This PR moves https://github.com/kolide/launcher/pull/2699 into the config.