### PR TITLE
Notification localization

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -62,6 +62,11 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 			"",
 			"path to read menu data",
 		)
+		flLocalizationPath = flagset.String(
+			"localization_path",
+			"",
+			"path to read localization data",
+		)
 		fldebug = flagset.Bool(
 			"debug",
 			false,
@@ -148,7 +153,7 @@ func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 	}
 
 	// Set up notification sending and listening
-	notifier := notify.NewDesktopNotifier(slogger, *flIconPath)
+	notifier := notify.NewDesktopNotifier(slogger, *flIconPath, *flLocalizationPath)
 	runGroup.Add("desktopNotifier", notifier.Execute, notifier.Interrupt)
 
 	server, err := userserver.New(slogger, *flUserServerAuthToken, *flUserServerSocketPath, shutdownChan, showDesktopChan, notifier)

--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -493,6 +493,11 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 
 		runGroup.Add("desktopRunner", runner.Execute, runner.Interrupt)
 		controlService.RegisterConsumer(desktopMenuSubsystemName, runner)
+		// Subscribe the runner to the localizations subsystem so it can re-write
+		// the shared localization file whenever the control server pushes new
+		// translations. Desktop child processes pick up the new file on their
+		// next read.
+		controlService.RegisterSubscriber(localizationsSubsystemName, runner)
 
 		// create an action queue for all other action style commands
 		actionsQueue = actionqueue.New(

--- a/ee/agent/types/localization.go
+++ b/ee/agent/types/localization.go
@@ -16,7 +16,16 @@ type LocalizationData struct {
 }
 
 type Translations struct {
-	Datetime Datetime `json:"datetime"`
+	Datetime      Datetime      `json:"datetime"`
+	Notifications Notifications `json:"notifications,omitempty"`
+}
+
+// Notifications holds translations for desktop notification UI strings
+// rendered by the launcher itself (not server-controlled title/body).
+type Notifications struct {
+	Actions struct {
+		LearnMore string `json:"learn_more,omitempty"`
+	} `json:"actions,omitempty"`
 }
 
 // PluralForms holds translations for all CLDR plural categories.

--- a/ee/control/consumers/localizationconsumer/assets/en-US.json
+++ b/ee/control/consumers/localizationconsumer/assets/en-US.json
@@ -56,6 +56,11 @@
         "future": "in %{time}",
         "past": "%{time} ago"
       }
+    },
+    "notifications": {
+      "actions": {
+        "learn_more": "Learn More"
+      }
     }
   }
 }

--- a/ee/control/consumers/localizationconsumer/assets/en.json
+++ b/ee/control/consumers/localizationconsumer/assets/en.json
@@ -56,6 +56,11 @@
         "future": "in %{time}",
         "past": "%{time} ago"
       }
+    },
+    "notifications": {
+      "actions": {
+        "learn_more": "Learn More"
+      }
     }
   }
 }

--- a/ee/control/consumers/localizationconsumer/localizationconsumer.go
+++ b/ee/control/consumers/localizationconsumer/localizationconsumer.go
@@ -19,7 +19,7 @@ var assets embed.FS
 
 const (
 	localizationsDataKey = "localization"
-	defaultLocale        = "en-US"
+	defaultLocale        = "es-ES"
 )
 
 type LocalizationConsumer struct {

--- a/ee/control/consumers/localizationconsumer/localizationconsumer.go
+++ b/ee/control/consumers/localizationconsumer/localizationconsumer.go
@@ -19,7 +19,7 @@ var assets embed.FS
 
 const (
 	localizationsDataKey = "localization"
-	defaultLocale        = "es-ES"
+	defaultLocale        = "en-US"
 )
 
 type LocalizationConsumer struct {

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -592,18 +592,21 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 }
 
 // Ping handles notifications from the control service that a subscribed
-// subsystem (e.g. localizations) has been updated. The runner re-writes the
-// shared localization file so desktop child processes pick up the new
-// translations on their next read, and refreshes the menu so any localized
-// menu strings reflect the new locale as well.
+// subsystem (e.g. localizations) has been updated. Refreshing the menu
+// re-writes the shared localization file so desktop child processes pick up
+// the new translations on their next read, and refreshes any localized menu
+// strings so they reflect the new locale as well.
+//
+// We deliberately do not restart the desktop process here. Most localized
+// strings (menu items, and notification labels on Windows/Linux) are read
+// fresh and update live via the menu refresh. The one exception is the macOS
+// notification "Learn More" label, which is baked into the registered
+// notification category at listener startup and so only picks up a new locale
+// after the desktop process restarts. Since that label changes very rarely and
+// restarting is disruptive (drops the menu bar item, notification listener, and
+// presence sessions), we leave it to update on the next natural desktop
+// process restart rather than forcing one on every update.
 func (r *DesktopUsersProcessesRunner) Ping() {
-	if err := r.writeLocalizationFile(); err != nil {
-		r.slogger.Log(context.TODO(), slog.LevelWarn,
-			"failed to write localization file after subsystem update",
-			"err", err,
-		)
-	}
-
 	r.refreshMenu()
 }
 

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -240,6 +241,16 @@ func (r *DesktopUsersProcessesRunner) Execute() error {
 			)
 		}
 	})
