### PR TITLE
Native messaging host support

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -39,7 +39,9 @@ func main() {
 // or running `runLauncher`. We wrap it so that all our deferred calls will execute before we call
 // `os.Exit` in `main()`.
 func runMain() int {
-	// Check to see if this is a native messaging host invocation. We have to check this first,
+	// Check to see if this is a native messaging host invocation, which looks like:
+	// `some-path-to/launcher chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo/`
+	// We have to check and handle the native messaging host invocation case first,
 	// before even initializing logging, because we should not write logs to os.Stdout when following
 	// the native messaging protocol.
 	if len(os.Args) == 2 {

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -39,17 +39,14 @@ func main() {
 // or running `runLauncher`. We wrap it so that all our deferred calls will execute before we call
 // `os.Exit` in `main()`.
 func runMain() int {
-	// Check to see if this is a native messaging host invocation, which looks like:
-	// `some-path-to/launcher chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo/`
+	// Check to see if this is a native messaging host invocation.
 	// We have to check and handle the native messaging host invocation case first,
 	// before even initializing logging, because we should not write logs to os.Stdout when following
 	// the native messaging protocol.
-	if len(os.Args) == 2 {
-		if _, ok := nativemessaging.AllowlistedDt4aOriginsLookup()[strings.TrimSuffix(os.Args[1], "/")]; ok {
-			// Native messaging host invocation -- continues reading until closed
-			nativemessaging.ReadNativeMessages(context.Background())
-			return 0
-		}
+	if _, err := nativemessaging.ValidateNativeMessagingArgs(os.Args); err == nil {
+		// Native messaging host invocation -- continues reading until closed
+		nativemessaging.ReadNativeMessages(context.Background())
+		return 0
 	}
 
 	systemSlogger, logCloser, err := multislogger.SystemSlogger()

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kolide/launcher/v2/ee/agent"
 	"github.com/kolide/launcher/v2/ee/control/consumers/remoterestartconsumer"
 	"github.com/kolide/launcher/v2/ee/disclaim"
+	"github.com/kolide/launcher/v2/ee/nativemessaging"
 	"github.com/kolide/launcher/v2/ee/tuf"
 	"github.com/kolide/launcher/v2/ee/watchdog"
 	"github.com/kolide/launcher/v2/pkg/contexts/ctxlog"
@@ -38,6 +39,17 @@ func main() {
 // or running `runLauncher`. We wrap it so that all our deferred calls will execute before we call
 // `os.Exit` in `main()`.
 func runMain() int {
+	// Check to see if this is a native messaging host invocation. We have to check this first,
+	// before even initializing logging, because we should not write logs to os.Stdout when following
+	// the native messaging protocol.
+	if len(os.Args) == 2 {
+		if _, ok := nativemessaging.AllowlistedDt4aOriginsLookup()[strings.TrimSuffix(os.Args[1], "/")]; ok {
+			// Native messaging host invocation -- continues reading until closed
+			nativemessaging.ReadNativeMessages(context.Background())
+			return 0
+		}
+	}
+
 	systemSlogger, logCloser, err := multislogger.SystemSlogger()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating system logger: %v\n", err)

--- a/ee/allowedcmd/cmd_darwin.go
+++ b/ee/allowedcmd/cmd_darwin.go
@@ -10,6 +10,8 @@ var Bputil = newAllowedCommand("/usr/bin/bputil")
 
 var Brew = newAllowedCommand("/opt/homebrew/bin/brew", "/usr/local/bin/brew").WithEnv("HOMEBREW_NO_AUTO_UPDATE=1")
 
+var Codesign = newAllowedCommand("/usr/bin/codesign")
+
 var Diskutil = newAllowedCommand("/usr/sbin/diskutil")
 
 var Echo = newAllowedCommand("/bin/echo")

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -3,8 +3,6 @@ package nativemessaging
 import (
 	"bufio"
 	"context"
-	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,13 +16,6 @@ import (
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/peterbourgon/ff/v3"
 	"github.com/shirou/gopsutil/v4/process"
-)
-
-const (
-	// msgBufferSize is the maximum message size we expect. Technically the extension is allowed to send a message
-	// with size up to 64 MiB, but we restrict further.
-	msgBufferSize      = 8192
-	maxSendMessageSize = 1000000 // 1MB
 )
 
 // nopCloser wraps a Writer with a no-op Close function; we use it
@@ -75,57 +66,25 @@ func ReadNativeMessages(ctx context.Context) {
 
 	// Handle input until the connection is closed
 	stdinReader := bufio.NewReaderSize(os.Stdin, msgBufferSize)
-	header := make([]byte, 4)
 	for {
-		headerBytesRead, err := io.ReadFull(stdinReader, header)
-		if err != nil && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
-			slogger.Log(ctx, slog.LevelInfo,
-				"stream closed",
-			)
-			break
-		}
-		if headerBytesRead != 4 || err != nil {
-			slogger.Log(ctx, slog.LevelWarn,
-				"could not read next header",
-				"err", err,
-			)
-			break
-		}
+		msgContent, err := readMessage(stdinReader)
+		if err != nil {
+			// May be a genuine error, or may just be the stream closing
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				slogger.Log(ctx, slog.LevelInfo,
+					"stream closed",
+				)
+			} else {
+				slogger.Log(ctx, slog.LevelError,
+					"terminating processing after error",
+					"err", err,
+				)
+			}
 
-		msgLength := binary.NativeEndian.Uint32(header)
-
-		if msgLength > msgBufferSize {
-			slogger.Log(ctx, slog.LevelInfo,
-				"received message with length exceeding max, terminating processing",
-				"length", msgLength,
-				"max_length", msgBufferSize,
-			)
 			break
 		}
 
-		slogger.Log(ctx, slog.LevelInfo,
-			"received message with length",
-			"length", msgLength,
-		)
-
-		msgContent := make([]byte, int(msgLength))
-		msgBytesRead, err := io.ReadFull(stdinReader, msgContent)
-		if msgBytesRead < int(msgLength) {
-			slogger.Log(ctx, slog.LevelWarn,
-				"could not read all bytes in message",
-				"length", msgLength,
-				"bytes_read", msgBytesRead,
-			)
-			break
-		} else if err != nil {
-			slogger.Log(ctx, slog.LevelWarn,
-				"could not read message",
-				"err", err,
-			)
-			break
-		}
-
-		// In the future, we would forward this request
+		// In the future, we would JSON unmarshal this request and then forward it
 		slogger.Log(ctx, slog.LevelInfo,
 			"message",
 			"contents", string(msgContent),
@@ -134,7 +93,7 @@ func ReadNativeMessages(ctx context.Context) {
 		// Write a test message
 		if err := sendMessage(map[string]any{
 			"msg":     "received message",
-			"msg_len": msgLength,
+			"msg_len": len(msgContent),
 		}); err != nil {
 			slogger.Log(ctx, slog.LevelError,
 				"sending message",
@@ -295,29 +254,4 @@ func getBrowserProcess(ctx context.Context) (*process.Process, int32, string, er
 	}
 
 	return parentProcess, ppid, processName, nil
-}
-
-// sendMessage formats the given body by marshalling it to JSON,
-// adding the expected header, and writing it to stdout.
-// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol
-func sendMessage(msgBody any) error {
-	bodyRaw, err := json.Marshal(msgBody)
-	if err != nil {
-		return fmt.Errorf("marshalling msg body to JSON: %w", err)
-	}
-	bodyLen := len(bodyRaw)
-	totalMsgLen := bodyLen + 4
-	if totalMsgLen > maxSendMessageSize {
-		return fmt.Errorf("message with size %d bytes exceeds max of 1 MB", totalMsgLen)
-	}
-
-	header := make([]byte, 4)
-	binary.NativeEndian.PutUint32(header, uint32(bodyLen))
-
-	written, err := os.Stdout.Write(append(header, bodyRaw...))
-	if written != totalMsgLen || err != nil {
-		return fmt.Errorf("sending message: wrote %d of %d expected bytes: %w", written, totalMsgLen, err)
-	}
-
-	return nil
 }

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -40,7 +40,8 @@ func ReadNativeMessages(ctx context.Context) {
 	// We can't write to kv.sqlite (as the watchdog does) because this process
 	// won't have sufficient permissions. For now, we write to a file in the desktop
 	// directory. If that's not possible (i.e. on Windows there is no desktop directory),
-	// we write logs to io.Discard instead.
+	// we write logs to io.Discard instead. In the future, root launcher will create
+	// an appropriate directory for logs when it calls WriteNativeMessagingManifest.
 	var logWriter io.WriteCloser
 	var err error
 	logFile := filepath.Join(determineRootDirectory(), fmt.Sprintf("desktop_%d", os.Getuid()), "nativemessaging.log")

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -199,9 +199,13 @@ func validateNativeMessagingRequest(ctx context.Context) (string, error) {
 	if err != nil {
 		return potentialExtension, fmt.Errorf("getting browser process create time for request from %s: %w", potentialExtension, err)
 	}
+	browserPath, err := browserProcess.ExeWithContext(ctx)
+	if err != nil {
+		return potentialExtension, fmt.Errorf("getting executable for browser process: %w", err)
+	}
 
 	// Perform per-OS validation
-	if err := validateBrowser(ctx, browserProcess, browserProcessName); err != nil {
+	if err := validateBrowser(ctx, browserPath, browserProcessName); err != nil {
 		return potentialExtension, fmt.Errorf("validating browser process %s: %w", browserProcessName, err)
 	}
 

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -43,7 +44,7 @@ func ReadNativeMessages(ctx context.Context) {
 	var logWriter io.WriteCloser
 	var err error
 	logFile := filepath.Join(determineRootDirectory(), fmt.Sprintf("desktop_%d", os.Getuid()), "nativemessaging.log")
-	logWriter, err = os.OpenFile(logFile, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
+	logWriter, err = os.OpenFile(logFile, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
 		logWriter = newNopCloser(io.Discard)
 	}
@@ -54,25 +55,32 @@ func ReadNativeMessages(ctx context.Context) {
 	// Validate the request that started this process
 	extension, err := validateNativeMessagingRequest(ctx)
 	if err != nil {
-		slogger.Log(context.TODO(), slog.LevelError,
+		slogger.Log(ctx, slog.LevelError,
 			"invalid native messaging request",
 			"err", err,
 			"extension", extension,
 		)
+		return
 	}
 
-	slogger.Log(context.TODO(), slog.LevelInfo,
+	slogger.Log(ctx, slog.LevelInfo,
 		"native messaging app opened",
 		"extension", extension,
 	)
 
 	// Handle input until the connection is closed
-	stdinReader := bufio.NewReaderSize(bufio.NewReader(os.Stdin), msgBufferSize)
+	stdinReader := bufio.NewReaderSize(os.Stdin, msgBufferSize)
 	header := make([]byte, 4)
 	for {
-		headerBytesRead, err := stdinReader.Read(header)
-		if headerBytesRead == 0 || err != nil {
-			slogger.Log(context.TODO(), slog.LevelWarn,
+		headerBytesRead, err := io.ReadFull(stdinReader, header)
+		if err != nil && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
+			slogger.Log(ctx, slog.LevelInfo,
+				"stream closed",
+			)
+			break
+		}
+		if headerBytesRead != 4 || err != nil {
+			slogger.Log(ctx, slog.LevelWarn,
 				"could not read next header",
 				"err", err,
 			)
@@ -81,22 +89,31 @@ func ReadNativeMessages(ctx context.Context) {
 
 		msgLength := binary.NativeEndian.Uint32(header)
 
-		slogger.Log(context.TODO(), slog.LevelInfo,
+		if msgLength > msgBufferSize {
+			slogger.Log(ctx, slog.LevelInfo,
+				"received message with length exceeding max, terminating processing",
+				"length", msgLength,
+				"max_length", msgBufferSize,
+			)
+			break
+		}
+
+		slogger.Log(ctx, slog.LevelInfo,
 			"received message with length",
 			"length", msgLength,
 		)
 
 		msgContent := make([]byte, int(msgLength))
-		msgBytesRead, err := stdinReader.Read(msgContent)
+		msgBytesRead, err := io.ReadFull(stdinReader, msgContent)
 		if msgBytesRead < int(msgLength) {
-			slogger.Log(context.TODO(), slog.LevelWarn,
+			slogger.Log(ctx, slog.LevelWarn,
 				"could not read all bytes in message",
 				"length", msgLength,
 				"bytes_read", msgBytesRead,
 			)
 			break
 		} else if err != nil {
-			slogger.Log(context.TODO(), slog.LevelWarn,
+			slogger.Log(ctx, slog.LevelWarn,
 				"could not read message",
 				"err", err,
 			)
@@ -104,13 +121,13 @@ func ReadNativeMessages(ctx context.Context) {
 		}
 
 		// In the future, we would forward this request
-		slogger.Log(context.TODO(), slog.LevelInfo,
+		slogger.Log(ctx, slog.LevelInfo,
 			"message",
 			"contents", string(msgContent),
 		)
 	}
 
-	slogger.Log(context.TODO(), slog.LevelInfo,
+	slogger.Log(ctx, slog.LevelInfo,
 		"shutting down",
 	)
 }

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -176,18 +176,34 @@ func extractIdentifierFromExecutable(executablePath string) string {
 	return identifier
 }
 
-// validateNativeMessagingRequest validates that launcher has been launched by the expected process --
-// Chrome, on behalf of a known extension.
-func validateNativeMessagingRequest(ctx context.Context) (string, error) {
-	// launcher should be called with exactly 1 argument, which is the extension.
-	if len(os.Args) != 2 {
-		return "", fmt.Errorf("unexpected number of args: expected 2, got %d", len(os.Args))
+func ValidateNativeMessagingArgs(osArgs []string) (string, error) {
+	// launcher should be called with exactly 1 argument, which is the extension,
+	// or with one additional argument on Windows:
+	// `some-path-to/launcher chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo/ --parent-window=0`.
+	if len(osArgs) != 2 && len(osArgs) != 3 {
+		return "", fmt.Errorf("unexpected number of args: expected 2 or 3, got %d", len(osArgs))
+	}
+	if len(osArgs) == 3 {
+		if osArgs[2] != "--parent-window=0" {
+			return "", fmt.Errorf("unexpected third arg %s, expected --parent-window=0", osArgs[2])
+		}
 	}
 	// The extension should be one that we know about. It will have an extra / at the end, which we remove
 	// before performing the lookup against our known origins.
-	potentialExtension := strings.TrimSuffix(os.Args[1], "/")
+	potentialExtension := strings.TrimSuffix(osArgs[1], "/")
 	if _, ok := allowlistedDt4aOriginsLookup[potentialExtension]; !ok {
 		return "", fmt.Errorf("native messaging called from unexpected extension %s", potentialExtension)
+	}
+
+	return potentialExtension, nil
+}
+
+// validateNativeMessagingRequest validates that launcher has been launched by the expected process --
+// Chrome, on behalf of a known extension.
+func validateNativeMessagingRequest(ctx context.Context) (string, error) {
+	potentialExtension, err := ValidateNativeMessagingArgs(os.Args)
+	if err != nil {
+		return "", fmt.Errorf("unexpected args for native messaging request: %w", err)
 	}
 
 	// Get the calling process so we can validate it

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -1,0 +1,213 @@
+package nativemessaging
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kolide/kit/env"
+	"github.com/kolide/launcher/v2/pkg/launcher"
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
+	"github.com/peterbourgon/ff/v3"
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+// msgBufferSize is the maximum message size we expect. Technically the extension is allowed to send a message
+// with size up to 64 MiB, but we restrict further.
+const msgBufferSize = 8192
+
+// nopCloser wraps a Writer with a no-op Close function; we use it
+// to wrap io.Discard so it can be an io.WriteCloser
+type nopCloser struct {
+	io.Writer
+}
+
+func newNopCloser(w io.Writer) io.WriteCloser {
+	return nopCloser{w}
+}
+
+func (nopCloser) Close() error { return nil }
+
+func ReadNativeMessages(ctx context.Context) {
+	// Set up logging so that we can capture any errors that occur when processing messages.
+	// We can't write to kv.sqlite (as the watchdog does) because this process
+	// won't have sufficient permissions. For now, we write to a file in the desktop
+	// directory. If that's not possible (i.e. on Windows there is no desktop directory),
+	// we write logs to io.Discard instead.
+	var logWriter io.WriteCloser
+	var err error
+	logFile := filepath.Join(determineRootDirectory(), fmt.Sprintf("desktop_%d", os.Getuid()), "nativemessaging.log")
+	logWriter, err = os.OpenFile(logFile, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
+	if err != nil {
+		logWriter = newNopCloser(io.Discard)
+	}
+	defer logWriter.Close()
+	slogHandler := slog.NewJSONHandler(logWriter, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slogger := multislogger.New(slogHandler)
+
+	// Validate the request that started this process
+	extension, err := validateNativeMessagingRequest(ctx)
+	if err != nil {
+		slogger.Log(context.TODO(), slog.LevelError,
+			"invalid native messaging request",
+			"err", err,
+			"extension", extension,
+		)
+	}
+
+	slogger.Log(context.TODO(), slog.LevelInfo,
+		"native messaging app opened",
+		"extension", extension,
+	)
+
+	// Handle input until the connection is closed
+	stdinReader := bufio.NewReaderSize(bufio.NewReader(os.Stdin), msgBufferSize)
+	header := make([]byte, 4)
+	for {
+		headerBytesRead, err := stdinReader.Read(header)
+		if headerBytesRead == 0 || err != nil {
+			slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not read next header",
+				"err", err,
+			)
+			break
+		}
+
+		msgLength := binary.NativeEndian.Uint32(header)
+
+		slogger.Log(context.TODO(), slog.LevelInfo,
+			"received message with length",
+			"length", msgLength,
+		)
+
+		msgContent := make([]byte, int(msgLength))
+		msgBytesRead, err := stdinReader.Read(msgContent)
+		if msgBytesRead < int(msgLength) {
+			slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not read all bytes in message",
+				"length", msgLength,
+				"bytes_read", msgBytesRead,
+			)
+			break
+		} else if err != nil {
+			slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not read message",
+				"err", err,
+			)
+			break
+		}
+
+		// In the future, we would forward this request
+		slogger.Log(context.TODO(), slog.LevelInfo,
+			"message",
+			"contents", string(msgContent),
+		)
+	}
+
+	slogger.Log(context.TODO(), slog.LevelInfo,
+		"shutting down",
+	)
+}
+
+// determineRootDirectory discovers the root directory associated with this installation
+// of launcher. It pulls the identifier from the current running executable, uses that to find
+// the config path, and pulls the root directory from the config.
+func determineRootDirectory() string {
+	rootDir := launcher.DefaultRootDirectoryPath
+	currentExecutable, err := os.Executable()
+	if err != nil {
+		return rootDir
+	}
+
+	identifier := extractIdentifierFromExecutable(currentExecutable)
+
+	// We could probably assume the correct root directory given the identifier,
+	// but just in case, we go through the config file to discover the configured
+	// root directory.
+	configFilePath := launcher.DefaultPath(launcher.ConfigFile)
+	if identifier != launcher.DefaultLauncherIdentifier {
+		configFilePath = strings.ReplaceAll(configFilePath, launcher.DefaultLauncherIdentifier, identifier)
+		rootDir = strings.ReplaceAll(rootDir, launcher.DefaultLauncherIdentifier, identifier)
+	}
+
+	// Parse out only the root directory from the config file.
+	cfgFileHandle, err := os.Open(configFilePath)
+	if err != nil {
+		return rootDir
+	}
+	defer cfgFileHandle.Close()
+	_ = ff.PlainParser(cfgFileHandle, func(name, value string) error {
+		switch name {
+		case "root_directory":
+			rootDir = value
+		}
+		return nil
+	})
+
+	return rootDir
+}
+
+// extractIdentifierFromExecutable pulls the identifier (e.g. kolide-k2) out of
+// the path for the current running executable `executablePath`.
+// We're either running out of the original install location (the bin directory)
+// or out of the update directory (inside the root directory). On all OSes, all
+// of these options should contain the identifier for this installation.
+// We check this path to extract the identifier, which will allow us to determine
+// the root directory location.
+func extractIdentifierFromExecutable(executablePath string) string {
+	identifier := launcher.DefaultLauncherIdentifier
+	if strings.Contains(executablePath, identifier) {
+		// Default identifier
+		return identifier
+	}
+
+	// Assume that local paths use the kolide-nababe-k2 identifier, since we don't
+	// have another way of determining it for them.
+	if strings.Contains(executablePath, filepath.Join("launcher", "build")) && !env.Bool("LAUNCHER_FORCE_UPDATE_IN_BUILD", false) {
+		return "kolide-nababe-k2"
+	}
+
+	// We have a custom identifier, taking the format `kolide-<id>-k2`
+	_, afterIdentifierStart, foundIdentifierStart := strings.Cut(executablePath, "kolide-")
+	if foundIdentifierStart {
+		isolatedIdentifier, _, foundIdentifierEnd := strings.Cut(afterIdentifierStart, "-k2")
+		if foundIdentifierEnd {
+			identifier = fmt.Sprintf("kolide-%s-k2", isolatedIdentifier)
+		}
+	}
+	return identifier
+}
+
+// validateNativeMessagingRequest validates that launcher has been launched by the expected process --
+// Chrome, on behalf of a known extension.
+func validateNativeMessagingRequest(ctx context.Context) (string, error) {
+	// launcher should be called with exactly 1 argument, which is the extension.
+	if len(os.Args) != 2 {
+		return "", fmt.Errorf("unexpected number of args: expected 2, got %d", len(os.Args))
+	}
+	// The extension should be one that we know about. It will have an extra / at the end, which we remove
+	// before performing the lookup against our known origins.
+	potentialExtension := strings.TrimSuffix(os.Args[1], "/")
+	if _, ok := allowlistedDt4aOriginsLookup[potentialExtension]; !ok {
+		return "", fmt.Errorf("native messaging called from unexpected extension %s", potentialExtension)
+	}
+
+	// Get the calling process so we can validate it
+	ppid := os.Getppid()
+	parentProcess, err := process.NewProcessWithContext(ctx, int32(ppid))
+	if err != nil {
+		return potentialExtension, fmt.Errorf("getting parent process (%d) for request from %s: %w", ppid, potentialExtension, err)
+	}
+
+	if err := validateBrowser(ctx, parentProcess); err != nil {
+		return potentialExtension, fmt.Errorf("validating browser process with ppid %d: %w", ppid, err)
+	}
+
+	return potentialExtension, nil
+}

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -221,9 +221,24 @@ func validateNativeMessagingRequest(ctx context.Context) (string, error) {
 	if err != nil {
 		return potentialExtension, fmt.Errorf("getting parent process (%d) for request from %s: %w", ppid, potentialExtension, err)
 	}
+	parentProcessCreateTime, err := parentProcess.CreateTimeWithContext(ctx)
+	if err != nil {
+		return potentialExtension, fmt.Errorf("getting parent process create time for request from %s: %w", potentialExtension, err)
+	}
 
+	// Perform per-OS validation
 	if err := validateBrowser(ctx, parentProcess); err != nil {
 		return potentialExtension, fmt.Errorf("validating browser process with ppid %d: %w", ppid, err)
+	}
+
+	// Check that the create time is still the same, so that we know the process hasn't died
+	// and had its PID reused by some other process.
+	parentProcessCreateTimeAfterValidation, err := parentProcess.CreateTimeWithContext(ctx)
+	if err != nil {
+		return potentialExtension, fmt.Errorf("getting parent process create time after performing validation: %w", err)
+	}
+	if parentProcessCreateTime != parentProcessCreateTimeAfterValidation {
+		return potentialExtension, fmt.Errorf("PID reuse: parent process originally created at %d, now %d has create time at %d", parentProcessCreateTime, ppid, parentProcessCreateTimeAfterValidation)
 	}
 
 	return potentialExtension, nil

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -249,7 +249,11 @@ func validateNativeMessagingRequest(ctx context.Context) (string, error) {
 
 	// Check that the create time is still the same, so that we know the process hasn't died
 	// and had its PID reused by some other process.
-	parentProcessCreateTimeAfterValidation, err := parentProcess.CreateTimeWithContext(ctx)
+	parentProcessAfterValidation, err := process.NewProcessWithContext(ctx, int32(ppid))
+	if err != nil {
+		return potentialExtension, fmt.Errorf("getting parent process after performing validation: %w", err)
+	}
+	parentProcessCreateTimeAfterValidation, err := parentProcessAfterValidation.CreateTimeWithContext(ctx)
 	if err != nil {
 		return potentialExtension, fmt.Errorf("getting parent process create time after performing validation: %w", err)
 	}

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -183,11 +183,7 @@ func ValidateNativeMessagingArgs(osArgs []string) (string, error) {
 	if len(osArgs) != 2 && len(osArgs) != 3 {
 		return "", fmt.Errorf("unexpected number of args: expected 2 or 3, got %d", len(osArgs))
 	}
-	if len(osArgs) == 3 {
-		if osArgs[2] != "--parent-window=0" {
-			return "", fmt.Errorf("unexpected third arg %s, expected --parent-window=0", osArgs[2])
-		}
-	}
+
 	// The extension should be one that we know about. It will have an extra / at the end, which we remove
 	// before performing the lookup against our known origins.
 	potentialExtension := strings.TrimSuffix(osArgs[1], "/")

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,9 +20,12 @@ import (
 	"github.com/shirou/gopsutil/v4/process"
 )
 
-// msgBufferSize is the maximum message size we expect. Technically the extension is allowed to send a message
-// with size up to 64 MiB, but we restrict further.
-const msgBufferSize = 8192
+const (
+	// msgBufferSize is the maximum message size we expect. Technically the extension is allowed to send a message
+	// with size up to 64 MiB, but we restrict further.
+	msgBufferSize      = 8192
+	maxSendMessageSize = 1000000 // 1MB
+)
 
 // nopCloser wraps a Writer with a no-op Close function; we use it
 // to wrap io.Discard so it can be an io.WriteCloser
@@ -126,6 +130,17 @@ func ReadNativeMessages(ctx context.Context) {
 			"message",
 			"contents", string(msgContent),
 		)
+
+		// Write a test message
+		if err := sendMessage(map[string]any{
+			"msg":     "received message",
+			"msg_len": msgLength,
+		}); err != nil {
+			slogger.Log(ctx, slog.LevelError,
+				"sending message",
+				"err", err,
+			)
+		}
 	}
 
 	slogger.Log(ctx, slog.LevelInfo,
@@ -243,4 +258,29 @@ func validateNativeMessagingRequest(ctx context.Context) (string, error) {
 	}
 
 	return potentialExtension, nil
+}
+
+// sendMessage formats the given body by marshalling it to JSON,
+// adding the expected header, and writing it to stdout.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol
+func sendMessage(msgBody any) error {
+	bodyRaw, err := json.Marshal(msgBody)
+	if err != nil {
+		return fmt.Errorf("marshalling msg body to JSON: %w", err)
+	}
+	bodyLen := len(bodyRaw)
+	totalMsgLen := bodyLen + 4
+	if totalMsgLen > maxSendMessageSize {
+		return fmt.Errorf("message with size %d bytes exceeds max of 1 MB", totalMsgLen)
+	}
+
+	header := make([]byte, 4)
+	binary.NativeEndian.PutUint32(header, uint32(bodyLen))
+
+	written, err := os.Stdout.Write(append(header, bodyRaw...))
+	if written != totalMsgLen || err != nil {
+		return fmt.Errorf("sending message: wrote %d of %d expected bytes: %w", written, totalMsgLen, err)
+	}
+
+	return nil
 }

--- a/ee/nativemessaging/host.go
+++ b/ee/nativemessaging/host.go
@@ -232,36 +232,69 @@ func validateNativeMessagingRequest(ctx context.Context) (string, error) {
 	}
 
 	// Get the calling process so we can validate it
-	ppid := os.Getppid()
-	parentProcess, err := process.NewProcessWithContext(ctx, int32(ppid))
+	browserProcess, browserPid, browserProcessName, err := getBrowserProcess(ctx)
 	if err != nil {
-		return potentialExtension, fmt.Errorf("getting parent process (%d) for request from %s: %w", ppid, potentialExtension, err)
+		return potentialExtension, fmt.Errorf("getting browser process: %w", err)
 	}
-	parentProcessCreateTime, err := parentProcess.CreateTimeWithContext(ctx)
+	browserProcessCreateTime, err := browserProcess.CreateTimeWithContext(ctx)
 	if err != nil {
-		return potentialExtension, fmt.Errorf("getting parent process create time for request from %s: %w", potentialExtension, err)
+		return potentialExtension, fmt.Errorf("getting browser process create time for request from %s: %w", potentialExtension, err)
 	}
 
 	// Perform per-OS validation
-	if err := validateBrowser(ctx, parentProcess); err != nil {
-		return potentialExtension, fmt.Errorf("validating browser process with ppid %d: %w", ppid, err)
+	if err := validateBrowser(ctx, browserProcess, browserProcessName); err != nil {
+		return potentialExtension, fmt.Errorf("validating browser process %s: %w", browserProcessName, err)
 	}
 
 	// Check that the create time is still the same, so that we know the process hasn't died
 	// and had its PID reused by some other process.
-	parentProcessAfterValidation, err := process.NewProcessWithContext(ctx, int32(ppid))
+	browserProcessAfterValidation, err := process.NewProcessWithContext(ctx, browserPid)
 	if err != nil {
-		return potentialExtension, fmt.Errorf("getting parent process after performing validation: %w", err)
+		return potentialExtension, fmt.Errorf("getting browser process after performing validation: %w", err)
 	}
-	parentProcessCreateTimeAfterValidation, err := parentProcessAfterValidation.CreateTimeWithContext(ctx)
+	browserProcessCreateTimeAfterValidation, err := browserProcessAfterValidation.CreateTimeWithContext(ctx)
 	if err != nil {
-		return potentialExtension, fmt.Errorf("getting parent process create time after performing validation: %w", err)
+		return potentialExtension, fmt.Errorf("getting browser process create time after performing validation: %w", err)
 	}
-	if parentProcessCreateTime != parentProcessCreateTimeAfterValidation {
-		return potentialExtension, fmt.Errorf("PID reuse: parent process originally created at %d, now %d has create time at %d", parentProcessCreateTime, ppid, parentProcessCreateTimeAfterValidation)
+	if browserProcessCreateTime != browserProcessCreateTimeAfterValidation {
+		return potentialExtension, fmt.Errorf("PID reuse: browser process originally created at %d, now %d has create time at %d", browserProcessCreateTime, browserPid, browserProcessCreateTimeAfterValidation)
 	}
 
 	return potentialExtension, nil
+}
+
+// getBrowserProcess returns the process that ultimately created this process. Usually
+// this is the parent process, but on Windows it can be one level above the parent.
+func getBrowserProcess(ctx context.Context) (*process.Process, int32, string, error) {
+	ppid := int32(os.Getppid())
+	parentProcess, err := process.NewProcessWithContext(ctx, ppid)
+	if err != nil {
+		return nil, ppid, "", fmt.Errorf("getting parent process (%d): %w", ppid, err)
+	}
+	processName, err := parentProcess.NameWithContext(ctx)
+	if err != nil {
+		return nil, ppid, "", fmt.Errorf("getting name for parent process: %w", err)
+	}
+
+	// Some older versions of Chrome on Windows launch via cmd.exe, so we have to go up
+	// one more level.
+	if processName == "cmd.exe" {
+		ppid, err = parentProcess.PpidWithContext(ctx)
+		if err != nil {
+			return nil, ppid, "", fmt.Errorf("getting cmd.exe parent process: %w", err)
+		}
+		parentProcess, err = process.NewProcessWithContext(ctx, ppid)
+		if err != nil {
+			return nil, ppid, "", fmt.Errorf("getting cmd.exe parent process (%d): %w", ppid, err)
+		}
+
+		processName, err = parentProcess.NameWithContext(ctx)
+		if err != nil {
+			return nil, ppid, "", fmt.Errorf("getting name for browser process: %w", err)
+		}
+	}
+
+	return parentProcess, ppid, processName, nil
 }
 
 // sendMessage formats the given body by marshalling it to JSON,

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -5,7 +5,6 @@ package nativemessaging
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
 	"github.com/shirou/gopsutil/v4/process"
@@ -42,14 +41,10 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 		return fmt.Errorf("getting executable for browser process: %w", err)
 	}
 
-	// Verify the codesigning for the app bundle
-	if err := validateCodesigning(ctx, pathToVerify); err != nil {
+	// Verify the codesigning for the app bundle, and that it is associated with
+	// the expected team identifier
+	if err := validateCodesigning(ctx, pathToVerify, teamIdentifier); err != nil {
 		return fmt.Errorf("validating codesigning: %w", err)
-	}
-
-	// Validate that the codesigning is associated with an expected team identifier
-	if err := validateTeamIdentifier(ctx, pathToVerify, teamIdentifier); err != nil {
-		return fmt.Errorf("validating team identifier: %w", err)
 	}
 
 	return nil
@@ -57,8 +52,12 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 
 // validateCodesigning runs codesign --verify against the given path to confirm
 // whether it has a valid signature.
-func validateCodesigning(ctx context.Context, pathToVerify string) error {
-	verifyCmd, err := allowedcmd.Codesign.Cmd(ctx, "--verify", "--verbose", "--deep", pathToVerify)
+func validateCodesigning(ctx context.Context, pathToVerify string, teamIdentifier string) error {
+	// Build our identity assertion:
+	// 1. "anchor apple generic" guarantees the signing chain roots are in Apple's CA
+	// 2. "certificate leaf[subject.OU] = <teamIdentifier>" guarantees the team ID matches what we expect
+	identityAssertion := fmt.Sprintf(`anchor apple generic and certificate leaf[subject.OU] = "%s"`, teamIdentifier)
+	verifyCmd, err := allowedcmd.Codesign.Cmd(ctx, "--verify", "--deep", "--verbose", "-R", "="+identityAssertion, pathToVerify)
 	if err != nil {
 		return fmt.Errorf("creating codesign --verify cmd: %w", err)
 	}
@@ -68,35 +67,4 @@ func validateCodesigning(ctx context.Context, pathToVerify string) error {
 	}
 
 	return nil
-}
-
-// validateTeamIdentifier runs codesign --display against the given path, parses the output
-// to extract the team identifier, and confirms it matches the expected identifier.
-func validateTeamIdentifier(ctx context.Context, pathToVerify string, teamIdentifier string) error {
-	displayCmd, err := allowedcmd.Codesign.Cmd(ctx, "--display", "--verbose", "--deep", pathToVerify)
-	if err != nil {
-		return fmt.Errorf("creating codesign --display cmd: %w", err)
-	}
-	displayOutput, err := displayCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("running codesign --display against %s: output: `%s`: %w", pathToVerify, string(displayOutput), err)
-	}
-
-	displayOutputStr := strings.ReplaceAll(string(displayOutput), "\r\n", "\n")
-	for line := range strings.SplitSeq(displayOutputStr, "\n") {
-		key, val, found := strings.Cut(line, "=")
-		if !found {
-			continue
-		}
-		if key != "TeamIdentifier" {
-			continue
-		}
-		foundTeamIdentifier := strings.TrimSpace(val)
-		if foundTeamIdentifier != teamIdentifier {
-			return fmt.Errorf("team identifier mismatch: expected %s, got %s", teamIdentifier, foundTeamIdentifier)
-		}
-		return nil
-	}
-
-	return fmt.Errorf("codesign --display output does not contain TeamIdentifier: %s", displayOutputStr)
 }

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -39,6 +39,8 @@ func validateBrowser(ctx context.Context, browserPath string, browserProcessName
 	if err != nil {
 		return fmt.Errorf("creating codesign --verify cmd: %w", err)
 	}
+	// The command will return an error if codesigning doesn't pass -- we don't need
+	// to parse verifyOutput to confirm. We capture it only to include in the error string.
 	verifyOutput, err := verifyCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("running codesign --verify against %s: output: `%s`: %w", browserPath, string(verifyOutput), err)

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -5,24 +5,97 @@ package nativemessaging
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/kolide/launcher/v2/ee/allowedcmd"
 	"github.com/shirou/gopsutil/v4/process"
 )
 
-var allowlistedChromePaths = map[string]struct{}{
-	`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`: {},
+// allowlistedBrowsers maps allowlisted browsers to their expected team identifiers.
+// In case of variable install locations, we allowlist the executable name rather than
+// the full path.
+// In testing, Google Chrome for Testing (installed via npx puppeteer browsers) and Chromium
+// (installed via homebrew) were not codesigned adequately, and the Chromium one has a pending
+// deprecation notice, so I omitted them from this list.
+var allowlistedBrowsers = map[string]string{
+	`Google Chrome`:        "EQHXZ8M8AV",
+	`Google Chrome Beta`:   "EQHXZ8M8AV",
+	`Google Chrome Dev`:    "EQHXZ8M8AV",
+	`Google Chrome Canary`: "EQHXZ8M8AV",
 }
 
+// validateBrowser confirms that the calling process is a known browser on our allowlist
+// that has a valid code signature belonging to a known team identifier.
 func validateBrowser(ctx context.Context, proc *process.Process) error {
-	browserProcessExe, err := proc.ExeWithContext(ctx)
+	// The calling process must be in our allowlist
+	browserProcessName, err := proc.NameWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting name for browser process: %w", err)
+	}
+	teamIdentifier, found := allowlistedBrowsers[browserProcessName]
+	if !found {
+		return fmt.Errorf("name %s for browser process not in allowlisted chrome paths", browserProcessName)
+	}
+
+	pathToVerify, err := proc.ExeWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("getting executable for browser process: %w", err)
 	}
 
-	// The calling process must have a path in our allowlist
-	if _, found := allowlistedChromePaths[browserProcessExe]; !found {
-		return fmt.Errorf("path %s for browser process not in allowlisted chrome paths", browserProcessExe)
+	// Verify the codesigning for the app bundle
+	if err := validateCodesigning(ctx, pathToVerify); err != nil {
+		return fmt.Errorf("validating codesigning: %w", err)
+	}
+
+	// Validate that the codesigning is associated with an expected team identifier
+	if err := validateTeamIdentifier(ctx, pathToVerify, teamIdentifier); err != nil {
+		return fmt.Errorf("validating team identifier: %w", err)
 	}
 
 	return nil
+}
+
+// validateCodesigning runs codesign --verify against the given path to confirm
+// whether it has a valid signature.
+func validateCodesigning(ctx context.Context, pathToVerify string) error {
+	verifyCmd, err := allowedcmd.Codesign.Cmd(ctx, "--verify", "--verbose", "--deep", pathToVerify)
+	if err != nil {
+		return fmt.Errorf("creating codesign --verify cmd: %w", err)
+	}
+	verifyOutput, err := verifyCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running codesign --verify against %s: output: `%s`: %w", pathToVerify, string(verifyOutput), err)
+	}
+
+	return nil
+}
+
+// validateTeamIdentifier runs codesign --display against the given path, parses the output
+// to extract the team identifier, and confirms it matches the expected identifier.
+func validateTeamIdentifier(ctx context.Context, pathToVerify string, teamIdentifier string) error {
+	displayCmd, err := allowedcmd.Codesign.Cmd(ctx, "--display", "--verbose", "--deep", pathToVerify)
+	if err != nil {
+		return fmt.Errorf("creating codesign --display cmd: %w", err)
+	}
+	displayOutput, err := displayCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running codesign --display against %s: output: `%s`: %w", pathToVerify, string(displayOutput), err)
+	}
+
+	displayOutputStr := strings.ReplaceAll(string(displayOutput), "\r\n", "\n")
+	for line := range strings.SplitSeq(displayOutputStr, "\n") {
+		key, val, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		if key != "TeamIdentifier" {
+			continue
+		}
+		if strings.TrimSpace(val) != teamIdentifier {
+			return fmt.Errorf("team identifier mismatch: expected %s, got %s", teamIdentifier, val)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("codesign --display output does not contain TeamIdentifier: %s", displayOutputStr)
 }

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
-	"github.com/shirou/gopsutil/v4/process"
 )
 
 // allowlistedBrowsers maps allowlisted browsers to their expected team identifiers.
@@ -23,31 +22,26 @@ var allowlistedBrowsers = map[string]string{
 	`Google Chrome Canary`: "EQHXZ8M8AV",
 }
 
-// validateBrowser confirms that the calling process is a known browser on our allowlist
+// validateBrowser confirms that the given path is a known browser on our allowlist
 // that has a valid code signature belonging to a known team identifier.
-func validateBrowser(ctx context.Context, proc *process.Process, browserProcessName string) error {
-	// The calling process must be in our allowlist
+func validateBrowser(ctx context.Context, browserPath string, browserProcessName string) error {
+	// The path must be in our allowlist
 	teamIdentifier, found := allowlistedBrowsers[browserProcessName]
 	if !found {
 		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)
-	}
-
-	pathToVerify, err := proc.ExeWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("getting executable for browser process: %w", err)
 	}
 
 	// Build our identity assertion:
 	// 1. "anchor apple generic" guarantees the signing chain roots are in Apple's CA
 	// 2. "certificate leaf[subject.OU] = <teamIdentifier>" guarantees the team ID matches what we expect
 	identityAssertion := fmt.Sprintf(`anchor apple generic and certificate leaf[subject.OU] = "%s"`, teamIdentifier)
-	verifyCmd, err := allowedcmd.Codesign.Cmd(ctx, "--verify", "--deep", "--verbose", "-R", "="+identityAssertion, pathToVerify)
+	verifyCmd, err := allowedcmd.Codesign.Cmd(ctx, "--verify", "--deep", "--verbose", "-R", "="+identityAssertion, browserPath)
 	if err != nil {
 		return fmt.Errorf("creating codesign --verify cmd: %w", err)
 	}
 	verifyOutput, err := verifyCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("running codesign --verify against %s: output: `%s`: %w", pathToVerify, string(verifyOutput), err)
+		return fmt.Errorf("running codesign --verify against %s: output: `%s`: %w", browserPath, string(verifyOutput), err)
 	}
 
 	return nil

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -33,7 +33,7 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 	}
 	teamIdentifier, found := allowlistedBrowsers[browserProcessName]
 	if !found {
-		return fmt.Errorf("name %s for browser process not in allowlisted chrome paths", browserProcessName)
+		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)
 	}
 
 	pathToVerify, err := proc.ExeWithContext(ctx)
@@ -41,18 +41,6 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 		return fmt.Errorf("getting executable for browser process: %w", err)
 	}
 
-	// Verify the codesigning for the app bundle, and that it is associated with
-	// the expected team identifier
-	if err := validateCodesigning(ctx, pathToVerify, teamIdentifier); err != nil {
-		return fmt.Errorf("validating codesigning: %w", err)
-	}
-
-	return nil
-}
-
-// validateCodesigning runs codesign --verify against the given path to confirm
-// whether it has a valid signature.
-func validateCodesigning(ctx context.Context, pathToVerify string, teamIdentifier string) error {
 	// Build our identity assertion:
 	// 1. "anchor apple generic" guarantees the signing chain roots are in Apple's CA
 	// 2. "certificate leaf[subject.OU] = <teamIdentifier>" guarantees the team ID matches what we expect

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -25,12 +25,8 @@ var allowlistedBrowsers = map[string]string{
 
 // validateBrowser confirms that the calling process is a known browser on our allowlist
 // that has a valid code signature belonging to a known team identifier.
-func validateBrowser(ctx context.Context, proc *process.Process) error {
+func validateBrowser(ctx context.Context, proc *process.Process, browserProcessName string) error {
 	// The calling process must be in our allowlist
-	browserProcessName, err := proc.NameWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("getting name for browser process: %w", err)
-	}
 	teamIdentifier, found := allowlistedBrowsers[browserProcessName]
 	if !found {
 		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -91,8 +91,9 @@ func validateTeamIdentifier(ctx context.Context, pathToVerify string, teamIdenti
 		if key != "TeamIdentifier" {
 			continue
 		}
-		if strings.TrimSpace(val) != teamIdentifier {
-			return fmt.Errorf("team identifier mismatch: expected %s, got %s", teamIdentifier, val)
+		foundTeamIdentifier := strings.TrimSpace(val)
+		if foundTeamIdentifier != teamIdentifier {
+			return fmt.Errorf("team identifier mismatch: expected %s, got %s", teamIdentifier, foundTeamIdentifier)
 		}
 		return nil
 	}

--- a/ee/nativemessaging/host_darwin.go
+++ b/ee/nativemessaging/host_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package nativemessaging
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+var allowlistedChromePaths = map[string]struct{}{
+	`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`: {},
+}
+
+func validateBrowser(ctx context.Context, proc *process.Process) error {
+	browserProcessExe, err := proc.ExeWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting executable for browser process: %w", err)
+	}
+
+	// The calling process must have a path in our allowlist
+	if _, found := allowlistedChromePaths[browserProcessExe]; !found {
+		return fmt.Errorf("path %s for browser process not in allowlisted chrome paths", browserProcessExe)
+	}
+
+	return nil
+}

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -19,7 +19,7 @@ var allowlistedBrowsers = map[string]struct{}{
 	"chrome":                   {},
 	"chromium":                 {},
 	"chromium-browser":         {},
-	"chromium-browser-privacy": {},
+	"chromium-browser-privacy": {}, // RPM
 }
 
 // validateBrowser checks that the process is a known browser where the executable

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -24,7 +24,7 @@ var allowlistedBrowsers = map[string]struct{}{
 
 // validateBrowser checks that the process is a known browser where the executable
 // is owned by root with appropriate permissions.
-func validateBrowser(ctx context.Context, proc *process.Process) error {
+func validateBrowser(ctx context.Context, proc *process.Process, _ string) error {
 	pathToVerify, err := proc.ExeWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("getting executable for browser process: %w", err)

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package nativemessaging
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+func validateBrowser(ctx context.Context, proc *process.Process) error {
+	return errors.New("not implemented")
+}

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/shirou/gopsutil/v4/process"
 )
 
 // allowlistedBrowsers maps is a lookup of allowlisted browsers on Linux.
@@ -22,34 +20,29 @@ var allowlistedBrowsers = map[string]struct{}{
 	"chromium-browser-privacy": {}, // RPM
 }
 
-// validateBrowser checks that the process is a known browser where the executable
+// validateBrowser checks that the given path is a known browser where the executable
 // is owned by root with appropriate permissions.
-func validateBrowser(ctx context.Context, proc *process.Process, _ string) error {
-	pathToVerify, err := proc.ExeWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("getting executable for browser process: %w", err)
-	}
-
+func validateBrowser(_ context.Context, browserPath string, _ string) error {
 	// Confirm that this is a known browser
-	if _, found := allowlistedBrowsers[filepath.Base(pathToVerify)]; !found {
-		return fmt.Errorf("filename of executable %s for browser process not in allowlisted browser names", pathToVerify)
+	if _, found := allowlistedBrowsers[filepath.Base(browserPath)]; !found {
+		return fmt.Errorf("filename of executable %s for browser process not in allowlisted browser names", browserPath)
 	}
 
 	// We can't check codesigning, so confirm that this path is root-owned
 	// and not group- or world-writable.
-	fi, err := os.Stat(pathToVerify)
+	fi, err := os.Stat(browserPath)
 	if err != nil {
-		return fmt.Errorf("getting file info for %s: %w", pathToVerify, err)
+		return fmt.Errorf("getting file info for %s: %w", browserPath, err)
 	}
 	fileStats, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("getting stat_t for %s", pathToVerify)
+		return fmt.Errorf("getting stat_t for %s", browserPath)
 	}
 	if fileStats.Uid != 0 {
-		return fmt.Errorf("browser %s is not root-owned -- owned by %d", pathToVerify, fileStats.Uid)
+		return fmt.Errorf("browser %s is not root-owned -- owned by %d", browserPath, fileStats.Uid)
 	}
 	if fi.Mode()&022 != 0 {
-		return fmt.Errorf("%s is group- or world-writable: %s", pathToVerify, fi.Mode().String())
+		return fmt.Errorf("%s is group- or world-writable: %s", browserPath, fi.Mode().String())
 	}
 
 	return nil

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -43,13 +43,13 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 	}
 	fileStats, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("getting stat_t for %s: %w", pathToVerify, err)
+		return fmt.Errorf("getting stat_t for %s", pathToVerify)
 	}
 	if fileStats.Uid != 0 {
 		return fmt.Errorf("browser %s is not root-owned -- owned by %d", pathToVerify, fileStats.Uid)
 	}
 	if fi.Mode()&022 != 0 {
-		return fmt.Errorf("%s is group- or world-writable: %s", fi, fi.Mode().String())
+		return fmt.Errorf("%s is group- or world-writable: %s", pathToVerify, fi.Mode().String())
 	}
 
 	return nil

--- a/ee/nativemessaging/host_linux.go
+++ b/ee/nativemessaging/host_linux.go
@@ -4,11 +4,53 @@ package nativemessaging
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
 
 	"github.com/shirou/gopsutil/v4/process"
 )
 
+// allowlistedBrowsers maps is a lookup of allowlisted browsers on Linux.
+// In case of variable install locations, we allowlist the executable filename rather than
+// the full path.
+var allowlistedBrowsers = map[string]struct{}{
+	"chrome":                   {},
+	"chromium":                 {},
+	"chromium-browser":         {},
+	"chromium-browser-privacy": {},
+}
+
+// validateBrowser checks that the process is a known browser where the executable
+// is owned by root with appropriate permissions.
 func validateBrowser(ctx context.Context, proc *process.Process) error {
-	return errors.New("not implemented")
+	pathToVerify, err := proc.ExeWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting executable for browser process: %w", err)
+	}
+
+	// Confirm that this is a known browser
+	if _, found := allowlistedBrowsers[filepath.Base(pathToVerify)]; !found {
+		return fmt.Errorf("filename of executable %s for browser process not in allowlisted browser names", pathToVerify)
+	}
+
+	// We can't check codesigning, so confirm that this path is root-owned
+	// and not group- or world-writable.
+	fi, err := os.Stat(pathToVerify)
+	if err != nil {
+		return fmt.Errorf("getting file info for %s: %w", pathToVerify, err)
+	}
+	fileStats, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("getting stat_t for %s: %w", pathToVerify, err)
+	}
+	if fileStats.Uid != 0 {
+		return fmt.Errorf("browser %s is not root-owned -- owned by %d", pathToVerify, fileStats.Uid)
+	}
+	if fi.Mode()&022 != 0 {
+		return fmt.Errorf("%s is group- or world-writable: %s", fi, fi.Mode().String())
+	}
+
+	return nil
 }

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -1,6 +1,7 @@
 package nativemessaging
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
@@ -116,6 +117,87 @@ func Test_extractIdentifierFromExecutable(t *testing.T) {
 			}
 
 			require.Equal(t, tt.expectedIdentifier, extractIdentifierFromExecutable(tt.executablePath))
+		})
+	}
+}
+
+func Test_validateBrowserPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName string
+		platform     string
+		browserPath  string
+		browserName  string
+		shouldPass   bool
+	}{
+		{
+			testCaseName: "darwin + chrome",
+			platform:     "darwin",
+			browserPath:  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			browserName:  "Google Chrome",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "darwin + chrome beta",
+			platform:     "darwin",
+			browserPath:  "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+			browserName:  "Google Chrome Beta",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "darwin + chrome dev",
+			platform:     "darwin",
+			browserPath:  "/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev",
+			browserName:  "Google Chrome Dev",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "darwin + chrome canary",
+			platform:     "darwin",
+			browserPath:  "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+			browserName:  "Google Chrome Canary",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "darwin + chromium",
+			platform:     "darwin",
+			browserPath:  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+			browserName:  "Chromium",
+			shouldPass:   false, // inadequate codesigning
+		},
+		{
+			testCaseName: "windows + chrome",
+			platform:     "windows",
+			browserPath:  `C:\Program Files\Google\Chrome\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "linux + chrome",
+			platform:     "linux",
+			browserPath:  "/opt/google/chrome/chrome",
+			browserName:  "chrome",
+			shouldPass:   true,
+		},
+	} {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.platform != runtime.GOOS {
+				return
+			}
+			// Check whether browser is actually installed -- in CI, almost certainly not
+			if _, err := os.Stat(tt.browserPath); err != nil {
+				return
+			}
+
+			validationErr := validateBrowser(t.Context(), tt.browserPath, tt.browserName)
+			if tt.shouldPass {
+				require.NoError(t, validationErr)
+			} else {
+				require.Error(t, validationErr)
+			}
 		})
 	}
 }

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -1,0 +1,100 @@
+package nativemessaging
+
+import (
+	"testing"
+
+	"github.com/kolide/launcher/v2/pkg/launcher"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractIdentifierFromExecutable(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName       string
+		executablePath     string
+		expectedIdentifier string
+	}{
+		{
+			testCaseName:       "darwin - install location - default",
+			executablePath:     "/usr/local/kolide-k2/Kolide.app/Contents/MacOS",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "darwin - install location - non-default",
+			executablePath:     "/usr/local/kolide-test-k2/Kolide.app/Contents/MacOS",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "darwin - autoupdate location - default",
+			executablePath:     "/var/kolide-k2/k2device.kolide.com/updates/launcher/2.2.2/Kolide.app/Contents/MacOS/launcher",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "darwin - autoupdate location - non-default",
+			executablePath:     "/var/kolide-test-k2/k2device.kolide.com/updates/launcher/2.2.2/Kolide.app/Contents/MacOS/launcher",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "darwin - localdev location - non-default",
+			executablePath:     "/User/kolide-engineer/Repos/launcher/build/launcher",
+			expectedIdentifier: "kolide-nababe-k2",
+		},
+		{
+			testCaseName:       "linux - install location - default",
+			executablePath:     "/usr/local/kolide-k2/bin/launcher",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "linux - install location - non-default",
+			executablePath:     "/usr/local/kolide-test-k2/bin/launcher",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "linux - autoupdate location - default",
+			executablePath:     "/var/kolide-k2/k2device.kolide.com/updates/launcher/2.2.2/launcher",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "linux - autoupdate location - non-default",
+			executablePath:     "/var/kolide-test-k2/k2device.kolide.com/updates/launcher/2.2.2/launcher",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "windows - install location - default",
+			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\launcher.exe",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "windows - install location - non-default",
+			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-test-k2\\bin\\launcher.exe",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "windows - autoupdate location - default",
+			executablePath:     "C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "windows - autoupdate location - non-default",
+			executablePath:     "C:\\ProgramData\\Kolide\\Launcher-kolide-test-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
+			expectedIdentifier: "kolide-test-k2",
+		},
+		{
+			testCaseName:       "windows - autoupdate location, legacy root directory - default",
+			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
+			expectedIdentifier: launcher.DefaultLauncherIdentifier,
+		},
+		{
+			testCaseName:       "windows - autoupdate location, legacy root directory - non-default",
+			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-test-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
+			expectedIdentifier: "kolide-test-k2",
+		},
+	} {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expectedIdentifier, extractIdentifierFromExecutable(tt.executablePath))
+		})
+	}
+}

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -1,6 +1,7 @@
 package nativemessaging
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/kolide/launcher/v2/pkg/launcher"
@@ -12,87 +13,107 @@ func Test_extractIdentifierFromExecutable(t *testing.T) {
 
 	for _, tt := range []struct {
 		testCaseName       string
+		platform           string
 		executablePath     string
 		expectedIdentifier string
 	}{
 		{
 			testCaseName:       "darwin - install location - default",
+			platform:           "darwin",
 			executablePath:     "/usr/local/kolide-k2/Kolide.app/Contents/MacOS",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "darwin - install location - non-default",
+			platform:           "darwin",
 			executablePath:     "/usr/local/kolide-test-k2/Kolide.app/Contents/MacOS",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "darwin - autoupdate location - default",
+			platform:           "darwin",
 			executablePath:     "/var/kolide-k2/k2device.kolide.com/updates/launcher/2.2.2/Kolide.app/Contents/MacOS/launcher",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "darwin - autoupdate location - non-default",
+			platform:           "darwin",
 			executablePath:     "/var/kolide-test-k2/k2device.kolide.com/updates/launcher/2.2.2/Kolide.app/Contents/MacOS/launcher",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "darwin - localdev location - non-default",
+			platform:           "darwin",
 			executablePath:     "/User/kolide-engineer/Repos/launcher/build/launcher",
 			expectedIdentifier: "kolide-nababe-k2",
 		},
 		{
 			testCaseName:       "linux - install location - default",
+			platform:           "linux",
 			executablePath:     "/usr/local/kolide-k2/bin/launcher",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "linux - install location - non-default",
+			platform:           "linux",
 			executablePath:     "/usr/local/kolide-test-k2/bin/launcher",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "linux - autoupdate location - default",
+			platform:           "linux",
 			executablePath:     "/var/kolide-k2/k2device.kolide.com/updates/launcher/2.2.2/launcher",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "linux - autoupdate location - non-default",
+			platform:           "linux",
 			executablePath:     "/var/kolide-test-k2/k2device.kolide.com/updates/launcher/2.2.2/launcher",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "windows - install location - default",
+			platform:           "windows",
 			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\launcher.exe",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "windows - install location - non-default",
+			platform:           "windows",
 			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-test-k2\\bin\\launcher.exe",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "windows - autoupdate location - default",
+			platform:           "windows",
 			executablePath:     "C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "windows - autoupdate location - non-default",
+			platform:           "windows",
 			executablePath:     "C:\\ProgramData\\Kolide\\Launcher-kolide-test-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
 			expectedIdentifier: "kolide-test-k2",
 		},
 		{
 			testCaseName:       "windows - autoupdate location, legacy root directory - default",
+			platform:           "windows",
 			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
 			expectedIdentifier: launcher.DefaultLauncherIdentifier,
 		},
 		{
 			testCaseName:       "windows - autoupdate location, legacy root directory - non-default",
+			platform:           "windows",
 			executablePath:     "C:\\Program Files\\Kolide\\Launcher-kolide-test-k2\\data\\updates\\launcher\\2.2.2\\launcher.exe",
 			expectedIdentifier: "kolide-test-k2",
 		},
 	} {
 		t.Run(tt.testCaseName, func(t *testing.T) {
 			t.Parallel()
+
+			if tt.platform != runtime.GOOS {
+				return
+			}
 
 			require.Equal(t, tt.expectedIdentifier, extractIdentifierFromExecutable(tt.executablePath))
 		})

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -10,6 +10,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateNativeMessagingArgs(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		testCaseName      string
+		osArgs            []string
+		expectedExtension string
+		expectedValid     bool
+	}{
+		{
+			testCaseName:      "too few args",
+			osArgs:            []string{"launcher"},
+			expectedExtension: "",
+			expectedValid:     false,
+		},
+		{
+			testCaseName:      "too many args",
+			osArgs:            []string{"launcher", "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl/", "--parent-window=0", "another", "arg"},
+			expectedExtension: "",
+			expectedValid:     false,
+		},
+		{
+			testCaseName:      "macOS invocation",
+			osArgs:            []string{"launcher", "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl/"},
+			expectedExtension: "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl",
+			expectedValid:     true,
+		},
+		{
+			testCaseName:      "Windows invocation",
+			osArgs:            []string{"launcher", "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl/", "--parent-window=0"},
+			expectedExtension: "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl",
+			expectedValid:     true,
+		},
+		{
+			testCaseName:      "invalid extension",
+			osArgs:            []string{"launcher", "chrome-extension://abcdabcdabcdabcd/"},
+			expectedExtension: "",
+			expectedValid:     false,
+		},
+	} {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			extension, err := ValidateNativeMessagingArgs(tt.osArgs)
+			if tt.expectedValid {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedExtension, extension)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
 func Test_extractIdentifierFromExecutable(t *testing.T) {
 	t.Parallel()
 

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -125,6 +125,8 @@ func Test_extractIdentifierFromExecutable(t *testing.T) {
 func Test_validateBrowserPath(t *testing.T) {
 	t.Parallel()
 
+	isCi := os.Getenv("CI") == "true"
+
 	for _, tt := range []struct {
 		testCaseName string
 		platform     string
@@ -172,7 +174,7 @@ func Test_validateBrowserPath(t *testing.T) {
 			platform:     "windows",
 			browserPath:  `C:\Program Files\Google\Chrome\Application\chrome.exe`,
 			browserName:  "chrome.exe",
-			shouldPass:   true,
+			shouldPass:   !isCi, // This does exist on CI, but we can't run Get-AuthenticodeSignature there, so validation fails
 		},
 		{
 			testCaseName: "windows + chrome - Program Files (x86)",
@@ -256,7 +258,7 @@ func Test_validateBrowserPath(t *testing.T) {
 			platform:     "linux",
 			browserPath:  "/opt/google/chrome/chrome",
 			browserName:  "chrome",
-			shouldPass:   true,
+			shouldPass:   !isCi, // This does exist on CI machines, and has permissions `-rwxrwxrwx` there -- which should fail validation
 		},
 		{
 			testCaseName: "linux + chrome beta",

--- a/ee/nativemessaging/host_test.go
+++ b/ee/nativemessaging/host_test.go
@@ -2,6 +2,7 @@ package nativemessaging
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -167,17 +168,122 @@ func Test_validateBrowserPath(t *testing.T) {
 			shouldPass:   false, // inadequate codesigning
 		},
 		{
-			testCaseName: "windows + chrome",
+			testCaseName: "windows + chrome - Program Files",
 			platform:     "windows",
 			browserPath:  `C:\Program Files\Google\Chrome\Application\chrome.exe`,
 			browserName:  "chrome.exe",
 			shouldPass:   true,
 		},
 		{
+			testCaseName: "windows + chrome - Program Files (x86)",
+			platform:     "windows",
+			browserPath:  `C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome - per-user",
+			platform:     "windows",
+			browserPath:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Google", "Chrome", "Application", "chrome.exe"),
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome beta - Program Files",
+			platform:     "windows",
+			browserPath:  `C:\Program Files\Google\Chrome Beta\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome beta - Program Files (x86)",
+			platform:     "windows",
+			browserPath:  `C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome beta - per-user",
+			platform:     "windows",
+			browserPath:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Google", "Chrome Beta", "Application", "chrome.exe"),
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome dev - Program Files",
+			platform:     "windows",
+			browserPath:  `C:\Program Files\Google\Chrome Dev\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome dev - Program Files (x86)",
+			platform:     "windows",
+			browserPath:  `C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome dev - per-user",
+			platform:     "windows",
+			browserPath:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Google", "Chrome Dev", "Application", "chrome.exe"),
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chrome canary - per-user",
+			platform:     "windows",
+			browserPath:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Google", "Chrome SxS", "Application", "chrome.exe"),
+			browserName:  "chrome.exe",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "windows + chromium - Program Files",
+			platform:     "windows",
+			browserPath:  `C:\Program Files\Chromium\Application\chrome.exe`,
+			browserName:  "chrome.exe",
+			shouldPass:   false, // not signed by Google LLC
+		},
+		{
+			testCaseName: "windows + chromium - per-user",
+			platform:     "windows",
+			browserPath:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Chromium", "Application", "chrome.exe"),
+			browserName:  "chrome.exe",
+			shouldPass:   false, // not signed by Google LLC
+		},
+		{
 			testCaseName: "linux + chrome",
 			platform:     "linux",
 			browserPath:  "/opt/google/chrome/chrome",
 			browserName:  "chrome",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "linux + chrome beta",
+			platform:     "linux",
+			browserPath:  "/opt/google/chrome-beta/chrome",
+			browserName:  "chrome",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "linux + chrome dev",
+			platform:     "linux",
+			browserPath:  "/opt/google/chrome-unstable/chrome",
+			browserName:  "chrome",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "linux + chromium - snap",
+			platform:     "linux",
+			browserPath:  "/snap/chromium/current/usr/lib/chromium-browser/chrome",
+			browserName:  "chrome",
+			shouldPass:   true,
+		},
+		{
+			testCaseName: "linux + chromium - deb",
+			platform:     "linux",
+			browserPath:  "/usr/lib/chromium-browser/chromium-browser",
+			browserName:  "chromium-browser",
 			shouldPass:   true,
 		},
 	} {

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -15,10 +15,7 @@ import (
 // In case of variable install locations, we allowlist the executable name rather than
 // the full path.
 var allowlistedBrowsers = map[string]string{
-	`Google Chrome`:        "Google LLC",
-	`Google Chrome Beta`:   "Google LLC",
-	`Google Chrome Dev`:    "Google LLC",
-	`Google Chrome Canary`: "Google LLC",
+	"chrome.exe": "Google LLC", // Covers stable, beta, dev, and canary
 }
 
 // validateBrowser confirms that the calling process is a known browser

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -21,6 +21,8 @@ var allowlistedBrowsers = map[string]string{
 	`Google Chrome Canary`: "Google LLC",
 }
 
+// validateBrowser confirms that the calling process is a known browser
+// signed by a publisher in our allowlist.
 func validateBrowser(ctx context.Context, proc *process.Process) error {
 	browserProcessName, err := proc.NameWithContext(ctx)
 	if err != nil {

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -31,11 +31,11 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 	// Some older versions of Chrome launch via cmd.exe, so we have to go up
 	// one more level.
 	if browserProcessName == "cmd.exe" {
-		ppid, err := proc.Ppid()
+		ppid, err := proc.PpidWithContext(ctx)
 		if err != nil {
 			return fmt.Errorf("getting cmd.exe parent process: %w", err)
 		}
-		proc, err = process.NewProcessWithContext(ctx, int32(ppid))
+		proc, err = process.NewProcessWithContext(ctx, ppid)
 		if err != nil {
 			return fmt.Errorf("getting cmd.exe parent process (%d): %w", ppid, err)
 		}

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
-	"github.com/shirou/gopsutil/v4/process"
 )
 
 const (
@@ -29,17 +28,12 @@ var allowlistedBrowsers = map[string]string{
 	"chrome.exe": "Google LLC", // Covers stable, beta, dev, and canary
 }
 
-// validateBrowser confirms that the calling process is a known browser
+// validateBrowser confirms that the given path is a known browser
 // signed by a publisher in our allowlist.
-func validateBrowser(ctx context.Context, proc *process.Process, browserProcessName string) error {
+func validateBrowser(ctx context.Context, browserPath string, browserProcessName string) error {
 	publisher, found := allowlistedBrowsers[browserProcessName]
 	if !found {
 		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)
-	}
-
-	pathToVerify, err := proc.ExeWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("getting executable for browser process: %w", err)
 	}
 
 	// Run Get-AuthenticodeSignature to confirm the codesigning is valid,
@@ -49,10 +43,10 @@ func validateBrowser(ctx context.Context, proc *process.Process, browserProcessN
 	if err != nil {
 		return fmt.Errorf("creating powershell Get-AuthenticodeSignature cmd: %w", err)
 	}
-	authenticodeCmd.Env = append(os.Environ(), authenticodePathEnvVar+"="+pathToVerify)
+	authenticodeCmd.Env = append(os.Environ(), authenticodePathEnvVar+"="+browserPath)
 	authenticodeOutput, err := authenticodeCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("running powershell Get-AuthenticodeSignature against %s: output: `%s`: %w", pathToVerify, string(authenticodeOutput), err)
+		return fmt.Errorf("running powershell Get-AuthenticodeSignature against %s: output: `%s`: %w", browserPath, string(authenticodeOutput), err)
 	}
 	gotSubject := string(authenticodeOutput)
 	if !strings.Contains(gotSubject, fmt.Sprintf("O=%s", publisher)) {

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -31,29 +31,7 @@ var allowlistedBrowsers = map[string]string{
 
 // validateBrowser confirms that the calling process is a known browser
 // signed by a publisher in our allowlist.
-func validateBrowser(ctx context.Context, proc *process.Process) error {
-	browserProcessName, err := proc.NameWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("getting name for browser process: %w", err)
-	}
-	// Some older versions of Chrome launch via cmd.exe, so we have to go up
-	// one more level.
-	if browserProcessName == "cmd.exe" {
-		ppid, err := proc.PpidWithContext(ctx)
-		if err != nil {
-			return fmt.Errorf("getting cmd.exe parent process: %w", err)
-		}
-		proc, err = process.NewProcessWithContext(ctx, ppid)
-		if err != nil {
-			return fmt.Errorf("getting cmd.exe parent process (%d): %w", ppid, err)
-		}
-
-		browserProcessName, err = proc.NameWithContext(ctx)
-		if err != nil {
-			return fmt.Errorf("getting name for browser process: %w", err)
-		}
-	}
-
+func validateBrowser(ctx context.Context, proc *process.Process, browserProcessName string) error {
 	publisher, found := allowlistedBrowsers[browserProcessName]
 	if !found {
 		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -5,10 +5,21 @@ package nativemessaging
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
 	"github.com/shirou/gopsutil/v4/process"
+)
+
+const (
+	authenticodePathEnvVar = `LAUNCHER_NATIVEMESSAGING_VERIFY_PATH`
+	// authenticodeVerifyCmd uses -LiteralPath over -FilePath, plus the authenticodePathEnvVar,
+	// to avoid command injection in the case that the path to verify contains a single-quote escape
+	// or wildcard glob characters.
+	authenticodeVerifyCmd = `Get-AuthenticodeSignature -LiteralPath $env:` + authenticodePathEnvVar + ` | ` +
+		`Where-Object {$_.Status -eq "Valid"} | ` +
+		`ForEach-Object { $_.SignerCertificate.Subject }`
 )
 
 // allowlistedBrowsers maps allowlisted browsers to their expected publishers.
@@ -56,11 +67,11 @@ func validateBrowser(ctx context.Context, proc *process.Process) error {
 	// Run Get-AuthenticodeSignature to confirm the codesigning is valid,
 	// and extract the subject to check against `publisher.`
 	// See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-authenticodesignature
-	cmdStr := fmt.Sprintf(`Get-AuthenticodeSignature -FilePath '%s' | Where-Object {$_.Status -eq "Valid"} | ForEach-Object { $_.SignerCertificate.Subject }`, pathToVerify)
-	authenticodeCmd, err := allowedcmd.Powershell.Cmd(ctx, cmdStr)
+	authenticodeCmd, err := allowedcmd.Powershell.Cmd(ctx, "-Command", authenticodeVerifyCmd)
 	if err != nil {
 		return fmt.Errorf("creating powershell Get-AuthenticodeSignature cmd: %w", err)
 	}
+	authenticodeCmd.Env = append(os.Environ(), authenticodePathEnvVar+"="+pathToVerify)
 	authenticodeOutput, err := authenticodeCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("running powershell Get-AuthenticodeSignature against %s: output: `%s`: %w", pathToVerify, string(authenticodeOutput), err)

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package nativemessaging
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+func validateBrowser(ctx context.Context, proc *process.Process) error {
+	return errors.New("not implemented")
+}

--- a/ee/nativemessaging/host_windows.go
+++ b/ee/nativemessaging/host_windows.go
@@ -4,11 +4,72 @@ package nativemessaging
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/kolide/launcher/v2/ee/allowedcmd"
 	"github.com/shirou/gopsutil/v4/process"
 )
 
+// allowlistedBrowsers maps allowlisted browsers to their expected publishers.
+// In case of variable install locations, we allowlist the executable name rather than
+// the full path.
+var allowlistedBrowsers = map[string]string{
+	`Google Chrome`:        "Google LLC",
+	`Google Chrome Beta`:   "Google LLC",
+	`Google Chrome Dev`:    "Google LLC",
+	`Google Chrome Canary`: "Google LLC",
+}
+
 func validateBrowser(ctx context.Context, proc *process.Process) error {
-	return errors.New("not implemented")
+	browserProcessName, err := proc.NameWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting name for browser process: %w", err)
+	}
+	// Some older versions of Chrome launch via cmd.exe, so we have to go up
+	// one more level.
+	if browserProcessName == "cmd.exe" {
+		ppid, err := proc.Ppid()
+		if err != nil {
+			return fmt.Errorf("getting cmd.exe parent process: %w", err)
+		}
+		proc, err = process.NewProcessWithContext(ctx, int32(ppid))
+		if err != nil {
+			return fmt.Errorf("getting cmd.exe parent process (%d): %w", ppid, err)
+		}
+
+		browserProcessName, err = proc.NameWithContext(ctx)
+		if err != nil {
+			return fmt.Errorf("getting name for browser process: %w", err)
+		}
+	}
+
+	publisher, found := allowlistedBrowsers[browserProcessName]
+	if !found {
+		return fmt.Errorf("name %s for browser process not in allowlisted browser names", browserProcessName)
+	}
+
+	pathToVerify, err := proc.ExeWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("getting executable for browser process: %w", err)
+	}
+
+	// Run Get-AuthenticodeSignature to confirm the codesigning is valid,
+	// and extract the subject to check against `publisher.`
+	// See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-authenticodesignature
+	cmdStr := fmt.Sprintf(`Get-AuthenticodeSignature -FilePath '%s' | Where-Object {$_.Status -eq "Valid"} | ForEach-Object { $_.SignerCertificate.Subject }`, pathToVerify)
+	authenticodeCmd, err := allowedcmd.Powershell.Cmd(ctx, cmdStr)
+	if err != nil {
+		return fmt.Errorf("creating powershell Get-AuthenticodeSignature cmd: %w", err)
+	}
+	authenticodeOutput, err := authenticodeCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running powershell Get-AuthenticodeSignature against %s: output: `%s`: %w", pathToVerify, string(authenticodeOutput), err)
+	}
+	gotSubject := string(authenticodeOutput)
+	if !strings.Contains(gotSubject, fmt.Sprintf("O=%s", publisher)) {
+		return fmt.Errorf("certificate not issued to expected publisher %s -- got %s", publisher, gotSubject)
+	}
+
+	return nil
 }

--- a/ee/nativemessaging/protocol.go
+++ b/ee/nativemessaging/protocol.go
@@ -1,0 +1,81 @@
+package nativemessaging
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	// msgBufferSize is the maximum message size we expect. Technically the extension is allowed to send a message
+	// with size up to 64 MiB, but we restrict further.
+	msgBufferSize      = 8192
+	maxSendMessageSize = 1000000 // 1MB
+)
+
+// readMessage reads the incoming message from the msgReader.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol
+func readMessage(msgReader io.Reader) ([]byte, error) {
+	header := make([]byte, 4)
+	headerBytesRead, err := io.ReadFull(msgReader, header)
+	if err != nil && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
+		return nil, fmt.Errorf("stream closed: %w", err)
+	}
+	if headerBytesRead != 4 || err != nil {
+		return nil, fmt.Errorf("reading next header: %w", err)
+	}
+
+	msgLength := binary.NativeEndian.Uint32(header)
+	if msgLength > msgBufferSize {
+		return nil, fmt.Errorf("received message with length %d exceeding max %d", msgLength, msgBufferSize)
+	}
+
+	msgContentRaw := make([]byte, int(msgLength))
+	msgBytesRead, err := io.ReadFull(msgReader, msgContentRaw)
+	if err != nil {
+		return nil, fmt.Errorf("reading message of length %d: %w", msgLength, err)
+	}
+	if msgBytesRead < int(msgLength) {
+		return nil, fmt.Errorf("could only read %d of %d bytes in message", msgBytesRead, msgLength)
+	}
+
+	return msgContentRaw, nil
+}
+
+// sendMessage formats the given message body appropropriately
+// and then writes it to stdout.
+func sendMessage(msgBody any) error {
+	msg, err := formatMessage(msgBody)
+	if err != nil {
+		return fmt.Errorf("formatting message: %w", err)
+	}
+	written, err := os.Stdout.Write(msg)
+	if written != len(msg) || err != nil {
+		return fmt.Errorf("sending message: wrote %d of %d expected bytes: %w", written, len(msg), err)
+	}
+
+	return nil
+}
+
+// formatMessage formats the given body by marshalling it to JSON and
+// adding the expected header.
+// See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol
+func formatMessage(msgBody any) ([]byte, error) {
+	bodyRaw, err := json.Marshal(msgBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling msg body to JSON: %w", err)
+	}
+	bodyLen := len(bodyRaw)
+	totalMsgLen := bodyLen + 4
+	if totalMsgLen > maxSendMessageSize {
+		return nil, fmt.Errorf("message with size %d bytes exceeds max of 1 MB", totalMsgLen)
+	}
+
+	header := make([]byte, 4)
+	binary.NativeEndian.PutUint32(header, uint32(bodyLen))
+
+	return append(header, bodyRaw...), nil
+}

--- a/ee/nativemessaging/protocol.go
+++ b/ee/nativemessaging/protocol.go
@@ -43,6 +43,8 @@ func readMessage(msgReader io.Reader) ([]byte, error) {
 
 // sendMessage formats the given message body appropropriately
 // and then writes it to stdout.
+// The native messaging documentation states that I/O mode must be explicitly set to O_BINARY
+// on Windows -- however, this appears to already be handled appropriately for Golang.
 func sendMessage(msgBody any) error {
 	msg, err := formatMessage(msgBody)
 	if err != nil {

--- a/ee/nativemessaging/protocol.go
+++ b/ee/nativemessaging/protocol.go
@@ -34,12 +34,8 @@ func readMessage(msgReader io.Reader) ([]byte, error) {
 	}
 
 	msgContentRaw := make([]byte, int(msgLength))
-	msgBytesRead, err := io.ReadFull(msgReader, msgContentRaw)
-	if err != nil {
+	if _, err := io.ReadFull(msgReader, msgContentRaw); err != nil {
 		return nil, fmt.Errorf("reading message of length %d: %w", msgLength, err)
-	}
-	if msgBytesRead < int(msgLength) {
-		return nil, fmt.Errorf("could only read %d of %d bytes in message", msgBytesRead, msgLength)
 	}
 
 	return msgContentRaw, nil

--- a/ee/nativemessaging/protocol_test.go
+++ b/ee/nativemessaging/protocol_test.go
@@ -1,0 +1,35 @@
+package nativemessaging
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_formatMessage_readMessage(t *testing.T) {
+	t.Parallel()
+
+	// Create and format the message
+	msg := map[string]any{
+		"key": "value",
+	}
+	msgRaw, err := formatMessage(msg)
+	require.NoError(t, err)
+
+	// Write the message
+	var buf bytes.Buffer
+	written, err := buf.Write(msgRaw)
+	require.NoError(t, err)
+	require.Equal(t, len(msgRaw), written)
+
+	// Now, read the message
+	readRaw, err := readMessage(&buf)
+	require.NoError(t, err)
+
+	// Confirm output is same as input
+	var read map[string]any
+	require.NoError(t, json.Unmarshal(readRaw, &read))
+	require.Equal(t, msg, read)
+}


### PR DESCRIPTION
Part 2 of native messaging support --

This PR updates launcher to detect when it's being called as a native messaging host, and to validate the incoming message appropriately. For now, it only logs the incoming messages.

I suggest briefly skimming https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging (at least https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol) for context about the native messaging protocol.