### PR TITLE
Remove port from ServerName in tls client config

### DIFF
--- a/pkg/service/tls.go
+++ b/pkg/service/tls.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"log/slog"
+	"net"
 
 	"github.com/kolide/launcher/v2/ee/agent/types"
 )
@@ -15,6 +16,14 @@ import (
 func makeTLSConfig(k types.Knapsack, rootPool *x509.CertPool) *tls.Config {
 
 	hostname := k.KolideServerURL()
+
+	// ServerName must be host-only: certificate SANs (DNS or IP) never encode a
+	// port, and Go matches ServerName against the SANs literally. SplitHostPort
+	// correctly handles bracketed IPv6 literals; it errors when no port is
+	// present, in which case we leave hostname untouched.
+	if host, _, err := net.SplitHostPort(hostname); err == nil {
+		hostname = host
+	}
 
 	conf := &tls.Config{
 		ServerName:         hostname,

--- a/pkg/service/tls_test.go
+++ b/pkg/service/tls_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"testing"
+
+	typesmocks "github.com/kolide/launcher/v2/ee/agent/types/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeTLSConfig_ServerNameStripsPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		kolideServerURL    string
+		expectedServerName string
+	}{
+		{
+			name:               "dns hostname with port",
+			kolideServerURL:    "localhost:3443",
+			expectedServerName: "localhost",
+		},
+		{
+			name:               "dns hostname without port",
+			kolideServerURL:    "k2device.kolide.com",
+			expectedServerName: "k2device.kolide.com",
+		},
+		{
+			name:               "ipv4 with port",
+			kolideServerURL:    "127.0.0.1:3443",
+			expectedServerName: "127.0.0.1",
+		},
+		{
+			name:               "ipv6 with port",
+			kolideServerURL:    "[::1]:3443",
+			expectedServerName: "::1",
+		},
+		{
+			name:               "ipv6 without port",
+			kolideServerURL:    "::1",
+			expectedServerName: "::1",
+		},
+		{
+			// Unbracketed IPv6 with a port is genuinely ambiguous (the last colon
+			// could be part of the address or a port separator), so SplitHostPort
+			// errors and we leave it untouched -- ServerName keeps the full string
+			// and verification will fail. This matches Go convention and is
+			// consistent with the bare-IPv6 caveat noted at
+			// cmd/launcher/launcher.go:129. Documented here rather than "fixed".
+			name:               "unbracketed ipv6 with port is left unstripped",
+			kolideServerURL:    "2001:db8::1:443",
+			expectedServerName: "2001:db8::1:443",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			k := typesmocks.NewKnapsack(t)
+			k.On("KolideServerURL").Return(tt.kolideServerURL)
+			k.On("InsecureTLS").Return(false)
+			k.On("CertPins").Return([][]byte{})
+
+			conf := makeTLSConfig(k, nil)
+
+			assert.Equal(t, tt.expectedServerName, conf.ServerName)
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

Using `host:port` for KolideServerURL results in a certificate verification failure because go is asserting the `host:port` matches a DNS or IP SAN, but a port is not valid in those names.

In cases where KolideServerURL contains a host+port, this exact string is used for TLS SNI _and_ certificate hostname verification. Since ServerName contains the port, cert verification fails even when the certificate's SANs include the *host* in the ServerName. Go TLS verification asserts the tlsConfig.ServerName matches the certificate SANs *exactly*, but a port is not valid in a SAN (DNS or IP).

## Approach

When deriving a TLS ServerName from the KolideServerURL, we should do what `http.Transport` does and strip the port (if present). Thus, localhost:3443, IP:PORT, or any other address used as KolideServerURL can be verified against a valid certificate's names correctly.

Strip port from host before using for SNI and hostname verification:
https://github.com/golang/go/blob/beed654b97d1fe530df2e7de764079ba4dd5dcc2/src/net/http/transport.go#L1927-L1932

Clone + set ServerName when blank:
https://github.com/golang/go/blob/beed654b97d1fe530df2e7de764079ba4dd5dcc2/src/net/http/transport.go#L1783-L1786

## Alternatives Considered

It would also be possible to drop ServerName entirely and allow http.Transport to set ServerName for us in addTLS, but this behavior is specific to http.Transport and it would be preferable to be explicit so another transport retained the same behavior (like grpc, which originally did this same splitting in 7046f38ba7cf9f5d69acf017c6707908b25048b1).