### PR TITLE
Remove span from generatePath in dataflatten

### DIFF
--- a/ee/tables/dataflattentable/tables.go
+++ b/ee/tables/dataflattentable/tables.go
@@ -206,9 +206,6 @@ func (t *Table) generateRawData(ctx context.Context, qc table.QueryContext, rawd
 }
 
 func (t *Table) generatePath(ctx context.Context, qc table.QueryContext, filePath string, dataQuery string, flattenOpts ...dataflatten.FlattenOpts) ([]map[string]string, error) {
-	ctx, span := observability.StartSpan(ctx, "path", filePath)
-	defer span.End()
-
 	var data []dataflatten.Row
 	var err error
 	if t.flattenFileFunc != nil {


### PR DESCRIPTION
We see this span a ton in e.g. kolide_jsonl -- it's not giving us a lot of info and may have a performance impact, as we saw in https://github.com/kolide/launcher/pull/2547.