### PR TITLE
Escape control server ampersands for Windows

### DIFF
--- a/ee/desktop/user/menu/action_open_url_windows.go
+++ b/ee/desktop/user/menu/action_open_url_windows.go
@@ -5,6 +5,7 @@ package menu
 import (
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
@@ -13,6 +14,7 @@ import (
 // open opens the specified URL in the default browser of the user
 // See https://stackoverflow.com/a/39324149/1705598
 func open(url string) error {
+	url = strings.ReplaceAll(url, "&", "^&")
 	cmd, err := allowedcmd.CommandPrompt.Cmd(context.TODO(), "/C", "start", url)
 	if err != nil {
 		return fmt.Errorf("creating command: %w", err)

--- a/ee/desktop/user/notify/notify_windows.go
+++ b/ee/desktop/user/notify/notify_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 
 	"github.com/kolide/toast"
@@ -56,15 +57,17 @@ func (w *windowsNotifier) SendNotification(n Notification) error {
 	}
 
 	if n.ActionUri != "" {
+		actionUri := strings.ReplaceAll(n.ActionUri, "&", "&amp;")
+
 		// Set the default action when the user clicks on the notification
-		notification.ActivationArguments = n.ActionUri
+		notification.ActivationArguments = actionUri
 
 		// Additionally, create a "Learn more" button that will open the same URL
 		notification.Actions = []toast.Action{
 			{
 				Type:      "protocol",
 				Label:     "Learn More",
-				Arguments: n.ActionUri,
+				Arguments: actionUri,
 			},
 		}
 	}


### PR DESCRIPTION
* The XML for the toast notification can't handle ampersands in URLs, so we have to escape them for the XML
* The command prompt exec to open a url also can't handle an ampersand without an escape; in this case, we need to escape with a caret