### PR TITLE
Include quarantine directory/directories in quarantine checkup summary

### DIFF
--- a/ee/debug/checkups/quarantine.go
+++ b/ee/debug/checkups/quarantine.go
@@ -145,7 +145,11 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 
 	totalQuarantinedFiles := 0
 
+	quarantineDirs := make([]string, 0)
 	for path, fileNames := range q.quarantineDirPathFilenames {
+		if len(fileNames) > 0 {
+			quarantineDirs = append(quarantineDirs, path)
+		}
 		fmt.Fprintf(extraFh, "%s: %d files\n", path, len(fileNames))
 		totalQuarantinedFiles += len(fileNames)
 
@@ -161,7 +165,7 @@ func (q *quarantine) Run(ctx context.Context, extraFh io.Writer) error {
 	}
 
 	q.status = Warning
-	q.summary = fmt.Sprintf("found %d quarantined files and %d files with quarantine attr set", totalQuarantinedFiles, len(bundlesWithQuarantineAttrSet))
+	q.summary = fmt.Sprintf("found %d quarantined files (in %s) and %d files with quarantine attr set", totalQuarantinedFiles, strings.Join(quarantineDirs, ","), len(bundlesWithQuarantineAttrSet))
 
 	return nil
 }


### PR DESCRIPTION
Will now give doctor output that looks like:

```
Quarantine: found 1 quarantined files (in some/path/to/quarantine_db) and 0 files with quarantine attr set
```

Went with the directories, rather than the entire list of files, in an effort to keep doctor output succinct. Full list of files is available in flare.