### PR TITLE
protect against panic in deferred osquerypublisher logging

### DIFF
--- a/ee/osquerypublisher/client.go
+++ b/ee/osquerypublisher/client.go
@@ -271,15 +271,19 @@ func (lpc *LogPublisherClient) publish(ctx context.Context, payload any, publica
 
 	requestUUID := uuid.NewForRequest()
 	ctx = uuid.NewContext(ctx, requestUUID)
-	resp := &http.Response{}
+	var resp *http.Response
 	var publicationResponse types.OsqueryPublicationResponse
 
 	defer func(begin time.Time) {
+		statusCode := 0
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
 		lpc.slogger.Log(ctx, levelForError(err), "attempted osquery publication",
 			"request_uuid", requestUUID,
 			"publication_type", publicationPath,
 			"response", publicationResponse,
-			"status_code", resp.StatusCode,
+			"status_code", statusCode,
 			"err", err,
 			"took", time.Since(begin),
 			"batch_metadata", logAttrs,

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -338,9 +338,9 @@ func TestLogPublisherClient_PublishLogs_httpClientErrorNilResponse(t *testing.T)
 
 	client := NewLogPublisherClient(slogger, mockKnapsack, mockHTTPClient)
 
-	_, err = client.PublishLogs(t.Context(), osqlog.LogTypeStatus, []string{"log1"})
+	resp, err := client.PublishLogs(t.Context(), osqlog.LogTypeStatus, []string{"log1"})
 	mockHTTPClient.AssertExpectations(t)
-
+	require.Nil(t, resp)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, doErr)
 	assert.Contains(t, err.Error(), "issuing publication request")

--- a/ee/osquerypublisher/client_test.go
+++ b/ee/osquerypublisher/client_test.go
@@ -35,6 +35,9 @@ type mockHTTPClient struct {
 
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 
@@ -302,6 +305,45 @@ func TestLogPublisherClient_PublishLogs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLogPublisherClient_PublishLogs_httpClientErrorNilResponse verifies that a
+// nil *http.Response from Client.Do does not panic in the publication logging defer
+func TestLogPublisherClient_PublishLogs_httpClientErrorNilResponse(t *testing.T) {
+	t.Parallel()
+
+	mockKnapsack := mocks.NewKnapsack(t)
+	mockHTTPClient := &mockHTTPClient{}
+	slogger := multislogger.NewNopLogger()
+
+	mockKnapsack.On("OsqueryPublisherURL").Return("https://example.com")
+	mockKnapsack.On("OsqueryPublisherPercentEnabled").Return(100)
+	tokenStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.TokenStore.String())
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.Set(storage.AgentIngesterAuthTokenKey, []byte("test-token")))
+	suite := hpke.NewSuite(hpke.KEM_X25519_HKDF_SHA256, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES256GCM)
+	kemID, _, _ := suite.Params()
+	kemScheme := kemID.Scheme()
+	pkR, _, err := kemScheme.GenerateKeyPair()
+	require.NoError(t, err)
+	pkRBytes, err := pkR.MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.Set(storage.AgentIngesterHPKEPublicKey, []byte("test-hpke-id:"+base64.StdEncoding.EncodeToString(pkRBytes))))
+	require.NoError(t, tokenStore.Set(storage.AgentIngesterHPKEPresharedKey, []byte("test-psk-id:"+base64.StdEncoding.EncodeToString([]byte("test-psk-key-data")))))
+	mockKnapsack.On("TokenStore").Return(tokenStore).Maybe()
+	mockKnapsack.On("ServerProvidedDataStore").Return(makeTestServerProvidedDataStore(t)).Maybe()
+
+	doErr := errors.New("connection refused")
+	mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return((*http.Response)(nil), doErr)
+
+	client := NewLogPublisherClient(slogger, mockKnapsack, mockHTTPClient)
+
+	_, err = client.PublishLogs(t.Context(), osqlog.LogTypeStatus, []string{"log1"})
+	mockHTTPClient.AssertExpectations(t)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, doErr)
+	assert.Contains(t, err.Error(), "issuing publication request")
 }
 
 func TestLogPublisherClient_PublishResults(t *testing.T) {


### PR DESCRIPTION
There is a potential panic in the deferred logging for the osquery publisher. While this was previously initializing `resp` prior to the deferred logging call, it was still possible for certain network failures later to result in resp being rewritten to nil. After the deferred call fired later it would panic trying to access `resp.StatusCode`.

- Returns to the original var initialization and then nil checks in the deferred call to ensure this won't happen
- Adds a test to simulate network failures and ensure an error is returned without panic as expected