+
+	// Write the localization file once at startup so it is available before
+	// any desktop child process is spawned. Failures here are non-fatal --
+	// child processes fall back to English when the file is missing.
+	if err := r.writeLocalizationFile(); err != nil {
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to write initial localization file",
+			"err", err,
+		)
+	}
 
 	defer r.updateTicker.Stop()
 	menuRefreshTicker := time.NewTicker(r.menuRefreshInterval)
@@ -580,6 +591,22 @@ func (r *DesktopUsersProcessesRunner) Update(data io.Reader) error {
 	return nil
 }
 
+// Ping handles notifications from the control service that a subscribed
+// subsystem (e.g. localizations) has been updated. The runner re-writes the
+// shared localization file so desktop child processes pick up the new
+// translations on their next read, and refreshes the menu so any localized
+// menu strings reflect the new locale as well.
+func (r *DesktopUsersProcessesRunner) Ping() {
+	if err := r.writeLocalizationFile(); err != nil {
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to write localization file after subsystem update",
+			"err", err,
+		)
+	}
+
+	r.refreshMenu()
+}
+
 func (r *DesktopUsersProcessesRunner) FlagsChanged(ctx context.Context, flagKeys ...keys.FlagKey) {
 	ctx, span := observability.StartSpan(ctx)
 	defer span.End()
@@ -698,6 +725,16 @@ func (r *DesktopUsersProcessesRunner) refreshMenu() {
 				"err", err,
 			)
 		}
+	}
+
+	// Defensively re-write the localization file alongside the menu so the
+	// shared file stays in sync with the latest translations even if the
+	// localizations subsystem update was missed.
+	if err := r.writeLocalizationFile(); err != nil {
+		r.slogger.Log(context.TODO(), slog.LevelWarn,
+			"failed to write localization file during menu refresh",
+			"err", err,
+		)
 	}
 
 	if r.knapsack.InModernStandby() {
@@ -1120,6 +1157,25 @@ func (r *DesktopUsersProcessesRunner) menuTemplatePath() string {
 	return filepath.Join(r.usersFilesRoot, "menu_template.json")
 }
 
+// localizationPath returns the path to the localization data file shared
+// with the desktop child processes.
+func (r *DesktopUsersProcessesRunner) localizationPath() string {
+	return filepath.Join(r.usersFilesRoot, "localization.json")
+}
+
+// writeLocalizationFile serializes the current LocalizationData from the
+// knapsack and writes it to the shared file consumed by desktop child processes.
+func (r *DesktopUsersProcessesRunner) writeLocalizationFile() error {
+	data, err := json.Marshal(r.knapsack.LocalizationData())
+	if err != nil {
+		return fmt.Errorf("marshalling localization data: %w", err)
+	}
+	if err := r.writeSharedFile(r.localizationPath(), data); err != nil {
+		return fmt.Errorf("writing localization file: %w", err)
+	}
+	return nil
+}
+
 // desktopCommand invokes the launcher desktop executable with the appropriate env vars
 func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socketPath, menuPath string) (*exec.Cmd, error) {
 	// Whenever we swap to using allowedcmd.Launcher instead, we should account for
@@ -1139,6 +1195,7 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(executablePath, uid, socket
 		fmt.Sprintf("USER_SERVER_SOCKET_PATH=%s", socketPath),
 		fmt.Sprintf("ICON_PATH=%s", r.iconFileLocation()),
 		fmt.Sprintf("MENU_PATH=%s", menuPath),
+		fmt.Sprintf("LOCALIZATION_PATH=%s", r.localizationPath()),
 		fmt.Sprintf("PPID=%d", os.Getpid()),
 		fmt.Sprintf("RUNNER_SERVER_URL=%s", r.runnerServer.Url()),
 		fmt.Sprintf("RUNNER_SERVER_AUTH_TOKEN=%s", r.runnerServer.RegisterClient(uid)),

--- a/ee/desktop/runner/runner_test.go
+++ b/ee/desktop/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -553,4 +554,81 @@ func TestDesktopUsersProcessesRunner_DetectPresence(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, presencedetection.DetectionFailedDurationValue, d)
 	})
