### PR TITLE
More attempts at making Windows + osquery tests less flaky

### DIFF
--- a/pkg/osquery/testutil/testutil.go
+++ b/pkg/osquery/testutil/testutil.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/fsutil"
+	"github.com/kolide/launcher/v2/pkg/backoff"
 	"github.com/kolide/launcher/v2/pkg/packaging"
 )
 
@@ -69,10 +70,17 @@ func DownloadOsquery(version string) (binaryPath string, cleanup func() error, e
 			return "", nil, fmt.Errorf("fetching osqueryd binary: %w", err)
 		}
 
-		// Copy to our standardized cache location
-		if err := fsutil.CopyFile(dlPath, binaryPath); err != nil {
-			return "", nil, fmt.Errorf("copying osqueryd binary from %s to %s: %w", dlPath, binaryPath, err)
+		// Copy to our standardized cache location. We do a couple retries because
+		// Windows is slow to release file handles.
+		if err := backoff.WaitFor(func() error {
+			if err := fsutil.CopyFile(dlPath, binaryPath); err != nil {
+				return fmt.Errorf("copying osqueryd binary from %s to %s: %w", dlPath, binaryPath, err)
+			}
+			return nil
+		}, 5*time.Second, 500*time.Millisecond); err != nil {
+			return "", nil, fmt.Errorf("copying osqueryd binary failed after retries: %w", err)
 		}
+
 	}
 
 	// Always ensure the binary is executable and has no quarantine attributes,


### PR DESCRIPTION
Builds on changes from https://github.com/kolide/launcher/pull/2706.

Retry on copy failure for osquery download in tests, to address this error:

> Error:      	Received unexpected error:
>        	            	copying osqueryd binary from C:\Users\RUNNER1\AppData\Local\Temp\osquery-download-2091319648\amd64\osqueryd-windows-amd64-stable\osqueryd.exe to C:\Users\RUNNER1\AppData\Local\Temp\launcher-test-osquery\osqueryd-stable-windows-amd64.exe: open C:\Users\RUNNER1\AppData\Local\Temp\launcher-test-osquery\osqueryd-stable-windows-amd64.exe: The process cannot access the file because it is being used by another process.

https://github.com/kolide/launcher/actions/runs/24847296029/job/72738353018?pr=2707