### PR TITLE
support update downloads during autoupdater initial delay

### DIFF
--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kolide/launcher/v2/ee/agent/flags/keys"
 	"github.com/kolide/launcher/v2/ee/agent/types"
 	"github.com/kolide/launcher/v2/ee/observability"
+	kolideatomic "github.com/kolide/launcher/v2/pkg/atomic"
 	"github.com/kolide/launcher/v2/pkg/osquery/runsimple"
 	client "github.com/theupdateframework/go-tuf/client"
 	filejsonstore "github.com/theupdateframework/go-tuf/client/filejsonstore"
@@ -103,6 +104,7 @@ type TufAutoupdater struct {
 	pinnedVersionGetters map[autoupdatableBinary]func() string // maps the binaries to the knapsack function to retrieve updated pinned versions
 	initialDelayStart    time.Time                             // when the autoupdater was created
 	initialDelayEnd      atomic.Value                          // stores time.Time for thread-safe access
+	initialDelayTimer    *time.Timer                           // fires when the initial delay ends so deferred restarts can run
 	updateLock           *sync.Mutex
 	checkTicker          *time.Ticker
 	interrupt            chan struct{}
@@ -112,6 +114,10 @@ type TufAutoupdater struct {
 	restartFuncs         map[autoupdatableBinary]func(context.Context) error
 	calculatedSplayDelay *atomic.Int64          // the randomly selected delay within the download splay window
 	osqueryHistory       types.OsqueryHistorian // used to determine the version of the currently-running osquery process
+	// Restarts are gated by the initial delay: during the delay we still check for and download
+	// updates, but defer the restart until the delay ends, recording the pending restart here.
+	pendingRestartLauncherVersion *kolideatomic.String // launcher version awaiting restart (empty if none)
+	pendingRestartOsquerydVersion *kolideatomic.String // osqueryd version awaiting restart (empty if none)
 }
 
 type TufAutoupdaterOption func(*TufAutoupdater)
@@ -153,11 +159,13 @@ func NewTufAutoupdater(ctx context.Context, k types.Knapsack, metadataHttpClient
 			binaryLauncher: func() string { return k.PinnedLauncherVersion() },
 			binaryOsqueryd: func() string { return k.PinnedOsquerydVersion() },
 		},
-		updateLock:           &sync.Mutex{},
-		osqueryTimeout:       30 * time.Second,
-		slogger:              k.Slogger().With("component", "tuf_autoupdater"),
-		restartFuncs:         make(map[autoupdatableBinary]func(context.Context) error),
-		calculatedSplayDelay: &atomic.Int64{},
+		updateLock:                    &sync.Mutex{},
+		osqueryTimeout:                30 * time.Second,
+		slogger:                       k.Slogger().With("component", "tuf_autoupdater"),
+		restartFuncs:                  make(map[autoupdatableBinary]func(context.Context) error),
+		calculatedSplayDelay:          &atomic.Int64{},
+		pendingRestartLauncherVersion: kolideatomic.NewString(""),
+		pendingRestartOsquerydVersion: kolideatomic.NewString(""),
 	}
 
 	// Set initial delay end time atomically (calculated from start time)