+}
+
+func Test_writeLocalizationFile(t *testing.T) {
+	t.Parallel()
+
+	expected := types.LocalizationData{
+		Locale: "es-ES",
+		Translations: map[string]types.Translations{
+			"es-ES": {},
+		},
+	}
+
+	mockKnapsack := mocks.NewKnapsack(t)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopEnabled)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopGoMaxProcs)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopUpdateInterval)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.KolideServerURL)
+	mockKnapsack.On("DesktopUpdateInterval").Return(time.Millisecond * 250)
+	mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
+	mockKnapsack.On("DesktopGoMaxProcs").Return(2).Maybe()
+	mockKnapsack.On("KolideServerURL").Return("somewhere-over-the-rainbow.example.com")
+	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+	mockKnapsack.On("InModernStandby").Return(false).Maybe()
+	mockKnapsack.On("DebugServerData").Return(false).Maybe()
+	mockKnapsack.On("LocalizationData").Return(expected)
+
+	dir := t.TempDir()
+	r, err := New(mockKnapsack, nil, WithUsersFilesRoot(dir))
+	require.NoError(t, err)
+
+	require.NoError(t, r.writeLocalizationFile())
+
+	contents, err := os.ReadFile(r.localizationPath())
+	require.NoError(t, err)
+
+	var got types.LocalizationData
+	require.NoError(t, json.Unmarshal(contents, &got))
+	require.Equal(t, expected.Locale, got.Locale)
+	require.Contains(t, got.Translations, "es-ES")
+}
+
+func Test_Ping_writesLocalizationFile(t *testing.T) {
+	t.Parallel()
+
+	expected := types.LocalizationData{
+		Locale: "fr-FR",
+		Translations: map[string]types.Translations{
+			"fr-FR": {},
+		},
+	}
+
+	mockKnapsack := mocks.NewKnapsack(t)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopEnabled)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopGoMaxProcs)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.DesktopUpdateInterval)
+	mockKnapsack.On("RegisterChangeObserver", mock.Anything, keys.KolideServerURL)
+	mockKnapsack.On("DesktopUpdateInterval").Return(time.Millisecond * 250)
+	mockKnapsack.On("DesktopMenuRefreshInterval").Return(time.Millisecond * 250)
+	mockKnapsack.On("DesktopGoMaxProcs").Return(2).Maybe()
+	mockKnapsack.On("KolideServerURL").Return("somewhere-over-the-rainbow.example.com")
+	mockKnapsack.On("Slogger").Return(multislogger.NewNopLogger())
+	mockKnapsack.On("InModernStandby").Return(false)
+	mockKnapsack.On("DebugServerData").Return(false).Maybe()
+	mockKnapsack.On("LocalizationData").Return(expected)
+
+	dir := t.TempDir()
+	r, err := New(mockKnapsack, nil, WithUsersFilesRoot(dir))
+	require.NoError(t, err)
+
+	r.Ping()
+
+	contents, err := os.ReadFile(r.localizationPath())
+	require.NoError(t, err)
+
+	var got types.LocalizationData
+	require.NoError(t, json.Unmarshal(contents, &got))
+	require.Equal(t, expected.Locale, got.Locale)
 }

