### PR TITLE
Capture stderr and return it when table commands fail

### DIFF
--- a/ee/tables/tablehelpers/exec.go
+++ b/ee/tables/tablehelpers/exec.go
@@ -45,8 +45,9 @@ func RunSimple(ctx context.Context, slogger *slog.Logger, timeoutSeconds int, cm
 	defer span.End()
 
 	var stdout bytes.Buffer
-	if err := Run(ctx, slogger, timeoutSeconds, cmd, args, &stdout, io.Discard, opts...); err != nil {
-		return nil, err
+	var stderr bytes.Buffer // capture stderr for logging purposes in case of failure
+	if err := Run(ctx, slogger, timeoutSeconds, cmd, args, &stdout, &stderr, opts...); err != nil {
+		return nil, fmt.Errorf("running %s: stderr: %s: %w", cmd.Name(), stderr.String(), err)
 	}
 
 	return stdout.Bytes(), nil


### PR DESCRIPTION
Right now, when tables using `RunSimple` fail to run commands, we get output like this:

```
exec '[/opt/CrowdStrike/falconctl -g --aid]': exit status 1
flattening at path []: unknown type on map[_error:falconctl parse failure: exec '[/opt/CrowdStrike/falconctl -g --aid]': exit status 1]
```

This doesn't capture stderr, so we can't diagnose the issue. This PR updates to capture the stderr.

With these changes, output now looks like this:

```
running fdesetup: stderr: fdesetup: unrecognized option `--some-fake-arg'\nError: Unrecognized option. (-\u0000)\n: exec '[/usr/bin/fdesetup status --some-fake-arg]': exit status 12
```