### PR TITLE
update dt4a auth origin allowlist regex

### DIFF
--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -45,7 +45,7 @@ var (
 		"https://dev.sites.gitlab.1password.io": {},
 	}
 
-	allowlisted1POriginRegex = regexp.MustCompile(`https:\/\/.+\.1password\.(com|ca|eu)`)
+	allowlisted1POriginRegex = regexp.MustCompile(`https:\/\/.+\.1password\.(com|ca|eu)$`)
 )
 
 const (

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -369,6 +369,11 @@ func Test_originIsAllowlisted(t *testing.T) {
 			requestOrigin:     "https://example.com",
 			expectAllowlisted: false,
 		},
+		{
+			testCaseName:      "crafted origin not on allowlist",
+			requestOrigin:     "https://evil.1password.com.evilbaddomain.com",
+			expectAllowlisted: false,
+		},
 	}
 
 	for allowlistedOrigin := range allowlistedDt4aOriginsLookup {


### PR DESCRIPTION
- updates the dt4a allowlist regexp to protect against crafted subdomain matches
- adds test case to ensure these will not be matched and allowed