### PR TITLE
Add schema generation and merging for platform-specific tables in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -651,12 +651,10 @@ jobs:
           path: build/
           if-no-files-found: error
 
-  # Generate each platform's table schema from its built binary. Tables are
-  # selected at compile time per GOOS, so each runner emits only its own
-  # platform's tables; they're combined in the combine_schema job. This runs the
-  # cached binary (no build needed) on a regular runner matrix, which avoids
-  # both duplicating the step across build/build_linux and colliding with the
-  # reproducible build twins (those produce no schema artifact).
+  # Generate each platform's table schema by running its cached binary (tables
+  # are compile-time per GOOS, so each runner emits only its own). A separate
+  # matrix job, rather than steps in build/build_linux, avoids duplicating the
+  # step and avoids colliding with the reproducible build twins.
   generate_schema:
     permissions:
       contents: read
@@ -695,14 +693,6 @@ jobs:
           path: launcher-specs-${{ runner.os }}.json
           if-no-files-found: error
 
-  # Fan-in: combine the per-platform schemas emitted by generate_schema into a
-  # single cross-platform launcher-schema.json (JSON array, platforms unioned),
-  # which k2 ingests for its table docs. On tag builds this job also attaches the
-  # combined schema to the tag's GitHub release directly -- we're already inside
-  # the tag's ci run with the artifact in hand, so this avoids racing a separate
-  # release-triggered workflow against ci (a freshly published release fires
-  # `release: published` before this ci run finishes) and avoids re-downloading
-  # the artifact.
   combine_schema:
     permissions:
       contents: write # required to attach the schema to the release on tag builds
@@ -754,12 +744,19 @@ jobs:
           merge-multiple: true
 
       - name: Combine schemas
+        shell: bash
         run: |
+          # Glob the downloaded schemas rather than naming each file, so this is
+          # robust to $RUNNER_OS casing or the platform set changing.
+          shopt -s nullglob
+          schema_files=(schemas/launcher-specs-*.json)
+          if [ ${#schema_files[@]} -eq 0 ]; then
+            echo "no per-platform schema files found in schemas/" >&2
+            exit 1
+          fi
           go run ./cmd/launcher specs --merge \
             --output launcher-schema.json \
-            schemas/launcher-specs-macOS.json \
-            schemas/launcher-specs-Linux.json \
-            schemas/launcher-specs-Windows.json
+            "${schema_files[@]}"
 
       - name: Upload combined schema
         uses: actions/upload-artifact@v4
@@ -775,15 +772,21 @@ jobs:
       # release exists.
       - name: Attach schema to release
         if: github.ref_type == 'tag'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          # A missing release is expected and non-fatal (the manual
+          # release-schema.yml backfill handles it); any other error must fail.
+          if err=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" 2>&1 >/dev/null); then
             gh release upload "$TAG" launcher-schema.json --repo "$GITHUB_REPOSITORY" --clobber
             echo "Attached launcher-schema.json to release $TAG"
-          else
+          elif printf '%s' "$err" | grep -qi 'release not found'; then
             echo "::notice::No GitHub release found for tag $TAG; skipping schema upload. Use the 'Attach table schema to release' workflow to attach it once the release exists."
+          else
+            echo "failed to look up release $TAG: $err" >&2
+            exit 1
           fi
 
   package_builder_test:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -701,40 +701,16 @@ jobs:
     needs:
       - generate_schema
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # need a full checkout for `git describe`
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: "./go.mod"
-          check-latest: true
-          cache: false
-
-      - id: go-cache-paths
-        shell: bash
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-
-      - name: cache restore - GOCACHE
+      # Reuse the Linux launcher binary built by build_linux rather than
+      # rebuilding from source -- the merge logic is platform-independent, so the
+      # cached binary does the combine without a checkout, Go toolchain, or deps.
+      - name: cache restore build output
         uses: actions/cache/restore@v5
         with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          path: ./build
+          key: ${{ runner.os }}-${{ github.run_id }}
+          fail-on-cache-miss: true # need the launcher binary to run it below
           enableCrossOsArchive: true
-
-      - name: cache restore - GOMODCACHE
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-          enableCrossOsArchive: true
-
-      - name: Get dependencies
-        run: make deps
 
       - name: Download platform schemas
         uses: actions/download-artifact@v4
@@ -754,7 +730,7 @@ jobs:
             echo "no per-platform schema files found in schemas/" >&2
             exit 1
           fi
-          go run ./cmd/launcher specs --merge \
+          build/launcher specs --merge \
             --output launcher-schema.json \
             "${schema_files[@]}"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -85,6 +85,27 @@ jobs:
         run: make github-launcherapp
         if: ${{ contains(matrix.os, 'macos') }}
 
+      # Generate this platform's table schema from the freshly-built binary.
+      # Tables are selected at compile time per GOOS, so each runner emits only
+      # its own platform's tables; they're combined in the combine_schema job.
+      # Guarded to the main build so the reproducible twin doesn't collide on
+      # the artifact name.
+      - name: Generate table schema
+        if: env.CACHE_KEY_PREFIX == ''
+        shell: bash
+        run: |
+          launcher_bin=build/launcher
+          if [ "$RUNNER_OS" = "Windows" ]; then launcher_bin=build/launcher.exe; fi
+          "$launcher_bin" specs --output "launcher-specs-${RUNNER_OS}.json"
+
+      - name: Upload table schema
+        if: env.CACHE_KEY_PREFIX == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-${{ runner.os }}
+          path: launcher-specs-${{ runner.os }}.json
+          if-no-files-found: error
+
       - name: Cache build output
         uses: actions/cache@v5
         with:
@@ -173,6 +194,20 @@ jobs:
       - name: Build
         if: github.ref_type == 'tag'
         run: make -j2 github-build
+
+      # See the note in the non-container build: emit this platform's schema
+      # for the combine_schema job, guarded to the main (non-reproducible) build.
+      - name: Generate table schema
+        if: env.CACHE_KEY_PREFIX == ''
+        run: ./build/launcher specs --output "launcher-specs-${RUNNER_OS}.json"
+
+      - name: Upload table schema
+        if: env.CACHE_KEY_PREFIX == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-${{ runner.os }}
+          path: launcher-specs-${{ runner.os }}.json
+          if-no-files-found: error
 
       - name: Cache build output
         uses: actions/cache@v5
@@ -651,6 +686,76 @@ jobs:
           path: build/
           if-no-files-found: error
 
+  # Fan-in: combine the per-platform schemas emitted by the build jobs into a
+  # single cross-platform launcher-schema.json (JSON array, platforms unioned).
+  # Gated on store_artifacts so we only publish a schema for a fully-passing
+  # build. The combined artifact is what endpoint-releaser / the release-attach
+  # workflow uploads to the GitHub release for k2 to ingest.
+  combine_schema:
+    permissions:
+      contents: read
+    name: Combine table schema
+    runs-on: ubuntu-22.04
+    needs:
+      - store_artifacts
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need a full checkout for `git describe`
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "./go.mod"
+          check-latest: true
+          cache: false
+
+      - id: go-cache-paths
+        shell: bash
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: cache restore - GOCACHE
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          enableCrossOsArchive: true
+
+      - name: cache restore - GOMODCACHE
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          enableCrossOsArchive: true
+
+      - name: Get dependencies
+        run: make deps
+
+      - name: Download platform schemas
+        uses: actions/download-artifact@v4
+        with:
+          pattern: schema-*
+          path: schemas
+          merge-multiple: true
+
+      - name: Combine schemas
+        run: |
+          go run ./cmd/launcher specs --merge \
+            --output launcher-schema.json \
+            schemas/launcher-specs-macOS.json \
+            schemas/launcher-specs-Linux.json \
+            schemas/launcher-specs-Windows.json
+
+      - name: Upload combined schema
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-schema
+          path: launcher-schema.json
+          if-no-files-found: error
+
   package_builder_test:
     permissions:
       contents: read
@@ -732,3 +837,4 @@ jobs:
       - package_builder_test
       - exec_testing
       - container_exec_testing
+      - combine_schema

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -85,27 +85,6 @@ jobs:
         run: make github-launcherapp
         if: ${{ contains(matrix.os, 'macos') }}
 
-      # Generate this platform's table schema from the freshly-built binary.
-      # Tables are selected at compile time per GOOS, so each runner emits only
-      # its own platform's tables; they're combined in the combine_schema job.
-      # Guarded to the main build so the reproducible twin doesn't collide on
-      # the artifact name.
-      - name: Generate table schema
-        if: env.CACHE_KEY_PREFIX == ''
-        shell: bash
-        run: |
-          launcher_bin=build/launcher
-          if [ "$RUNNER_OS" = "Windows" ]; then launcher_bin=build/launcher.exe; fi
-          "$launcher_bin" specs --output "launcher-specs-${RUNNER_OS}.json"
-
-      - name: Upload table schema
-        if: env.CACHE_KEY_PREFIX == ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: schema-${{ runner.os }}
-          path: launcher-specs-${{ runner.os }}.json
-          if-no-files-found: error
-
       - name: Cache build output
         uses: actions/cache@v5
         with:
@@ -194,20 +173,6 @@ jobs:
       - name: Build
         if: github.ref_type == 'tag'
         run: make -j2 github-build
-
-      # See the note in the non-container build: emit this platform's schema
-      # for the combine_schema job, guarded to the main (non-reproducible) build.
-      - name: Generate table schema
-        if: env.CACHE_KEY_PREFIX == ''
-        run: ./build/launcher specs --output "launcher-specs-${RUNNER_OS}.json"
-
-      - name: Upload table schema
-        if: env.CACHE_KEY_PREFIX == ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: schema-${{ runner.os }}
-          path: launcher-specs-${{ runner.os }}.json
-          if-no-files-found: error
 
       - name: Cache build output
         uses: actions/cache@v5
@@ -686,18 +651,65 @@ jobs:
           path: build/
           if-no-files-found: error
 
-  # Fan-in: combine the per-platform schemas emitted by the build jobs into a
-  # single cross-platform launcher-schema.json (JSON array, platforms unioned).
-  # Gated on store_artifacts so we only publish a schema for a fully-passing
-  # build. The combined artifact is what endpoint-releaser / the release-attach
-  # workflow uploads to the GitHub release for k2 to ingest.
-  combine_schema:
+  # Generate each platform's table schema from its built binary. Tables are
+  # selected at compile time per GOOS, so each runner emits only its own
+  # platform's tables; they're combined in the combine_schema job. This runs the
+  # cached binary (no build needed) on a regular runner matrix, which avoids
+  # both duplicating the step across build/build_linux and colliding with the
+  # reproducible build twins (those produce no schema artifact).
+  generate_schema:
     permissions:
       contents: read
+    name: Generate table schema
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-26
+          - windows-2025
+    needs:
+      - build
+      - build_linux
+    steps:
+      - name: cache restore build output
+        uses: actions/cache/restore@v5
+        with:
+          path: ./build
+          key: ${{ runner.os }}-${{ github.run_id }}
+          fail-on-cache-miss: true # need the launcher binary to run it below
+          enableCrossOsArchive: true
+
+      - name: Generate table schema
+        shell: bash
+        run: |
+          launcher_bin=build/launcher
+          if [ "$RUNNER_OS" = "Windows" ]; then launcher_bin=build/launcher.exe; fi
+          "$launcher_bin" specs --output "launcher-specs-${RUNNER_OS}.json"
+
+      - name: Upload table schema
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-${{ runner.os }}
+          path: launcher-specs-${{ runner.os }}.json
+          if-no-files-found: error
+
+  # Fan-in: combine the per-platform schemas emitted by generate_schema into a
+  # single cross-platform launcher-schema.json (JSON array, platforms unioned),
+  # which k2 ingests for its table docs. On tag builds this job also attaches the
+  # combined schema to the tag's GitHub release directly -- we're already inside
+  # the tag's ci run with the artifact in hand, so this avoids racing a separate
+  # release-triggered workflow against ci (a freshly published release fires
+  # `release: published` before this ci run finishes) and avoids re-downloading
+  # the artifact.
+  combine_schema:
+    permissions:
+      contents: write # required to attach the schema to the release on tag builds
     name: Combine table schema
     runs-on: ubuntu-22.04
     needs:
-      - store_artifacts
+      - generate_schema
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -755,6 +767,24 @@ jobs:
           name: launcher-schema
           path: launcher-schema.json
           if-no-files-found: error
+
+      # On tag builds, attach the freshly-combined schema to the tag's GitHub
+      # release so k2 can ingest it. If no release exists yet for the tag (e.g.
+      # the tag was pushed without a release), we skip rather than fail the build
+      # -- use the manual `release-schema.yml` workflow to attach it once the
+      # release exists.
+      - name: Attach schema to release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" launcher-schema.json --repo "$GITHUB_REPOSITORY" --clobber
+            echo "Attached launcher-schema.json to release $TAG"
+          else
+            echo "::notice::No GitHub release found for tag $TAG; skipping schema upload. Use the 'Attach table schema to release' workflow to attach it once the release exists."
+          fi
 
   package_builder_test:
     permissions:

--- a/.github/workflows/release-schema.yml
+++ b/.github/workflows/release-schema.yml
@@ -1,22 +1,9 @@
 name: Attach table schema to release
 
-# Manual backfill: attach the combined launcher-schema.json (produced by the
-# `ci` workflow's combine_schema job for a given tag) to that tag's GitHub
-# release. k2 ingests this asset from the GitHub "Latest" release to power Live
-# Query table docs, autocomplete, SQL validation, and NLQ query generation.
-#
-# The common path is automatic: combine_schema in the `ci` workflow attaches the
-# schema during the tag's build (see .github/workflows/go.yml). This workflow
-# exists for the cases that path can't cover -- e.g. the tag was pushed before
-# the release existed (so the ci-time upload was skipped), the release was cut
-# from a tag built before schema support landed, or the asset needs to be
-# regenerated/re-attached.
-#
-# Note on immutability: this uploads to an existing (mutable) release. If/when
-# releases are made immutable, asset attachment must happen at release-creation
-# time (e.g. `gh release create --draft ... && gh release edit --draft=false`)
-# or be folded into an atomic tag -> build -> sign -> release step. The producing
-# artifact (launcher-schema) does not change -- only where it is attached.
+# Manual backfill for attaching launcher-schema.json to a tag's GitHub release.
+# The common path is automatic (combine_schema in the `ci` workflow); this covers
+# the cases it can't -- e.g. the tag was pushed before its release existed, or the
+# asset needs re-attaching.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-schema.yml
+++ b/.github/workflows/release-schema.yml
@@ -1,21 +1,23 @@
 name: Attach table schema to release
 
-# When a release is published, attach the combined launcher-schema.json (produced
-# by the `ci` workflow's combine_schema job for this tag) as a release asset. k2
-# ingests this asset from the GitHub "Latest" release to power Live Query table
-# docs, autocomplete, SQL validation, and NLQ query generation.
+# Manual backfill: attach the combined launcher-schema.json (produced by the
+# `ci` workflow's combine_schema job for a given tag) to that tag's GitHub
+# release. k2 ingests this asset from the GitHub "Latest" release to power Live
+# Query table docs, autocomplete, SQL validation, and NLQ query generation.
 #
-# Note on immutability: this uploads after publish, which works for mutable
-# releases. If/when releases are made immutable, this should move to attaching
-# the asset at release-creation time (e.g. `gh release create --draft ... && gh
-# release edit --draft=false`) or be folded into an atomic
-# tag -> build -> sign -> release step. The producing artifact (launcher-schema)
-# does not change -- only where it is attached.
+# The common path is automatic: combine_schema in the `ci` workflow attaches the
+# schema during the tag's build (see .github/workflows/go.yml). This workflow
+# exists for the cases that path can't cover -- e.g. the tag was pushed before
+# the release existed (so the ci-time upload was skipped), the release was cut
+# from a tag built before schema support landed, or the asset needs to be
+# regenerated/re-attached.
+#
+# Note on immutability: this uploads to an existing (mutable) release. If/when
+# releases are made immutable, asset attachment must happen at release-creation
+# time (e.g. `gh release create --draft ... && gh release edit --draft=false`)
+# or be folded into an atomic tag -> build -> sign -> release step. The producing
+# artifact (launcher-schema) does not change -- only where it is attached.
 on:
-  release:
-    types: [published]
-  # Allow manual re-attach for a given tag if a release was created before this
-  # workflow existed, or if the asset needs to be regenerated.
   workflow_dispatch:
     inputs:
       tag:
@@ -35,15 +37,13 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          tag="${EVENT_TAG:-$INPUT_TAG}"
-          if [ -z "$tag" ]; then
+          if [ -z "$INPUT_TAG" ]; then
             echo "could not determine release tag" >&2
             exit 1
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Find ci run for tag
         id: cirun

--- a/.github/workflows/release-schema.yml
+++ b/.github/workflows/release-schema.yml
@@ -1,0 +1,80 @@
+name: Attach table schema to release
+
+# When a release is published, attach the combined launcher-schema.json (produced
+# by the `ci` workflow's combine_schema job for this tag) as a release asset. k2
+# ingests this asset from the GitHub "Latest" release to power Live Query table
+# docs, autocomplete, SQL validation, and NLQ query generation.
+#
+# Note on immutability: this uploads after publish, which works for mutable
+# releases. If/when releases are made immutable, this should move to attaching
+# the asset at release-creation time (e.g. `gh release create --draft ... && gh
+# release edit --draft=false`) or be folded into an atomic
+# tag -> build -> sign -> release step. The producing artifact (launcher-schema)
+# does not change -- only where it is attached.
+on:
+  release:
+    types: [published]
+  # Allow manual re-attach for a given tag if a release was created before this
+  # workflow existed, or if the asset needs to be regenerated.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach the schema to (e.g. 1.23.4)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  attach_schema:
+    name: Attach schema
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # required to upload the release asset
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          tag="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$tag" ]; then
+            echo "could not determine release tag" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Find ci run for tag
+        id: cirun
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow ci \
+            --branch "${{ steps.tag.outputs.tag }}" \
+            --json databaseId,status,conclusion \
+            --jq 'first(.[] | select(.conclusion == "success" and .status == "completed")) | .databaseId')
+          if [ -z "$run_id" ]; then
+            echo "no successful ci run found for tag ${{ steps.tag.outputs.tag }}" >&2
+            exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download combined schema
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download "${{ steps.cirun.outputs.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --name launcher-schema \
+            --dir .
+
+      - name: Attach schema to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" launcher-schema.json \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/cmd/launcher/specs.go
+++ b/cmd/launcher/specs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/kolide/launcher/v2/ee/agent/flags"
 	"github.com/kolide/launcher/v2/ee/agent/knapsack"