--- a/ee/desktop/user/notify/localization.go
+++ b/ee/desktop/user/notify/localization.go
@@ -1,0 +1,43 @@
+package notify
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/kolide/launcher/v2/ee/agent/types"
+)
+
+// learnMoreFallback is the English default used when no localized string is
+// available (path empty, file missing/corrupt, locale not present, or key empty).
+const learnMoreFallback = "Learn More"
+
+// loadLocalizationData reads the localization file written by the runner.
+// Returns a zero-value LocalizationData on any error so callers can fall back
+// to defaults without surfacing errors at the UI layer.
+func loadLocalizationData(path string) types.LocalizationData {
+	if path == "" {
+		return types.LocalizationData{}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return types.LocalizationData{}
+	}
+
+	var ld types.LocalizationData
+	if err := json.Unmarshal(data, &ld); err != nil {
+		return types.LocalizationData{}
+	}
+
+	return ld
+}
+
+// learnMoreLabel returns the localized "Learn More" action label for the
+// configured locale, or the English default if no translation is available.
+func learnMoreLabel(path string) string {
+	ld := loadLocalizationData(path)
+	if t, ok := ld.Translations[ld.Locale]; ok && t.Notifications.Actions.LearnMore != "" {
+		return t.Notifications.Actions.LearnMore
+	}
+	return learnMoreFallback
+}

--- a/ee/desktop/user/notify/localization_test.go
+++ b/ee/desktop/user/notify/localization_test.go
@@ -1,0 +1,171 @@
+package notify
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kolide/launcher/v2/ee/agent/types"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLocalizationFile is a tiny test helper that writes a LocalizationData
+// to a temp file and returns the path.
+func writeTestLocalizationFile(t *testing.T, ld types.LocalizationData) string {
+	t.Helper()
+	data, err := json.Marshal(ld)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "localization.json")
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+// localizationDataWithLearnMore builds a LocalizationData with the given
+// locale and Learn More translation.
+func localizationDataWithLearnMore(locale, learnMore string) types.LocalizationData {
+	var n types.Notifications
+	n.Actions.LearnMore = learnMore
+
+	return types.LocalizationData{
+		Locale: locale,
+		Translations: map[string]types.Translations{
+			locale: {Notifications: n},
+		},
+	}
+}
+
+func TestLoadLocalizationData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		path        func(t *testing.T) string
+		wantLocale  string
+		wantInMap   bool
+		wantMissing bool
+	}{
+		{
+			name:        "empty path returns zero value",
+			path:        func(t *testing.T) string { return "" },
+			wantMissing: true,
+		},
+		{
+			name: "missing file returns zero value",
+			path: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "does-not-exist.json")
+			},
+			wantMissing: true,
+		},
+		{
+			name: "corrupt JSON returns zero value",
+			path: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "bad.json")
+				require.NoError(t, os.WriteFile(p, []byte("not valid json"), 0644))
+				return p
+			},
+			wantMissing: true,
+		},
+		{
+			name: "valid file is parsed",
+			path: func(t *testing.T) string {
+				return writeTestLocalizationFile(t, localizationDataWithLearnMore("es-ES", "Más información"))
+			},
+			wantLocale: "es-ES",
+			wantInMap:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ld := loadLocalizationData(tt.path(t))
+
+			if tt.wantMissing {
+				require.Empty(t, ld.Locale)
+				require.Empty(t, ld.Translations)
+				return
+			}
+
+			require.Equal(t, tt.wantLocale, ld.Locale)
+			if tt.wantInMap {
+				require.Contains(t, ld.Translations, tt.wantLocale)
+			}
+		})
+	}
+}
+
+func TestLearnMoreLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path func(t *testing.T) string
+		want string
+	}{
+		{
+			name: "empty path falls back to English",
+			path: func(t *testing.T) string { return "" },
+			want: learnMoreFallback,
+		},
+		{
+			name: "missing file falls back to English",
+			path: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.json")
+			},
+			want: learnMoreFallback,
+		},
+		{
+			name: "corrupt JSON falls back to English",
+			path: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "bad.json")
+				require.NoError(t, os.WriteFile(p, []byte("{not json"), 0644))
+				return p
+			},
+			want: learnMoreFallback,
+		},
+		{
+			name: "active locale not in translations falls back to English",
+			path: func(t *testing.T) string {
+				ld := types.LocalizationData{
+					Locale: "fr-FR",
+					Translations: map[string]types.Translations{
+						"es-ES": {},
+					},
+				}
+				return writeTestLocalizationFile(t, ld)
+			},
+			want: learnMoreFallback,
+		},
+		{
+			name: "locale present but learn_more empty falls back to English",
+			path: func(t *testing.T) string {
+				return writeTestLocalizationFile(t, localizationDataWithLearnMore("es-ES", ""))
+			},
+			want: learnMoreFallback,
+		},
+		{
+			name: "spanish translation returns localized value",
+			path: func(t *testing.T) string {
+				return writeTestLocalizationFile(t, localizationDataWithLearnMore("es-ES", "Más información"))
+			},
+			want: "Más información",
+		},
+		{
+			name: "japanese translation returns localized value",
+			path: func(t *testing.T) string {
+				return writeTestLocalizationFile(t, localizationDataWithLearnMore("ja", "詳細"))
+			},
+			want: "詳細",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, learnMoreLabel(tt.path(t)))
+		})
+	}
+}

