### PR TITLE
Accurately check current running osquery version in autoupdater

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -634,6 +634,7 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 			metadataClient,
 			mirrorClient,
 			tuf.WithOsqueryRestart(osqueryRunner.Restart),
+			tuf.WithOsqueryHistory(k.OsqueryHistory()),
 		)
 		if err != nil {
 			return fmt.Errorf("creating TUF autoupdater updater: %w", err)

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -110,7 +110,8 @@ type TufAutoupdater struct {
 	signalRestart        chan error
 	slogger              *slog.Logger
 	restartFuncs         map[autoupdatableBinary]func(context.Context) error
-	calculatedSplayDelay *atomic.Int64 // the randomly selected delay within the download splay window
+	calculatedSplayDelay *atomic.Int64          // the randomly selected delay within the download splay window
+	osqueryHistory       types.OsqueryHistorian // used to determine the version of the currently-running osquery process
 }
 
 type TufAutoupdaterOption func(*TufAutoupdater)
@@ -121,6 +122,14 @@ func WithOsqueryRestart(restart func(context.Context) error) TufAutoupdaterOptio
 			ta.restartFuncs = make(map[autoupdatableBinary]func(context.Context) error)
 		}
 		ta.restartFuncs[binaryOsqueryd] = restart
+	}
+}
+
+// WithOsqueryHistory provides the autoupdater with osquery instance history, so that it can
+// determine the version of the currently-running osquery process.
+func WithOsqueryHistory(osqueryHistory types.OsqueryHistorian) TufAutoupdaterOption {
+	return func(ta *TufAutoupdater) {
+		ta.osqueryHistory = osqueryHistory
 	}
 }
 
@@ -521,7 +530,24 @@ func (ta *TufAutoupdater) currentRunningVersion(binary autoupdatableBinary) (str
 		}
 		return launcherVersion, nil
 	case binaryOsqueryd:
-		// Query via runsimple instead of client to avoid any socket contention
+		// If possible, we pull the currently-running osquery version from the osquery history,
+		// recorded by our current osquery instance after startup. We prefer this over `LatestOsquerydPath`
+		// because that path is resolved against the TUF metadata we just refreshed, so during
+		// a rollback it points to the rollback target that already exists in the update library --
+		// leading the autoupdater to incorrectly conclude that it's already running the appropriate version
+		// and not perform the osquery restart. This leaves us running the stale version until launcher
+		// or osquery restarts independently.
+		if ta.osqueryHistory != nil {
+			if stats, err := ta.osqueryHistory.LatestInstanceStats(types.DefaultEnrollmentID); err == nil {
+				if runningVersion, ok := stats["version"]; ok && runningVersion != "" {
+					return runningVersion, nil
+				}
+			}
+		}
+
+		// Fall back to querying the binary directly -- for example, if there's no history
+		// because osquery hasn't started up yet on a fresh install.
+		// Query via runsimple, instead of osquery client, to avoid any socket contention.
 		ctx, cancel := context.WithTimeout(context.Background(), ta.osqueryTimeout)
 		defer cancel()
 

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -21,9 +21,12 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/kolide/launcher/v2/ee/agent/flags/keys"
+	"github.com/kolide/launcher/v2/ee/agent/storage/inmemory"
+	"github.com/kolide/launcher/v2/ee/agent/types"
 	typesmocks "github.com/kolide/launcher/v2/ee/agent/types/mocks"
 	tufci "github.com/kolide/launcher/v2/ee/tuf/ci"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
+	"github.com/kolide/launcher/v2/pkg/osquery/runtime/history"
 	"github.com/kolide/launcher/v2/pkg/threadsafebuffer"
 	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -327,19 +330,21 @@ func TestExecute_osquerydUpdate(t *testing.T) {
 	mockKnapsack.AssertExpectations(t)
 }
 