@@ -53,11 +55,21 @@ func runSpecs(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 	flQuiet := flagset.Bool("quiet", false, "don't print specs. Used in testing")
 	flOutput := flagset.String("output", "", "write specs to file (default: stdout)")
 	flMissingOk := flagset.Bool("missing-ok", false, "do not exit with error when required fields are missing or blank")
+	flMerge := flagset.Bool("merge", false, "merge mode: combine the NDJSON spec files given as arguments into a single, platform-unioned JSON array")
 	var flRequired requiredFields
 	flagset.Var(&flRequired, "required", "field name that must be present in the spec (repeatable); warns if missing")
 
 	if err := ff.Parse(flagset, args, ff.WithEnvVarNoPrefix()); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
+	}
+
+	// In merge mode we don't generate specs from the running binary; instead we
+	// combine the per-platform NDJSON spec files produced by each platform's
+	// `launcher specs` run into a single JSON array, unioning the platforms for
+	// any table that appears in more than one file. This is how CI combines the
+	// platform-specific schemas into one cross-platform launcher-schema.json.
+	if *flMerge {
+		return runMergeSpecs(flagset.Args(), *flOutput)
 	}
 
 	// Reject unknown -required field names so the user gets a clear error.
@@ -154,4 +166,111 @@ func runSpecs(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		return errors.New("one or more required fields were missing or blank")
 	}
 	return nil
