### PR TITLE
Remove unused osquery.autoload file

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -717,11 +717,10 @@ func (i *OsqueryInstance) startKolideSaasExtension(ctx context.Context) error {
 // osqueryFilePaths is a struct which contains the relevant file paths needed to
 // launch an osqueryd instance.
 type osqueryFilePaths struct {
-	augeasPath            string
-	databasePath          string
-	extensionAutoloadPath string
-	extensionSocketPath   string
-	pidfilePath           string
+	augeasPath          string
+	databasePath        string
+	extensionSocketPath string
+	pidfilePath         string
 }
 
 // calculateOsqueryPaths accepts a path to a working osqueryd binary and a root
@@ -737,28 +736,19 @@ func calculateOsqueryPaths(rootDirectory string, enrollmentId string, runId stri
 		extensionSocketPath = SocketPath(rootDirectory, runId)
 	}
 
-	extensionAutoloadPath := filepath.Join(rootDirectory, "osquery.autoload")
-
 	// We want to use a unique pidfile per launcher run to avoid file locking issues.
 	// See: https://github.com/kolide/launcher/issues/1599
 	osqueryFilePaths := &osqueryFilePaths{
-		pidfilePath:           filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.pid", runId)),
-		databasePath:          filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.db", enrollmentId)),
-		augeasPath:            filepath.Join(rootDirectory, "augeas-lenses"),
-		extensionSocketPath:   extensionSocketPath,
-		extensionAutoloadPath: extensionAutoloadPath,
+		pidfilePath:         filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.pid", runId)),
+		databasePath:        filepath.Join(rootDirectory, fmt.Sprintf("osquery-%s.db", enrollmentId)),
+		augeasPath:          filepath.Join(rootDirectory, "augeas-lenses"),
+		extensionSocketPath: extensionSocketPath,
 	}
 
 	// Keep default database path for default instance
 	if enrollmentId == types.DefaultEnrollmentID {
 		osqueryFilePaths.databasePath = filepath.Join(rootDirectory, "osquery.db")
 	}
-
-	osqueryAutoloadFile, err := os.Create(extensionAutoloadPath)
-	if err != nil {
-		return nil, fmt.Errorf("creating autoload file: %w", err)
-	}
-	defer osqueryAutoloadFile.Close()
 
 	return osqueryFilePaths, nil
 }
@@ -855,7 +845,6 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string) (*exec.Cm
 		fmt.Sprintf("--pidfile=%s", i.paths.pidfilePath),
 		fmt.Sprintf("--database_path=%s", i.paths.databasePath),
 		fmt.Sprintf("--extensions_socket=%s", i.paths.extensionSocketPath),
-		fmt.Sprintf("--extensions_autoload=%s", i.paths.extensionAutoloadPath),
 		"--disable_extensions=false",
 		"--extensions_timeout=20",
 		fmt.Sprintf("--config_plugin=%s", KolideSaasExtensionName),

--- a/pkg/osquery/runtime/osqueryinstance_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_test.go
@@ -54,17 +54,14 @@ func TestCalculateOsqueryPaths(t *testing.T) {
 	} else {
 		require.Equal(t, fmt.Sprintf(`\\.\pipe\kolide-osquery-%s`, runId), paths.extensionSocketPath)
 	}
-
-	require.Equal(t, rootDir, filepath.Dir(paths.extensionAutoloadPath))
 }
 
 func TestCreateOsqueryCommand(t *testing.T) {
 	t.Parallel()
 	paths := &osqueryFilePaths{
-		pidfilePath:           "/foo/bar/osquery-abcd.pid",
-		databasePath:          "/foo/bar/osquery.db",
-		extensionSocketPath:   "/foo/bar/osquery.sock",
-		extensionAutoloadPath: "/foo/bar/osquery.autoload",
+		pidfilePath:         "/foo/bar/osquery-abcd.pid",
+		databasePath:        "/foo/bar/osquery.db",
+		extensionSocketPath: "/foo/bar/osquery.sock",
 	}
 
 	rootDir := t.TempDir()
@@ -116,8 +113,9 @@ func TestCreateOsqueryCommandWithFlags(t *testing.T) {
 	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test
 	require.NoError(t, err)
 
-	// count of flags that cannot be overridden with this option
-	const nonOverridableFlagsCount = 8
+	// count of flags that cannot be overridden with this option:
+	// pidfile, database_path, extensions_socket, disable_extensions, extensions_timeout, config_plugin, extensions_require
+	const nonOverridableFlagsCount = 7
 
 	// Ensure that the provided flags were placed last (so that they can override)
 	assert.Equal(

--- a/pkg/osquery/runtime/osqueryinstance_windows_test.go
+++ b/pkg/osquery/runtime/osqueryinstance_windows_test.go
@@ -30,10 +30,9 @@ func TestCreateOsqueryCommandEnvVars(t *testing.T) {
 
 	i := newInstance(types.DefaultEnrollmentID, k, lpc, settingsstoremock.NewSettingsStoreWriter(t))
 	i.paths = &osqueryFilePaths{
-		pidfilePath:           "/foo/bar/osquery-abcd.pid",
-		databasePath:          "/foo/bar/osquery.db",
-		extensionSocketPath:   "/foo/bar/osquery.sock",
-		extensionAutoloadPath: "/foo/bar/osquery.autoload",
+		pidfilePath:         "/foo/bar/osquery-abcd.pid",
+		databasePath:        "/foo/bar/osquery.db",
+		extensionSocketPath: "/foo/bar/osquery.sock",
 	}
 
 	cmd, err := i.createOsquerydCommand("") // we do not actually exec so don't need to download a real osquery for this test


### PR DESCRIPTION
I believe we used this option before when we shipped extensions (like tables.ext), but we have not shipped these in a very long time. This file is empty and unused. So, no point in creating it.

https://osquery.readthedocs.io/en/stable/deployment/extensions/