-func TestExecute_downgrade(t *testing.T) {
+func TestExecute_downgrade_osquery(t *testing.T) {
 	t.Parallel()
 
 	testRootDir := t.TempDir()
-	testReleaseVersion := "3.22.9"
+	testReleaseVersion := tufci.OlderBinaryVersion // 5.17.0
+	currentRunningOsqueryVersion := "5.18.0"
 	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, testReleaseVersion)
 
-	// Set up osquery binary
+	// Make sure the binary is available on disk so that this is a true rollback
+	// (i.e. no TUF download required)
 	osqBinaryPath := filepath.Join(t.TempDir(), "osqueryd")
 	if runtime.GOOS == "windows" {
 		osqBinaryPath += ".exe"
 	}
-	tufci.CopyBinary(t, osqBinaryPath)
+	tufci.CopyOlderBinary(t, osqBinaryPath)
 
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("RootDirectory").Return(testRootDir)
@@ -353,19 +358,38 @@ func TestExecute_downgrade(t *testing.T) {
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
 	mockKnapsack.On("InModernStandby").Return(false)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
-	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath)
+	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath).Maybe()
 
 	// Set logger so that we can capture output
 	var logBytes threadsafebuffer.ThreadSafeBuffer
 	slogger := multislogger.New(slog.NewJSONHandler(&logBytes, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockKnapsack.On("Slogger").Return(slogger.Logger)
 
+	// Track whether the osqueryd restart func is ever invoked
+	var osquerydRestartCount atomic.Int64
+
+	// Set up osquery instance history with currentRunningOsqueryVersion
+	osqHistory, err := history.InitHistory(inmemory.NewStore())
+	require.NoError(t, err)
+	require.NoError(t, osqHistory.NewInstance(types.DefaultEnrollmentID, "test-run-id"))
+	runningQuerier := typesmocks.NewQuerier(t)
+	runningQuerier.On("Query", mock.Anything).Return([]map[string]string{
+		{"instance_id": "test-instance-id", "version": currentRunningOsqueryVersion},
+	}, nil)
+	require.NoError(t, osqHistory.SetConnected("test-run-id", runningQuerier))
+
 	// Set up autoupdater
 	client := &http.Client{}
 	t.Cleanup(func() {
 		client.CloseIdleConnections()
 	})
-	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client, WithOsqueryRestart(func(context.Context) error { return nil }))
+	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client,
+		WithOsqueryRestart(func(context.Context) error {
+			osquerydRestartCount.Add(1)
+			return nil
+		}),
+		WithOsqueryHistory(osqHistory),
+	)
 	require.NoError(t, err, "could not initialize new TUF autoupdater")
 
 	// Update the metadata client with our test root JSON
@@ -380,45 +404,32 @@ func TestExecute_downgrade(t *testing.T) {
 	autoupdater.libraryManager = mockLibraryManager
 	mockLibraryManager.On("TidyLibrary", binaryOsqueryd, mock.Anything).Return().Once()
 
-	// Expect that we do not attempt to update the library (i.e. the osquery update was previously downloaded)
-	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(true)
+	// The rollback target is already present in the library, so no download is needed -- the
+	// autoupdater should detect the already-available rollback version and restart osqueryd onto it.
+	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(true).Maybe()
 	mockLibraryManager.On("Available", binaryLauncher, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)).Return(true)
 
 	// Let the autoupdater run for a bit
 	go autoupdater.Execute()
+	time.Sleep(3 * time.Second)
 
-	// Wait up to 5 seconds to confirm we see log lines `restarted binary after update`, indicating that
-	// the autoupdater restarted osqueryd even though it did not perform a download
-	shutdownDeadline := time.Now().Add(5 * time.Second).Unix()
-	for {
-		if time.Now().Unix() > shutdownDeadline {
-			t.Error("autoupdater did not restart osquery within 5 seconds -- logs: ", logBytes.String())
-			t.FailNow()
-		}
+	// Stop the autoupdater
+	autoupdater.Interrupt(errors.New("test error"))
+	time.Sleep(100 * time.Millisecond)
 
-		// Wait for Execute to do its thing
-		time.Sleep(100 * time.Millisecond)
+	// osqueryd should be restarted in order to load the rollback version
+	require.GreaterOrEqual(t, osquerydRestartCount.Load(), int64(1), "expected osqueryd to be restarted on rollback -- logs: %s", logBytes.String())
 
-		logLines := strings.Split(strings.TrimSpace(logBytes.String()), "\n")
-		osquerydRestarted := false
-		for _, line := range logLines {
-			if strings.Contains(line, "restarted binary after update") {
-				osquerydRestarted = true
-				break
-			}
-		}
-
-		if osquerydRestarted {
+	logLines := strings.Split(strings.TrimSpace(logBytes.String()), "\n")
+	restartFound := false
+	for _, line := range logLines {
+		if strings.Contains(line, "restarted binary after update") {
+			restartFound = true
 			break
 		}
 	}
-
-	// Assert expectation that we checked to see if version was available in library
-	mockLibraryManager.AssertExpectations(t)
-
-	// The autoupdater won't stop after an osqueryd download, so interrupt it and let it shut down
-	autoupdater.Interrupt(errors.New("test error"))
-	time.Sleep(100 * time.Millisecond)
+	require.True(t, restartFound,
+		"expected osqueryd to be restarted on rollback -- logs: %s", logBytes.String())
 
 	// Confirm we pulled all config items as expected
 	mockKnapsack.AssertExpectations(t)


### PR DESCRIPTION
The current behavior on rolling back osquery is as follows:

* The autoupdater refreshes TUF metadata
* The autoupdater checks the current running version of osquery, which pulls from the knapsack (LatestOsquerydPath), which pulls from the TUF metadata -- and since this is a _rollback_, the osquery version is already downloaded, and CheckOutLatest will return its path
* The autoupdater believes incorrectly that it's running the rollback version, and does not restart osquery <- this is the bug

This PR fixes the bug by improving how we check the current running version of osquery -- pulling it from our osquery history's latest instance.