+}
+
+// runMergeSpecs combines the per-platform NDJSON spec files in inputPaths into a
+// single JSON array, deduplicating tables by name and unioning their platforms.
+// Each input is expected to be the NDJSON output of `launcher specs` from one
+// platform (one OsqueryTableSpec per line). The combined output is sorted by
+// table name and written to outputPath (or stdout when empty) as a JSON array,
+// which is the shape k2 ingests for its table docs.
+func runMergeSpecs(inputPaths []string, outputPath string) error {
+	if len(inputPaths) == 0 {
+		return errors.New("merge mode requires one or more spec files as arguments")
+	}
+
+	merged := make(map[string]osquerytable.OsqueryTableSpec)
+	for _, inputPath := range inputPaths {
+		if err := mergeSpecFile(inputPath, merged); err != nil {
+			return fmt.Errorf("merging %s: %w", inputPath, err)
+		}
+	}
+
+	combined := slices.Collect(maps.Values(merged))
+	slices.SortFunc(combined, func(a, b osquerytable.OsqueryTableSpec) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	combinedBytes, err := json.MarshalIndent(combined, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling combined specs: %w", err)
+	}
+
+	out := io.Writer(os.Stdout)
+	if outputPath != "" {
+		f, err := os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("creating output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if _, err := fmt.Fprintln(out, string(combinedBytes)); err != nil {
+		return fmt.Errorf("writing combined specs: %w", err)
+	}
+
+	return nil
+}
+
+// mergeSpecFile reads a single NDJSON spec file and folds its tables into merged,
+// unioning the platforms of any table already present from another file.
+func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTableSpec) error {
+	f, err := os.Open(inputPath)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Specs can include lengthy descriptions/examples, so allow large lines.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var spec osquerytable.OsqueryTableSpec
+		if err := json.Unmarshal([]byte(line), &spec); err != nil {
+			return fmt.Errorf("unmarshalling spec line %q: %w", line, err)
+		}
+
+		existing, ok := merged[spec.Name]
+		if !ok {
+			merged[spec.Name] = spec
+			continue
+		}
+
+		// Same table from another platform: union the platforms onto the
+		// already-seen spec so the combined entry lists every platform it
+		// is available on.
+		existing.Platforms = unionPlatforms(existing.Platforms, spec.Platforms)
+		merged[spec.Name] = existing
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	return nil
+}
+
+// unionPlatforms returns the de-duplicated union of two platform slices,
+// preserving the order in which platforms are first seen (existing platforms
+// first, then any new ones). It is generic over the unexported platformName
+// type used by OsqueryTableSpec.Platforms.
+func unionPlatforms[T ~string](existing, additional []T) []T {
+	seen := make(map[T]struct{}, len(existing)+len(additional))
+	union := make([]T, 0, len(existing)+len(additional))
+	for _, platforms := range [][]T{existing, additional} {
+		for _, platform := range platforms {
+			if _, ok := seen[platform]; ok {
+				continue
+			}
+			seen[platform] = struct{}{}
+			union = append(union, platform)
+		}
+	}
+	return union
 }

--- a/cmd/launcher/specs.go
+++ b/cmd/launcher/specs.go
@@ -241,6 +241,8 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 		}
 
 		conflicts = append(conflicts, schemaConflicts(existing, spec)...)
+		// Only platforms are merged; description/url/notes/examples keep the
+		// first-seen file's values, so divergence there is resolved by input order.
 		existing.Platforms = unionPlatforms(existing.Platforms, spec.Platforms)
 		merged[spec.Name] = existing
 	}

--- a/cmd/launcher/specs.go
+++ b/cmd/launcher/specs.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -227,10 +227,14 @@ func runMergeSpecs(inputPaths []string, outputPath string) error {
 	return nil
 }
 
-// mergeSpecFile reads a single NDJSON spec file and folds its tables into merged,
+// mergeSpecFile reads a single spec file and folds its tables into merged,
 // unioning the platforms of any table already present from another file. It
 // returns descriptions of any column-schema conflicts found between a table in
 // this file and the already-merged entry of the same name (see schemaConflicts).