@@ -242,33 +250,6 @@ func DefaultLibraryDirectory(rootDirectory string) string {
 // has been published; less frequently, it removes old/outdated TUF errors from the bucket
 // we store them in.
 func (ta *TufAutoupdater) Execute() (err error) {
-	// Delay startup, if initial delay is set. We use a ticker-based approach
-	// so that we can respect changes to ta.initialDelayEnd from FlagsChanged.
-	initialDelayTicker := time.NewTicker(100 * time.Millisecond)
-	defer initialDelayTicker.Stop()
-
-	for time.Now().Before(ta.initialDelayEnd.Load().(time.Time)) {
-		select {
-		case <-ta.interrupt:
-			ta.slogger.Log(context.TODO(), slog.LevelDebug,
-				"received external interrupt during initial delay, stopping",
-			)
-			return nil
-		case signalRestartErr := <-ta.signalRestart:
-			ta.slogger.Log(context.TODO(), slog.LevelDebug,
-				"received interrupt to restart launcher after update during initial delay, stopping",
-			)
-			return signalRestartErr
-		case <-initialDelayTicker.C:
-			// Check if we've passed the initial delay period in the next loop iteration
-			continue
-		}
-	}
-
-	ta.slogger.Log(context.TODO(), slog.LevelInfo,
-		"exiting initial delay",
-	)
-
 	// For now, tidy the library on startup. In the future, we will tidy the library
 	// earlier, after version selection.
 	ta.tidyLibrary()
@@ -276,12 +257,18 @@ func (ta *TufAutoupdater) Execute() (err error) {
 	ta.checkTicker = time.NewTicker(ta.knapsack.AutoupdateInterval())
 	defer ta.checkTicker.Stop()
 
+	// We begin checking for and downloading updates immediately, but we defer any restart
+	// until the initial delay has elapsed. This timer fires when the initial delay ends so
+	// that we can perform any restart that was deferred during the delay.
+	ta.initialDelayTimer = time.NewTimer(time.Until(ta.initialDelayEnd.Load().(time.Time)))
+	defer ta.initialDelayTimer.Stop()
+
 	for {
 		ta.slogger.Log(context.TODO(), slog.LevelInfo,
 			"checking for updates",
 		)
 		// always allow our AutoupdateDownloadSplay delay during routine checks for autoupdates
-		if err := ta.checkForUpdate(context.TODO(), binaries, true); err != nil {
+		if err := ta.checkForUpdate(context.TODO(), binaries, true, false); err != nil {
 			observability.AutoupdateFailureCounter.Add(context.TODO(), 1)
 			ta.slogger.Log(context.TODO(), slog.LevelError,
 				"error checking for update",
@@ -304,10 +291,60 @@ func (ta *TufAutoupdater) Execute() (err error) {
 				"received interrupt to restart launcher after update, stopping",
 			)
 			return signalRestartErr
+		case <-ta.initialDelayTimer.C:
+			ta.slogger.Log(context.TODO(), slog.LevelInfo,
+				"exiting initial delay",
+			)
+
+			// The initial delay has ended -- perform any restart that was deferred during the delay.
+			if signalRestartErr := ta.restartIfPending(context.TODO()); signalRestartErr != nil {
+				ta.slogger.Log(context.TODO(), slog.LevelDebug,
+					"restarting launcher after deferred update at end of initial delay",
+				)
+				return signalRestartErr
+			}
+			continue
 		case <-ta.checkTicker.C:
 			continue
 		}
 	}
+}
+
+// restartIfPending performs any restart that was deferred during the initial delay. If a launcher
+// restart is pending, it returns a LauncherReloadNeeded error so that Execute exits and the newly
+// downloaded launcher is loaded. Otherwise, if an osqueryd restart is
+// pending, it invokes the osqueryd restart function.
+func (ta *TufAutoupdater) restartIfPending(ctx context.Context) error {
+	if pendingVersion := ta.pendingRestartLauncherVersion.Load(); pendingVersion != "" {
+		ta.pendingRestartLauncherVersion.Store("")
+		ta.slogger.Log(ctx, slog.LevelInfo,
+			"performing deferred launcher restart after initial delay",
+			"new_binary_version", pendingVersion,
+		)
+		return NewLauncherReloadNeededErr(pendingVersion)
+	}
+
+	if pendingVersion := ta.pendingRestartOsquerydVersion.Load(); pendingVersion != "" {
+		restart, ok := ta.restartFuncs[binaryOsqueryd]
+		if !ok {
+			return nil
+		}
+
+		ta.pendingRestartOsquerydVersion.Store("")
+
+		ta.slogger.Log(ctx, slog.LevelInfo,
+			"performing deferred osqueryd restart after initial delay",
+			"new_binary_version", pendingVersion,
+		)
+		if err := restart(ctx); err != nil {
+			ta.slogger.Log(ctx, slog.LevelWarn,
+				"failed to restart osqueryd after deferred update at end of initial delay",
+				"err", err,
+			)
+		}
+	}
+
+	return nil
 }
 
 func (ta *TufAutoupdater) Interrupt(_ error) {
@@ -342,7 +379,7 @@ func (ta *TufAutoupdater) Do(data io.Reader) error {
 			"initial_delay_end", initialDelayEnd.UTC().Format(time.RFC3339),
 		)
 		// We don't return an error because there's no need for the actionqueue to retry this request --
-		// we're going to perform an autoupdate check as soon as we exit the delay anyway.
+		// we're going to perform an autoupdate check on the next interval anyway.
 		return nil
 	}
 
@@ -371,7 +408,7 @@ func (ta *TufAutoupdater) Do(data io.Reader) error {
 	)
 
 	// do not allow AutoupdateDownloadSplay delay during autoupdate now requests
-	if err := ta.checkForUpdate(ctx, binariesToUpdate, false); err != nil {
+	if err := ta.checkForUpdate(ctx, binariesToUpdate, false, updateRequest.BypassInitialDelay); err != nil {
 		observability.AutoupdateFailureCounter.Add(ctx, 1)
 		ta.slogger.Log(ctx, slog.LevelError,
 			"error checking for update per control server request",
@@ -411,6 +448,10 @@ func (ta *TufAutoupdater) FlagsChanged(ctx context.Context, flagKeys ...keys.Fla
 			// Calculate the new delay end time from the original start time
 			newDelayEnd := ta.initialDelayStart.Add(newDelay)
 			ta.initialDelayEnd.Store(newDelayEnd)
+			// Keep the timer that triggers deferred restarts in sync with the new delay end.
+			if ta.initialDelayTimer != nil {
+				ta.initialDelayTimer.Reset(time.Until(newDelayEnd))
+			}
 			ta.slogger.Log(ctx, slog.LevelInfo,
 				"autoupdate initial delay changed while in delay period",
 				"old_delay_end", currentDelayEnd,
@@ -480,7 +521,7 @@ func (ta *TufAutoupdater) FlagsChanged(ctx context.Context, flagKeys ...keys.Fla
 
 	// At least one binary requires a recheck or the interval changed -- perform that now
 	// do not allow AutoupdateDownloadSplay delay when responding to flag changes
-	if err := ta.checkForUpdate(ctx, binariesToCheckForUpdate, false); err != nil {
+	if err := ta.checkForUpdate(ctx, binariesToCheckForUpdate, false, false); err != nil {
 		observability.AutoupdateFailureCounter.Add(ctx, 1)
 		ta.slogger.Log(ctx, slog.LevelError,
 			"error checking for update after autoupdate setting changed",
@@ -580,7 +621,9 @@ func (ta *TufAutoupdater) currentRunningVersion(binary autoupdatableBinary) (str
 // a new release that we should download. If so, it will add the release to our updates library.
 // If allowDelay is set to false, our knapsack.AutoupdateDownloadSplay will be ignored and the update
 // will be downloaded immediately, regardless of promotion time.
-func (ta *TufAutoupdater) checkForUpdate(ctx context.Context, binariesToCheck []autoupdatableBinary, allowDelay bool) error {
+// If bypassInitialDelay is false and we are still within the initial delay, any required restart is
+// deferred (recorded as pending) rather than performed immediately.
+func (ta *TufAutoupdater) checkForUpdate(ctx context.Context, binariesToCheck []autoupdatableBinary, allowSplayDelay bool, bypassInitialDelay bool) error {
 	ctx, span := observability.StartSpan(ctx, "binaries", fmt.Sprintf("%+v", binariesToCheck))
 	defer span.End()
 
@@ -624,7 +667,7 @@ func (ta *TufAutoupdater) checkForUpdate(ctx context.Context, binariesToCheck []
 	updatesDownloaded := make(map[autoupdatableBinary]string)
 	updateErrors := make([]error, 0)
 	for _, binary := range binariesToCheck {
-		downloadedUpdateVersion, err := ta.downloadUpdate(binary, targets, allowDelay)
+		downloadedUpdateVersion, err := ta.downloadUpdate(binary, targets, allowSplayDelay)
 		if err != nil {
 			updateErrors = append(updateErrors, fmt.Errorf("could not download update for %s: %w", binary, err))
 		}
@@ -645,10 +688,28 @@ func (ta *TufAutoupdater) checkForUpdate(ctx context.Context, binariesToCheck []
 		return fmt.Errorf("could not download updates: %+v", updateErrors)
 	}
 
+	// Determine whether we should defer any restart because we're still within the initial delay.
+	// During the initial delay we still download updates, but we hold off on restarting so that we
+	// don't restart immediately after installation. The deferred restart is performed once the delay ends.
+	inInitialDelay := !bypassInitialDelay && time.Now().Before(ta.initialDelayEnd.Load().(time.Time))
+
 	// If launcher was updated, we want to exit and reload
 	if updatedVersion, ok := updatesDownloaded[binaryLauncher]; ok {
 		// Only reload if we're not using a localdev path
 		if ta.knapsack.LocalDevelopmentPath() == "" {
+			if inInitialDelay {
+				ta.pendingRestartLauncherVersion.Store(updatedVersion)
+				ta.slogger.Log(ctx, slog.LevelInfo,
+					"launcher updated during initial delay -- deferring restart until delay ends",
+					"new_binary_version", updatedVersion,
+				)
+
+				// it is okay to return early here- even if there was also an osquery update at the exact same time
+				// we would pick it up when we leave the initial delay and restart launcher, it is cleaner to
+				// get the latest versions of both binaries that way anyway
+				return nil
+			}
+
 			ta.slogger.Log(ctx, slog.LevelInfo,
 				"launcher updated -- exiting to load new version",
 				"new_binary_version", updatedVersion,
@@ -661,6 +722,16 @@ func (ta *TufAutoupdater) checkForUpdate(ctx context.Context, binariesToCheck []
 	// For non-launcher binaries (i.e. osqueryd), call any reload functions we have saved
 	for binary, newBinaryVersion := range updatesDownloaded {
 		if binary == binaryLauncher {
+			continue
+		}
+
+		if inInitialDelay {
+			ta.pendingRestartOsquerydVersion.Store(newBinaryVersion)
+			ta.slogger.Log(ctx, slog.LevelInfo,
+				"binary updated during initial delay -- deferring restart until delay ends",
+				"binary", binary,
+				"new_binary_version", newBinaryVersion,
+			)
 			continue
 		}
 

--- a/ee/tuf/autoupdate.go
+++ b/ee/tuf/autoupdate.go
@@ -298,7 +298,7 @@ func (ta *TufAutoupdater) Execute() (err error) {
 
 			// The initial delay has ended -- perform any restart that was deferred during the delay.
 			if signalRestartErr := ta.restartIfPending(context.TODO()); signalRestartErr != nil {
-				ta.slogger.Log(context.TODO(), slog.LevelDebug,
+				ta.slogger.Log(context.TODO(), slog.LevelInfo,
 					"restarting launcher after deferred update at end of initial delay",
 				)
 				return signalRestartErr

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -1390,6 +1390,8 @@ func TestFlagsChanged_DuringInitialDelay(t *testing.T) {
 	t.Parallel()
 
 	testRootDir := t.TempDir()
+	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, "1.2.3")
+
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("RootDirectory").Return(testRootDir)
 	mockKnapsack.On("UpdateChannel").Return("nightly")
@@ -1398,16 +1400,17 @@ func TestFlagsChanged_DuringInitialDelay(t *testing.T) {
 	mockKnapsack.On("AutoupdateInterval").Return(interval).Maybe()
 	initialDelay := 1 * time.Second
 	mockKnapsack.On("AutoupdateInitialDelay").Return(initialDelay)
-	mockKnapsack.On("TufServerURL").Return("https://example.com")
+	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
-	// The autoupdater now checks for updates during the initial delay, so its loop may interact with
-	// these dependencies. The metadata update fails against example.com, so no download/restart occurs.
+	// tidyLibrary queries osqueryd version at startup; return an empty path so version lookup fails
+	// immediately without spawning a subprocess.
 	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return("").Maybe()
-	mockKnapsack.On("InModernStandby").Return(false).Maybe()
-	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second).Maybe()
+	// Skip the update check loop so Execute reaches its select quickly and can be interrupted
+	// without performing library operations.
+	mockKnapsack.On("InModernStandby").Return(true).Maybe()
 
 	// Start out with a pinned version, then unset the pinned version
 	pinnedLauncherVersion := "1.7.3"
@@ -1421,19 +1424,34 @@ func TestFlagsChanged_DuringInitialDelay(t *testing.T) {
 	})
 	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client, WithOsqueryRestart(func(context.Context) error { return nil }))
 	require.NoError(t, err, "could not initialize new TUF autoupdater")
+	require.NoError(t, autoupdater.metadataClient.Init(rootJson), "could not initialize metadata client with test root JSON")
 	require.Equal(t, pinnedLauncherVersion, autoupdater.pinnedVersions[binaryLauncher])
 
-	// Start the autoupdater, then notify flag change right away, during the initial delay
-	go autoupdater.Execute()
+	mockLibraryManager := NewMocklibrarian(t)
+	autoupdater.libraryManager = mockLibraryManager
+
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- autoupdater.Execute()
+	}()
+
+	// Wait for Execute to reach its select loop before sending flag changes / interrupt.
 	time.Sleep(100 * time.Millisecond)
 	autoupdater.FlagsChanged(t.Context(), keys.PinnedLauncherVersion)
 
-	// Stop the autoupdater
+	// Stop the autoupdater and wait for Execute to exit so we don't leak its goroutine.
 	autoupdater.Interrupt(errors.New("test error"))
+	select {
+	case err := <-executeDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not exit after interrupt")
+	}
 
 	// Confirm we unset the pinned launcher version
 	require.Equal(t, "", autoupdater.pinnedVersions[binaryLauncher])
 
+	mockLibraryManager.AssertExpectations(t)
 	// Confirm we pulled all config items as expected
 	mockKnapsack.AssertExpectations(t)
 }

--- a/ee/tuf/autoupdate_test.go
+++ b/ee/tuf/autoupdate_test.go
@@ -438,13 +438,24 @@ func TestExecute_downgrade_osquery(t *testing.T) {
 func TestExecute_withInitialDelay(t *testing.T) {
 	t.Parallel()
 
-	initialDelay := 500 * time.Millisecond
+	// Use a long initial delay so that we remain in the delay while the autoupdater checks for and
+	// downloads updates -- we want to confirm that the restart is deferred, not performed, during the delay.
+	initialDelay := 10 * time.Second
 
 	testRootDir := t.TempDir()
 	testReleaseVersion := "1.2.3"
-	tufServerUrl, _ := tufci.InitRemoteTufServer(t, testReleaseVersion)
+	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, testReleaseVersion)
+
+	// Set up osquery binary
+	osqBinaryPath := filepath.Join(t.TempDir(), "osqueryd")
+	if runtime.GOOS == "windows" {
+		osqBinaryPath += ".exe"
+	}
+	tufci.CopyOlderBinary(t, osqBinaryPath)
+
 	mockKnapsack := typesmocks.NewKnapsack(t)
 	mockKnapsack.On("RootDirectory").Return(testRootDir)
+	mockKnapsack.On("AutoupdateInterval").Return(100 * time.Millisecond)
 	mockKnapsack.On("AutoupdateInitialDelay").Return(initialDelay)
 	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
 	mockKnapsack.On("UpdateDirectory").Return("")
@@ -452,6 +463,10 @@ func TestExecute_withInitialDelay(t *testing.T) {
 	mockKnapsack.On("UpdateChannel").Return("nightly")
 	mockKnapsack.On("PinnedLauncherVersion").Return("")
 	mockKnapsack.On("PinnedOsquerydVersion").Return("")
+	mockKnapsack.On("LocalDevelopmentPath").Return("")
+	mockKnapsack.On("InModernStandby").Return(false)
+	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath)
+	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second)
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
 
 	// Set logger so that we can capture output
@@ -467,13 +482,46 @@ func TestExecute_withInitialDelay(t *testing.T) {
 	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client, WithOsqueryRestart(func(context.Context) error { return nil }))
 	require.NoError(t, err, "could not initialize new TUF autoupdater")
 
-	// Expect that we interrupt
+	// Update the metadata client with our test root JSON
+	require.NoError(t, autoupdater.metadataClient.Init(rootJson), "could not initialize metadata client with test root JSON")
+	_, err = autoupdater.metadataClient.Update()
+	require.NoError(t, err, "could not update metadata client to fetch target metadata")
+	osquerydMetadata, err := autoupdater.metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryOsqueryd, runtime.GOOS, PlatformArch(), binaryOsqueryd, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for osqueryd")
+	launcherMetadata, err := autoupdater.metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryLauncher, runtime.GOOS, PlatformArch(), binaryLauncher, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for launcher")
+
+	// We expect that the autoupdater tidies the library and downloads the available updates during the delay
 	mockLibraryManager := NewMocklibrarian(t)
 	autoupdater.libraryManager = mockLibraryManager
+	currentLauncherVersion := "" // cannot determine using version package in test
+	mockLibraryManager.On("TidyLibrary", binaryOsqueryd, mock.Anything).Return().Once()
+	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(false).Once()
+	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(true).Maybe()
+	mockLibraryManager.On("Available", binaryLauncher, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)).Return(false).Once()
+	mockLibraryManager.On("Available", binaryLauncher, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)).Return(true).Maybe()
+	mockLibraryManager.On("AddToLibrary", binaryOsqueryd, tufci.OlderBinaryVersion, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion), osquerydMetadata).Return(nil).Once()
+	mockLibraryManager.On("AddToLibrary", binaryLauncher, currentLauncherVersion, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion), launcherMetadata).Return(nil).Once()
 
-	// Let the autoupdater run for less than the initial delay
+	// Let the autoupdater run -- it should download the update and defer the restart
 	go autoupdater.Execute()
-	time.Sleep(300 * time.Millisecond)
+
+	// Wait until we observe that the launcher restart was deferred due to the initial delay
+	deferDeadline := time.Now().Add(initialDelay)
+	deferred := false
+	for time.Now().Before(deferDeadline) {
+		time.Sleep(100 * time.Millisecond)
+		if strings.Contains(logBytes.String(), "deferring restart until delay ends") {
+			deferred = true
+			break
+		}
+	}
+	require.True(t, deferred, "expected restart to be deferred during initial delay -- logs: "+logBytes.String())
+
+	// Confirm that we recorded a pending launcher restart for the downloaded version, and did NOT restart
+	require.Equal(t, testReleaseVersion, autoupdater.pendingRestartLauncherVersion.Load())
+	require.NotContains(t, logBytes.String(), "exiting initial delay", "should not have exited the initial delay yet")
+	require.NotContains(t, logBytes.String(), "received interrupt to restart launcher after update, stopping", "should not have restarted during initial delay")
 
 	// Shut down the autoupdater
 	autoupdater.Interrupt(errors.New("test error"))
@@ -482,15 +530,8 @@ func TestExecute_withInitialDelay(t *testing.T) {
 	// Assert expectation that we closed the library
 	mockLibraryManager.AssertExpectations(t)
 
-	// Check log lines to confirm that we see the log `received external interrupt during initial delay, stopping`,
-	// indicating that we halted during the initial delay
-	logLines := strings.Split(strings.TrimSpace(logBytes.String()), "\n")
-
-	// We expect at least 1 log for the shutdown line.
-	require.GreaterOrEqual(t, len(logLines), 1)
-
-	// Check that we shut down
-	require.Contains(t, logLines[len(logLines)-1], "received external interrupt during initial delay, stopping")
+	// Confirm we shut down via the standard interrupt path
+	require.Contains(t, logBytes.String(), "received external interrupt, stopping")
 
 	// Confirm we pulled all config items as expected
 	mockKnapsack.AssertExpectations(t)
@@ -598,6 +639,162 @@ func TestExecute_withInitialDelayExtendedDuringDelay(t *testing.T) {
 
 	// Confirm we pulled all config items as expected
 	mockKnapsack.AssertExpectations(t)
+}
+
+// TestExecute_deferredLauncherRestartAfterInitialDelay confirms that a launcher update downloaded
+// during the initial delay is not acted upon until the delay ends, at which point the autoupdater
+// exits with a LauncherReloadNeeded error to load the new version.
+func TestExecute_deferredLauncherRestartAfterInitialDelay(t *testing.T) {
+	t.Parallel()
+
+	initialDelay := 3 * time.Second
+
+	testRootDir := t.TempDir()
+	testReleaseVersion := "1.2.3"
+	tufServerUrl, rootJson := tufci.InitRemoteTufServer(t, testReleaseVersion)
+
+	// Set up osquery binary
+	osqBinaryPath := filepath.Join(t.TempDir(), "osqueryd")
+	if runtime.GOOS == "windows" {
+		osqBinaryPath += ".exe"
+	}
+	tufci.CopyOlderBinary(t, osqBinaryPath)
+
+	mockKnapsack := typesmocks.NewKnapsack(t)
+	mockKnapsack.On("RootDirectory").Return(testRootDir)
+	mockKnapsack.On("AutoupdateInterval").Return(100 * time.Millisecond)
+	mockKnapsack.On("AutoupdateInitialDelay").Return(initialDelay)
+	mockKnapsack.On("TufServerURL").Return(tufServerUrl)
+	mockKnapsack.On("UpdateDirectory").Return("")
+	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("UpdateChannel").Return("nightly")
+	mockKnapsack.On("PinnedLauncherVersion").Return("")
+	mockKnapsack.On("PinnedOsquerydVersion").Return("")
+	mockKnapsack.On("LocalDevelopmentPath").Return("")
+	mockKnapsack.On("InModernStandby").Return(false)
+	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return(osqBinaryPath)
+	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
+	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+
+	// Set up autoupdater
+	client := &http.Client{}
+	t.Cleanup(func() {
+		client.CloseIdleConnections()
+	})
+	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client, WithOsqueryRestart(func(context.Context) error { return nil }))
+	require.NoError(t, err, "could not initialize new TUF autoupdater")
+
+	require.NoError(t, autoupdater.metadataClient.Init(rootJson), "could not initialize metadata client with test root JSON")
+	_, err = autoupdater.metadataClient.Update()
+	require.NoError(t, err, "could not update metadata client to fetch target metadata")
+	osquerydMetadata, err := autoupdater.metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryOsqueryd, runtime.GOOS, PlatformArch(), binaryOsqueryd, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for osqueryd")
+	launcherMetadata, err := autoupdater.metadataClient.Target(fmt.Sprintf("%s/%s/%s/%s-%s.tar.gz", binaryLauncher, runtime.GOOS, PlatformArch(), binaryLauncher, testReleaseVersion))
+	require.NoError(t, err, "could not get test metadata for launcher")
+
+	mockLibraryManager := NewMocklibrarian(t)
+	autoupdater.libraryManager = mockLibraryManager
+	currentLauncherVersion := "" // cannot determine using version package in test
+	mockLibraryManager.On("TidyLibrary", binaryOsqueryd, mock.Anything).Return().Once()
+	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(false).Once()
+	mockLibraryManager.On("Available", binaryOsqueryd, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion)).Return(true).Maybe()
+	mockLibraryManager.On("Available", binaryLauncher, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)).Return(false).Once()
+	mockLibraryManager.On("Available", binaryLauncher, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)).Return(true).Maybe()
+	mockLibraryManager.On("AddToLibrary", binaryOsqueryd, tufci.OlderBinaryVersion, fmt.Sprintf("osqueryd-%s.tar.gz", testReleaseVersion), osquerydMetadata).Return(nil).Once()
+	mockLibraryManager.On("AddToLibrary", binaryLauncher, currentLauncherVersion, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion), launcherMetadata).Return(nil).Once()
+
+	// Run Execute and capture its return value -- it should exit with a LauncherReloadNeeded error
+	// once the initial delay ends and the deferred restart is performed.
+	executeErr := make(chan error, 1)
+	go func() {
+		executeErr <- autoupdater.Execute()
+	}()
+
+	select {
+	case err := <-executeErr:
+		require.True(t, IsLauncherReloadNeededErr(err), "expected Execute to exit with a launcher reload error, got: %v", err)
+	case <-time.After(initialDelay + 2*time.Second):
+		autoupdater.Interrupt(errors.New("test timeout"))
+		t.Fatal("autoupdater did not perform deferred restart after initial delay ended")
+	}
+
+	mockLibraryManager.AssertExpectations(t)
+	mockKnapsack.AssertExpectations(t)
+}
+
+// TestRestartIfPending confirms that restartIfPending performs the correct deferred restart action
+// depending on which binary has a pending restart recorded.
+func TestRestartIfPending(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pending launcher restart returns reload error", func(t *testing.T) {
+		t.Parallel()
+
+		autoupdater := testAutoupdaterForRestartIfPending(t, func(context.Context) error {
+			t.Fatal("osqueryd restart should not be called when a launcher restart is pending")
+			return nil
+		})
+
+		autoupdater.pendingRestartLauncherVersion.Store("9.9.9")
+		autoupdater.pendingRestartOsquerydVersion.Store("8.8.8")
+
+		err := autoupdater.restartIfPending(context.TODO())
+		require.True(t, IsLauncherReloadNeededErr(err), "expected launcher reload error, got: %v", err)
+	})
+
+	t.Run("pending osqueryd restart calls restart func", func(t *testing.T) {
+		t.Parallel()
+
+		var osquerydRestartCalled atomic.Bool
+		autoupdater := testAutoupdaterForRestartIfPending(t, func(context.Context) error {
+			osquerydRestartCalled.Store(true)
+			return nil
+		})
+
+		autoupdater.pendingRestartOsquerydVersion.Store("8.8.8")
+
+		err := autoupdater.restartIfPending(context.TODO())
+		require.NoError(t, err, "should not return an error for a pending osqueryd restart")
+		require.True(t, osquerydRestartCalled.Load(), "expected osqueryd restart func to be called")
+		require.Empty(t, autoupdater.pendingRestartOsquerydVersion.Load(), "expected pending osqueryd restart to be cleared")
+	})
+
+	t.Run("no pending restart is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		autoupdater := testAutoupdaterForRestartIfPending(t, func(context.Context) error {
+			t.Fatal("osqueryd restart should not be called when no restart is pending")
+			return nil
+		})
+
+		err := autoupdater.restartIfPending(context.TODO())
+		require.NoError(t, err, "should not return an error when no restart is pending")
+	})
+}
+
+func testAutoupdaterForRestartIfPending(t *testing.T, osqueryRestart func(context.Context) error) *TufAutoupdater {
+	testRootDir := t.TempDir()
+	mockKnapsack := typesmocks.NewKnapsack(t)
+	mockKnapsack.On("RootDirectory").Return(testRootDir)
+	mockKnapsack.On("TufServerURL").Return("https://example.com")
+	mockKnapsack.On("UpdateDirectory").Return("")
+	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
+	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+	mockKnapsack.On("UpdateChannel").Return("nightly")
+	mockKnapsack.On("PinnedLauncherVersion").Return("")
+	mockKnapsack.On("PinnedOsquerydVersion").Return("")
+	mockKnapsack.On("AutoupdateInitialDelay").Return(15 * time.Minute)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
+
+	client := &http.Client{}
+	t.Cleanup(func() {
+		client.CloseIdleConnections()
+	})
+	autoupdater, err := NewTufAutoupdater(t.Context(), mockKnapsack, client, client, WithOsqueryRestart(osqueryRestart))
+	require.NoError(t, err, "could not initialize new TUF autoupdater")
+
+	return autoupdater
 }
 
 func TestExecute_inModernStandby(t *testing.T) {
@@ -1206,6 +1403,11 @@ func TestFlagsChanged_DuringInitialDelay(t *testing.T) {
 	mockKnapsack.On("MirrorServerURL").Return("https://example.com")
 	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
 	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel, keys.PinnedLauncherVersion, keys.PinnedOsquerydVersion, keys.AutoupdateDownloadSplay, keys.AutoupdateInterval, keys.AutoupdateInitialDelay).Return()
+	// The autoupdater now checks for updates during the initial delay, so its loop may interact with
+	// these dependencies. The metadata update fails against example.com, so no download/restart occurs.
+	mockKnapsack.On("LatestOsquerydPath", mock.Anything).Return("").Maybe()
+	mockKnapsack.On("InModernStandby").Return(false).Maybe()
+	mockKnapsack.On("AutoupdateDownloadSplay").Return(0 * time.Second).Maybe()
 
 	// Start out with a pinned version, then unset the pinned version
 	pinnedLauncherVersion := "1.7.3"


### PR DESCRIPTION
This updates the autoupdater behavior to not block during the initial delay. Instead, it will support downloading updates, and note any new versions as pending. The initial delay now works as a timer which will check for any pending version updates and restart accordingly.

This is a defensive measure for devices which may see launcher restarting repeatedly or early for any reason. In cases where functionality from an updated version would prevent the restarts, we may not currently outlive the initial delay long enough to see our updates downloaded. This ensures that when launcher restarts (even if it is not intentional) it can still choose the newly selected version on startup. See KOL-945 for additional details.