### PR TITLE
Replace serenize/snaker with internal pkg/snake helper

### DIFF
--- a/ee/katc/case.go
+++ b/ee/katc/case.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/kolide/launcher/v2/ee/observability"
-	"github.com/serenize/snaker"
+	"github.com/kolide/launcher/v2/pkg/snake"
 )
 
 func camelToSnake(ctx context.Context, _ *slog.Logger, row map[string][]byte) ([]map[string][]byte, error) {
@@ -14,7 +14,7 @@ func camelToSnake(ctx context.Context, _ *slog.Logger, row map[string][]byte) ([
 
 	snakeCaseRow := make(map[string][]byte)
 	for k, v := range row {
-		snakeCaseKey := snaker.CamelToSnake(k)
+		snakeCaseKey := snake.CamelToSnake(k)
 		snakeCaseRow[snakeCaseKey] = v
 	}
 

--- a/ee/ui/assets/generator/generator.go
+++ b/ee/ui/assets/generator/generator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/kolide/kit/logutil"
-	"github.com/serenize/snaker"
+	"github.com/kolide/launcher/v2/pkg/snake"
 )
 
 // icoSizes are the ico sizes we generate. It's a tradeoff between size and quality.
@@ -211,7 +211,7 @@ func constName(name string) string {
 		"\\", "_",
 	)
 
-	return snaker.SnakeToCamel(r.Replace(name))
+	return snake.SnakeToCamel(r.Replace(name))
 }
 
 // skipFile implements timestamp logic akin to how Make does. This allows us to skip processing if the file

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/osquery/osquery-go v0.0.0-20260226222546-0cc22f415e57
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/pkg/errors v0.9.1
-	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
 	github.com/stretchr/testify v1.11.1
 	github.com/theupdateframework/go-tuf v0.5.2
 	github.com/tklauser/go-sysconf v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -380,8 +380,6 @@ github.com/samber/slog-multi v1.7.0 h1:GKhbkxU3ujkyMsefkuz4qvE6EcgtSuqjFisPnfdzV
 github.com/samber/slog-multi v1.7.0/go.mod h1:qTqzmKdPpT0h4PFsTN5rYRgLwom1v+fNGuIrl1Xnnts=
 github.com/secure-systems-lab/go-securesystemslib v0.5.0 h1:oTiNu0QnulMQgN/hLK124wJD/r2f9ZhIUuKIeBsCBT8=
 github.com/secure-systems-lab/go-securesystemslib v0.5.0/go.mod h1:uoCqUC0Ap7jrBSEanxT+SdACYJTVplRXWLkGMuDjXqk=
-github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 h1:ofR1ZdrNSkiWcMsRrubK9tb2/SlZVWttAfqUjJi6QYc=
-github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/shirou/gopsutil/v4 v4.25.8 h1:NnAsw9lN7587WHxjJA9ryDnqhJpFH6A+wagYWTOH970=
 github.com/shirou/gopsutil/v4 v4.25.8/go.mod h1:q9QdMmfAOVIw7a+eF86P7ISEU6ka+NLgkUxlopV4RwI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/pkg/launcher/pkg_utils_windows.go
+++ b/pkg/launcher/pkg_utils_windows.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/serenize/snaker"
+	"github.com/kolide/launcher/v2/pkg/snake"
 )
 
 var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
@@ -22,7 +22,7 @@ func ServiceName(identifier string) string {
 
 	sanitizedServiceName := nonAlphanumericRegex.ReplaceAllString(identifier, "_") // e.g. identifier=kolide-k2 becomes kolide_k2
 	sanitizedServiceName = fmt.Sprintf("launcher_%s_svc", sanitizedServiceName)    // wrapped as launcher_kolide_k2_svc
-	return snaker.SnakeToCamel(sanitizedServiceName)                               // will produce LauncherKolideK2Svc
+	return snake.SnakeToCamel(sanitizedServiceName)                                // will produce LauncherKolideK2Svc
 }
 
 // TaskName embeds the given identifier into our task name template after sanitization,
@@ -35,5 +35,5 @@ func TaskName(identifier, taskType string) string {
 	sanitizedIdentifier := nonAlphanumericRegex.ReplaceAllString(identifier, "_")                   // e.g. identifier=kolide-k2 becomes kolide_k2
 	sanitizedTaskType := nonAlphanumericRegex.ReplaceAllString(taskType, "_")                       // e.g. taskName=watchdog
 	sanitizedTaskName := fmt.Sprintf("launcher_%s_%s_task", sanitizedIdentifier, sanitizedTaskType) // wrapped as launcher_kolide_k2_watchdog_task
-	return snaker.SnakeToCamel(sanitizedTaskName)                                                   // will produce LauncherKolideK2WatchdogTask
+	return snake.SnakeToCamel(sanitizedTaskName)                                                    // will produce LauncherKolideK2WatchdogTask
 }

