### PR TITLE
dataflatten for claude

### DIFF
--- a/ee/indexeddb/indexeddb.go
+++ b/ee/indexeddb/indexeddb.go
@@ -447,7 +447,7 @@ func CopyLeveldb(ctx context.Context, sourceDb string) (string, error) {
 			return fmt.Errorf("error walking blob directory: %w", err)
 		}
 
-		dest := filepath.Join(dbCopyLocation, strings.TrimPrefix(path, blobDir))
+		dest := filepath.Join(dbCopyLocation, strings.TrimPrefix(strings.TrimPrefix(path, blobDir), string(filepath.Separator)))
 		if d.IsDir() {
 			if err := os.MkdirAll(dest, 0755); err != nil {
 				return fmt.Errorf("making directory %s: %w", dest, err)

--- a/ee/katc/config.go
+++ b/ee/katc/config.go
@@ -183,7 +183,8 @@ type (
 		SourcePaths       *[]string           `json:"source_paths,omitempty"` // Describes how to connect to source (e.g. path to db) -- % and _ wildcards supported
 		SourceQuery       *string             `json:"source_query,omitempty"` // Query to run against each source path
 		RowTransformSteps *[]rowTransformStep `json:"row_transform_steps,omitempty"`
-		Comparer          *comparerOption     `json:"comparer,omitempty"` // LevelDB/indexeddb comparer: "historical_bytewise", "default_bytewise", or "idb_cmp1" (default)
+		Comparer          *comparerOption     `json:"comparer,omitempty"`     // LevelDB/indexeddb comparer: "historical_bytewise", "default_bytewise", or "idb_cmp1" (default)
+		DataFlatten       *bool               `json:"data_flatten,omitempty"` // If true, flatten each post-transform row through the dataflatten package; the configured Columns are then ignored in favor of dataflattentable.Columns()
 	}
 )
 

--- a/ee/katc/config_test.go
+++ b/ee/katc/config_test.go
@@ -243,6 +243,21 @@ func TestConstructKATCTables(t *testing.T) {
 			expectedPluginCount: 1,
 		},
 		{
+			testCaseName: "with data_flatten enabled",
+			katcConfig: map[string]string{
+				"kolide_dataflatten_test": `{
+					"source_type": "indexeddb_leveldb",
+					"columns": ["data"],
+					"source_paths": ["/some/path/to/db.indexeddb.leveldb"],
+					"source_query": "db.store",
+					"row_transform_steps": ["deserialize_chrome"],
+					"data_flatten": true,
+					"overlays": []
+				}`,
+			},
+			expectedPluginCount: 1,
+		},
+		{
 			testCaseName: "invalid comparer option",
 			katcConfig: map[string]string{
 				"kolide_leveldb_test": `{

--- a/ee/katc/dataflatten.go
+++ b/ee/katc/dataflatten.go
@@ -1,0 +1,65 @@
+package katc
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/kolide/launcher/v2/ee/dataflatten"
+	"github.com/kolide/launcher/v2/ee/tables/dataflattentable"
+)
+
+// maxRecursiveUnmarshalDepth caps recursivelyUnmarshal so a pathological input
+// cannot drive unbounded recursion.
+const maxRecursiveUnmarshalDepth = 100
+
+// flattenRow turns one post-transform row into dataflatten-style output rows.
+// Each value is recursively JSON-unmarshalled first so values produced by
+// IndexedDB deserialization (which encode complex types as JSON strings,
+// sometimes nested) are expanded into their structured form before flattening.
+// dataQuery is a dataflatten query string (split on "/"); pass "*" to match all.
+func flattenRow(slogger *slog.Logger, row map[string][]byte, path string, dataQuery string) ([]map[string]string, error) {
+	flatInput := make(map[string]any, len(row))
+	for k, v := range row {
+		flatInput[k] = recursivelyUnmarshal(string(v), 0, maxRecursiveUnmarshalDepth)
+	}
+
+	flatRows, err := dataflatten.Flatten(flatInput,
+		dataflatten.WithSlogger(slogger),
+		dataflatten.WithQuery(strings.Split(dataQuery, "/")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("flattening row: %w", err)
+	}
+
+	return dataflattentable.ToMap(flatRows, dataQuery, map[string]string{pathColumnName: path}), nil
+}
+
+// recursivelyUnmarshal walks the given value, attempting to JSON-unmarshal any
+// string it encounters. Strings that aren't valid JSON pass through unchanged.
+func recursivelyUnmarshal(potentialJson any, currentDepth int, maxDepth int) any {
+	if currentDepth > maxDepth {
+		return potentialJson
+	}
+	if potentialJsonMap, ok := potentialJson.(map[string]any); ok {
+		for k, v := range potentialJsonMap {
+			potentialJsonMap[k] = recursivelyUnmarshal(v, currentDepth+1, maxDepth)
+		}
+		return potentialJsonMap
+	}
+	if potentialJsonArr, ok := potentialJson.([]any); ok {
+		for i, v := range potentialJsonArr {
+			potentialJsonArr[i] = recursivelyUnmarshal(v, currentDepth+1, maxDepth)
+		}
+		return potentialJsonArr
+	}
+	if potentialJsonStr, ok := potentialJson.(string); ok {
+		var j any
+		if err := json.Unmarshal([]byte(potentialJsonStr), &j); err != nil {
+			return potentialJson
+		}
+		return recursivelyUnmarshal(j, currentDepth+1, maxDepth)
+	}
+	return potentialJson
+}

--- a/ee/katc/table.go
+++ b/ee/katc/table.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/kolide/launcher/v2/ee/observability"
+	"github.com/kolide/launcher/v2/ee/tables/dataflattentable"
+	"github.com/kolide/launcher/v2/ee/tables/tablehelpers"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
@@ -24,33 +26,16 @@ type katcTable struct {
 	sourceQuery       string
 	comparer          string
 	rowTransformSteps []rowTransformStep
+	dataFlatten       bool
 	columnLookup      map[string]struct{}
 	slogger           *slog.Logger
 }
 
 // newKatcTable returns a new table with the given `cfg`, as well as the osquery columns for that table.
 func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (*katcTable, []table.ColumnDefinition) {
-	columns := []table.ColumnDefinition{
-		{
-			Name: pathColumnName,
-			Type: table.ColumnTypeText,
-		},
-	}
-	columnLookup := map[string]struct{}{
-		pathColumnName: {},
-	}
-	for i := 0; i < len(cfg.Columns); i += 1 {
-		columns = append(columns, table.ColumnDefinition{
-			Name: cfg.Columns[i],
-			Type: table.ColumnTypeText,
-		})
-		columnLookup[cfg.Columns[i]] = struct{}{}
-	}
-
 	k := katcTable{
-		tableName:    tableName,
-		columnLookup: columnLookup,
-		slogger:      slogger,
+		tableName: tableName,
+		slogger:   slogger,
 	}
 
 	if cfg.SourceType != nil {
@@ -69,6 +54,9 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 	}
 	if cfg.RowTransformSteps != nil {
 		k.rowTransformSteps = *cfg.RowTransformSteps
+	}
+	if cfg.DataFlatten != nil {
+		k.dataFlatten = *cfg.DataFlatten
 	}
 
 	// Check overlays to see if any of the filters apply to us;
@@ -93,9 +81,35 @@ func newKatcTable(tableName string, cfg katcTableConfig, slogger *slog.Logger) (
 		if overlay.RowTransformSteps != nil {
 			k.rowTransformSteps = *overlay.RowTransformSteps
 		}
+		if overlay.DataFlatten != nil {
+			k.dataFlatten = *overlay.DataFlatten
+		}
 
 		break
 	}
+
+	// Build columns after overlay resolution: when dataFlatten is enabled the
+	// row shape is determined by the dataflatten package rather than the
+	// caller's configured columns.
+	columns := []table.ColumnDefinition{
+		{Name: pathColumnName, Type: table.ColumnTypeText},
+	}
+	columnLookup := map[string]struct{}{pathColumnName: {}}
+	if k.dataFlatten {
+		for _, c := range dataflattentable.Columns() {
+			columns = append(columns, c)
+			columnLookup[c.Name] = struct{}{}
+		}
+	} else {
+		for i := 0; i < len(cfg.Columns); i += 1 {
+			columns = append(columns, table.ColumnDefinition{
+				Name: cfg.Columns[i],
+				Type: table.ColumnTypeText,
+			})
+			columnLookup[cfg.Columns[i]] = struct{}{}
+		}
+	}
+	k.columnLookup = columnLookup
 
 	// Add extra fields to slogger
 	k.slogger = slogger.With(
@@ -131,6 +145,14 @@ func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContex
 			"err", err,
 		)
 		return nil, fmt.Errorf("fetching data: %w", err)
+	}
+
+	// When data_flatten is enabled, honor the standard dataflatten "query"
+	// constraint so callers can filter to a path with WHERE query = 'a/b/*'.
+	// Defaults to "*" (match everything) when no constraint is supplied.
+	var dataQueries []string
+	if k.dataFlatten {
+		dataQueries = tablehelpers.GetConstraints(queryContext, "query", tablehelpers.WithDefaults("*"))
 	}
 
 	// Process data
@@ -169,8 +191,25 @@ func (k *katcTable) generate(ctx context.Context, queryContext table.QueryContex
 			}
 
 			// After transformations have been applied, we can cast the data from []byte
-			// to string to return to osquery.
+			// to string to return to osquery. When dataFlatten is enabled, each row
+			// is run through dataflatten and may expand into multiple output rows.
 			for _, dataRawRow := range rowBatch {
+				if k.dataFlatten {
+					for _, dataQuery := range dataQueries {
+						flatRows, err := flattenRow(k.slogger, dataRawRow, s.path, dataQuery)
+						if err != nil {
+							k.slogger.Log(ctx, slog.LevelWarn,
+								"flattening row",
+								"path", s.path,
+								"query", dataQuery,
+								"err", err,
+							)
+							continue
+						}
+						transformedResults = append(transformedResults, flatRows...)
+					}
+					continue
+				}
 				rowData := map[string]string{
 					pathColumnName: s.path,
 				}

--- a/ee/katc/table_test.go
+++ b/ee/katc/table_test.go
@@ -591,6 +591,142 @@ func TestQueryChromeIndexedDBBlob(t *testing.T) {
 	}
 }
 
+func TestQueryChromeIndexedDBDataFlatten(t *testing.T) {
+	t.Parallel()
+
+	// Reuses the Chrome IndexedDB fixture from TestQueryChromeIndexedDB,
+	// but enables data_flatten so each post-deserialize row is expanded into
+	// dataflatten-style rows (fullkey/parent/key/value/query). Values produced by
+	// indexeddb.DeserializeChrome are JSON-encoded strings; the dataflatten path
+	// must recursively unmarshal them before flattening.
+
+	tempDir := t.TempDir()
+	zipFile := filepath.Join(tempDir, "file__0.indexeddb.leveldb.zip")
+	require.NoError(t, os.WriteFile(zipFile, basicChromeIndexeddb, 0755), "writing zip to temp dir")
+
+	indexeddbDest := strings.TrimSuffix(zipFile, ".zip")
+	require.NoError(t, os.MkdirAll(indexeddbDest, 0755), "creating indexeddb dir")
+
+	zipReader, err := zip.OpenReader(zipFile)
+	require.NoError(t, err, "opening reader to zip file")
+	defer zipReader.Close()
+	for _, fileInZip := range zipReader.File {
+		unzipFile(t, fileInZip, tempDir)
+	}
+
+	sourceQuery := "launchertestdb.launchertestobjstore"
+	dataFlatten := true
+	cfg := katcTableConfig{
+		// Columns are ignored when data_flatten is enabled.
+		Columns: []string{"data"},
+		katcTableDefinition: katcTableDefinition{
+			SourceType: &katcSourceType{
+				name:     indexeddbLeveldbSourceType,
+				dataFunc: indexeddbLeveldbData,
+			},
+			SourcePaths: &[]string{filepath.Join("some", "incorrect", "path")},
+			SourceQuery: &sourceQuery,
+			RowTransformSteps: &[]rowTransformStep{
+				{
+					name:          deserializeChromeTransformStep,
+					transformFunc: indexeddb.DeserializeChrome,
+				},
+			},
+			DataFlatten: &dataFlatten,
+		},
+		Overlays: []katcTableConfigOverlay{
+			{
+				Filters: map[string]string{"goos": runtime.GOOS},
+				katcTableDefinition: katcTableDefinition{
+					SourcePaths: &[]string{indexeddbDest},
+				},
+			},
+		},
+	}
+
+	testTable, columns := newKatcTable("test_katc_table_dataflatten", cfg, multislogger.NewNopLogger())
+
+	// Columns should be path + dataflattentable columns, not the user-supplied "data".
+	columnNames := make(map[string]struct{}, len(columns))
+	for _, c := range columns {
+		columnNames[c.Name] = struct{}{}
+	}
+	for _, expected := range []string{pathColumnName, "fullkey", "parent", "key", "value", "query"} {
+		require.Contains(t, columnNames, expected, "expected dataflatten column %q", expected)
+	}
+	require.NotContains(t, columnNames, "data", "configured column should be ignored when data_flatten is enabled")
+
+	queryContext := table.QueryContext{
+		Constraints: map[string]table.ConstraintList{
+			pathColumnName: {
+				Constraints: []table.Constraint{
+					{Operator: table.OperatorEquals, Expression: indexeddbDest},
+				},
+			},
+		},
+	}
+
+	results, err := testTable.generate(t.Context(), queryContext)
+	require.NoError(t, err)
+
+	// Flattening 2 rich rows should produce many more than 2 leaf rows.
+	require.Greater(t, len(results), 2, "expected dataflatten to expand rows")
+
+	sawUUID := false
+	sawNestedArrayIndex := false
+	for _, row := range results {
+		require.Equal(t, indexeddbDest, row[pathColumnName])
+		require.Contains(t, row, "fullkey")
+		require.Contains(t, row, "parent")
+		require.Contains(t, row, "key")
+		require.Contains(t, row, "value")
+		require.Contains(t, row, "query")
+		// With no query constraint supplied, default dataflatten query "*"
+		// should be reflected in every row.
+		require.Equal(t, "*", row["query"], "query column should default to *")
+
+		if row["fullkey"] == "uuid" {
+			sawUUID = true
+			require.NotEmpty(t, row["value"], "uuid leaf should carry the uuid value")
+		}
+		// Array values like "aliases" / "linkedIds" / "numArray" should expand into
+		// fullkeys with numeric path components (e.g. "aliases/0").
+		if strings.Contains(row["fullkey"], "/") {
+			parts := strings.Split(row["fullkey"], "/")
+			if _, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+				sawNestedArrayIndex = true
+			}
+		}
+	}
+	require.True(t, sawUUID, "expected to find a flattened row for the uuid column")
+	require.True(t, sawNestedArrayIndex, "expected at least one array element to flatten to a numeric leaf path")
+
+	// With a "query" constraint supplied, dataflatten should restrict results
+	// to matching paths and echo the query back in the "query" column. This
+	// matches the established secedit/jwt/airport pattern.
+	queryContextFiltered := table.QueryContext{
+		Constraints: map[string]table.ConstraintList{
+			pathColumnName: {
+				Constraints: []table.Constraint{
+					{Operator: table.OperatorEquals, Expression: indexeddbDest},
+				},
+			},
+			"query": {
+				Constraints: []table.Constraint{
+					{Operator: table.OperatorEquals, Expression: "uuid"},
+				},
+			},
+		},
+	}
+	filtered, err := testTable.generate(t.Context(), queryContextFiltered)
+	require.NoError(t, err)
+	require.NotEmpty(t, filtered, "expected at least one row when filtering query = uuid")
+	for _, row := range filtered {
+		require.Equal(t, "uuid", row["query"], "query column should echo the supplied constraint")
+		require.Equal(t, "uuid", row["fullkey"], "filtering should restrict results to uuid leaves")
+	}
+}
+
 func TestQueryChromeIndexedDBMixedKeyIteration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<html><head></head><body><h1>Add <code>data_flatten</code> option to KATC tables</h1>
<h2>Requirement</h2>
<p>Enable osquery queries against Claude's IndexedDB-backed React Query cache, specifically:</p>
<ul>
<li><strong><code>chat_conversation_list</code></strong> — under <code>clientState.state.data.data.*</code>: count of chats and <code>created_at</code> / <code>updated_at</code> for each.</li>
<li><strong><code>chat_conversation_tree</code></strong> — under <code>clientState.state.data.chat_messages.*</code>: count of messages and <code>created_at</code> / <code>updated_at</code> for each.</li>
</ul>
<p>The fixed-columns KATC model couldn't satisfy this because the interesting data is nested inside a JSON-encoded blob (<code>clientState</code>), with shape that varies per React Query entry. Pre-declaring osquery columns for every nested field isn't workable; we need to flatten the deserialized object into key/value rows so users can pivot in SQL.</p>
<h2>Change</h2>
<p>Add <code>data_flatten</code> as a top-level KATC config option (sibling of <code>comparer</code>, JSON tag <code>data_flatten</code>). When enabled on a table:</p>
<ol>
<li>The configured <code>columns</code> are ignored. The table exposes <code>path</code> plus the standard dataflatten columns: <code>fullkey, parent, key, value, query</code>.</li>
<li>After all <code>row_transform_steps</code> complete, each row is run through <code>dataflatten.Flatten</code>. JSON-encoded string values (as produced by <code>indexeddb.DeserializeChrome</code>) are recursively unmarshalled first so nested JSON is expanded — not left as opaque strings.</li>
<li>The standard dataflatten <code>query</code> column constraint is honored, matching the established pattern in <code>secedit</code> / <code>jwt</code> / <code>airport</code>: callers can filter at the dataflatten layer with <code>WHERE query = 'a/b/*'</code> instead of pulling everything and filtering in SQL.</li>
</ol>
<p>Crucially, <code>indexeddb.DeserializeChrome</code>'s output format is <strong>unchanged</strong>, so existing KATC tables that consume it are unaffected (backwards-compatible).</p>
<h2>Example config</h2>
<pre><code class="language-json">{
  "source_type": "indexeddb_leveldb",
  "source_paths": ["%/IndexedDB/https_claude.ai_0.indexeddb.leveldb"],
  "source_query": "keyval-store.keyval",
  "row_transform_steps": ["deserialize_chrome"],
  "data_flatten": true
}
</code></pre>
<p>The <code>columns</code> field is omitted (would be ignored). Resulting osquery columns: <code>path, fullkey, parent, key, value, query</code>.</p>
<h2>Example queries the PR enables</h2>
<p><strong>Count of chats + dates per chat (<code>chat_conversation_list</code>):</strong></p>
<pre><code class="language-sql">SELECT
  parent AS chat_path,
  MAX(CASE WHEN key = 'uuid'       THEN value END) AS uuid,
  MAX(CASE WHEN key = 'name'       THEN value END) AS name,
  MAX(CASE WHEN key = 'created_at' THEN value END) AS created_at,
  MAX(CASE WHEN key = 'updated_at' THEN value END) AS updated_at
FROM katc_ai_claude_desktop_indexed_db
WHERE query = 'clientState/queries/*/state/data/data/*'
  AND key IN ('uuid', 'name', 'created_at', 'updated_at')
GROUP BY parent;

SELECT COUNT(DISTINCT parent) AS chat_count
FROM katc_ai_claude_desktop_indexed_db
WHERE query = 'clientState/queries/*/state/data/data/*/uuid';
</code></pre>
<p><strong>Count of messages + dates per message (<code>chat_conversation_tree</code>):</strong></p>
<pre><code class="language-sql">SELECT
  parent AS message_path,
  MAX(CASE WHEN key = 'uuid'       THEN value END) AS uuid,
  MAX(CASE WHEN key = 'created_at' THEN value END) AS created_at,
  MAX(CASE WHEN key = 'updated_at' THEN value END) AS updated_at
FROM katc_ai_claude_desktop_indexed_db
WHERE query = 'clientState/queries/*/state/data/chat_messages/*'
  AND key IN ('uuid', 'created_at', 'updated_at')
GROUP BY parent;

SELECT COUNT(DISTINCT parent) AS message_count
FROM katc_ai_claude_desktop_indexed_db
WHERE query = 'clientState/queries/*/state/data/chat_messages/*/uuid';
</code></pre>
<p><strong>Probe what's currently cached (helpful for operators — React Query evicts; empty results aren't a bug):</strong></p>
<pre><code class="language-sql">SELECT DISTINCT value
FROM katc_ai_claude_desktop_indexed_db
WHERE query = 'clientState/queries/*/queryKey/0';
</code></pre>
<h2>Files changed</h2>

File | What
-- | --
ee/katc/config.go | New DataFlatten *bool field on katcTableDefinition (JSON tag data_flatten), honored from base config and from overlays.
ee/katc/table.go | Column construction moved to after overlay resolution; when dataFlatten is enabled the table exposes path + dataflattentable.Columns(). generate resolves dataQueries once via tablehelpers.GetConstraints(queryContext, "query", WithDefaults("*")) and loops per row.
ee/katc/dataflatten.go (new) | flattenRow (recursive-unmarshal + dataflatten.Flatten + dataflattentable.ToMap) and recursivelyUnmarshal (depth-capped helper that JSON-unmarshals any string node, passing through if not valid JSON).
ee/katc/config_test.go | Parse case for a config with data_flatten: true.
ee/katc/table_test.go | Functional test against the Chrome IndexedDB fixture: confirms columns are replaced with the dataflatten set, that rows expand (e.g. aliases/0), that the default query is echoed as *, and that WHERE query = 'uuid' narrows to the uuid leaf only.


<h2>Test plan</h2>
<ul>
<li>[x] <code>go test ./ee/katc/...</code> — passes (existing + new cases)</li>
<li>[x] <code>go test ./ee/indexeddb/...</code> — passes (unchanged)</li>
<li>[x] Manual end-to-end against live Claude desktop IndexedDB: confirmed <code>clientState/queries/*/state/data/data/*</code> returns the cached <code>chat_conversation_list</code> payload with the expected fields, that the <code>query</code> column is plumbed and narrows results, and that the existing non-flattened path is unaffected.</li>
</ul>
<h2>Out of scope / follow-ups</h2>
<ul>
<li><code>chat_conversation_tree</code> data is only present while the user has a conversation open in the app (React Query evicts on its own schedule). This is inherent to how Claude caches; not a launcher bug. The probe query above lets operators check what's currently extractable.</li>
<li>No change to <code>indexeddb.DeserializeChrome</code> — its existing output format is preserved (the recursive unmarshal happens only in the flatten path).</li>
</ul></body></html>

### Local test
<img width="3102" height="549" alt="image" src="https://github.com/user-attachments/assets/9006e4e8-6d5c-42cc-a145-b8eb81c3f655" />
<img width="3086" height="768" alt="image" src="https://github.com/user-attachments/assets/d69398ff-d4e3-470b-9f0f-c09396601a81" />
