### PR TITLE
removing slogwith from hot path

### DIFF
--- a/ee/control/control.go
+++ b/ee/control/control.go
@@ -353,8 +353,6 @@ func (cs *ControlService) fetchAndUpdate(ctx context.Context, subsystem, hash st
 	ctx, span := observability.StartSpan(ctx, "subsystem", subsystem)
 	defer span.End()
 
-	slogger := cs.slogger.With("subsystem", subsystem)
-
 	data, err := cs.fetcher.GetSubsystemData(ctx, hash)
 	if err != nil {
 		return fmt.Errorf("failed to get control data: %w", err)
@@ -367,8 +365,9 @@ func (cs *ControlService) fetchAndUpdate(ctx context.Context, subsystem, hash st
 	// Consumer and subscriber(s) notified now
 	if err := cs.update(ctx, subsystem, data); err != nil {
 		// Returning the error so we don't store the hash and we can try again next time
-		slogger.Log(ctx, slog.LevelWarn,
+		cs.slogger.Log(ctx, slog.LevelWarn,
 			"failed to update consumers and subscribers",
+			"subsystem", subsystem,
 			"err", err,
 		)
 		return err
@@ -384,8 +383,9 @@ func (cs *ControlService) fetchAndUpdate(ctx context.Context, subsystem, hash st
 
 	// Store the hash so we can persist the last fetched data across launcher restarts
 	if err := cs.store.Set([]byte(subsystem), []byte(hash)); err != nil {
-		slogger.Log(ctx, slog.LevelError,
+		cs.slogger.Log(ctx, slog.LevelError,
 			"failed to store last fetched control data",
+			"subsystem", subsystem,
 			"err", err,
 		)
 	}

--- a/ee/tuf/util.go
+++ b/ee/tuf/util.go
@@ -20,11 +20,14 @@ func CheckExecutable(ctx context.Context, slogger *slog.Logger, potentialBinary 
 	ctx, span := observability.StartSpan(ctx, "binary_path", potentialBinary)
 	defer span.End()
 
-	slogger = slogger.With("subcomponent", "CheckExecutable", "binary_path", potentialBinary, "args", fmt.Sprintf("%+v", args))
+	argsStr := fmt.Sprintf("%+v", args)
 
 	if err := checkExecutablePermissions(ctx, potentialBinary); err != nil {
 		slogger.Log(ctx, slog.LevelWarn,
 			"failed executable permissions check",
+			"subcomponent", "CheckExecutable",
+			"binary_path", potentialBinary,
+			"args", argsStr,
 			"err", err,
 		)
 		return fmt.Errorf("checking executable permissions: %w", err)
@@ -37,6 +40,9 @@ func CheckExecutable(ctx context.Context, slogger *slog.Logger, potentialBinary 
 	if filepath.Clean(selfPath) == filepath.Clean(potentialBinary) {
 		slogger.Log(ctx, slog.LevelInfo,
 			"binary path matches current executable path, no need to exec",
+			"subcomponent", "CheckExecutable",
+			"binary_path", potentialBinary,
+			"args", argsStr,
 			"self_path", selfPath,
 		)
 		return nil
@@ -51,6 +57,9 @@ func CheckExecutable(ctx context.Context, slogger *slog.Logger, potentialBinary 
 		if execErr == nil {
 			slogger.Log(ctx, slog.LevelInfo,
 				"successfully checked executable",
+				"subcomponent", "CheckExecutable",
+				"binary_path", potentialBinary,
+				"args", argsStr,
 			)
 			return nil
 		}
@@ -63,6 +72,9 @@ func CheckExecutable(ctx context.Context, slogger *slog.Logger, potentialBinary 
 		// Non-retryable error
 		slogger.Log(ctx, slog.LevelWarn,
 			"executable check returned error",
+			"subcomponent", "CheckExecutable",
+			"binary_path", potentialBinary,
+			"args", argsStr,
 			"exec_err", execErr,
 			"command_output", string(out),
 		)
@@ -71,6 +83,9 @@ func CheckExecutable(ctx context.Context, slogger *slog.Logger, potentialBinary 
 
 	slogger.Log(ctx, slog.LevelWarn,
 		"received ETXTBSY multiple times when running executable check",
+		"subcomponent", "CheckExecutable",
+		"binary_path", potentialBinary,
+		"args", argsStr,
 	)
 
 	return fmt.Errorf("could not exec %s despite retries due to text file busy", potentialBinary)


### PR DESCRIPTION
***Why:***

slog.Logger.With(...) returns a new logger carrying the attributes as handler-chain attributes. Two downsides when it's used outside one-time setup:

Allocation per call. In repeated code paths (fetchAndUpdate runs every control fetch cycle per subsystem; CheckExecutable runs on every executable verification during autoupdate), each .With() allocates a fresh logger just to emit a log line or two. Following the recent indexeddb-comparer and osquerypublisher cleanups, this moves the bound attributes inline into the .Log() calls instead.
Handler attributes are invisible to slog.Record. Attributes bound via .With() live on the handler chain, not on the record itself, so downstream record-level handling (e.g. our log dedup middleware that hashes records) can't see them. Passing the attributes directly to .Log() makes them part of the record.
Both changes preserve the exact same flat log keys and output — no log loses context.

***Scope:*** 
ee/control/control.go (fetchAndUpdate) and ee/tuf/util.go (CheckExecutable). waitOnProcessAsync in the desktop runner was intentionally left as-is, since its .With() feeds gowrapper.Go's panic logger and is the only way to retain uid/pid context on a panic (and it's a once-per-process-lifetime path, not hot).