### PR TITLE
Another attempt at making Windows + osquery tests less flaky

### DIFF
--- a/cmd/launcher/launcher_test.go
+++ b/cmd/launcher/launcher_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/kolide/launcher/v2/pkg/backoff"
 	"github.com/kolide/launcher/v2/pkg/launcher"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/kolide/launcher/v2/pkg/osquery/testutil"
@@ -47,6 +49,15 @@ func Test_runLauncher(t *testing.T) {
 		t.Run(tt.testCaseName, func(t *testing.T) {
 			// Set up opts
 			testRootDir := t.TempDir()
+			t.Cleanup(func() {
+				// Do a couple retries in case the directory is still in use --
+				// Windows is a little slow on this sometimes
+				if err := backoff.WaitFor(func() error {
+					return os.RemoveAll(testRootDir)
+				}, 5*time.Second, 500*time.Millisecond); err != nil {
+					t.Logf("testRootDirectory RemoveAll cleanup: %v", err)
+				}
+			})
 			downloadOnceFunc() // get an osquery binary
 			require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 			defaultOpts, err := launcher.ParseOptions("launcher", []string{

--- a/cmd/launcher/launcher_test.go
+++ b/cmd/launcher/launcher_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("nightly")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("nightly")
 })
 
 // Test_runLauncher confirms that runLauncher can start up without error,
@@ -47,6 +48,7 @@ func Test_runLauncher(t *testing.T) {
 			// Set up opts
 			testRootDir := t.TempDir()
 			downloadOnceFunc() // get an osquery binary
+			require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 			defaultOpts, err := launcher.ParseOptions("launcher", []string{
 				"--root_directory", testRootDir,
 				"--osqueryd_path", testOsqueryBinary,

--- a/ee/agent/reset_test.go
+++ b/ee/agent/reset_test.go
@@ -31,17 +31,19 @@ func TestMain(m *testing.M) {
 }
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("nightly")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("nightly")
 })
 
 func TestDetectAndRemediateHardwareChange(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	// Pre-compute hardware serial and UUID once rather than in each parallel subtest.
 	// All subtests query the same hardware and get the same result, so running 16+
@@ -506,6 +508,7 @@ func TestDetectAndRemediateHardwareChange(t *testing.T) {
 func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	slogger := multislogger.NewNopLogger()
 
@@ -603,6 +606,7 @@ func TestDetectAndRemediateHardwareChange_SavesDataOverMultipleResets(t *testing
 func TestExecute(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
@@ -659,6 +663,7 @@ func TestExecute(t *testing.T) {
 func TestInterrupt_Multiple(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{

--- a/ee/tuf/ci/valid_executable.go
+++ b/ee/tuf/ci/valid_executable.go
@@ -11,12 +11,13 @@ import (
 )
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("nightly")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("nightly")
 })
 
 // CopyBinary ensures we've downloaded a test osquery binary, then creates a symlink
@@ -24,6 +25,7 @@ var downloadOnceFunc = sync.OnceFunc(func() {
 // so the symlink will point to an executable binary.
 func CopyBinary(t *testing.T, executablePath string) {
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
 	require.NoError(t, os.Symlink(testOsqueryBinary, executablePath))

--- a/pkg/osquery/interactive/interactive_test.go
+++ b/pkg/osquery/interactive/interactive_test.go
@@ -35,12 +35,13 @@ func TestMain(m *testing.M) {
 }
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("nightly")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("nightly")
 })
 
 // copyBinary ensures we've downloaded a test osquery binary, then creates a symlink
@@ -48,6 +49,7 @@ var downloadOnceFunc = sync.OnceFunc(func() {
 // so the symlink will point to an executable binary.
 func copyBinary(t *testing.T, executablePath string) {
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0755))
 	require.NoError(t, os.Symlink(testOsqueryBinary, executablePath))

--- a/pkg/osquery/runsimple/osqueryrunner_test.go
+++ b/pkg/osquery/runsimple/osqueryrunner_test.go
@@ -20,16 +20,18 @@ func TestMain(m *testing.M) {
 }
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("stable")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("stable")
 })
 
 func Test_OsqueryRunSqlNoIO(t *testing.T) {
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	osq, err := NewOsqueryProcess(testOsqueryBinary)
 	require.NoError(t, err)
@@ -39,6 +41,7 @@ func Test_OsqueryRunSqlNoIO(t *testing.T) {
 
 func Test_OsqueryRunSql(t *testing.T) {
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	tests := []struct {
 		name      string

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -276,6 +276,7 @@ func Test_healthcheckWithRetries(t *testing.T) {
 func TestHealthy(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	// Set up instance dependencies
@@ -377,6 +378,7 @@ func TestHealthy(t *testing.T) {
 func TestLaunch(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	logBytes, slogger := setUpTestSlogger()
@@ -471,6 +473,7 @@ func TestLaunch(t *testing.T) {
 func TestReloadKatcExtension(t *testing.T) {
 	t.Parallel()
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 
 	// Set up all million dependencies
 	logBytes, slogger := setUpTestSlogger()

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -298,7 +298,11 @@ func TestHealthy(t *testing.T) {
 	k.On("NodeKey", types.DefaultEnrollmentID).Return(ulid.New(), nil).Maybe()
 	k.On("EnsureEnrollmentStored", types.DefaultEnrollmentID).Return(nil).Maybe()
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinary)
-	k.On("OsqueryHealthcheckStartupDelay").Return(10 * time.Second)
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout)
 	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
 	k.On("InModernStandby").Return(false).Maybe()
@@ -400,7 +404,11 @@ func TestLaunch(t *testing.T) {
 	k.On("NodeKey", types.DefaultEnrollmentID).Return(ulid.New(), nil).Maybe()
 	k.On("EnsureEnrollmentStored", types.DefaultEnrollmentID).Return(nil).Maybe()
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinary)
-	k.On("OsqueryHealthcheckStartupDelay").Return(10 * time.Second)
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout)
 	k.On("InModernStandby").Return(false).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
@@ -507,7 +515,11 @@ func TestReloadKatcExtension(t *testing.T) {
 	k.On("EnsureEnrollmentStored", types.DefaultEnrollmentID).Return(nil).Maybe()
 	k.On("InModernStandby").Return(false).Maybe()
 	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinary)
-	k.On("OsqueryHealthcheckStartupDelay").Return(10 * time.Second)
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout)
 	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
 	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -49,7 +49,11 @@ func TestOsquerySlowStart(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RootDirectory").Return(rootDirectory).Maybe()
 	k.On("OsqueryVerbose").Return(true).Maybe()
@@ -124,7 +128,11 @@ func TestExtensionSocketPath(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -40,6 +40,7 @@ func TestOsquerySlowStart(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -114,6 +115,7 @@ func TestExtensionSocketPath(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -93,8 +93,6 @@ func makeTestOsqLogPublisher(t *testing.T, mk *typesMocks.Knapsack) types.Osquer
 func TestBadBinaryPath(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
-	downloadOnceFunc()
-	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := t.TempDir()
@@ -1018,8 +1016,6 @@ func TestOsqueryDies(t *testing.T) {
 func TestNotStarted(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
-	downloadOnceFunc()
-	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := t.TempDir()

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -162,7 +162,11 @@ func TestWithOsqueryFlags(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -219,8 +223,12 @@ func TestFlagsChanged(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
-	k.On("WatchdogEnabled").Return(false).Once() // WatchdogEnabled should initially return false
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
+	k.On("WatchdogEnabled").Return(false)
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)
 	k.On("WatchdogDelaySec").Return(120)
@@ -259,7 +267,7 @@ func TestFlagsChanged(t *testing.T) {
 	s.On("WriteSettings").Return(nil).Maybe()
 
 	// set to false initially so osq can start
-	k.On("InModernStandby").Return(false).Twice()
+	k.On("InModernStandby").Return(false)
 
 	// Start the runner
 	runner := New(k, lpc, s)
@@ -285,18 +293,22 @@ func TestFlagsChanged(t *testing.T) {
 	require.False(t, runner.needsRestart.Load(), "runner should not be flagged as needing restart since it just started")
 
 	// change just the InModernStandby flag -- this should not trigger a restart, since no changes need to be applied
-	k.On("InModernStandby").Return(true).Once()
+	k.On("InModernStandby").Unset()
+	k.On("InModernStandby").Return(true)
 	runner.FlagsChanged(t.Context(), keys.InModernStandby)
 	require.False(t, runner.needsRestart.Load(), "runner should not be marked as needing a restart when only InModernStandby changed")
 
 	// change both the InModernStandby and WatchdogEnabled flags -- this should trigger a restart, but not until InModernStandby is false again
-	k.On("WatchdogEnabled").Return(true).Once()
-	k.On("InModernStandby").Return(true).Twice()
+	k.On("WatchdogEnabled").Unset()
+	k.On("WatchdogEnabled").Return(true)
+	k.On("InModernStandby").Unset()
+	k.On("InModernStandby").Return(true)
 	runner.FlagsChanged(t.Context(), keys.WatchdogEnabled, keys.InModernStandby)
 
 	require.True(t, runner.needsRestart.Load(), "runner should be marked as needing a restart after WatchdogEnabled changed while in modern standby")
 
 	// no simulate coming out of modern standby -- this should trigger a restart
+	k.On("InModernStandby").Unset()
 	k.On("InModernStandby").Return(false)
 	runner.FlagsChanged(t.Context(), keys.InModernStandby)
 
@@ -305,7 +317,7 @@ func TestFlagsChanged(t *testing.T) {
 	waitHealthy(t, runner, logBytes, osqHistory)
 
 	// Now confirm that the instance is new
-	require.NotEqual(t, startingInstance, runner.instances[types.DefaultEnrollmentID], "instance not replaced")
+	require.NotEqual(t, startingInstance, runner.instances[types.DefaultEnrollmentID], "instance not replaced", logBytes.String())
 
 	require.False(t, runner.needsRestart.Load(), "runner should no longer be marked as needing a restart after restart completed")
 
@@ -356,7 +368,11 @@ func TestPing(t *testing.T) {
 	logBytes, slogger := setUpTestSlogger()
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -633,7 +649,11 @@ func TestSimplePath(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -693,7 +713,11 @@ func TestMultipleInstances(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID, extraEnrollmentId})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -788,7 +812,11 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -879,7 +907,11 @@ func TestMultipleShutdowns(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -940,7 +972,11 @@ func TestOsqueryDies(t *testing.T) {
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(false)
 	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	k.On("Slogger").Return(slogger)
@@ -1129,7 +1165,11 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 
 	k := typesMocks.NewKnapsack(t)
 	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	k.On("OsqueryHealthcheckStartupDelay").Return(0 * time.Second).Maybe()
+	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
+	// We don't want an extremely short interval, though, because we need to give the osquery instance
+	// time to actually start before we begin healthchecking it. So, we wait for at least the
+	// amount of time that we give for the socket to appear.
+	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
 	k.On("WatchdogEnabled").Return(true)
 	k.On("WatchdogMemoryLimitMB").Return(150)
 	k.On("WatchdogUtilizationLimitPercent").Return(20)

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -44,12 +44,13 @@ import (
 )
 
 var testOsqueryBinary string
+var osqueryBinaryDownloadErr error
 
 // downloadOnceFunc downloads a real osquery binary for use in tests. This function
 // can be called multiple times but will only execute once -- the osquery binary is
 // stored at path `testOsqueryBinary` and can be reused by all subsequent tests.
 var downloadOnceFunc = sync.OnceFunc(func() {
-	testOsqueryBinary, _, _ = testutil.DownloadOsquery("stable")
+	testOsqueryBinary, _, osqueryBinaryDownloadErr = testutil.DownloadOsquery("stable")
 })
 
 // setupOnceFunc sets up test configuration that should only happen once.
@@ -93,6 +94,7 @@ func TestBadBinaryPath(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := t.TempDir()
@@ -153,6 +155,7 @@ func TestWithOsqueryFlags(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -209,6 +212,7 @@ func TestFlagsChanged(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -346,6 +350,7 @@ func TestPing(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	// Set up all dependencies
@@ -621,6 +626,7 @@ func TestSimplePath(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -677,6 +683,7 @@ func TestMultipleInstances(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -774,6 +781,7 @@ func TestRunnerHandlesImmediateShutdownWithMultipleInstances(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -864,6 +872,7 @@ func TestMultipleShutdowns(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -924,6 +933,7 @@ func TestOsqueryDies(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := testRootDirectory(t)
@@ -1009,6 +1019,7 @@ func TestNotStarted(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	rootDirectory := t.TempDir()
@@ -1044,6 +1055,7 @@ func TestExtensionIsCleanedUp(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	runner, logBytes, osqHistory := setupOsqueryInstanceForTests(t)
@@ -1076,6 +1088,7 @@ func TestRestart(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
 	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
 	runner, logBytes, osqHistory := setupOsqueryInstanceForTests(t)


### PR DESCRIPTION
Improvements:

* Surface error in tests when testutil.DownloadOsquery fails, to make it clearer when the missing osquery binary is the cause of the test failure
* Sets OsqueryHealthcheckStartupDelay to a reasonably short value instead of 0s, so we don't immediately start healthchecking before the instance has even started up
* Replaces fragile `Once()` and `Twice()` mock calls with `Unset()`
* Adds t.Cleanup func for removing root dir to avoid flaky failures removing directory automatically on Windows (we already do this in runtime_test -- added it to Test_runLauncher too)