+//
+// The file may be NDJSON (one spec per line, as emitted by `launcher specs`) or
+// a single JSON array (as emitted by `launcher specs --merge`); both compact and
+// pretty-printed forms are accepted. See readSpecs.
 func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTableSpec) ([]string, error) {
 	f, err := os.Open(inputPath)
 	if err != nil {
@@ -238,21 +242,13 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 	}
 	defer f.Close()
 
+	specs, err := readSpecs(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading specs: %w", err)
+	}
+
 	var conflicts []string
-	scanner := bufio.NewScanner(f)
-	// Specs can include lengthy descriptions/examples, so allow large lines.
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-
-		var spec osquerytable.OsqueryTableSpec
-		if err := json.Unmarshal([]byte(line), &spec); err != nil {
-			return nil, fmt.Errorf("unmarshalling spec line %q: %w", line, err)
-		}
-
+	for _, spec := range specs {
 		existing, ok := merged[spec.Name]
 		if !ok {
 			merged[spec.Name] = spec
@@ -270,11 +266,58 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 		merged[spec.Name] = existing
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
+	return conflicts, nil
+}
+
+// readSpecs decodes osquery table specs from r, accepting either of the two
+// shapes used in this flow, in both compact and pretty-printed forms:
+//
+//   - A stream of JSON objects (NDJSON), as emitted by `launcher specs` — one
+//     OsqueryTableSpec per line, though any whitespace separation works.
+//   - A single JSON array of specs, as emitted by `launcher specs --merge`.
+//
+// The shape is detected from the first non-whitespace byte: '[' is decoded as a
+// JSON array, anything else as a stream of objects. Using encoding/json (rather
+// than scanning lines) means newlines/indentation inside a spec do not matter
+// and there is no per-line size limit to overflow.
+func readSpecs(r io.Reader) ([]osquerytable.OsqueryTableSpec, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
 	}
 
-	return conflicts, nil
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	// A leading '[' is the JSON-array shape (the --merge output, possibly
+	// pretty-printed); decode it in one shot.
+	if data[0] == '[' {
+		var specs []osquerytable.OsqueryTableSpec
+		if err := json.Unmarshal(data, &specs); err != nil {
+			return nil, fmt.Errorf("decoding JSON array of specs: %w", err)
+		}
+		return specs, nil
+	}
+
+	// Otherwise treat the input as a stream of JSON objects. The decoder skips
+	// whitespace between values, so this transparently handles NDJSON as well as
+	// pretty-printed, multi-line objects.
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var specs []osquerytable.OsqueryTableSpec
+	for {
+		var spec osquerytable.OsqueryTableSpec
+		if err := dec.Decode(&spec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decoding spec near byte offset %d: %w", dec.InputOffset(), err)
+		}
+		specs = append(specs, spec)
+	}
+
+	return specs, nil
 }
 
 // schemaConflicts compares the column schemas of two specs for the same table

--- a/cmd/launcher/specs.go
+++ b/cmd/launcher/specs.go
@@ -63,11 +63,6 @@ func runSpecs(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	// In merge mode we don't generate specs from the running binary; instead we
-	// combine the per-platform NDJSON spec files produced by each platform's
-	// `launcher specs` run into a single JSON array, unioning the platforms for
-	// any table that appears in more than one file. This is how CI combines the
-	// platform-specific schemas into one cross-platform launcher-schema.json.
 	if *flMerge {
 		return runMergeSpecs(flagset.Args(), *flOutput)
 	}
@@ -76,7 +71,7 @@ func runSpecs(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 	requiredFieldValidators := make(map[string]requiredFieldValidator)
 	for _, field := range flRequired {
 		if validator, ok := specRequiredFieldValidators[field]; !ok {
-			return fmt.Errorf("unknown field to equire: %s. Must be %v", field, slices.Collect(maps.Keys(specRequiredFieldValidators)))
+			return fmt.Errorf("unknown field to require: %s. Must be %v", field, slices.Collect(maps.Keys(specRequiredFieldValidators)))
 		} else {
 			requiredFieldValidators[field] = validator
 		}
@@ -168,12 +163,10 @@ func runSpecs(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 	return nil
 }
 
-// runMergeSpecs combines the per-platform NDJSON spec files in inputPaths into a
-// single JSON array, deduplicating tables by name and unioning their platforms.
-// Each input is expected to be the NDJSON output of `launcher specs` from one
-// platform (one OsqueryTableSpec per line). The combined output is sorted by
-// table name and written to outputPath (or stdout when empty) as a JSON array,
-// which is the shape k2 ingests for its table docs.
+// runMergeSpecs combines the per-platform spec files in inputPaths into a single
+// JSON array (the shape k2 ingests), deduplicating tables by name and unioning
+// their platforms. Output is sorted by name and written to outputPath, or stdout
+// when empty.
 func runMergeSpecs(inputPaths []string, outputPath string) error {
 	if len(inputPaths) == 0 {
 		return errors.New("merge mode requires one or more spec files as arguments")
@@ -189,12 +182,9 @@ func runMergeSpecs(inputPaths []string, outputPath string) error {
 		conflicts = append(conflicts, fileConflicts...)
 	}
 
-	// A table that appears on more than one platform is expected to expose the
-	// same column schema everywhere. If it does not, the unioned entry would
-	// advertise columns for a platform that does not actually have them, which
-	// would break k2's autocomplete, validation, and docs for that platform.
-	// Fail loudly so the divergence is reconciled at the source rather than
-	// silently shipping a schema that is wrong for some platforms.
+	// A table seen on multiple platforms must expose the same columns everywhere;
+	// otherwise the unioned entry would advertise columns a platform lacks. Fail
+	// so the divergence is fixed at the source rather than shipped to k2.
 	if len(conflicts) > 0 {
 		slices.Sort(conflicts)
 		return fmt.Errorf("cross-platform table schema mismatch:\n\t%s", strings.Join(conflicts, "\n\t"))
@@ -227,14 +217,9 @@ func runMergeSpecs(inputPaths []string, outputPath string) error {
 	return nil
 }
 
-// mergeSpecFile reads a single spec file and folds its tables into merged,
-// unioning the platforms of any table already present from another file. It
-// returns descriptions of any column-schema conflicts found between a table in
-// this file and the already-merged entry of the same name (see schemaConflicts).
-//
-// The file may be NDJSON (one spec per line, as emitted by `launcher specs`) or
-// a single JSON array (as emitted by `launcher specs --merge`); both compact and
-// pretty-printed forms are accepted. See readSpecs.
+// mergeSpecFile folds the tables from one spec file into merged, unioning
+// platforms for tables already seen and returning any column-schema conflicts
+// (see schemaConflicts). The file may be NDJSON or a JSON array (see readSpecs).
 func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTableSpec) ([]string, error) {
 	f, err := os.Open(inputPath)
 	if err != nil {
@@ -255,13 +240,7 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 			continue
 		}
 
-		// Same table from another platform. The platforms are unioned below, but
-		// the column schema is expected to be identical regardless of which
-		// platform's binary emitted the spec, so record any divergence.
 		conflicts = append(conflicts, schemaConflicts(existing, spec)...)
-
-		// Union the platforms onto the already-seen spec so the combined entry
-		// lists every platform the table is available on.
 		existing.Platforms = unionPlatforms(existing.Platforms, spec.Platforms)
 		merged[spec.Name] = existing
 	}
@@ -269,17 +248,10 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 	return conflicts, nil
 }
 
-// readSpecs decodes osquery table specs from r, accepting either of the two
-// shapes used in this flow, in both compact and pretty-printed forms:
-//
-//   - A stream of JSON objects (NDJSON), as emitted by `launcher specs` — one
-//     OsqueryTableSpec per line, though any whitespace separation works.
-//   - A single JSON array of specs, as emitted by `launcher specs --merge`.
-//
-// The shape is detected from the first non-whitespace byte: '[' is decoded as a
-// JSON array, anything else as a stream of objects. Using encoding/json (rather
-// than scanning lines) means newlines/indentation inside a spec do not matter
-// and there is no per-line size limit to overflow.
+// readSpecs decodes table specs from r, accepting either NDJSON (one spec per
+// line, from `launcher specs`) or a single JSON array (from `launcher specs
+// --merge`), in compact or pretty-printed form. The shape is detected from the
+// first non-whitespace byte.
 func readSpecs(r io.Reader) ([]osquerytable.OsqueryTableSpec, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -291,8 +263,6 @@ func readSpecs(r io.Reader) ([]osquerytable.OsqueryTableSpec, error) {
 		return nil, nil
 	}
 
-	// A leading '[' is the JSON-array shape (the --merge output, possibly
-	// pretty-printed); decode it in one shot.
 	if data[0] == '[' {
 		var specs []osquerytable.OsqueryTableSpec
 		if err := json.Unmarshal(data, &specs); err != nil {
@@ -301,9 +271,6 @@ func readSpecs(r io.Reader) ([]osquerytable.OsqueryTableSpec, error) {
 		return specs, nil
 	}
 
-	// Otherwise treat the input as a stream of JSON objects. The decoder skips
-	// whitespace between values, so this transparently handles NDJSON as well as
-	// pretty-printed, multi-line objects.
 	dec := json.NewDecoder(bytes.NewReader(data))
 	var specs []osquerytable.OsqueryTableSpec
 	for {
@@ -320,18 +287,10 @@ func readSpecs(r io.Reader) ([]osquerytable.OsqueryTableSpec, error) {
 	return specs, nil
 }
 
-// schemaConflicts compares the column schemas of two specs for the same table
-// (each seen on different platforms) and returns human-readable descriptions of
-// any differences. Platform lists are intentionally ignored, since unioning them
-// is the whole point of the merge; the columns, however, are expected to be
-// identical no matter which platform's binary emitted the spec. A conflict
-// almost always means a table whose definition diverged across its
-// platform-specific, build-tagged files and should be reconciled at the source.
-//
-// Columns are matched by name (order-insensitive). Conflicts are reported when a
-// column is present for one platform set but not the other, or when a shared
-// column has a different type. Description/notes and other documentation fields
-// are not considered part of the schema and are not compared here.
+// schemaConflicts returns descriptions of any column differences between two
+// specs for the same table seen on different platforms. Columns are matched by
+// name; a conflict is a column on one side but not the other, or a type
+// mismatch. Platform lists and doc fields (description/notes) are not compared.
 func schemaConflicts(a, b osquerytable.OsqueryTableSpec) []string {
 	aCols := columnsByName(a.Columns)
 	bCols := columnsByName(b.Columns)
@@ -360,7 +319,6 @@ func schemaConflicts(a, b osquerytable.OsqueryTableSpec) []string {
 	return conflicts
 }
 
-// columnsByName indexes a column slice by column name for easy lookup.
 func columnsByName(cols []osquerytable.ColumnDefinition) map[string]osquerytable.ColumnDefinition {
 	byName := make(map[string]osquerytable.ColumnDefinition, len(cols))
 	for _, col := range cols {
@@ -370,9 +328,7 @@ func columnsByName(cols []osquerytable.ColumnDefinition) map[string]osquerytable
 }
 
 // unionPlatforms returns the de-duplicated union of two platform slices,
-// preserving the order in which platforms are first seen (existing platforms
-// first, then any new ones). It is generic over the unexported platformName
-// type used by OsqueryTableSpec.Platforms.
+// preserving first-seen order. Generic over the unexported platformName type.
 func unionPlatforms[T ~string](existing, additional []T) []T {
 	seen := make(map[T]struct{}, len(existing)+len(additional))
 	union := make([]T, 0, len(existing)+len(additional))

--- a/cmd/launcher/specs.go
+++ b/cmd/launcher/specs.go
@@ -180,10 +180,24 @@ func runMergeSpecs(inputPaths []string, outputPath string) error {
 	}
 
 	merged := make(map[string]osquerytable.OsqueryTableSpec)
+	var conflicts []string
 	for _, inputPath := range inputPaths {
-		if err := mergeSpecFile(inputPath, merged); err != nil {
+		fileConflicts, err := mergeSpecFile(inputPath, merged)
+		if err != nil {
 			return fmt.Errorf("merging %s: %w", inputPath, err)
 		}
+		conflicts = append(conflicts, fileConflicts...)
+	}
+
+	// A table that appears on more than one platform is expected to expose the
+	// same column schema everywhere. If it does not, the unioned entry would
+	// advertise columns for a platform that does not actually have them, which
+	// would break k2's autocomplete, validation, and docs for that platform.
+	// Fail loudly so the divergence is reconciled at the source rather than
+	// silently shipping a schema that is wrong for some platforms.
+	if len(conflicts) > 0 {
+		slices.Sort(conflicts)
+		return fmt.Errorf("cross-platform table schema mismatch:\n\t%s", strings.Join(conflicts, "\n\t"))
 	}
 
 	combined := slices.Collect(maps.Values(merged))
@@ -214,14 +228,17 @@ func runMergeSpecs(inputPaths []string, outputPath string) error {
 }
 
 // mergeSpecFile reads a single NDJSON spec file and folds its tables into merged,
-// unioning the platforms of any table already present from another file.
-func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTableSpec) error {
+// unioning the platforms of any table already present from another file. It
+// returns descriptions of any column-schema conflicts found between a table in
+// this file and the already-merged entry of the same name (see schemaConflicts).
+func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTableSpec) ([]string, error) {
 	f, err := os.Open(inputPath)
 	if err != nil {
-		return fmt.Errorf("opening file: %w", err)
+		return nil, fmt.Errorf("opening file: %w", err)
 	}
 	defer f.Close()
 
+	var conflicts []string
 	scanner := bufio.NewScanner(f)
 	// Specs can include lengthy descriptions/examples, so allow large lines.
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -233,7 +250,7 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 
 		var spec osquerytable.OsqueryTableSpec
 		if err := json.Unmarshal([]byte(line), &spec); err != nil {
-			return fmt.Errorf("unmarshalling spec line %q: %w", line, err)
+			return nil, fmt.Errorf("unmarshalling spec line %q: %w", line, err)
 		}
 
 		existing, ok := merged[spec.Name]
@@ -242,18 +259,71 @@ func mergeSpecFile(inputPath string, merged map[string]osquerytable.OsqueryTable
 			continue
 		}
 
-		// Same table from another platform: union the platforms onto the
-		// already-seen spec so the combined entry lists every platform it
-		// is available on.
+		// Same table from another platform. The platforms are unioned below, but
+		// the column schema is expected to be identical regardless of which
+		// platform's binary emitted the spec, so record any divergence.
+		conflicts = append(conflicts, schemaConflicts(existing, spec)...)
+
+		// Union the platforms onto the already-seen spec so the combined entry
+		// lists every platform the table is available on.
 		existing.Platforms = unionPlatforms(existing.Platforms, spec.Platforms)
 		merged[spec.Name] = existing
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("reading file: %w", err)
+		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	return nil
+	return conflicts, nil
+}
+
+// schemaConflicts compares the column schemas of two specs for the same table
+// (each seen on different platforms) and returns human-readable descriptions of
+// any differences. Platform lists are intentionally ignored, since unioning them
+// is the whole point of the merge; the columns, however, are expected to be
+// identical no matter which platform's binary emitted the spec. A conflict
+// almost always means a table whose definition diverged across its
+// platform-specific, build-tagged files and should be reconciled at the source.
+//
+// Columns are matched by name (order-insensitive). Conflicts are reported when a
+// column is present for one platform set but not the other, or when a shared
+// column has a different type. Description/notes and other documentation fields
+// are not considered part of the schema and are not compared here.
+func schemaConflicts(a, b osquerytable.OsqueryTableSpec) []string {
+	aCols := columnsByName(a.Columns)
+	bCols := columnsByName(b.Columns)
+
+	var conflicts []string
+	for name := range aCols {
+		if _, ok := bCols[name]; !ok {
+			conflicts = append(conflicts, fmt.Sprintf("table %q: column %q present on %v but not %v", a.Name, name, a.Platforms, b.Platforms))
+		}
+	}
+	for name := range bCols {
+		if _, ok := aCols[name]; !ok {
+			conflicts = append(conflicts, fmt.Sprintf("table %q: column %q present on %v but not %v", a.Name, name, b.Platforms, a.Platforms))
+		}
+	}
+	for name, aCol := range aCols {
+		bCol, ok := bCols[name]
+		if !ok {
+			continue
+		}
+		if aCol.Type != bCol.Type {
+			conflicts = append(conflicts, fmt.Sprintf("table %q: column %q is type %q on %v but %q on %v", a.Name, name, aCol.Type, a.Platforms, bCol.Type, b.Platforms))
+		}
+	}
+
+	return conflicts
+}
+
+// columnsByName indexes a column slice by column name for easy lookup.
+func columnsByName(cols []osquerytable.ColumnDefinition) map[string]osquerytable.ColumnDefinition {
+	byName := make(map[string]osquerytable.ColumnDefinition, len(cols))
+	for _, col := range cols {
+		byName[col.Name] = col
+	}
+	return byName
 }
 
 // unionPlatforms returns the de-duplicated union of two platform slices,

--- a/cmd/launcher/specs_test.go
+++ b/cmd/launcher/specs_test.go
@@ -130,6 +130,109 @@ func Test_runMergeSpecs_noInputs(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_runMergeSpecs_schemaMismatch_columnPresence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// table_shared has an extra "b" column on darwin that linux does not have.
+	darwin := filepath.Join(dir, "darwin.json")
+	require.NoError(t, os.WriteFile(darwin, []byte(
+		`{"name":"table_shared","description":"shared","platforms":["darwin"],"columns":[{"name":"a","type":"text"},{"name":"b","type":"text"}]}`+"\n"), 0644))
+
+	linux := filepath.Join(dir, "linux.json")
+	require.NoError(t, os.WriteFile(linux, []byte(
+		`{"name":"table_shared","description":"shared","platforms":["linux"],"columns":[{"name":"a","type":"text"}]}`+"\n"), 0644))
+
+	outPath := filepath.Join(dir, "launcher-schema.json")
+	err := runMergeSpecs([]string{darwin, linux}, outPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema mismatch")
+	require.Contains(t, err.Error(), "table_shared")
+	require.Contains(t, err.Error(), `"b"`)
+
+	// The conflicting schema must not be written out.
+	_, statErr := os.Stat(outPath)
+	require.True(t, os.IsNotExist(statErr), "no output file should be written when a schema conflict is detected")
+}
+
+func Test_runMergeSpecs_schemaMismatch_columnType(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// table_shared.c is text on darwin but integer on windows.
+	darwin := filepath.Join(dir, "darwin.json")
+	require.NoError(t, os.WriteFile(darwin, []byte(
+		`{"name":"table_shared","description":"shared","platforms":["darwin"],"columns":[{"name":"c","type":"text"}]}`+"\n"), 0644))
+
+	windows := filepath.Join(dir, "windows.json")
+	require.NoError(t, os.WriteFile(windows, []byte(
+		`{"name":"table_shared","description":"shared","platforms":["windows"],"columns":[{"name":"c","type":"integer"}]}`+"\n"), 0644))
+
+	err := runMergeSpecs([]string{darwin, windows}, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema mismatch")
+	require.Contains(t, err.Error(), "table_shared")
+	require.Contains(t, err.Error(), `"c"`)
+}
+
+func Test_schemaConflicts(t *testing.T) {
+	t.Parallel()
+
+	col := func(name, ctype string) osquerytable.ColumnDefinition {
+		return osquerytable.ColumnDefinition{Name: name, Type: osquerytable.ColumnType(ctype)}
+	}
+
+	tests := []struct {
+		name     string
+		a        []osquerytable.ColumnDefinition
+		b        []osquerytable.ColumnDefinition
+		wantSame bool
+	}{
+		{
+			name:     "identical columns",
+			a:        []osquerytable.ColumnDefinition{col("a", "text"), col("b", "integer")},
+			b:        []osquerytable.ColumnDefinition{col("a", "text"), col("b", "integer")},
+			wantSame: true,
+		},
+		{
+			name:     "reordered columns still match",
+			a:        []osquerytable.ColumnDefinition{col("a", "text"), col("b", "integer")},
+			b:        []osquerytable.ColumnDefinition{col("b", "integer"), col("a", "text")},
+			wantSame: true,
+		},
+		{
+			name:     "column missing on one side",
+			a:        []osquerytable.ColumnDefinition{col("a", "text"), col("b", "integer")},
+			b:        []osquerytable.ColumnDefinition{col("a", "text")},
+			wantSame: false,
+		},
+		{
+			name:     "differing column type",
+			a:        []osquerytable.ColumnDefinition{col("a", "text")},
+			b:        []osquerytable.ColumnDefinition{col("a", "integer")},
+			wantSame: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conflicts := schemaConflicts(
+				osquerytable.OsqueryTableSpec{Name: "t", Columns: tt.a},
+				osquerytable.OsqueryTableSpec{Name: "t", Columns: tt.b},
+			)
+			if tt.wantSame {
+				require.Empty(t, conflicts)
+			} else {
+				require.NotEmpty(t, conflicts)
+			}
+		})
+	}
+}
+
 func platformStrings[T ~string](platforms []T) []string {
 	out := make([]string, 0, len(platforms))
 	for _, p := range platforms {

--- a/cmd/launcher/specs_test.go
+++ b/cmd/launcher/specs_test.go
@@ -177,6 +177,110 @@ func Test_runMergeSpecs_schemaMismatch_columnType(t *testing.T) {
 	require.Contains(t, err.Error(), `"c"`)
 }
 
+func Test_readSpecs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantNames []string
+	}{
+		{
+			name:      "ndjson",
+			input:     `{"name":"a","columns":[]}` + "\n" + `{"name":"b","columns":[]}` + "\n",
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name:      "ndjson with blank lines",
+			input:     `{"name":"a","columns":[]}` + "\n\n" + `{"name":"b","columns":[]}` + "\n",
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name:      "compact json array",
+			input:     `[{"name":"a","columns":[]},{"name":"b","columns":[]}]`,
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name: "pretty printed json array",
+			input: `[
+  {
+    "name": "a",
+    "columns": []
+  },
+  {
+    "name": "b",
+    "columns": []
+  }
+]
+`,
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name:      "empty input",
+			input:     "   \n\t ",
+			wantNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			specs, err := readSpecs(strings.NewReader(tt.input))
+			require.NoError(t, err)
+
+			var names []string
+			for _, s := range specs {
+				names = append(names, s.Name)
+			}
+			require.Equal(t, tt.wantNames, names)
+		})
+	}
+}
+
+// A pretty-printed JSON array is exactly what `launcher specs --merge` emits, so
+// re-feeding that output into the merge must work, not fail like it would if the
+// reader assumed one complete spec per line.
+func Test_runMergeSpecs_acceptsPrettyPrintedArray(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	arrayInput := filepath.Join(dir, "array.json")
+	require.NoError(t, os.WriteFile(arrayInput, []byte(`[
+  {
+    "name": "table_a",
+    "description": "a",
+    "platforms": ["darwin"],
+    "columns": [
+      { "name": "c", "type": "text" }
+    ]
+  },
+  {
+    "name": "table_b",
+    "description": "b",
+    "platforms": ["linux"],
+    "columns": []
+  }
+]
+`), 0644))
+
+	outPath := filepath.Join(dir, "out.json")
+	require.NoError(t, runMergeSpecs([]string{arrayInput}, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var combined []osquerytable.OsqueryTableSpec
+	require.NoError(t, json.Unmarshal(data, &combined))
+
+	names := make([]string, 0, len(combined))
+	for _, s := range combined {
+		names = append(names, s.Name)
+	}
+	require.ElementsMatch(t, []string{"table_a", "table_b"}, names)
+}
+
 func Test_schemaConflicts(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/launcher/specs_test.go
+++ b/cmd/launcher/specs_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
+	osquerytable "github.com/osquery/osquery-go/plugin/table"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,4 +60,89 @@ func Test_runSpecs_outputFlag(t *testing.T) {
 		require.True(t, strings.HasPrefix(line, "{"), "expected JSON object line: %q", line)
 		require.True(t, strings.HasSuffix(line, "}"), "expected JSON object line: %q", line)
 	}
+}
+
+func Test_runMergeSpecs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Each platform emits NDJSON (one OsqueryTableSpec per line). table_shared
+	// appears on all three platforms with differing single-element platform
+	// lists; the platform-specific tables appear only in their own file.
+	darwin := filepath.Join(dir, "darwin.json")
+	require.NoError(t, os.WriteFile(darwin, []byte(strings.Join([]string{
+		`{"name":"table_shared","description":"shared","platforms":["darwin"],"columns":[{"name":"c","type":"text"}]}`,
+		`{"name":"table_darwin","description":"mac only","platforms":["darwin"],"columns":[]}`,
+	}, "\n")+"\n"), 0644))
+
+	linux := filepath.Join(dir, "linux.json")
+	require.NoError(t, os.WriteFile(linux, []byte(strings.Join([]string{
+		`{"name":"table_shared","description":"shared","platforms":["linux"],"columns":[{"name":"c","type":"text"}]}`,
+		`{"name":"table_linux","description":"linux only","platforms":["linux"],"columns":[]}`,
+	}, "\n")+"\n"), 0644))
+
+	windows := filepath.Join(dir, "windows.json")
+	require.NoError(t, os.WriteFile(windows, []byte(strings.Join([]string{
+		`{"name":"table_shared","description":"shared","platforms":["windows"],"columns":[{"name":"c","type":"text"}]}`,
+		`{"name":"table_windows","description":"windows only","platforms":["windows"],"columns":[]}`,
+	}, "\n")+"\n"), 0644))
+
+	outPath := filepath.Join(dir, "launcher-schema.json")
+	require.NoError(t, runMergeSpecs([]string{darwin, linux, windows}, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	// Output must be a single JSON array (the shape k2 ingests), not NDJSON.
+	var combined []osquerytable.OsqueryTableSpec
+	require.NoError(t, json.Unmarshal(data, &combined), "merged output should be a JSON array")
+
+	byName := make(map[string]osquerytable.OsqueryTableSpec, len(combined))
+	names := make([]string, 0, len(combined))
+	for _, spec := range combined {
+		byName[spec.Name] = spec
+		names = append(names, spec.Name)
+	}
+
+	// Deduplicated: table_shared collapses to a single entry across 3 files.
+	require.Len(t, combined, 4)
+	require.ElementsMatch(t, []string{"table_darwin", "table_linux", "table_shared", "table_windows"}, names)
+
+	// Platforms unioned for the shared table.
+	sharedPlatforms := make([]string, 0, len(byName["table_shared"].Platforms))
+	for _, p := range byName["table_shared"].Platforms {
+		sharedPlatforms = append(sharedPlatforms, string(p))
+	}
+	require.ElementsMatch(t, []string{"darwin", "linux", "windows"}, sharedPlatforms)
+
+	// Platform-specific tables retain their single platform.
+	require.Equal(t, []string{"linux"}, platformStrings(byName["table_linux"].Platforms))
+
+	// Sorted by name.
+	require.True(t, sortedStrings(names), "combined tables should be sorted by name: %v", names)
+}
+
+func Test_runMergeSpecs_noInputs(t *testing.T) {
+	t.Parallel()
+
+	err := runMergeSpecs(nil, "")
+	require.Error(t, err)
+}
+
+func platformStrings[T ~string](platforms []T) []string {
+	out := make([]string, 0, len(platforms))
+	for _, p := range platforms {
+		out = append(out, string(p))
+	}
+	return out
+}
+
+func sortedStrings(s []string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i-1] > s[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -76,8 +76,22 @@ table available on several platforms ends up with a single entry like
 `"platforms":["darwin","linux","windows"]`. The combined list is sorted by table
 name. Output goes to stdout or `--output <file>`.
 
-Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, and
-`unionPlatforms` in `cmd/launcher/specs.go`; tests in `cmd/launcher/specs_test.go`.
+A table that appears on more than one platform is expected to expose the **same
+column schema** everywhere. Before writing output, the merge compares the columns
+(by name and type) of each duplicate against the already-merged entry and
+**fails with a non-zero exit** if they diverge — e.g. a column present on one
+platform but not another, or the same column with a different type. This prevents
+a unioned entry from advertising columns for a platform that does not actually
+have them (which would corrupt k2 autocomplete/validation/docs for that
+platform). A failure here means a table's definition has drifted across its
+platform-specific, build-tagged files and should be reconciled at the source.
+Platform lists themselves are not compared (unioning them is the point), and
+documentation-only fields such as `description`/`notes` are not treated as part
+of the schema.
+
+Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, `schemaConflicts`,
+and `unionPlatforms` in `cmd/launcher/specs.go`; tests in
+`cmd/launcher/specs_test.go`.
 
 ### CI: generate, combine, publish
 

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -35,13 +35,11 @@ flowchart TD
     end
     cj -->|"on tag: gh release upload"| ghr["launcher-schema.json on the GitHub release"]
     rw["release-schema.yml (manual backfill)"] -.->|"gh release upload"| ghr
-    ghr -->|"rails launcher_schemas:sync"| k2data["k2: lib/kolide/launcher/schemas/data/VERSION.json"]
-    k2data --> merge["Kolide::Osquery::Schemas.load_schema merges launcher tables in"]
-    merge --> docs["Live Query docs sidebar"]
-    merge --> ac["SQL editor autocomplete"]
-    merge --> val["SQL validation"]
-    merge --> nlq["NLQ / LLM query generation"]
+    ghr -.->|"ingested downstream by k2"| k2["k2: Live Query docs, autocomplete, validation, NLQ"]
 ```
+
+The launcher side of this flow ends at the schema asset attached to the GitHub
+release; how k2 ingests and serves it is owned by k2 and out of scope here.
 
 ## Launcher behavior
 
@@ -95,7 +93,11 @@ platform). A failure here means a table's definition has drifted across its
 platform-specific, build-tagged files and should be reconciled at the source.
 Platform lists themselves are not compared (unioning them is the point), and
 documentation-only fields such as `description`/`notes` are not treated as part
-of the schema.
+of the schema. Because those fields are not compared, a multi-platform table
+keeps the values from the **first input file in which it appears** (in CI the
+per-platform files are merged in alphabetical order). Divergence there is
+resolved silently rather than flagged, so keep cross-platform tables'
+descriptions/notes in sync at the source if it matters.
 
 Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, `readSpecs`,
 `schemaConflicts`, and `unionPlatforms` in `cmd/launcher/specs.go`; tests in

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -110,62 +110,8 @@ Then in `.github/workflows/release-schema.yml`:
 > The artifact that produces the schema does not change — only where it is
 > attached.
 
-## k2 behavior
-
-### Sync (`rails launcher_schemas:sync`)
-
-`lib/tasks/launcher_schemas.rake` fetches
-`https://api.github.com/repos/kolide/launcher/releases/latest`. That endpoint
-returns **only the release GitHub has marked "Latest"**, which by definition
-excludes drafts and prereleases — so nightly/alpha/beta launcher builds are
-never ingested and k2 always tracks the current stable launcher schema. The task
-finds the `launcher-schema.json` asset, strips a leading `v` from the tag (tags
-look like `v2.3.2`), and writes `lib/kolide/launcher/schemas/data/<version>.json`.
-The file is then committed in a PR (the data dir is listed in `.ignore` for
-search tooling, but the JSON is committed, same as the osquery schema files).
-
-> Coupling requirement: because k2 reads only the "Latest" release, the schema
-> asset must ride the stable release that becomes Latest. Nightly/alpha builds
-> must be created as prereleases (or not as GitHub releases at all) so they never
-> become Latest.
-
-### Loader and merge
-
-`Kolide::Launcher::Schemas` (`lib/kolide/launcher/schemas.rb`) loads the synced
-JSON, reusing `Kolide::Osquery::Schemas::Table` since the launcher schema has the
-same shape as the osquery schema. `Kolide::Launcher::Schemas.latest` returns an
-empty hash when no schema file is present yet, so k2 degrades gracefully to
-osquery-only until the first sync.
-
-The single integration point is `Kolide::Osquery::Schemas.load_schema`
-(`lib/kolide/osquery/schemas.rb`), which now merges the launcher tables into the
-osquery table map:
-
-```ruby
-SCHEMAS[version] = Kolide::Launcher::Schemas.latest.merge(osquery_tables)
-```
-
-Because every consumer reads that same map (directly or through
-`Kolide::Osquery::Schemas::Schema`), the launcher tables automatically appear in:
-
-- **Live Query docs sidebar** — `app/views/live_query/campaigns/_docs.html.erb`
-  (the "View on GitHub" link is shown only when a table has a `url`, since many
-  launcher tables have none; the fragment cache key includes the launcher schema
-  version so it busts when the schema updates).
-- **SQL editor autocomplete** — `app/views/api/internal/editor/auto_complete/osquery.json.jbuilder`.
-- **SQL validation** — `Schema#valid_query`, used by
-  `app/validators/osquery_sql_validator.rb`; launcher tables stop being flagged
-  "not found".
-- **NLQ / LLM query generation** — `Kolide::Osquery::Schemas::LlmFormatter` and
-  the `list_osquery_tables` / `get_osquery_table_schema` LLM tools.
-
-The launcher schema is independent of the osquery version, so the latest launcher
-tables are merged regardless of which osquery schema version is loaded. On the
-(unlikely) event of a name collision, the osquery definition wins.
 
 ## Local testing
-
-### Launcher
 
 Generate the current platform's schema (NDJSON) without installing anything:
 
@@ -193,41 +139,3 @@ the table should collapse to one entry with the platforms unioned. This is what
 go test ./cmd/launcher/ -run 'Test_runSpecs|Test_runMergeSpecs'
 ```
 
-### k2
-
-Since a published release with the asset may not exist yet, drop a schema file in
-manually using a locally-generated one, then confirm the surfaces pick it up:
-
-```sh
-# Produce a combined schema from your local launcher and place it where k2 loads from.
-cd ~/repos/launcher
-go run ./cmd/launcher specs --output /tmp/launcher-specs.json
-go run ./cmd/launcher specs --merge --output \
-  ~/repos/k2/lib/kolide/launcher/schemas/data/0.0.0-local.json /tmp/launcher-specs.json
-```
-
-```sh
-cd ~/repos/k2
-
-# Loader sees the file:
-bundle exec rails runner 'pp Kolide::Launcher::Schemas.latest_version; pp Kolide::Launcher::Schemas.latest.keys.first(5)'
-
-# Launcher tables are merged into the shared schema map:
-bundle exec rails runner 'pp Kolide::Osquery::Schemas::Schema.new.find_table_by_name("kolide_launcher_info")&.name'
-
-# Validation now accepts a launcher table (no "not found" error):
-bundle exec rails runner 'pp Kolide::Osquery::Schemas::Schema.new.valid_query("select * from kolide_launcher_info").errors'
-```
-
-Then load a Live Query page and confirm the launcher tables appear in the docs
-sidebar and in editor autocomplete. Remove the temporary
-`0.0.0-local.json` when you are done so it is not committed.
-
-To test the real sync path against a launcher release that already carries the
-asset (set `GITHUB_TOKEN` to avoid unauthenticated rate limits):
-
-```sh
-cd ~/repos/k2
-GITHUB_TOKEN=<token> bundle exec rails launcher_schemas:sync
-git status lib/kolide/launcher/schemas/data/   # new <version>.json to commit
-```

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -27,13 +27,14 @@ plus `PlatformTables` (see `pkg/osquery/table/table.go`). It deliberately does
 ```mermaid
 flowchart TD
     subgraph ci [launcher CI - go.yml]
-        bd["build: macOS, Windows"] -->|"launcher specs --output"| sd["schema-* artifacts (one NDJSON file per platform)"]
-        bl["build_linux"] -->|"launcher specs --output"| sd
+        bd["build: macOS, Windows"] --> gs["generate_schema (matrix: runs cached binary per platform)"]
+        bl["build_linux"] --> gs
+        gs -->|"launcher specs --output"| sd["schema-* artifacts (one NDJSON file per platform)"]
         sd --> cj["combine_schema job"]
         cj -->|"launcher specs --merge"| lsj["launcher-schema artifact (single JSON array)"]
     end
-    lsj -->|"release published"| rw["release-schema.yml"]
-    rw -->|"gh release upload"| ghr["launcher-schema.json on the GitHub release"]
+    cj -->|"on tag: gh release upload"| ghr["launcher-schema.json on the GitHub release"]
+    rw["release-schema.yml (manual backfill)"] -.->|"gh release upload"| ghr
     ghr -->|"rails launcher_schemas:sync"| k2data["k2: lib/kolide/launcher/schemas/data/VERSION.json"]
     k2data --> merge["Kolide::Osquery::Schemas.load_schema merges launcher tables in"]
     merge --> docs["Live Query docs sidebar"]
@@ -104,32 +105,45 @@ Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, `readSpecs`,
 
 In `.github/workflows/go.yml`:
 
-1. **Generate (per platform).** The `build` (macOS, Windows) and `build_linux`
-   jobs run the freshly-built binary as `launcher specs --output
-   launcher-specs-<RUNNER_OS>.json` and upload it as a `schema-<os>` artifact.
-   These steps are gated on `env.CACHE_KEY_PREFIX == ''` so the reproducible
-   build twin does not race the main build on the artifact name.
-2. **Combine (fan-in).** The `combine_schema` job (`needs: store_artifacts`)
+1. **Generate (per platform).** The `generate_schema` job runs on a matrix of
+   `[ubuntu-24.04, macos-26, windows-2025]` and `needs: [build, build_linux]`.
+   It restores the cached `build/` output (it runs the already-built binary, so
+   it needs no checkout or Go toolchain) and runs `launcher specs --output
+   launcher-specs-<RUNNER_OS>.json`, uploading each as a `schema-<os>` artifact.
+   Running each platform's binary on its own runner is required because the
+   schema is platform-specific. Keeping this in its own job (rather than as steps
+   inside `build`/`build_linux`) avoids duplicating the step across two jobs and
+   avoids the reproducible build twins racing on the artifact name — they don't
+   feed `generate_schema`, so they produce no schema artifact at all.
+2. **Combine (fan-in).** The `combine_schema` job (`needs: generate_schema`)
    downloads all `schema-*` artifacts and runs
    `go run ./cmd/launcher specs --merge --output launcher-schema.json ...`,
    then uploads the result as the `launcher-schema` artifact. It is part of the
    `ci_mergeable` gate.
-
-Then in `.github/workflows/release-schema.yml`:
-
-3. **Attach to the release.** On `release: published` (or via `workflow_dispatch`
-   with a `tag` input), the workflow finds the successful `ci` run for the tag,
-   downloads the `launcher-schema` artifact, and runs
+3. **Attach to the release (tag builds).** On a tag build
+   (`if: github.ref_type == 'tag'`), `combine_schema` has a final step that runs
    `gh release upload <tag> launcher-schema.json --clobber` (the job has
-   `contents: write`). The asset name is always `launcher-schema.json`; the
+   `contents: write`). Doing this inside the tag's own `ci` run — where the
+   freshly combined artifact is already in hand — avoids racing a separate
+   release-triggered workflow against `ci`: a release published against a new tag
+   fires `release: published` almost immediately, before this `ci` run finishes,
+   so a `release`-triggered upload would not yet find a successful run. If no
+   release exists for the tag yet, the step emits a notice and skips rather than
+   failing the build. The asset name is always `launcher-schema.json`; the
    release tag carries the version.
 
-> Note on immutability: attaching after publish works for mutable releases. If
-> releases are made immutable, this step should attach the asset at
-> release-creation time (e.g. `gh release create --draft ... && gh release edit
-> --draft=false`) or be folded into an atomic tag → build → sign → release step.
-> The artifact that produces the schema does not change — only where it is
-> attached.
+`.github/workflows/release-schema.yml` is a **manual backfill** (`workflow_dispatch`
+with a `tag` input) for the cases the in-`ci` attach can't cover: a tag pushed
+before its release existed (so the ci-time upload was skipped), a release cut
+from a tag built before schema support landed, or a needed re-attach. It finds
+the successful `ci` run for the tag, downloads the `launcher-schema` artifact,
+and runs `gh release upload <tag> launcher-schema.json --clobber`.
+
+> Note on immutability: both paths upload to an existing (mutable) release. If
+> releases are made immutable, asset attachment must happen at release-creation
+> time (e.g. `gh release create --draft ... && gh release edit --draft=false`)
+> or be folded into an atomic tag → build → sign → release step. The artifact
+> that produces the schema does not change — only where it is attached.
 
 
 ## Local testing

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -1,0 +1,233 @@
+## Table schema publishing
+
+Launcher can emit a machine-readable schema for the osquery tables it provides
+(the Launcher and Kolide extension tables). This schema is generated per
+platform during launcher CI, combined into a single cross-platform document,
+attached to the launcher GitHub release, and ingested by k2 so the tables show
+up in Live Query docs, the SQL editor autocomplete, query validation, and
+natural-language query generation.
+
+This document describes the expected behavior on both sides (launcher and k2)
+and how to exercise the flow locally.
+
+### Scope
+
+The schema covers **only the tables launcher itself registers**: `LauncherTables`
+plus `PlatformTables` (see `pkg/osquery/table/table.go`). It deliberately does
+**not** include:
+
+- osquery's built-in tables (`processes`, `users`, ...) — k2 already ingests
+  those from the upstream osquery schema.
+- KATC (Kolide ATC) tables — those are defined and gated server-side in k2 and
+  pushed to the agent at runtime via the control server, so they are not known
+  to a statically-built launcher binary.
+
+### End-to-end flow
+
+```mermaid
+flowchart TD
+    subgraph ci [launcher CI - go.yml]
+        bd["build: macOS, Windows"] -->|"launcher specs --output"| sd["schema-* artifacts (one NDJSON file per platform)"]
+        bl["build_linux"] -->|"launcher specs --output"| sd
+        sd --> cj["combine_schema job"]
+        cj -->|"launcher specs --merge"| lsj["launcher-schema artifact (single JSON array)"]
+    end
+    lsj -->|"release published"| rw["release-schema.yml"]
+    rw -->|"gh release upload"| ghr["launcher-schema.json on the GitHub release"]
+    ghr -->|"rails launcher_schemas:sync"| k2data["k2: lib/kolide/launcher/schemas/data/VERSION.json"]
+    k2data --> merge["Kolide::Osquery::Schemas.load_schema merges launcher tables in"]
+    merge --> docs["Live Query docs sidebar"]
+    merge --> ac["SQL editor autocomplete"]
+    merge --> val["SQL validation"]
+    merge --> nlq["NLQ / LLM query generation"]
+```
+
+## Launcher behavior
+
+### `launcher specs`
+
+`launcher specs` walks the tables launcher registers and prints each one as a
+single line of JSON (NDJSON — one `OsqueryTableSpec` per line) to stdout, or to
+a file with `--output`. Each spec contains the table `name`, `description`,
+`url`, `platforms`, `columns` (with `name`/`type`/`description`), and optional
+`notes`/`examples`.
+
+The output is **platform-specific by construction**: which tables compile into a
+given binary is decided at build time by Go build tags
+(`platform_tables_{darwin,linux,windows}.go`), and a spec's `platforms` field
+defaults to the binary's `GOOS`. A darwin binary therefore emits only the darwin
+tables, each marked `"platforms":["darwin"]`. This is why the schema must be
+generated on each target platform and then combined — it cannot be produced
+cross-platform from a single binary.
+
+Useful flags:
+
+- `--output <file>` — write to a file instead of stdout.
+- `--required <field>` (repeatable) — warn (and, unless `--missing-ok`, fail)
+  when a spec is missing a field such as `name` or `description`.
+- `--quiet` — validate without printing (used by the `lint` workflow).
+
+### `launcher specs --merge`
+
+`launcher specs --merge <file>...` is the combine step. It reads one or more
+per-platform NDJSON spec files and writes a single **JSON array** (the shape k2
+ingests), deduplicating tables by name and **unioning their platforms** so a
+table available on several platforms ends up with a single entry like
+`"platforms":["darwin","linux","windows"]`. The combined list is sorted by table
+name. Output goes to stdout or `--output <file>`.
+
+Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, and
+`unionPlatforms` in `cmd/launcher/specs.go`; tests in `cmd/launcher/specs_test.go`.
+
+### CI: generate, combine, publish
+
+In `.github/workflows/go.yml`:
+
+1. **Generate (per platform).** The `build` (macOS, Windows) and `build_linux`
+   jobs run the freshly-built binary as `launcher specs --output
+   launcher-specs-<RUNNER_OS>.json` and upload it as a `schema-<os>` artifact.
+   These steps are gated on `env.CACHE_KEY_PREFIX == ''` so the reproducible
+   build twin does not race the main build on the artifact name.
+2. **Combine (fan-in).** The `combine_schema` job (`needs: store_artifacts`)
+   downloads all `schema-*` artifacts and runs
+   `go run ./cmd/launcher specs --merge --output launcher-schema.json ...`,
+   then uploads the result as the `launcher-schema` artifact. It is part of the
+   `ci_mergeable` gate.
+
+Then in `.github/workflows/release-schema.yml`:
+
+3. **Attach to the release.** On `release: published` (or via `workflow_dispatch`
+   with a `tag` input), the workflow finds the successful `ci` run for the tag,
+   downloads the `launcher-schema` artifact, and runs
+   `gh release upload <tag> launcher-schema.json --clobber` (the job has
+   `contents: write`). The asset name is always `launcher-schema.json`; the
+   release tag carries the version.
+
+> Note on immutability: attaching after publish works for mutable releases. If
+> releases are made immutable, this step should attach the asset at
+> release-creation time (e.g. `gh release create --draft ... && gh release edit
+> --draft=false`) or be folded into an atomic tag → build → sign → release step.
+> The artifact that produces the schema does not change — only where it is
+> attached.
+
+## k2 behavior
+
+### Sync (`rails launcher_schemas:sync`)
+
+`lib/tasks/launcher_schemas.rake` fetches
+`https://api.github.com/repos/kolide/launcher/releases/latest`. That endpoint
+returns **only the release GitHub has marked "Latest"**, which by definition
+excludes drafts and prereleases — so nightly/alpha/beta launcher builds are
+never ingested and k2 always tracks the current stable launcher schema. The task
+finds the `launcher-schema.json` asset, strips a leading `v` from the tag (tags
+look like `v2.3.2`), and writes `lib/kolide/launcher/schemas/data/<version>.json`.
+The file is then committed in a PR (the data dir is listed in `.ignore` for
+search tooling, but the JSON is committed, same as the osquery schema files).
+
+> Coupling requirement: because k2 reads only the "Latest" release, the schema
+> asset must ride the stable release that becomes Latest. Nightly/alpha builds
+> must be created as prereleases (or not as GitHub releases at all) so they never
+> become Latest.
+
+### Loader and merge
+
+`Kolide::Launcher::Schemas` (`lib/kolide/launcher/schemas.rb`) loads the synced
+JSON, reusing `Kolide::Osquery::Schemas::Table` since the launcher schema has the
+same shape as the osquery schema. `Kolide::Launcher::Schemas.latest` returns an
+empty hash when no schema file is present yet, so k2 degrades gracefully to
+osquery-only until the first sync.
+
+The single integration point is `Kolide::Osquery::Schemas.load_schema`
+(`lib/kolide/osquery/schemas.rb`), which now merges the launcher tables into the
+osquery table map:
+
+```ruby
+SCHEMAS[version] = Kolide::Launcher::Schemas.latest.merge(osquery_tables)
+```
+
+Because every consumer reads that same map (directly or through
+`Kolide::Osquery::Schemas::Schema`), the launcher tables automatically appear in:
+
+- **Live Query docs sidebar** — `app/views/live_query/campaigns/_docs.html.erb`
+  (the "View on GitHub" link is shown only when a table has a `url`, since many
+  launcher tables have none; the fragment cache key includes the launcher schema
+  version so it busts when the schema updates).
+- **SQL editor autocomplete** — `app/views/api/internal/editor/auto_complete/osquery.json.jbuilder`.
+- **SQL validation** — `Schema#valid_query`, used by
+  `app/validators/osquery_sql_validator.rb`; launcher tables stop being flagged
+  "not found".
+- **NLQ / LLM query generation** — `Kolide::Osquery::Schemas::LlmFormatter` and
+  the `list_osquery_tables` / `get_osquery_table_schema` LLM tools.
+
+The launcher schema is independent of the osquery version, so the latest launcher
+tables are merged regardless of which osquery schema version is loaded. On the
+(unlikely) event of a name collision, the osquery definition wins.
+
+## Local testing
+
+### Launcher
+
+Generate the current platform's schema (NDJSON) without installing anything:
+
+```sh
+cd ~/repos/launcher
+go run ./cmd/launcher specs --output /tmp/launcher-specs.json
+head -1 /tmp/launcher-specs.json   # one JSON object per line
+```
+
+Exercise the combine step. On one machine you only have the local platform's
+tables, but merging a single file still produces the final JSON-array shape that
+k2 ingests:
+
+```sh
+go run ./cmd/launcher specs --merge --output /tmp/launcher-schema.json /tmp/launcher-specs.json
+jq 'length, .[0].name, .[0].platforms' /tmp/launcher-schema.json
+```
+
+To verify platform unioning, hand-write a couple of small NDJSON files with the
+same table name and different single-element `platforms` arrays and merge them;
+the table should collapse to one entry with the platforms unioned. This is what
+`Test_runMergeSpecs` does. Run the tests with:
+
+```sh
+go test ./cmd/launcher/ -run 'Test_runSpecs|Test_runMergeSpecs'
+```
+
+### k2
+
+Since a published release with the asset may not exist yet, drop a schema file in
+manually using a locally-generated one, then confirm the surfaces pick it up:
+
+```sh
+# Produce a combined schema from your local launcher and place it where k2 loads from.
+cd ~/repos/launcher
+go run ./cmd/launcher specs --output /tmp/launcher-specs.json
+go run ./cmd/launcher specs --merge --output \
+  ~/repos/k2/lib/kolide/launcher/schemas/data/0.0.0-local.json /tmp/launcher-specs.json
+```
+
+```sh
+cd ~/repos/k2
+
+# Loader sees the file:
+bundle exec rails runner 'pp Kolide::Launcher::Schemas.latest_version; pp Kolide::Launcher::Schemas.latest.keys.first(5)'
+
+# Launcher tables are merged into the shared schema map:
+bundle exec rails runner 'pp Kolide::Osquery::Schemas::Schema.new.find_table_by_name("kolide_launcher_info")&.name'
+
+# Validation now accepts a launcher table (no "not found" error):
+bundle exec rails runner 'pp Kolide::Osquery::Schemas::Schema.new.valid_query("select * from kolide_launcher_info").errors'
+```
+
+Then load a Live Query page and confirm the launcher tables appear in the docs
+sidebar and in editor autocomplete. Remove the temporary
+`0.0.0-local.json` when you are done so it is not committed.
+
+To test the real sync path against a launcher release that already carries the
+asset (set `GITHUB_TOKEN` to avoid unauthenticated rate limits):
+
+```sh
+cd ~/repos/k2
+GITHUB_TOKEN=<token> bundle exec rails launcher_schemas:sync
+git status lib/kolide/launcher/schemas/data/   # new <version>.json to commit
+```

--- a/docs/architecture/table_schema_publishing.md
+++ b/docs/architecture/table_schema_publishing.md
@@ -70,11 +70,18 @@ Useful flags:
 ### `launcher specs --merge`
 
 `launcher specs --merge <file>...` is the combine step. It reads one or more
-per-platform NDJSON spec files and writes a single **JSON array** (the shape k2
+per-platform spec files and writes a single **JSON array** (the shape k2
 ingests), deduplicating tables by name and **unioning their platforms** so a
 table available on several platforms ends up with a single entry like
 `"platforms":["darwin","linux","windows"]`. The combined list is sorted by table
 name. Output goes to stdout or `--output <file>`.
+
+Each input file may be either NDJSON (one spec per line, the `launcher specs`
+output) or a single JSON array (the `launcher specs --merge` output); both
+compact and pretty-printed forms are accepted, so a previously merged
+`launcher-schema.json` can be fed straight back in. Parsing uses `encoding/json`
+rather than line scanning, so indentation/newlines inside a spec are irrelevant
+and there is no per-line size limit.
 
 A table that appears on more than one platform is expected to expose the **same
 column schema** everywhere. Before writing output, the merge compares the columns
@@ -89,8 +96,8 @@ Platform lists themselves are not compared (unioning them is the point), and
 documentation-only fields such as `description`/`notes` are not treated as part
 of the schema.
 
-Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, `schemaConflicts`,
-and `unionPlatforms` in `cmd/launcher/specs.go`; tests in
+Implementation: `runSpecs`, `runMergeSpecs`, `mergeSpecFile`, `readSpecs`,
+`schemaConflicts`, and `unionPlatforms` in `cmd/launcher/specs.go`; tests in
 `cmd/launcher/specs_test.go`.
 
 ### CI: generate, combine, publish

--- a/ee/tables/nix_env/upgradeable/upgradeable.go
+++ b/ee/tables/nix_env/upgradeable/upgradeable.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux || darwin
+// +build linux darwin
 
 package nix_env_upgradeable
 

--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kolide/launcher/v2/ee/tables/apple_silicon_security_policy"
 	"github.com/kolide/launcher/v2/ee/tables/dataflattentable"
 	json "github.com/kolide/launcher/v2/ee/tables/execparsers/json"
-	"github.com/kolide/launcher/v2/ee/tables/execparsers/mapxml"
 	"github.com/kolide/launcher/v2/ee/tables/execparsers/plist"
 	"github.com/kolide/launcher/v2/ee/tables/execparsers/remotectl"
 	"github.com/kolide/launcher/v2/ee/tables/execparsers/repcli"
@@ -28,6 +27,7 @@ import (
 	"github.com/kolide/launcher/v2/ee/tables/macos_software_update"
 	"github.com/kolide/launcher/v2/ee/tables/mdmclient"
 	"github.com/kolide/launcher/v2/ee/tables/munki"
+	nix_env_upgradeable "github.com/kolide/launcher/v2/ee/tables/nix_env/upgradeable"
 	"github.com/kolide/launcher/v2/ee/tables/osquery_user_exec_table"
 	"github.com/kolide/launcher/v2/ee/tables/profiles"
 	"github.com/kolide/launcher/v2/ee/tables/pwpolicy"
@@ -126,7 +126,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 		systemprofiler.TablePlugin(k, slogger),
 		munki.ManagedInstalls(k, slogger),
 		munki.MunkiReport(k, slogger),
-		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_nix_upgradeable", mapxml.Parser, allowedcmd.NixEnv, []string{"--query", "--installed", "-c", "--xml"}),
+		nix_env_upgradeable.TablePlugin(k, slogger),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_remotectl", remotectl.Parser, allowedcmd.Remotectl, []string{`dumpstate`}),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_socketfilterfw", socketfilterfw.Parser, allowedcmd.Socketfilterfw, []string{"--getglobalstate", "--getblockall", "--getallowsigned", "--getstealthmode"}, dataflattentable.WithIncludeStderr()),
 		dataflattentable.NewExecAndParseTable(k, slogger, "kolide_socketfilterfw_apps", socketfilterfw.Parser, allowedcmd.Socketfilterfw, []string{"--listapps"}, dataflattentable.WithIncludeStderr()),


### PR DESCRIPTION
This pull request introduces a cross-platform schema generation and publishing workflow for the `launcher` project. It adds the ability for each platform's CI build to emit its own table schema, then combines these into a single, unioned schema artifact. This combined schema is then attached to GitHub releases for downstream use (e.g., by k2 for Live Query docs and validation). The changes include updates to CI workflows, new schema combination logic in `cmd/launcher/specs.go`, and corresponding tests.

**CI/CD workflow enhancements:**

* Each platform's build job in `.github/workflows/go.yml` now generates and uploads a platform-specific table schema artifact (`launcher-specs-<platform>.json`). [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR88-R108) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR198-R211)
* A new `combine_schema` job is added to the workflow, which downloads all platform schemas, merges them into a single cross-platform schema (`launcher-schema.json`), and uploads it as an artifact. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR689-R758) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR840)
* A new workflow (`.github/workflows/release-schema.yml`) is introduced to attach the combined schema artifact to GitHub releases, supporting both automatic and manual (re-)attachment.

**Schema merging logic:**

* The `launcher specs` command gains a `--merge` flag to combine multiple NDJSON schema files into a single JSON array, deduplicating tables by name and unioning their platforms. [[1]](diffhunk://#diff-25f18b1ee67e61e73f0c67c7b15a82bebc7a4e3ebd4db391b12952cb5433abf2R58-R74) [[2]](diffhunk://#diff-25f18b1ee67e61e73f0c67c7b15a82bebc7a4e3ebd4db391b12952cb5433abf2R170-R276)
* New helper functions (`runMergeSpecs`, `mergeSpecFile`, `unionPlatforms`) are implemented in `cmd/launcher/specs.go` to support merging and deduplication logic.

**Testing:**

* Unit tests are added in `cmd/launcher/specs_test.go` to verify correct merging of schemas, handling of missing inputs, and output format.
* Local setup with k2 parsing support for the spec on Mac

<img width="329" height="1010" alt="Screenshot 2026-06-18 at 8 55 15 AM" src="https://github.com/user-attachments/assets/9d82424b-1611-4a94-978f-5e24d0ea0e22" />

<img width="3440" height="1224" alt="image" src="https://github.com/user-attachments/assets/13fb5b20-2034-4647-a4e7-c8d5bd2bb04a" />




