### PR TITLE
Add rule for 1PRK 1Password Recovery Key secrets

### DIFF
--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -40,3 +40,18 @@ id = "private-key"
 description = "Ignore Cosign encrypted private keys (https://github.com/gitleaks/gitleaks/issues/1034)"
 condition = "AND"
 stopwords = ["BEGIN ENCRYPTED COSIGN PRIVATE KEY", "BEGIN ENCRYPTED SIGSTORE PRIVATE KEY"]
+
+# Custom Kolide detection rules (these add new rules not present in the default
+# gitleaks config, as opposed to the allowlists above which tune existing rules).
+
+[[rules]]
+id = "1password-recovery-key"
+description = "Uncovered a possible 1Password recovery key, potentially compromising account recovery and access to secrets in vaults."
+# Recovery keys are the literal prefix "1PRK" followed by 13 hyphen-separated
+# groups of 4 uppercase-alphanumeric characters, e.g.
+# 1PRK-25QX-VSEX-BGMD-7CEN-6YJN-JAVA-DRQ3-DH2B-OIC4-ST4F-CLUA-BUFS-VRNA
+regex = '''\b1PRK-(?:[A-Z0-9]{4}-){12}[A-Z0-9]{4}\b'''
+# Genuine keys carry ~4.5 bits/char of entropy; this floor drops doc placeholders
+# such as 1PRK-XXXX-XXXX-... while leaving wide margin for real keys.
+entropy = 3.5
+keywords = ["1prk"]

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -575,6 +575,31 @@ MC4CAQAwBQYDK2VwBCIEIALEbo1EFnWFqBK/wC+hhypG/8hXEerwdNetAoFoFVdv
 -----END PRIVATE KEY-----`,
 			expectedFinding: true,
 		},
+		{
+			testCaseName:    "1Password recovery key (true positive)",
+			rawData:         `recovery_key = "1PRK-25QX-VSEX-BGMD-7CEN-6YJN-JAVA-DRQ3-DH2B-OIC4-ST4F-CLUA-BUFS-VRNA"`,
+			expectedFinding: true,
+		},
+		{
+			testCaseName:    "1Password recovery key, bare token (true positive)",
+			rawData:         `1PRK-36V7-JAX6-K5F7-BQTQ-Z6LY-S5DJ-IOZU-J6B7-CTWV-2ZPL-ISPD-5DKW-QA4A`,
+			expectedFinding: true,
+		},
+		{
+			testCaseName:    "1Password recovery key placeholder (false positive, entropy too low)",
+			rawData:         `1PRK-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`,
+			expectedFinding: false,
+		},
+		{
+			testCaseName:    "1Password recovery key, too few groups",
+			rawData:         `1PRK-25QX-VSEX-BGMD`,
+			expectedFinding: false,
+		},
+		{
+			testCaseName:    "1Password recovery key, lowercase is not a match",
+			rawData:         `1prk-25qx-vsex-bgmd-7cen-6yjn-java-drq3-dh2b-oic4-st4f-clua-bufs-vrna`,
+			expectedFinding: false,
+		},
 	} {
 		t.Run(tt.testCaseName, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What is the purpose of this PR?
1Password added a new mechanism for generating 1Password Recovery Keys called `1PRK`'s. It is not currently in the canonical gitleaks project, and so I am attempting to band-aid fix it here.
<img width="892" height="792" alt="Screenshot 2026-06-22 at 11 07 09 AM" src="https://github.com/user-attachments/assets/97aac818-defe-4343-9381-c27ad6fe8962" />

Presumably we would want to upstream this detection rule but I figured the tail on that is longer than adding it here.

## How did you test this?
Built a local launcher and ran my query:
```
osquery> WITH discovered_files AS (
    ...> SELECT path, filename FROM mdfind CROSS JOIN file f USING(path)
    ...> WHERE query = "kMDItemTextContent == '1PASSWORD RECOVERY CODE*'"
    ...> )
    ...> SELECT * FROM discovered_files CROSS JOIN kolide_secret_scan USING (path)
    ...> WHERE REGEX_MATCH(filename, '\.(js|mjs|ts|tsx|rs)$', 0) IS NULL;

              path = /Users/fritz.ifertmiller/Downloads/1Password Recovery Code.txt
          filename = 1Password Recovery Code.txt
              name = 
          raw_data = 
           rule_id = 1password-recovery-key
       description = Uncovered a possible 1Password recovery key, potentially compromising account recovery and access to secrets in vaults.
       line_number = 4
      column_start = 2
        column_end = 70
           entropy = 4.53
     hash_argon2id = 
hash_argon2id_salt = 

              path = /Users/fritz.ifertmiller/Downloads/1Password Recovery Code-new.txt
          filename = 1Password Recovery Code-new.txt
              name = 
          raw_data = 
           rule_id = 1password-recovery-key
       description = Uncovered a possible 1Password recovery key, potentially compromising account recovery and access to secrets in vaults.
       line_number = 4
      column_start = 2
        column_end = 70
           entropy = 4.39
     hash_argon2id = 
hash_argon2id_salt = 
```