--- a/pkg/packagekit/wix/service.go
+++ b/pkg/packagekit/wix/service.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/serenize/snaker"
+	"github.com/kolide/launcher/v2/pkg/snake"
 )
 
 // http://wixtoolset.org/documentation/manual/v3/xsd/wix/serviceinstall.html
@@ -309,5 +309,5 @@ func cleanServiceName(in string) string {
 		"\\", "_",
 	)
 
-	return snaker.SnakeToCamel(r.Replace(in))
+	return snake.SnakeToCamel(r.Replace(in))
 }

--- a/pkg/snake/snake.go
+++ b/pkg/snake/snake.go
@@ -92,14 +92,10 @@ func CamelToSnake(s string) string {
 		words = append(words, s[lastPos:])
 	}
 
-	var b strings.Builder
-	for k, word := range words {
-		if k > 0 {
-			b.WriteByte('_')
-		}
-		b.WriteString(strings.ToLower(word))
-	}
-	return b.String()
+	// Every word is lower-cased and the separator is "_", which ToLower leaves
+	// untouched, so joining then lower-casing once is equivalent to lower-casing
+	// each word individually.
+	return strings.ToLower(strings.Join(words, "_"))
 }
 
 // SnakeToCamel converts a snake_case string to PascalCase, capitalizing the

--- a/pkg/snake/snake.go
+++ b/pkg/snake/snake.go
@@ -1,0 +1,156 @@
+// Package snake provides minimal helpers for converting strings between
+// camelCase/PascalCase and snake_case. It is a small in-tree replacement for
+// the previously-vendored github.com/serenize/snaker package, and preserves
+// that package's handling of common Go-style initialisms (e.g. ID, URL, HTTP)
+// so existing call sites continue to produce the same output.
+package snake
+
+import (
+	"strings"
+	"unicode"
+)
+
+// commonInitialisms mirrors the list used by github.com/golang/lint's golint
+// (and previously by serenize/snaker), so converted output keeps initialisms
+// such as "ID" or "URL" as a single word rather than splitting them up.
+var commonInitialisms = map[string]bool{
+	"ACL":   true,
+	"API":   true,
+	"ASCII": true,
+	"CPU":   true,
+	"CSS":   true,
+	"DNS":   true,
+	"EOF":   true,
+	"ETA":   true,
+	"GPU":   true,
+	"GUID":  true,
+	"HTML":  true,
+	"HTTP":  true,
+	"HTTPS": true,
+	"ID":    true,
+	"IP":    true,
+	"JSON":  true,
+	"LHS":   true,
+	"OS":    true,
+	"QPS":   true,
+	"RAM":   true,
+	"RHS":   true,
+	"RPC":   true,
+	"SLA":   true,
+	"SMTP":  true,
+	"SQL":   true,
+	"SSH":   true,
+	"TCP":   true,
+	"TLS":   true,
+	"TTL":   true,
+	"UDP":   true,
+	"UI":    true,
+	"UID":   true,
+	"UUID":  true,
+	"URI":   true,
+	"URL":   true,
+	"UTF8":  true,
+	"VM":    true,
+	"XML":   true,
+	"XMPP":  true,
+	"XSRF":  true,
+	"XSS":   true,
+	"OAuth": true,
+}
+
+// snakeToCamelExceptions maps lowercase snake words to their preferred camel
+// rendering when the default (just upper-casing the first letter) is wrong.
+var snakeToCamelExceptions = map[string]string{
+	"oauth": "OAuth",
+}
+
+// CamelToSnake converts a camelCase or PascalCase string to snake_case.
+// Recognized initialisms are kept together as a single word, e.g.
+// "userID" -> "user_id" rather than "user_i_d".
+func CamelToSnake(s string) string {
+	var words []string
+	lastPos := 0
+	rs := []rune(s)
+
+	for i := 0; i < len(rs); i++ {
+		if i == 0 || !unicode.IsUpper(rs[i]) {
+			continue
+		}
+
+		if initialism := startsWithInitialism(s[lastPos:]); initialism != "" {
+			words = append(words, initialism)
+			i += len(initialism) - 1
+			lastPos = i
+			continue
+		}
+
+		words = append(words, s[lastPos:i])
+		lastPos = i
+	}
+
+	if s[lastPos:] != "" {
+		words = append(words, s[lastPos:])
+	}
+
+	var b strings.Builder
+	for k, word := range words {
+		if k > 0 {
+			b.WriteByte('_')
+		}
+		b.WriteString(strings.ToLower(word))
+	}
+	return b.String()
+}
+
+// SnakeToCamel converts a snake_case string to PascalCase, capitalizing the
+// first letter of each underscore-separated segment. Segments matching a
+// recognized initialism are emitted in upper case (e.g. "user_id" -> "UserID").
+func SnakeToCamel(s string) string {
+	return convertSnakeToCamel(s, true)
+}
+
+// SnakeToCamelLower converts a snake_case string to camelCase, leaving the
+// first segment lowercase.
+func SnakeToCamelLower(s string) string {
+	return convertSnakeToCamel(s, false)
+}
+
+func convertSnakeToCamel(s string, upperFirst bool) string {
+	var b strings.Builder
+	for i, word := range strings.Split(s, "_") {
+		if exception, ok := snakeToCamelExceptions[word]; ok {
+			b.WriteString(exception)
+			continue
+		}
+
+		shouldCapitalize := upperFirst || i > 0
+		if shouldCapitalize {
+			if upper := strings.ToUpper(word); commonInitialisms[upper] {
+				b.WriteString(upper)
+				continue
+			}
+		}
+
+		if shouldCapitalize && len(word) > 0 {
+			rs := []rune(word)
+			rs[0] = unicode.ToUpper(rs[0])
+			b.WriteString(string(rs))
+			continue
+		}
+
+		b.WriteString(word)
+	}
+	return b.String()
+}
+
+// startsWithInitialism returns the longest commonInitialism prefix of s, or
+// the empty string if none match. Initialisms are at most 5 runes long.
+func startsWithInitialism(s string) string {
+	var initialism string
+	for i := 1; i <= 5 && i <= len(s); i++ {
+		if commonInitialisms[s[:i]] {
+			initialism = s[:i]
+		}
+	}
+	return initialism
+}

