### PR TITLE
If log is larger than current batch size but smaller than max, send it in its own batch

### DIFF
--- a/pkg/osquery/extension.go
+++ b/pkg/osquery/extension.go
@@ -805,12 +805,12 @@ func (e *Extension) writeBufferedLogsForType(typ logger.LogType) error {
 	err = store.ForEach(func(k, v []byte) error {
 		// A somewhat cumbersome if block...
 		//
-		// 1. If the log is too big, skip it and mark for deletion.
+		// 1. If the log is larger than our largest possible batch threshold size, skip it and mark for deletion
 		// 2. If the buffer would be too big with the log, break for
 		// 3. Else append it
 		//
 		// Note that (1) must come first, otherwise (2) will always trigger.
-		if e.logPublicationState.ExceedsCurrentBatchThreshold(len(v)) {
+		if e.logPublicationState.ExceedsMaxBatchThreshold(len(v)) {
 			// Discard logs that are too big
 			logheadSize := minInt(len(v), 100)
 			e.slogger.Log(context.TODO(), slog.LevelInfo,
@@ -820,7 +820,7 @@ func (e *Extension) writeBufferedLogsForType(typ logger.LogType) error {
 				"limit", e.Opts.MaxBytesPerBatch,
 				"loghead", string(v)[0:logheadSize],
 			)
-		} else if e.logPublicationState.ExceedsCurrentBatchThreshold(totalBytes + len(v)) {
+		} else if e.logPublicationState.ExceedsCurrentBatchThreshold(totalBytes+len(v)) && totalBytes > 0 {
 			// Buffer is filled. Break the loop and come back later.
 			return iterationTerminatedError{}
 		} else {

--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1096,7 +1096,7 @@ func TestExtensionWriteBufferedLogsLimit(t *testing.T) {
 	assert.Nil(t, gotResultLogs)
 }
 
-func TestExtensionWriteBufferedLogsDropsBigLog(t *testing.T) {
+func TestExtensionWriteBufferedLogsDropsBigLogIfLargerThanMax(t *testing.T) {
 	k, expectedNodeKey := makeKnapsackEnrolled(t)
 
 	var gotStatusLogs, gotResultLogs []string
@@ -1161,6 +1161,112 @@ func TestExtensionWriteBufferedLogsDropsBigLog(t *testing.T) {
 	e.writeBufferedLogsForType(logger.LogTypeString)
 	assert.True(t, m.PublishLogsFuncInvoked)
 	assert.Equal(t, expectedResultLogs[3:], gotResultLogs)
+
+	// No more logs to write
+	m.PublishLogsFuncInvoked = false
+	gotResultLogs = nil
+	gotStatusLogs = nil
+	e.writeBufferedLogsForType(logger.LogTypeString)
+	assert.False(t, m.PublishLogsFuncInvoked)
+	assert.Nil(t, gotResultLogs)
+	assert.Nil(t, gotStatusLogs)
+
+	finalLogCount, err := e.knapsack.ResultLogsStore().Count()
+	require.NoError(t, err)
+	require.Equal(t, 0, finalLogCount, "no more queued logs")
+}
+
+func TestExtensionWriteBufferedLogsSendsBigLogIfLessThanMax(t *testing.T) {
+	k, expectedNodeKey := makeKnapsackEnrolled(t)
+
+	var gotStatusLogs, gotResultLogs []string
+	m := &mock.KolideService{
+		PublishLogsFunc: func(ctx context.Context, nodeKey string, logType logger.LogType, logs []string) (string, string, bool, error) {
+			if nodeKey != expectedNodeKey {
+				return "", "", false, nil // invalid
+			}
+
+			switch logType {
+			case logger.LogTypeStatus:
+				gotStatusLogs = logs
+			case logger.LogTypeString:
+				gotResultLogs = logs
+			case logger.LogTypeSnapshot, logger.LogTypeHealth, logger.LogTypeInit:
+				t.Errorf("unexpected log type %v", logType)
+			default:
+				t.Error("Unknown log type")
+			}
+			return "", "", false, nil
+		},
+	}
+
+	lpc := makeTestOsqLogPublisher(t, k)
+	// Create these buckets ahead of time
+	resultLogsStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ResultLogsStore.String())
+	require.NoError(t, err)
+	k.On("ResultLogsStore").Return(resultLogsStore)
+
+	maxBytes := 100
+	e, err := NewExtension(t.Context(), lpc, settingsstoremock.NewSettingsStoreWriter(t), k, ulid.New(), ExtensionOpts{
+		MaxBytesPerBatch: maxBytes,
+	})
+	require.Nil(t, err)
+	e.serviceClient = m
+
+	startLogCount, err := e.knapsack.ResultLogsStore().Count()
+	require.NoError(t, err)
+	require.Equal(t, 0, startLogCount, "start with no buffered logs")
+
+	expectedResultLogs := []string{
+		"this_result_is_tooooooo_big! oh noes",
+		"res1", "res2",
+		"this_result_is_tooooooo_big! wow",
+	}
+	for _, log := range expectedResultLogs {
+		e.LogString(t.Context(), logger.LogTypeString, log)
+	}
+
+	queuedLogCount, err := e.knapsack.ResultLogsStore().Count()
+	require.NoError(t, err)
+	require.Equal(t, len(expectedResultLogs), queuedLogCount, "correct number of enqueued logs")
+
+	// Now, reduce current_batch_limit_bytes to 15, so that "this_result_is_tooooooo_big" would be
+	// larger than current_batch_limit_bytes but still smaller than options_batch_limit_bytes.
+	e.logPublicationState.currentMaxBytesPerBatch = 15
+
+	// Should write the first log in a batch of its own
+	e.writeBufferedLogsForType(logger.LogTypeString)
+	require.True(t, m.PublishLogsFuncInvoked)
+	require.Equal(t, 1, len(gotResultLogs))
+	require.Equal(t, expectedResultLogs[0], gotResultLogs[0])
+
+	// That should have counted as publishing a full batch, so our current_batch_limit_bytes
+	// should have increased. Confirm that it did, then reset it back down to 15 for the next
+	// test.
+	require.Equal(t, maxBytes, e.logPublicationState.currentMaxBytesPerBatch)
+	e.logPublicationState.currentMaxBytesPerBatch = 15
+
+	// Should write the next two logs together
+	m.PublishLogsFuncInvoked = false
+	gotResultLogs = nil
+	e.writeBufferedLogsForType(logger.LogTypeString)
+	require.True(t, m.PublishLogsFuncInvoked)
+	require.Equal(t, 2, len(gotResultLogs))
+
+	// Same as before:
+	// That should have counted as publishing a full batch, so our current_batch_limit_bytes
+	// should have increased. Confirm that it did, then reset it back down to 15 for the next
+	// test.
+	require.Equal(t, maxBytes, e.logPublicationState.currentMaxBytesPerBatch)
+	e.logPublicationState.currentMaxBytesPerBatch = 15
+
+	// Should write the next log in a batch of its own
+	m.PublishLogsFuncInvoked = false
+	gotResultLogs = nil
+	e.writeBufferedLogsForType(logger.LogTypeString)
+	require.True(t, m.PublishLogsFuncInvoked)
+	require.Equal(t, 1, len(gotResultLogs))
+	require.Equal(t, expectedResultLogs[3], gotResultLogs[0])
 
 	// No more logs to write
 	m.PublishLogsFuncInvoked = false

--- a/pkg/osquery/log_publication_state.go
+++ b/pkg/osquery/log_publication_state.go
@@ -82,6 +82,10 @@ func (lps *logPublicationState) EndBatch(logs []string, successful bool) {
 	lps.reduceBatchThreshold()
 }
 
+func (lps *logPublicationState) ExceedsMaxBatchThreshold(amountBytes int) bool {
+	return amountBytes > lps.maxBytesPerBatch
+}
+
 func (lps *logPublicationState) ExceedsCurrentBatchThreshold(amountBytes int) bool {
 	return amountBytes > lps.currentMaxBytesPerBatch
 }


### PR DESCRIPTION
We saw an issue today where a log of size 921443 bytes didn't send because the agent's current batch size was the minimum size of 524288. The agent had been stuck at the minimum batch size of 524288 for several days, even though it had been successfully publishing logs during this time, because it was never receiving enough logs to fill up an entire batch -- we only increase the batch size after a successful full-batch send.

Per @zackattack01 we don't want to change that behavior because we need to handle the case where people with bad network connections would intermittently successfully send very small batches, causing them to endlessly increase/decrease batch sizes.

Instead, to handle this case, this PR updates so that we ship logs in their own batches if they exceed the current batch size but are still smaller than the max batch size -- 921443 is smaller than our maximum batch size of 3145728, so we would have shipped that log in its own batch.

We likely need to revisit something here to prevent devices like this one from getting stuck at the minimum batch size for days when they aren't experiencing network issues, but this should fix the issue at hand.