--- a/ee/desktop/user/notify/notify_darwin.go
+++ b/ee/desktop/user/notify/notify_darwin.go
@@ -10,7 +10,7 @@ package notify
 #include <stdlib.h>
 
 bool sendNotification(char *cTitle, char *cBody, char *cActionUri);
-void runNotificationListenerApp(void);
+void runNotificationListenerApp(char *cLearnMoreLabel);
 */
 import "C"
 import (
@@ -24,13 +24,15 @@ import (
 )
 
 type macNotifier struct {
-	interrupt   chan struct{}
-	interrupted atomic.Bool
+	localizationPath string
+	interrupt        chan struct{}
+	interrupted      atomic.Bool
 }
 
-func NewDesktopNotifier(_ *slog.Logger, _ string) *macNotifier {
+func NewDesktopNotifier(_ *slog.Logger, _ string, localizationPath string) *macNotifier {
 	return &macNotifier{
-		interrupt: make(chan struct{}),
+		localizationPath: localizationPath,
+		interrupt:        make(chan struct{}),
 	}
 }
 
@@ -48,9 +50,17 @@ func (m *macNotifier) Interrupt(err error) {
 }
 
 func (m *macNotifier) Listen() {
-	if isBundle() {
-		C.runNotificationListenerApp()
+	if !isBundle() {
+		return
 	}
+
+	// Resolve the "Learn More" label once at listener startup. The action title
+	// is baked into the registered notification category, so live locale changes
+	// only take effect after the desktop process restarts.
+	learnMoreCStr := C.CString(learnMoreLabel(m.localizationPath))
+	defer C.free(unsafe.Pointer(learnMoreCStr))
+
+	C.runNotificationListenerApp(learnMoreCStr)
 }
 
 func (m *macNotifier) SendNotification(n Notification) error {

--- a/ee/desktop/user/notify/notify_darwin.m
+++ b/ee/desktop/user/notify/notify_darwin.m
@@ -24,15 +24,17 @@
 
 NotificationDelegate *notificationDelegate;
 
-void runNotificationListenerApp(void) {
+void runNotificationListenerApp(char *cLearnMoreLabel) {
     @autoreleasepool {
         [NSApplication sharedApplication];
 
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
+        NSString *learnMoreTitle = [NSString stringWithUTF8String:cLearnMoreLabel];
+
         // Define our custom notification category with actions we will want to use on notifications later
         UNNotificationAction *learnMoreAction = [UNNotificationAction actionWithIdentifier:@"LearnMoreAction"
-            title:@"Learn More" options:UNNotificationActionOptionNone];
+            title:learnMoreTitle options:UNNotificationActionOptionNone];
 
         UNNotificationCategory *category = [UNNotificationCategory categoryWithIdentifier:@"KolideNotificationWithButtonCategory"
             actions:@[learnMoreAction] intentIdentifiers:@[]

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -16,6 +16,7 @@ import (
 
 type dbusNotifier struct {
 	iconFilepath        string
+	localizationPath    string
 	slogger             *slog.Logger
 	conn                *dbus.Conn
 	signal              chan *dbus.Signal
@@ -35,7 +36,7 @@ const (
 // the correct default browser.
 var browserLaunchers = []allowedcmd.AllowedCommand{allowedcmd.XdgOpen, allowedcmd.XWwwBrowser}
 
-func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string) *dbusNotifier {
+func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationPath string) *dbusNotifier {
 	conn, err := dbus.ConnectSessionBus()
 	if err != nil {
 		slogger.Log(context.TODO(), slog.LevelWarn,
@@ -46,6 +47,7 @@ func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string) *dbusNotifier
 
 	return &dbusNotifier{
 		iconFilepath:        iconFilepath,
+		localizationPath:    localizationPath,
 		slogger:             slogger.With("component", "desktop_notifier"),
 		conn:                conn,
 		signal:              make(chan *dbus.Signal),
@@ -166,7 +168,7 @@ func (d *dbusNotifier) sendNotificationViaDbus(n Notification) error {
 
 	actions := []string{}
 	if n.ActionUri != "" {
-		actions = append(actions, n.ActionUri, "Learn More")
+		actions = append(actions, n.ActionUri, learnMoreLabel(d.localizationPath))
 	}
 
 	notificationsService := conn.Object(notificationServiceInterface, notificationServiceObj)
@@ -210,7 +212,7 @@ func (d *dbusNotifier) sendNotificationViaNotifySend(n Notification) error {
 	// notify-send doesn't support actions, but URLs in notifications are clickable in at least
 	// some desktop environments.
 	if n.ActionUri != "" {
-		n.Body += " Learn More: " + n.ActionUri
+		n.Body += " " + learnMoreLabel(d.localizationPath) + ": " + n.ActionUri
 	}
 
 	args := []string{n.Title, n.Body}

--- a/ee/desktop/user/notify/notify_windows.go
+++ b/ee/desktop/user/notify/notify_windows.go
@@ -13,17 +13,19 @@ import (
 )
 
 type windowsNotifier struct {
-	slogger      *slog.Logger
-	iconFilepath string
-	interrupt    chan struct{}
-	interrupted  atomic.Bool
+	slogger          *slog.Logger
+	iconFilepath     string
+	localizationPath string
+	interrupt        chan struct{}
+	interrupted      atomic.Bool
 }
 
-func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string) *windowsNotifier {
+func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationPath string) *windowsNotifier {
 	return &windowsNotifier{
-		slogger:      slogger.With("component", "desktop_notifier"),
-		iconFilepath: iconFilepath,
-		interrupt:    make(chan struct{}),
+		slogger:          slogger.With("component", "desktop_notifier"),
+		iconFilepath:     iconFilepath,
+		localizationPath: localizationPath,
+		interrupt:        make(chan struct{}),
 	}
 }
 
@@ -66,8 +68,8 @@ func (w *windowsNotifier) SendNotification(n Notification) error {
 		notification.Actions = []toast.Action{
 			{
 				Type:      "protocol",
-				Label:     "Learn More",
-				Arguments: actionUri,
+				Label:     learnMoreLabel(w.localizationPath),
+				Arguments: n.ActionUri,
 			},
 		}
 	}

--- a/ee/desktop/user/notify/notify_windows.go
+++ b/ee/desktop/user/notify/notify_windows.go
@@ -69,7 +69,7 @@ func (w *windowsNotifier) SendNotification(n Notification) error {
 			{
 				Type:      "protocol",
 				Label:     learnMoreLabel(w.localizationPath),
-				Arguments: n.ActionUri,
+				Arguments: actionUri,
 			},
 		}
 	}


### PR DESCRIPTION
This pull request adds support for localized desktop notification UI strings, specifically the "Learn More" action label, and ensures that localization data is correctly distributed and updated for desktop child processes. It introduces a new mechanism for the runner to write localization data to a shared file, updates the desktop notifier implementations to read and use this data, and adds robust tests for these behaviors.

**Localization infrastructure and data flow:**
* The runner now writes a `localization.json` file containing the current localization data at startup, on localization subsystem updates, and during menu refreshes, ensuring desktop child processes always have up-to-date translations. [[1]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR245-R254) [[2]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR594-R609) [[3]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR730-R739) [[4]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR1160-R1178) [[5]](diffhunk://#diff-dd532c327d56a5d3623a61b7983e174e88bf93ba87f785ddfe9811a8029a9a63R496-R500)
* The desktop runner is subscribed to localization subsystem updates, triggering re-writing of the localization file when translations change.

**Desktop notifier changes:**
* Both macOS and Linux desktop notifiers now accept a `localizationPath` parameter, and use it to load the localized "Learn More" label from the shared file, falling back to English if missing. [[1]](diffhunk://#diff-e914ac440f6b21605fc3a139d24343ee9ab92f2b8ee3b032c9a447e0956ee1cdR27-R34) [[2]](diffhunk://#diff-e914ac440f6b21605fc3a139d24343ee9ab92f2b8ee3b032c9a447e0956ee1cdL51-R63) [[3]](diffhunk://#diff-e914ac440f6b21605fc3a139d24343ee9ab92f2b8ee3b032c9a447e0956ee1cdL13-R13) [[4]](diffhunk://#diff-e305230a388e36493b9ba7565b5cbec92b499b73c73e554faa2f5a015c50f7dbR19) [[5]](diffhunk://#diff-e305230a388e36493b9ba7565b5cbec92b499b73c73e554faa2f5a015c50f7dbL38-R39) [[6]](diffhunk://#diff-13853b2809554a60e1bb04821951e81bfe367616208be0702ec1dfe84869391eR1-R43)
* On macOS, the localized action label is passed into the notification listener at startup, ensuring notifications show the correct translation. [[1]](diffhunk://#diff-e914ac440f6b21605fc3a139d24343ee9ab92f2b8ee3b032c9a447e0956ee1cdL51-R63) [[2]](diffhunk://#diff-da874a3c65eb3e9ff8b7fc72d07e33815dbffc3c5e787cc643facf9334e2eb20L27-R37)

**Localization data structure and assets:**
* The `Translations` struct now includes a `Notifications` field for notification UI translations, and English assets are updated to include the "Learn More" translation. [[1]](diffhunk://#diff-4a591395bce61f144bb1edc4756bff8398c61ee2b744ae06da599296e6ffa80eR20-R28) [[2]](diffhunk://#diff-8491cbe9ab557e5f037e7c9f1a758bd6478ad75c2f4aa54c4749a49547289849R59-R63) [[3]](diffhunk://#diff-b6db1feddc70054bdb36a190bd901f2ff398bed78d331467226c1d3811412a12R59-R63)

**Launcher and runner integration:**
* The launcher and runner are updated to pass the localization file path to child processes and notifiers, wiring the new localization flow end-to-end. [[1]](diffhunk://#diff-d97f83ae5c4e09e5ef0a3756c015c864a49104dda51a77263281e6a7dfd51cc1R65-R69) [[2]](diffhunk://#diff-d97f83ae5c4e09e5ef0a3756c015c864a49104dda51a77263281e6a7dfd51cc1L151-R156) [[3]](diffhunk://#diff-34484aea82f70e4748d3eaf100b9471c5050b3961ea5c50bac6c0409b0e6748eR1198)

**Testing:**
* Comprehensive tests are added for writing the localization file, updating on subsystem changes, and for the notification localization loading and fallback logic. [[1]](diffhunk://#diff-ef46dfd5dca9bec2770164e548424ada1d94b30ba3ce55eb948fdc5b42973470R558-R634) [[2]](diffhunk://#diff-4f47619b5e2ad468cf5584c9d11a91fcba7a4890798007b177b6d7c87431908cR1-R171)

These changes together enable dynamic, robust localization of desktop notification UI elements, with safe fallbacks and automated distribution of translation updates.