--- a/pkg/snake/snake_test.go
+++ b/pkg/snake/snake_test.go
@@ -1,0 +1,178 @@
+package snake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCamelToSnake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "already snake case",
+			input:    "email_address",
+			expected: "email_address",
+		},
+		{
+			name:     "basic camel case",
+			input:    "emailAddress",
+			expected: "email_address",
+		},
+		{
+			name:     "pascal case",
+			input:    "EmailAddress",
+			expected: "email_address",
+		},
+		{
+			name:     "single word lowercase",
+			input:    "email",
+			expected: "email",
+		},
+		{
+			name:     "trailing initialism kept whole",
+			input:    "userID",
+			expected: "user_id",
+		},
+		{
+			name:     "multi-letter initialism",
+			input:    "fetchHTTPResponse",
+			expected: "fetch_http_response",
+		},
+		{
+			name:     "leading initialism in pascal case",
+			input:    "URLPath",
+			expected: "url_path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, CamelToSnake(tt.input))
+		})
+	}
+}
+
+func TestSnakeToCamel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single word",
+			input:    "email",
+			expected: "Email",
+		},
+		{
+			name:     "two words",
+			input:    "email_address",
+			expected: "EmailAddress",
+		},
+		{
+			name:     "service name",
+			input:    "launcher_kolide_k2_svc",
+			expected: "LauncherKolideK2Svc",
+		},
+		{
+			name:     "watchdog task name",
+			input:    "launcher_kolide_k2_watchdog_task",
+			expected: "LauncherKolideK2WatchdogTask",
+		},
+		{
+			name:     "initialism segment kept upper",
+			input:    "user_id",
+			expected: "UserID",
+		},
+		{
+			name:     "oauth exception",
+			input:    "use_oauth",
+			expected: "UseOAuth",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, SnakeToCamel(tt.input))
+		})
+	}
+}
+
+func TestSnakeToCamelLower(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single word stays lower",
+			input:    "email",
+			expected: "email",
+		},
+		{
+			name:     "subsequent words upper",
+			input:    "email_address_book",
+			expected: "emailAddressBook",
+		},
+		{
+			name:     "initialism only applied after first segment",
+			input:    "id_value",
+			expected: "idValue",
+		},
+		{
+			name:     "initialism in later segment",
+			input:    "user_id",
+			expected: "userID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, SnakeToCamelLower(tt.input))
+		})
+	}
+}
+
+func TestCamelToSnake_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"launcher_kolide_k2_svc",
+		"launcher_kolide_k2_watchdog_task",
+		"email_address",
+		"user_id",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, in, CamelToSnake(SnakeToCamel(in)))
+		})
+	}
+}


### PR DESCRIPTION
Adds a small in-tree pkg/snake package providing CamelToSnake and SnakeToCamel helpers (preserving the original initialism handling) and migrates the four call sites to use it, removing the serenize/snaker third-party dependency.

Co-authored with Cursor