### PR TITLE
Remove unused logs in recursive hot path

### DIFF
--- a/ee/dataflatten/examples/flatten/main.go
+++ b/ee/dataflatten/examples/flatten/main.go
@@ -29,8 +29,6 @@ func main() {
 		flXml   = flagset.String("xml", "", "Path to xml file")
 		flIni   = flagset.String("ini", "", "Path to ini file")
 		flQuery = flagset.String("q", "", "query")
-
-		flDebug = flagset.Bool("debug", false, "use a debug logger")
 	)
 
 	if err := ff.Parse(flagset, os.Args[1:],
@@ -44,9 +42,6 @@ func main() {
 		dataflatten.WithSlogger(multislogger.NewNopLogger()),
 		dataflatten.WithNestedPlist(),
 		dataflatten.WithQuery(strings.Split(*flQuery, `/`)),
-	}
-	if *flDebug {
-		opts = append(opts, dataflatten.WithDebugLogging())
 	}
 
 	rows := []dataflatten.Row{}

--- a/ee/dataflatten/flatten.go
+++ b/ee/dataflatten/flatten.go
@@ -162,13 +162,21 @@ func Flatten(data any, opts ...FlattenOpts) ([]Row, error) {
 func (fl *Flattener) descend(path []string, data any, depth int) error {
 	queryTerm, isQueryMatched := fl.queryAtDepth(depth)
 
-	slogger := fl.slogger.With(
-		"caller", "descend",
-		"depth", depth,
-		"rows_so_far", len(fl.rows),
-		"query", queryTerm,
-		"path", strings.Join(path, "/"),
-	)
+	// Gate the contextual logger build behind an Enabled check. descend is
+	// recursive and called many times per row; an unconditional Logger.With
+	// here propagates through the slog-multi handler chain on every call,
+	// allocating large amounts even when the level is filtered out.
+	slogger := fl.slogger
+	loggingEnabled := fl.slogger.Enabled(context.TODO(), fl.logLevel)
+	if loggingEnabled {
+		slogger = fl.slogger.With(
+			"caller", "descend",
+			"depth", depth,
+			"rows_so_far", len(fl.rows),
+			"query", queryTerm,
+			"path", strings.Join(path, "/"),
+		)
+	}
 
 	switch v := data.(type) {
 	case []any:
@@ -193,7 +201,10 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 				keyQuery := strings.SplitN(after, "=>", 2)
 				keyName := keyQuery[0]
 
-				innerslogger := slogger.With("array_key_name", keyName)
+				innerslogger := slogger
+				if loggingEnabled {
+					innerslogger = slogger.With("array_key_name", keyName)
+				}
 				innerslogger.Log(context.TODO(), fl.logLevel,
 					"attempting to coerce array into map",
 				)
@@ -310,12 +321,17 @@ func (fl *Flattener) handleStringLike(slogger *slog.Logger, path []string, v any
 // embedded plist. In the case of failures, it falls back to treating
 // it like a plain string.
 func (fl *Flattener) descendMaybePlist(path []string, data []byte, depth int) error {
-	slogger := fl.slogger.With(
-		"caller", "descendMaybePlist",
-		"depth", depth,
-		"rows_so_far", len(fl.rows),
-		"path", strings.Join(path, "/"),
-	)
+	// Gate the contextual logger build behind an Enabled check; see the
+	// matching note in descend.
+	slogger := fl.slogger
+	if fl.slogger.Enabled(context.TODO(), fl.logLevel) {
+		slogger = fl.slogger.With(
+			"caller", "descendMaybePlist",
+			"depth", depth,
+			"rows_so_far", len(fl.rows),
+			"path", strings.Join(path, "/"),
+		)
+	}
 
 	// Skip if we're not expanding nested plists
 	if !fl.expandNestedPlist {
@@ -374,12 +390,17 @@ func (fl *Flattener) queryMatchNil(queryTerm string) bool {
 // We use `=>` as something that is reasonably intuitive, and not very
 // likely to occur on it's own. Unfortunately, `==` shows up in base64
 func (fl *Flattener) queryMatchArrayElement(data any, arrIndex int, queryTerm string) bool {
-	slogger := fl.slogger.With(
-		"caller", "queryMatchArrayElement",
-		"rows_so_far", len(fl.rows),
-		"query", queryTerm,
-		"arr_index", arrIndex,
-	)
+	// Gate the contextual logger build behind an Enabled check; see the
+	// matching note in descend.
+	slogger := fl.slogger
+	if fl.slogger.Enabled(context.TODO(), fl.logLevel) {
+		slogger = fl.slogger.With(
+			"caller", "queryMatchArrayElement",
+			"rows_so_far", len(fl.rows),
+			"query", queryTerm,
+			"arr_index", arrIndex,
+		)
+	}
 
 	// strip off the key re-write denotation before trying to match
 	queryTerm = strings.TrimPrefix(queryTerm, fl.queryKeyDenoter)

--- a/ee/dataflatten/flatten.go
+++ b/ee/dataflatten/flatten.go
@@ -66,8 +66,6 @@ import (
 //
 // It can optionally filtering and rewriting.
 type Flattener struct {
-	debugLogging      bool
-	logLevel          slog.Level // the level that logs should be logged at
 	expandNestedPlist bool
 	includeNestedRaw  bool
 	includeNils       bool
@@ -77,10 +75,6 @@ type Flattener struct {
 	queryWildcard     string
 	rows              []Row
 }
-
-// levelFlattenDebug is a log level below debug, so that we discard debugging logs
-// that we only want for development purposes.
-const levelFlattenDebug = slog.LevelDebug - 1
 
 type FlattenOpts func(*Flattener)
 
@@ -110,16 +104,6 @@ func WithSlogger(slogger *slog.Logger) FlattenOpts {
 	}
 }
 
-// WithDebugLogging enables debug logging intended for development use.
-// With debug logs, dataflatten is very verbose. This can overwhelm the
-// other launcher logs. As we're not generally debugging this library,
-// the default is to not enable debug logging.
-func WithDebugLogging() FlattenOpts {
-	return func(fl *Flattener) {
-		fl.debugLogging = true
-	}
-}
-
 // WithQuery Specifies a query to flatten with. This is used both for
 // re-writing arrays into maps, and for filtering. See "Query
 // Specification" for docs.
@@ -137,7 +121,6 @@ func WithQuery(q []string) FlattenOpts {
 func Flatten(data any, opts ...FlattenOpts) ([]Row, error) {
 	fl := &Flattener{
 		rows:            []Row{},
-		logLevel:        levelFlattenDebug, // by default, log at a level below debug
 		slogger:         multislogger.NewNopLogger(),
 		queryWildcard:   `*`,
 		queryKeyDenoter: `#`,
@@ -145,10 +128,6 @@ func Flatten(data any, opts ...FlattenOpts) ([]Row, error) {
 
 	for _, opt := range opts {
 		opt(fl)
-	}
-
-	if fl.debugLogging {
-		fl.logLevel = slog.LevelDebug
 	}
 
 	if err := fl.descend([]string{}, data, 0); err != nil {
@@ -162,30 +141,10 @@ func Flatten(data any, opts ...FlattenOpts) ([]Row, error) {
 func (fl *Flattener) descend(path []string, data any, depth int) error {
 	queryTerm, isQueryMatched := fl.queryAtDepth(depth)
 
-	// Gate the contextual logger build behind an Enabled check. descend is
-	// recursive and called many times per row; an unconditional Logger.With
-	// here propagates through the slog-multi handler chain on every call,
-	// allocating large amounts even when the level is filtered out.
-	slogger := fl.slogger
-	loggingEnabled := fl.slogger.Enabled(context.TODO(), fl.logLevel)
-	if loggingEnabled {
-		slogger = fl.slogger.With(
-			"caller", "descend",
-			"depth", depth,
-			"rows_so_far", len(fl.rows),
-			"query", queryTerm,
-			"path", strings.Join(path, "/"),
-		)
-	}
-
 	switch v := data.(type) {
 	case []any:
 		for i, e := range v {
 			pathKey := strconv.Itoa(i)
-			slogger.Log(context.TODO(), fl.logLevel,
-				"checking an array",
-				"index_str", pathKey,
-			)
 
 			// If the queryTerm starts with
 			// queryKeyDenoter, then we want to rewrite
@@ -201,37 +160,19 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 				keyQuery := strings.SplitN(after, "=>", 2)
 				keyName := keyQuery[0]
 
-				innerslogger := slogger
-				if loggingEnabled {
-					innerslogger = slogger.With("array_key_name", keyName)
-				}
-				innerslogger.Log(context.TODO(), fl.logLevel,
-					"attempting to coerce array into map",
-				)
-
 				e, ok := e.(map[string]any)
 				if !ok {
-					innerslogger.Log(context.TODO(), fl.logLevel,
-						"can't coerce into map",
-					)
 					continue
 				}
 
 				// Is keyName in this array?
 				val, ok := e[keyName]
 				if !ok {
-					innerslogger.Log(context.TODO(), fl.logLevel,
-						"keyName not in map",
-						"key_name", keyName,
-					)
 					continue
 				}
 
 				pathKey, ok = val.(string)
 				if !ok {
-					innerslogger.Log(context.TODO(), fl.logLevel,
-						"can't coerce pathKey val into string",
-					)
 					continue
 				}
 
@@ -239,9 +180,6 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 			}
 
 			if !(isQueryMatched || fl.queryMatchArrayElement(e, i, queryTerm)) {
-				slogger.Log(context.TODO(), fl.logLevel,
-					"query not matched",
-				)
 				continue
 			}
 
@@ -250,9 +188,6 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 			}
 		}
 	case map[string]any:
-		slogger.Log(context.TODO(), fl.logLevel,
-			"checking a map",
-		)
 		for k, e := range v {
 			// Check that the key name matches. If not, skip this entire
 			// branch of the map
@@ -265,9 +200,6 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 			}
 		}
 	case []map[string]any:
-		slogger.Log(context.TODO(), fl.logLevel,
-			"checking an array of maps",
-		)
 		for i, e := range v {
 			if err := fl.descend(append(path, strconv.Itoa(i)), e, depth+1); err != nil {
 				return fmt.Errorf("flattening array of maps: %w", err)
@@ -276,9 +208,6 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 	case nil:
 		// Because we want to filter nils out, we do _not_ examine isQueryMatched here
 		if !(fl.queryMatchNil(queryTerm)) {
-			slogger.Log(context.TODO(), fl.logLevel,
-				"query not matched",
-			)
 			return nil
 		}
 		fl.rows = append(fl.rows, NewRow(path, ""))
@@ -288,7 +217,7 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 		// Most string like data comes in this way
 		return fl.descendMaybePlist(path, v, depth)
 	default:
-		if err := fl.handleStringLike(slogger, path, v, depth); err != nil {
+		if err := fl.handleStringLike(path, v, depth); err != nil {
 			return fmt.Errorf("flattening at path %v: %w", path, err)
 		}
 	}
@@ -298,7 +227,7 @@ func (fl *Flattener) descend(path []string, data any, depth int) error {
 // handleStringLike is called when we finally have an object we think
 // can be converted to a string. It uses the depth to compare against
 // the query, and returns a stringify'ed value
-func (fl *Flattener) handleStringLike(slogger *slog.Logger, path []string, v any, depth int) error {
+func (fl *Flattener) handleStringLike(path []string, v any, depth int) error {
 	queryTerm, isQueryMatched := fl.queryAtDepth(depth)
 
 	stringValue, err := stringify(v)
@@ -307,9 +236,6 @@ func (fl *Flattener) handleStringLike(slogger *slog.Logger, path []string, v any
 	}
 
 	if !(isQueryMatched || fl.queryMatchString(stringValue, queryTerm)) {
-		slogger.Log(context.TODO(), fl.logLevel,
-			"query not matched",
-		)
 		return nil
 	}
 
@@ -321,48 +247,35 @@ func (fl *Flattener) handleStringLike(slogger *slog.Logger, path []string, v any
 // embedded plist. In the case of failures, it falls back to treating
 // it like a plain string.
 func (fl *Flattener) descendMaybePlist(path []string, data []byte, depth int) error {
-	// Gate the contextual logger build behind an Enabled check; see the
-	// matching note in descend.
-	slogger := fl.slogger
-	if fl.slogger.Enabled(context.TODO(), fl.logLevel) {
-		slogger = fl.slogger.With(
-			"caller", "descendMaybePlist",
-			"depth", depth,
-			"rows_so_far", len(fl.rows),
-			"path", strings.Join(path, "/"),
-		)
-	}
-
 	// Skip if we're not expanding nested plists
 	if !fl.expandNestedPlist {
-		return fl.handleStringLike(slogger, path, data, depth)
+		return fl.handleStringLike(path, data, depth)
 	}
 
 	// Skip if this doesn't look like a plist.
 	if !isPlist(data) {
-		return fl.handleStringLike(slogger, path, data, depth)
+		return fl.handleStringLike(path, data, depth)
 	}
-
-	// Looks like a plist. Try parsing it
-	slogger.Log(context.TODO(), fl.logLevel,
-		"parsing inner plist",
-	)
 
 	var innerData any
 
 	if err := plist.Unmarshal(data, &innerData); err != nil {
-		slogger.Log(context.TODO(), slog.LevelInfo,
+		fl.slogger.Log(context.TODO(), slog.LevelInfo,
 			"plist parsing failed",
+			"caller", "descendMaybePlist",
+			"path", strings.Join(path, "/"),
 			"err", err,
 		)
-		return fl.handleStringLike(slogger, path, data, depth)
+		return fl.handleStringLike(path, data, depth)
 	}
 
 	// have a parsed plist. Descend and return from here.
 	if fl.includeNestedRaw {
-		if err := fl.handleStringLike(slogger, append(path, "_raw"), data, depth); err != nil {
-			slogger.Log(context.TODO(), slog.LevelError,
+		if err := fl.handleStringLike(append(path, "_raw"), data, depth); err != nil {
+			fl.slogger.Log(context.TODO(), slog.LevelError,
 				"failed to add _raw key",
+				"caller", "descendMaybePlist",
+				"path", strings.Join(path, "/"),
 				"err", err,
 			)
 		}
@@ -390,18 +303,6 @@ func (fl *Flattener) queryMatchNil(queryTerm string) bool {
 // We use `=>` as something that is reasonably intuitive, and not very
 // likely to occur on it's own. Unfortunately, `==` shows up in base64
 func (fl *Flattener) queryMatchArrayElement(data any, arrIndex int, queryTerm string) bool {
-	// Gate the contextual logger build behind an Enabled check; see the
-	// matching note in descend.
-	slogger := fl.slogger
-	if fl.slogger.Enabled(context.TODO(), fl.logLevel) {
-		slogger = fl.slogger.With(
-			"caller", "queryMatchArrayElement",
-			"rows_so_far", len(fl.rows),
-			"query", queryTerm,
-			"arr_index", arrIndex,
-		)
-	}
-
 	// strip off the key re-write denotation before trying to match
 	queryTerm = strings.TrimPrefix(queryTerm, fl.queryKeyDenoter)
 
@@ -411,15 +312,8 @@ func (fl *Flattener) queryMatchArrayElement(data any, arrIndex int, queryTerm st
 
 	// If the queryTerm is an int, then we expect to match the index
 	if queryIndex, err := strconv.Atoi(queryTerm); err == nil {
-		slogger.Log(context.TODO(), fl.logLevel,
-			"using numeric index comparison",
-		)
 		return queryIndex == arrIndex
 	}
-
-	slogger.Log(context.TODO(), fl.logLevel,
-		"checking data type",
-	)
 
 	switch dataCasted := data.(type) {
 	case []any:

--- a/ee/tables/dataflattentable/exec_and_parse.go
+++ b/ee/tables/dataflattentable/exec_and_parse.go
@@ -29,7 +29,6 @@ type execTableV2 struct {
 	description         string
 	flattener           bytesFlattener
 	timeoutSeconds      int
-	tabledebug          bool
 	includeStderr       bool
 	reportStderr        bool
 	reportMissingBinary bool
@@ -42,12 +41,6 @@ type execTableV2Opt func(*execTableV2)
 func WithTimeoutSeconds(ts int) execTableV2Opt {
 	return func(t *execTableV2) {
 		t.timeoutSeconds = ts
-	}
-}
-
-func WithTableDebug() execTableV2Opt {
-	return func(t *execTableV2) {
-		t.tabledebug = true
 	}
 }
 
@@ -208,9 +201,6 @@ func (tbl *execTableV2) generate(ctx context.Context, queryContext table.QueryCo
 		flattenOpts := []dataflatten.FlattenOpts{
 			dataflatten.WithSlogger(tbl.slogger),
 			dataflatten.WithQuery(strings.Split(dataQuery, "/")),
-		}
-		if tbl.tabledebug {
-			flattenOpts = append(flattenOpts, dataflatten.WithDebugLogging())
 		}
 
 		flattened, err := tbl.flattener.FlattenBytes(stdout.Bytes(), flattenOpts...)


### PR DESCRIPTION
## Summary

Gates the four `slogger.With(...)` call sites in `ee/dataflatten/flatten.go`
behind a `Handler.Enabled(...)` check so we only build a contextual logger when
the level will actually be emitted.

## Why

A flare from a customer host ( showed
the launcher process with:

- `go_mem_bytes` (`Sys − HeapReleased`) sitting around 1.1–1.2 GB
- Lifetime allocations of **311 GB** across 3.18 B mallocs, with NumGC = 3632
- HeapSys peaking at ~38 GB 

There is **no leak** — inuse heap at flare time is 25 MB. The problem is
allocation churn driving GC pressure and intermittent heap growth.

The pprof `alloc_space` profile points unambiguously at one path:

| cum %  | function |
|--------|----------|
| 84.60% | `dataflattentable.(*Table).generate` (251 GB) |
| 77.23% | `dataflatten.flattenJsonl` |
| 71.63% | `dataflatten.(*Flattener).descend` |
| 71.01% | `slog.(*Logger).With` (210 GB) |
| 56.98% | `slog-multi.HandleInlineMiddleware.WithAttrs` |
| 55.49% | `dedup.(*dedupHandler).WithAttrs` (165 GB) |
| 13.55% | `slog.argsToAttrSlice` (40 GB) |
| 10.69% | `slices.Clone` of `[]slog.Attr` (32 GB) |
| 8.89%  | `slog.(*commonHandler).clone` (26 GB) |


### Root cause

`Flattener.descend` is recursive and is the engine behind every `kolide_*`
virtual table query. At the top of every recursion (and inside its inner
loops) it built a contextual logger via `fl.slogger.With(...)` — even though
the subsequent `slogger.Log(...)` calls all ran at
`levelFlattenDebug = slog.LevelDebug - 1` and were filtered out at the
handler.

`Logger.With` is **not** free: it propagates through the entire slog-multi
chain (`utcTimeMiddleware → ctxValuesMiddleWare → dedupHandler →
reportedErrorMiddleware → Fanout → leaf handlers`), and every middleware
clones the attribute slice. For one deep JSON/plist row, `descend` runs
thousands of times, so we ended up doing 6–10 attribute-slice clones per
recursion that produced no output.

### Why remove rather than gate

The first iteration of this fix gated each `With` site behind
`slogger.Enabled(...)` so the allocations only happened when debug logging
was actually requested. After discussing with the team, the call was that
dataflatten has been stable for long enough that the per-step debug logging
is no longer pulling its weight — the times we've actually needed to debug
this code in the last year, the rows themselves and the eventual error
messages have been sufficient. The cleaner fix is to delete the noisy
logging outright (and the `WithDebugLogging` knob, which was only ever wired
to a `tabledebug` flag that nothing sets in production).

The two log calls we kept in `descendMaybePlist` are real failure signals,
not per-iteration tracing, and they're on a cold path (only reached for
string/byte data that looks like a plist).

***Assisted with Claude Code***