### PR TITLE
Write native messaging manifest on launcher startup

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -612,7 +612,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		runGroup.Add("localserver", ls.Start, ls.Interrupt)
 
 		// Support native messaging as an alternative to the localserver
-		if err := nativemessaging.WriteNativeMessagingManifest(rootDirectory); err != nil {
+		if err := nativemessaging.WriteNativeMessagingManifest(rootDirectory, k.Identifier()); err != nil {
 			slogger.Log(ctx, slog.LevelError,
 				"could not write native messaging manifest",
 				"err", err,

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kolide/launcher/v2/ee/filewalker"
 	"github.com/kolide/launcher/v2/ee/gowrapper"
 	"github.com/kolide/launcher/v2/ee/localserver"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/ee/observability"
 	"github.com/kolide/launcher/v2/ee/observability/exporter"
 	"github.com/kolide/launcher/v2/ee/osquerypublisher"
@@ -609,6 +610,14 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 		ls.SetQuerier(osqueryRunner)
 		runGroup.Add("localserver", ls.Start, ls.Interrupt)
+
+		// Support native messaging as an alternative to the localserver
+		if err := nativemessaging.WriteNativeMessagingManifest(rootDirectory); err != nil {
+			slogger.Log(ctx, slog.LevelError,
+				"could not write native messaging manifest",
+				"err", err,
+			)
+		}
 	}
 
 	// If autoupdating is enabled, run the autoupdater

--- a/cmd/launcher/uninstall.go
+++ b/cmd/launcher/uninstall.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/pkg/launcher"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/peterbourgon/ff/v3"
@@ -46,6 +47,10 @@ func runUninstall(_ *multislogger.MultiSlogger, args []string) error {
 	if len(matches) == 1 && len(matches[0]) == 2 {
 		// Capture non-default identifiers if they match the regexp
 		identifier = strings.TrimSpace(matches[0][1])
+	}
+
+	if err := nativemessaging.RemoveNativeMessagingManifest(opts.RootDirectory); err != nil {
+		fmt.Printf("could not remove native messaging manifest: %s\n", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/cmd/launcher/uninstall.go
+++ b/cmd/launcher/uninstall.go
@@ -49,7 +49,7 @@ func runUninstall(_ *multislogger.MultiSlogger, args []string) error {
 		identifier = strings.TrimSpace(matches[0][1])
 	}
 
-	if err := nativemessaging.RemoveNativeMessagingManifest(opts.RootDirectory); err != nil {
+	if err := nativemessaging.RemoveNativeMessagingManifest(opts.RootDirectory, identifier); err != nil {
 		fmt.Printf("could not remove native messaging manifest: %s\n", err)
 	}
 

--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kolide/krypto/pkg/echelper"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/ee/observability"
 )
 
@@ -24,27 +25,6 @@ const (
 )
 
 var (
-	// allowlistedDt4aOriginsLookup contains the complete list of origins that are permitted to access the /dt4a endpoint.
-	allowlistedDt4aOriginsLookup = map[string]struct{}{
-		// Release extension
-		"chrome-extension://gejiddohjgogedgjnonbofjigllpkmbf":  {},
-		"chrome-extension://khgocmkkpikpnmmkgmdnfckapcdkgfaf":  {},
-		"chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa":  {},
-		"chrome-extension://dppgmdbiimibapkepcbdbmkaabgiofem":  {},
-		"moz-extension://dfbae458-fb6f-4614-856e-094108a80852": {},
-		"moz-extension://25fc87fa-4d31-4fee-b5c1-c32a7844c063": {},
-		"moz-extension://d634138d-c276-4fc8-924b-40a0ea21d284": {},
-		// Development and internal builds
-		"chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo":  {},
-		"moz-extension://0a75d802-9aed-41e7-8daa-24c067386e82": {},
-		"chrome-extension://hiajhnnfoihkhlmfejoljaokdpgboiea":  {},
-		"chrome-extension://kioanpobaefjdloichnjebbdafiloboa":  {},
-		"chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl":  {},
-		// Development web app
-		"https://my.b5local.com:4000":           {},
-		"https://dev.sites.gitlab.1password.io": {},
-	}
-
 	allowlisted1POriginRegex = regexp.MustCompile(`https:\/\/.+\.1password\.(com|ca|eu)$`)
 )
 
@@ -72,7 +52,7 @@ func originIsAllowlisted(requestOrigin string) bool {
 	}
 
 	// Allow origins in the allowlist
-	if _, ok := allowlistedDt4aOriginsLookup[requestOrigin]; ok {
+	if _, ok := nativemessaging.AllowlistedDt4aOriginsLookup()[requestOrigin]; ok {
 		return true
 	}
 

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kolide/krypto/pkg/echelper"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -376,7 +377,7 @@ func Test_originIsAllowlisted(t *testing.T) {
 		},
 	}
 
-	for allowlistedOrigin := range allowlistedDt4aOriginsLookup {
+	for allowlistedOrigin := range nativemessaging.AllowlistedDt4aOriginsLookup() {
 		testCases = append(testCases, testCase{
 			testCaseName:      allowlistedOrigin,
 			requestOrigin:     allowlistedOrigin,

--- a/ee/localserver/dt4a_test.go
+++ b/ee/localserver/dt4a_test.go
@@ -14,6 +14,7 @@ import (
 	storageci "github.com/kolide/launcher/v2/ee/agent/storage/ci"
 	"github.com/kolide/launcher/v2/ee/agent/types"
 	typesmocks "github.com/kolide/launcher/v2/ee/agent/types/mocks"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -186,7 +187,7 @@ func Test_requestDt4aInfoHandlerWithDt4aIdsNoData(t *testing.T) {
 func acceptableOrigin(t *testing.T) string {
 	// Just grab the first origin available in our allowlist
 	acceptableOrigin := ""
-	for k := range allowlistedDt4aOriginsLookup {
+	for k := range nativemessaging.AllowlistedDt4aOriginsLookup() {
 		acceptableOrigin = k
 		break
 	}

--- a/ee/nativemessaging/manifest.go
+++ b/ee/nativemessaging/manifest.go
@@ -20,7 +20,6 @@ type manifest struct {
 }
 
 const (
-	nativeMessagingHostName        = "com.kolide.agent"
 	nativeMessagingHostDescription = "Device Trust Agent"
 	nativeMessagingInterfaceType   = "stdio" // This is the only possible value for "type"
 )
@@ -60,19 +59,27 @@ func AllowlistedDt4aOriginsLookup() map[string]struct{} {
 
 // WriteNativeMessagingManifest is a thin wrapper around writeManifest, providing the paths
 // to write the manifest to, and the registry key path for the manifest file on Windows.
-func WriteNativeMessagingManifest(rootDir string) error {
-	return writeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations())
+func WriteNativeMessagingManifest(rootDir string, identifier string) error {
+	hostName := nativeMessagingHostName(identifier)
+	return writeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations(hostName), hostName)
 }
 
 func launcherManifestFilePath(rootDir string) string {
 	return filepath.Join(rootDir, "nmh-manifest.json")
 }
 
+func nativeMessagingHostName(identifier string) string {
+	hostName := fmt.Sprintf("com.%s.agent", identifier)
+	// Identifiers typically contain hyphens, but only lowercase alphanumeric characters, underscores,
+	// and periods are permitted.
+	return strings.ReplaceAll(hostName, "-", "_")
+}
+
 // writeManifest builds a manifest to register launcher as a native messaging host,
 // and writes it to the specified location at `manifestFilePath`, and then registers that location
 // with each location in `registrationLocations`.
-func writeManifest(manifestFilePath string, registrationLocations []string) error {
-	m, err := buildManifest()
+func writeManifest(manifestFilePath string, registrationLocations []string, hostName string) error {
+	m, err := buildManifest(hostName)
 	if err != nil {
 		return fmt.Errorf("building manifest: %w", err)
 	}
@@ -105,7 +112,7 @@ func writeManifest(manifestFilePath string, registrationLocations []string) erro
 	return nil
 }
 
-func buildManifest() (*manifest, error) {
+func buildManifest(hostName string) (*manifest, error) {
 	launcherPath, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("getting current executable path: %w", err)
@@ -119,7 +126,7 @@ func buildManifest() (*manifest, error) {
 	}
 	slices.Sort(allowedOrigins) // sort to maintain consistent ordering of origins
 	return &manifest{
-		Name:           nativeMessagingHostName,
+		Name:           hostName,
 		Description:    nativeMessagingHostDescription,
 		Path:           launcherPath,
 		Type:           nativeMessagingInterfaceType,
@@ -127,8 +134,9 @@ func buildManifest() (*manifest, error) {
 	}, nil
 }
 
-func RemoveNativeMessagingManifest(rootDir string) error {
-	return removeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations())
+func RemoveNativeMessagingManifest(rootDir string, identifier string) error {
+	hostName := nativeMessagingHostName(identifier)
+	return removeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations(hostName))
 }
 
 func removeManifest(manifestFilePath string, registrationLocations []string) error {

--- a/ee/nativemessaging/manifest.go
+++ b/ee/nativemessaging/manifest.go
@@ -1,0 +1,153 @@
+package nativemessaging
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// manifest represents a native messaging host config.
+// See https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host
+type manifest struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Path           string   `json:"path"`
+	Type           string   `json:"type"`
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+const (
+	nativeMessagingHostName        = "com.kolide.agent"
+	nativeMessagingHostDescription = "Device Trust Agent"
+	nativeMessagingInterfaceType   = "stdio" // This is the only possible value for "type"
+)
+
+var (
+	// allowlistedDt4aOriginsLookup contains the complete list of origins that are permitted to talk to launcher,
+	// via the /dt4a endpoint in localserver and via native messaging here.
+	allowlistedDt4aOriginsLookup = map[string]struct{}{
+		// Release extension
+		"chrome-extension://gejiddohjgogedgjnonbofjigllpkmbf":  {},
+		"chrome-extension://khgocmkkpikpnmmkgmdnfckapcdkgfaf":  {},
+		"chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa":  {},
+		"chrome-extension://dppgmdbiimibapkepcbdbmkaabgiofem":  {},
+		"moz-extension://dfbae458-fb6f-4614-856e-094108a80852": {},
+		"moz-extension://25fc87fa-4d31-4fee-b5c1-c32a7844c063": {},
+		"moz-extension://d634138d-c276-4fc8-924b-40a0ea21d284": {},
+		// Development and internal builds
+		"chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo":  {},
+		"moz-extension://0a75d802-9aed-41e7-8daa-24c067386e82": {},
+		"chrome-extension://hiajhnnfoihkhlmfejoljaokdpgboiea":  {},
+		"chrome-extension://kioanpobaefjdloichnjebbdafiloboa":  {},
+		"chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl":  {},
+		// Development web app
+		"https://my.b5local.com:4000":           {},
+		"https://dev.sites.gitlab.1password.io": {},
+	}
+)
+
+// AllowlistedDt4aOriginsLookup exports allowlistedDt4aOriginsLookup for use
+// elsewhere, e.g. in the localserver package. Returning the underlying map
+// technically would allow a caller outside this package to modify it -- we trust
+// callers to not do that, and we prefer to not return `maps.Copy(allowlistedDt4aOriginsLookup)`
+// to avoid e.g. a map copy operation on every single request to the dt4a endpoint.
+func AllowlistedDt4aOriginsLookup() map[string]struct{} {
+	return allowlistedDt4aOriginsLookup
+}
+
+// WriteNativeMessagingManifest is a thin wrapper around writeManifest, providing the paths
+// to write the manifest to, and the registry key path for the manifest file on Windows.
+func WriteNativeMessagingManifest(rootDir string) error {
+	return writeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations())
+}
+
+func launcherManifestFilePath(rootDir string) string {
+	return filepath.Join(rootDir, "nmh-manifest.json")
+}
+
+// writeManifest builds a manifest to register launcher as a native messaging host,
+// and writes it to the specified location at `manifestFilePath`, and then registers that location
+// with each location in `registrationLocations`.
+func writeManifest(manifestFilePath string, registrationLocations []string) error {
+	m, err := buildManifest()
+	if err != nil {
+		return fmt.Errorf("building manifest: %w", err)
+	}
+
+	rawManifest, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshalling manifest: %w", err)
+	}
+
+	// Write the manifest file
+	if err := os.WriteFile(manifestFilePath, rawManifest, 0644); err != nil {
+		return fmt.Errorf("writing manifest to %s: %w", manifestFilePath, err)
+	}
+
+	// Now, register `manifestFilePath` with each of our registration locations.
+	// On macOS and Linux, we do this by creating symlinks at well-known locations
+	// to `manifestFilePath`; on Windows, we do this by writing `manifestFilePath`
+	// to a well-known registry key.
+	registrationErrs := make([]error, 0)
+	for _, registrationLocation := range registrationLocations {
+		if err := registerManifestFileLocation(manifestFilePath, registrationLocation); err != nil {
+			registrationErrs = append(registrationErrs, fmt.Errorf("registering manifest file location at %s: %w", registrationLocation, err))
+		}
+	}
+
+	if len(registrationErrs) > 0 {
+		return fmt.Errorf("registering manifest with one or more locations: %+v: %w", registrationErrs, registrationErrs[0])
+	}
+
+	return nil
+}
+
+func buildManifest() (*manifest, error) {
+	launcherPath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("getting current executable path: %w", err)
+	}
+	allowedOrigins := make([]string, 0)
+	for allowedOrigin := range allowlistedDt4aOriginsLookup {
+		if !strings.HasPrefix(allowedOrigin, "chrome-extension://") {
+			continue
+		}
+		allowedOrigins = append(allowedOrigins, allowedOrigin+"/")
+	}
+	slices.Sort(allowedOrigins) // sort to maintain consistent ordering of origins
+	return &manifest{
+		Name:           nativeMessagingHostName,
+		Description:    nativeMessagingHostDescription,
+		Path:           launcherPath,
+		Type:           nativeMessagingInterfaceType,
+		AllowedOrigins: allowedOrigins,
+	}, nil
+}
+
+func RemoveNativeMessagingManifest(rootDir string) error {
+	return removeManifest(launcherManifestFilePath(rootDir), manifestFileRegistrationLocations())
+}
+
+func removeManifest(manifestFilePath string, registrationLocations []string) error {
+	deregistrationErrs := make([]error, 0)
+	// First, delete the registration locations
+	for _, registrationLocation := range registrationLocations {
+		if err := deregisterManifestFileLocation(registrationLocation); err != nil {
+			deregistrationErrs = append(deregistrationErrs, fmt.Errorf("deregistering manifest at %s: %w", registrationLocation, err))
+		}
+	}
+
+	if len(deregistrationErrs) > 0 {
+		return fmt.Errorf("deregistering manifest with one or more locations: %+v: %w", deregistrationErrs, deregistrationErrs[0])
+	}
+
+	// Finally, remove the manifest file
+	if err := os.Remove(manifestFilePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", manifestFilePath, err)
+	}
+
+	return nil
+}

--- a/ee/nativemessaging/manifest_darwin.go
+++ b/ee/nativemessaging/manifest_darwin.go
@@ -7,10 +7,10 @@ import "fmt"
 // manifestFileRegistrationLocations returns the filepaths where the native messaging manifest file should exist
 // for this OS.
 // See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
-func manifestFileRegistrationLocations() []string {
+func manifestFileRegistrationLocations(hostName string) []string {
 	return []string{
-		fmt.Sprintf("/Library/Google/Chrome/NativeMessagingHosts/%s.json", nativeMessagingHostName),
-		fmt.Sprintf("/Library/Google/ChromeForTesting/NativeMessagingHosts/%s.json", nativeMessagingHostName),
-		fmt.Sprintf("/Library/Application Support/Chromium/NativeMessagingHosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/Library/Google/Chrome/NativeMessagingHosts/%s.json", hostName),
+		fmt.Sprintf("/Library/Google/ChromeForTesting/NativeMessagingHosts/%s.json", hostName),
+		fmt.Sprintf("/Library/Application Support/Chromium/NativeMessagingHosts/%s.json", hostName),
 	}
 }

--- a/ee/nativemessaging/manifest_darwin.go
+++ b/ee/nativemessaging/manifest_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package nativemessaging
+
+import "fmt"
+
+// manifestFileRegistrationLocations returns the filepaths where the native messaging manifest file should exist
+// for this OS.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
+func manifestFileRegistrationLocations() []string {
+	return []string{
+		fmt.Sprintf("/Library/Google/Chrome/NativeMessagingHosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/Library/Google/ChromeForTesting/NativeMessagingHosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/Library/Application Support/Chromium/NativeMessagingHosts/%s.json", nativeMessagingHostName),
+	}
+}

--- a/ee/nativemessaging/manifest_linux.go
+++ b/ee/nativemessaging/manifest_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package nativemessaging
+
+import "fmt"
+
+// manifestFileRegistrationLocations returns the filepaths where the native messaging manifest file should exist
+// for this OS.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
+func manifestFileRegistrationLocations() []string {
+	return []string{
+		fmt.Sprintf("/etc/opt/chrome/native-messaging-hosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/etc/opt/chrome_for_testing/native-messaging-hosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/etc/chromium/native-messaging-hosts/%s.json", nativeMessagingHostName),
+	}
+}

--- a/ee/nativemessaging/manifest_linux.go
+++ b/ee/nativemessaging/manifest_linux.go
@@ -7,10 +7,10 @@ import "fmt"
 // manifestFileRegistrationLocations returns the filepaths where the native messaging manifest file should exist
 // for this OS.
 // See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
-func manifestFileRegistrationLocations() []string {
+func manifestFileRegistrationLocations(hostName string) []string {
 	return []string{
-		fmt.Sprintf("/etc/opt/chrome/native-messaging-hosts/%s.json", nativeMessagingHostName),
-		fmt.Sprintf("/etc/opt/chrome_for_testing/native-messaging-hosts/%s.json", nativeMessagingHostName),
-		fmt.Sprintf("/etc/chromium/native-messaging-hosts/%s.json", nativeMessagingHostName),
+		fmt.Sprintf("/etc/opt/chrome/native-messaging-hosts/%s.json", hostName),
+		fmt.Sprintf("/etc/opt/chrome_for_testing/native-messaging-hosts/%s.json", hostName),
+		fmt.Sprintf("/etc/chromium/native-messaging-hosts/%s.json", hostName),
 	}
 }

--- a/ee/nativemessaging/manifest_posix.go
+++ b/ee/nativemessaging/manifest_posix.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package nativemessaging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// registerManifestFileLocation creates a symlink at `registrationPath` (the well-known path
+// for Chrome) to `manifestFileLocation`, the file we've written to the launcher root directory.
+func registerManifestFileLocation(manifestFileLocation string, registrationPath string) error {
+	// Check if the symlink already exists and points to manifestFileLocation --
+	// if it does, no need to create it.
+	if _, err := os.Lstat(registrationPath); err == nil {
+		resolvedRegistrationPath, resolvedRegistrationPathErr := filepath.EvalSymlinks(registrationPath)
+
+		// We have to eval the manifestFileLocation too, to resolve `/var` to `/private/var` on macOS
+		resolvedManifestFileLocation, resolvedManifestFileLocationErr := filepath.EvalSymlinks(manifestFileLocation)
+
+		if resolvedRegistrationPathErr == nil && resolvedManifestFileLocationErr == nil && resolvedManifestFileLocation == resolvedRegistrationPath {
+			return nil
+		}
+
+		// registrationPath exists, but it's not pointing to manifestFileLocation -- remove it
+		// so we can set it correctly below.
+		if err := os.Remove(registrationPath); err != nil {
+			return fmt.Errorf("removing old symlink at %s before re-creating: %w", registrationPath, err)
+		}
+	}
+
+	// We may need to create this directory before writing to it.
+	registrationDir := filepath.Dir(registrationPath)
+	if err := os.MkdirAll(registrationDir, 0755); err != nil {
+		return fmt.Errorf("creating manifest registration directory %s: %w", registrationDir, err)
+	}
+
+	if err := os.Symlink(manifestFileLocation, registrationPath); err != nil {
+		return fmt.Errorf("creating symlink at %s to %s: %w", registrationPath, manifestFileLocation, err)
+	}
+
+	return nil
+}
+
+func deregisterManifestFileLocation(registrationPath string) error {
+	if err := os.Remove(registrationPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing symlink at %s: %w", registrationPath, err)
+	}
+
+	return nil
+}

--- a/ee/nativemessaging/manifest_test.go
+++ b/ee/nativemessaging/manifest_test.go
@@ -19,23 +19,26 @@ func TestMain(m *testing.M) {
 func Test_writeManifest_removeManifest(t *testing.T) {
 	t.Parallel()
 
+	identifier := "kolide-test-k2"
+	hostName := nativeMessagingHostName(identifier)
+
 	rootDir := t.TempDir()
 	manifestRegistrationPaths := make([]string, 0)
 	switch runtime.GOOS {
 	case "windows":
 		// Only one registry key on Windows
-		manifestRegistrationPaths = append(manifestRegistrationPaths, `SOFTWARE\Kolide\Launcher\Test_writeManifest_removeManifest\Google\Chrome\NativeMessagingHosts\`+nativeMessagingHostName)
+		manifestRegistrationPaths = append(manifestRegistrationPaths, `SOFTWARE\Kolide\Launcher\Test_writeManifest_removeManifest\Google\Chrome\NativeMessagingHosts\`+hostName)
 	default:
 		// Multiple paths on macOS/Linux
 		manifestRegistrationPaths = append(manifestRegistrationPaths,
-			filepath.Join(rootDir, fmt.Sprintf("chrome_%s.json", nativeMessagingHostName)),
-			filepath.Join(rootDir, "some", "deeper", "path", fmt.Sprintf("chrome_for_testing_%s.json", nativeMessagingHostName)), // tests having to make directories on the fly
-			filepath.Join(rootDir, fmt.Sprintf("chromium_%s.json", nativeMessagingHostName)),
+			filepath.Join(rootDir, fmt.Sprintf("chrome_%s.json", hostName)),
+			filepath.Join(rootDir, "some", "deeper", "path", fmt.Sprintf("chrome_for_testing_%s.json", hostName)), // tests having to make directories on the fly
+			filepath.Join(rootDir, fmt.Sprintf("chromium_%s.json", hostName)),
 		)
 	}
 
 	expectedManifestPath := launcherManifestFilePath(rootDir)
-	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths))
+	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths, hostName))
 
 	// Confirm valid data written to expected path
 	currentExe, err := os.Executable()
@@ -49,7 +52,7 @@ func Test_writeManifest_removeManifest(t *testing.T) {
 	var currentManifest manifest
 	require.NoError(t, json.Unmarshal(fileContents, &currentManifest))
 
-	require.Equal(t, nativeMessagingHostName, currentManifest.Name)
+	require.Equal(t, hostName, currentManifest.Name)
 	require.Equal(t, nativeMessagingHostDescription, currentManifest.Description)
 	require.Equal(t, currentExe, currentManifest.Path)
 	require.Equal(t, nativeMessagingInterfaceType, currentManifest.Type)
@@ -73,7 +76,7 @@ func Test_writeManifest_removeManifest(t *testing.T) {
 	}
 
 	// Confirm no error on re-writing manifest
-	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths))
+	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths, hostName))
 
 	// Now, remove the manifest
 	require.NoError(t, removeManifest(expectedManifestPath, manifestRegistrationPaths))

--- a/ee/nativemessaging/manifest_test.go
+++ b/ee/nativemessaging/manifest_test.go
@@ -1,0 +1,94 @@
+package nativemessaging
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func Test_writeManifest_removeManifest(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	manifestRegistrationPaths := make([]string, 0)
+	switch runtime.GOOS {
+	case "windows":
+		// Only one registry key on Windows
+		manifestRegistrationPaths = append(manifestRegistrationPaths, `SOFTWARE\Kolide\Launcher\Test_writeManifest_removeManifest\Google\Chrome\NativeMessagingHosts\`+nativeMessagingHostName)
+	default:
+		// Multiple paths on macOS/Linux
+		manifestRegistrationPaths = append(manifestRegistrationPaths,
+			filepath.Join(rootDir, fmt.Sprintf("chrome_%s.json", nativeMessagingHostName)),
+			filepath.Join(rootDir, "some", "deeper", "path", fmt.Sprintf("chrome_for_testing_%s.json", nativeMessagingHostName)), // tests having to make directories on the fly
+			filepath.Join(rootDir, fmt.Sprintf("chromium_%s.json", nativeMessagingHostName)),
+		)
+	}
+
+	expectedManifestPath := launcherManifestFilePath(rootDir)
+	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths))
+
+	// Confirm valid data written to expected path
+	currentExe, err := os.Executable()
+	require.NoError(t, err)
+	_, err = os.Stat(expectedManifestPath)
+	require.NoError(t, err)
+
+	fileContents, err := os.ReadFile(expectedManifestPath)
+	require.NoError(t, err)
+
+	var currentManifest manifest
+	require.NoError(t, json.Unmarshal(fileContents, &currentManifest))
+
+	require.Equal(t, nativeMessagingHostName, currentManifest.Name)
+	require.Equal(t, nativeMessagingHostDescription, currentManifest.Description)
+	require.Equal(t, currentExe, currentManifest.Path)
+	require.Equal(t, nativeMessagingInterfaceType, currentManifest.Type)
+	require.Less(t, 0, len(currentManifest.AllowedOrigins))
+
+	// Check existence of symlinks on macOS/Linux (registry key for Windows tested separately in Test_registerManifestFileLocation)
+	if runtime.GOOS != "windows" {
+		// Resolve the expected path (so that instead of `/var/...` on macOS we have `/private/var/...`)
+		resolvedExpectedManifestPath, err := filepath.EvalSymlinks(expectedManifestPath)
+		require.NoError(t, err)
+		for _, manifestRegistrationPath := range manifestRegistrationPaths {
+			fi, err := os.Lstat(manifestRegistrationPath)
+			require.NoError(t, err)
+
+			// Confirm it's a symlink, pointing at the correct file
+			require.NotEqual(t, 0, fi.Mode()&os.ModeSymlink)
+			resolvedPath, err := filepath.EvalSymlinks(manifestRegistrationPath)
+			require.NoError(t, err)
+			require.Equal(t, resolvedExpectedManifestPath, resolvedPath)
+		}
+	}
+
+	// Confirm no error on re-writing manifest
+	require.NoError(t, writeManifest(expectedManifestPath, manifestRegistrationPaths))
+
+	// Now, remove the manifest
+	require.NoError(t, removeManifest(expectedManifestPath, manifestRegistrationPaths))
+
+	// Confirm manifest file is gone
+	_, err = os.Stat(expectedManifestPath)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+
+	// Check that symlinks are gone on macOS/Linux
+	if runtime.GOOS != "windows" {
+		for _, manifestRegistrationPath := range manifestRegistrationPaths {
+			_, err := os.Lstat(manifestRegistrationPath)
+			require.Error(t, err)
+			require.True(t, os.IsNotExist(err))
+		}
+	}
+}

--- a/ee/nativemessaging/manifest_windows.go
+++ b/ee/nativemessaging/manifest_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package nativemessaging
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// manifestFileRegistrationLocations returns the registry key where we should write the path to the
+// native messaging manifest file.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
+func manifestFileRegistrationLocations() []string {
+	return []string{`SOFTWARE\Google\Chrome\NativeMessagingHosts\` + nativeMessagingHostName}
+}
+
+// registerManifestFileLocation writes the manifest file location to the expected registry key
+// at `registrationPath` so that Chrome knows where to find it.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
+func registerManifestFileLocation(manifestFileLocation string, registrationPath string) error {
+	manifestLocationKey, err := registry.OpenKey(registry.LOCAL_MACHINE, registrationPath, registry.ALL_ACCESS)
+
+	// If the key doesn't exist, create it
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		manifestLocationKey, _, err = registry.CreateKey(registry.LOCAL_MACHINE, registrationPath, registry.ALL_ACCESS)
+	}
+	if err != nil {
+		return fmt.Errorf("creating or opening registry key at %s: %w", registrationPath, err)
+	}
+
+	defer manifestLocationKey.Close()
+
+	// Get the default value of the key by passing in an empty string.
+	currentValue, _, err := manifestLocationKey.GetStringValue("")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("getting current default value of %s: %w", registrationPath, err)
+	}
+
+	// Already set correctly -- no need to edit
+	if currentValue == manifestFileLocation {
+		return nil
+	}
+
+	if err := manifestLocationKey.SetStringValue("", manifestFileLocation); err != nil {
+		return fmt.Errorf("setting default value of %s to %s: %w", registrationPath, manifestFileLocation, err)
+	}
+
+	return nil
+}
+
+func deregisterManifestFileLocation(registrationPath string) error {
+	if err := registry.DeleteKey(registry.LOCAL_MACHINE, registrationPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("deleting registry key at %s: %w", registrationPath, err)
+	}
+
+	return nil
+}

--- a/ee/nativemessaging/manifest_windows.go
+++ b/ee/nativemessaging/manifest_windows.go
@@ -13,8 +13,8 @@ import (
 // manifestFileRegistrationLocations returns the registry key where we should write the path to the
 // native messaging manifest file.
 // See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location
-func manifestFileRegistrationLocations() []string {
-	return []string{`SOFTWARE\Google\Chrome\NativeMessagingHosts\` + nativeMessagingHostName}
+func manifestFileRegistrationLocations(hostName string) []string {
+	return []string{`SOFTWARE\Google\Chrome\NativeMessagingHosts\` + hostName}
 }
 
 // registerManifestFileLocation writes the manifest file location to the expected registry key

--- a/ee/nativemessaging/manifest_windows_test.go
+++ b/ee/nativemessaging/manifest_windows_test.go
@@ -15,8 +15,9 @@ import (
 func Test_registerManifestFileLocation_deregisterManifestFileLocation(t *testing.T) {
 	t.Parallel()
 
+	hostName := nativeMessagingHostName("kolide-test-k2")
 	manifestPath := filepath.Join("some", "test", "dir", "nmh-manifest.json")
-	testRegistryKey := `SOFTWARE\Kolide\Launcher\Test_registerManifestFileLocation\Google\Chrome\NativeMessagingHosts\` + nativeMessagingHostName
+	testRegistryKey := `SOFTWARE\Kolide\Launcher\Test_registerManifestFileLocation\Google\Chrome\NativeMessagingHosts\` + hostName
 
 	// Test registration
 	require.NoError(t, registerManifestFileLocation(manifestPath, testRegistryKey))

--- a/ee/nativemessaging/manifest_windows_test.go
+++ b/ee/nativemessaging/manifest_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package nativemessaging
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
+)
+
+func Test_registerManifestFileLocation_deregisterManifestFileLocation(t *testing.T) {
+	t.Parallel()
+
+	manifestPath := filepath.Join("some", "test", "dir", "nmh-manifest.json")
+	testRegistryKey := `SOFTWARE\Kolide\Launcher\Test_registerManifestFileLocation\Google\Chrome\NativeMessagingHosts\` + nativeMessagingHostName
+
+	// Test registration
+	require.NoError(t, registerManifestFileLocation(manifestPath, testRegistryKey))
+
+	manifestLocationKey, err := registry.OpenKey(registry.LOCAL_MACHINE, testRegistryKey, registry.ALL_ACCESS)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		manifestLocationKey.Close()
+	})
+	currentValue, _, err := manifestLocationKey.GetStringValue("")
+	require.NoError(t, err)
+	require.Equal(t, manifestPath, currentValue)
+
+	// Test re-registration
+	require.NoError(t, registerManifestFileLocation(manifestPath, testRegistryKey))
+
+	// Test deregistration
+	require.NoError(t, deregisterManifestFileLocation(testRegistryKey))
+	_, err = registry.OpenKey(registry.LOCAL_MACHINE, testRegistryKey, registry.ALL_ACCESS)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist))
+}

--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kolide/launcher/v2/ee/agent"
 	agentbbolt "github.com/kolide/launcher/v2/ee/agent/storage/bbolt"
 	"github.com/kolide/launcher/v2/ee/agent/types"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 )
 
 const (
@@ -43,6 +44,13 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 				"err", err,
 			)
 		}
+	}
+
+	if err := nativemessaging.RemoveNativeMessagingManifest(k.RootDirectory()); err != nil {
+		slogger.Log(ctx, slog.LevelError,
+			"removing native messaging manifest",
+			"err", err,
+		)
 	}
 
 	if !exitOnCompletion {

--- a/ee/uninstall/uninstall.go
+++ b/ee/uninstall/uninstall.go
@@ -46,7 +46,7 @@ func Uninstall(ctx context.Context, k types.Knapsack, exitOnCompletion bool) {
 		}
 	}
 
-	if err := nativemessaging.RemoveNativeMessagingManifest(k.RootDirectory()); err != nil {
+	if err := nativemessaging.RemoveNativeMessagingManifest(k.RootDirectory(), k.Identifier()); err != nil {
 		slogger.Log(ctx, slog.LevelError,
 			"removing native messaging manifest",
 			"err", err,

--- a/ee/uninstall/uninstall_test.go
+++ b/ee/uninstall/uninstall_test.go
@@ -12,6 +12,7 @@ import (
 	storageci "github.com/kolide/launcher/v2/ee/agent/storage/ci"
 	"github.com/kolide/launcher/v2/ee/agent/types"
 	"github.com/kolide/launcher/v2/ee/agent/types/mocks"
+	"github.com/kolide/launcher/v2/pkg/launcher"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
@@ -73,6 +74,7 @@ func TestUninstall(t *testing.T) {
 			testServerProvidedDataStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.ServerProvidedDataStore.String())
 			require.NoError(t, err, "could not create test server provided data store")
 			k.On("ServerProvidedDataStore").Return(testServerProvidedDataStore)
+			k.On("Identifier").Return(launcher.DefaultLauncherIdentifier)
 			stores := map[storage.Store]types.KVStore{
 				storage.PersistentHostDataStore: testHostDataStore,
 				storage.ConfigStore:             testConfigStore,


### PR DESCRIPTION
Part 1 of native messaging support --

This PR updates launcher to create a manifest file to register itself as a native messaging host, and writes it to a location known by Chrome.

I moved `allowlistedDt4aOriginsLookup` out of the `localserver` package to avoid an import cycle.