### PR TITLE
Remove two launcher-orphaned sloggers,  observe sendbuffer errors

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -232,6 +232,13 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	gomaxprocsObs := newGomaxprocsObserver(slogger, k)
 	flagController.RegisterChangeObserver(gomaxprocsObs, keys.LauncherGoMaxProcs)
 
+	// Generates and stores a new run ID
+	newRunID := k.GetRunID()
+
+	// Update the local context logger and surface the knapsack-configured slogger
+	logger = log.With(logger, "run_id", newRunID)
+	slogger = k.Slogger()
+
 	// Apply GOMAXPROCS limit from control flag
 	gomaxprocsLimiter(ctx, slogger, k.LauncherGoMaxProcs())
 
@@ -241,13 +248,6 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 	flagController.RegisterChangeObserver(multiSlogger, keys.DuplicateLogWindow)
 	// Set initial dedup window from current flag value
 	multiSlogger.UpdateDuplicateLogWindow(flagController.DuplicateLogWindow())
-
-	// Generate a new run ID
-	newRunID := k.GetRunID()
-
-	// Apply the run ID to both logger and slogger
-	logger = log.With(logger, "run_id", newRunID)
-	slogger = slogger.With("run_id", newRunID)
 
 	// set start time, first runtime, first version
 	initLauncherHistory(k)

--- a/ee/agent/knapsack/knapsack.go
+++ b/ee/agent/knapsack/knapsack.go
@@ -81,8 +81,8 @@ func New(stores map[storage.Store]types.KVStore, flags types.Flags, db *bbolt.DB
 func (k *knapsack) GetRunID() string {
 	if runID == "" {
 		runID = ulid.New()
-		k.slogger.Logger = k.slogger.With("run_id", runID)
-		k.systemSlogger.Logger = k.systemSlogger.With("run_id", runID)
+		*k.slogger.Logger = *k.slogger.With("run_id", runID)
+		*k.systemSlogger.Logger = *k.systemSlogger.With("run_id", runID)
 	}
 	return runID
 }

--- a/ee/agent/knapsack/knapsack_test.go
+++ b/ee/agent/knapsack/knapsack_test.go
@@ -855,7 +855,7 @@ func createTestEnrollSecret(t *testing.T, munemo string) string {
 
 // Retrieving a RunID should fetch a consistent ID. It also shouldn't replace the pointers
 // to our internal loggers which are exposed via APIs.
-func TestGetRunID(t *testing.T) {
+func TestGetRunID(t *testing.T) { //nolint:paralleltest
 	newKnapsack := func() *knapsack {
 		enrollmentDetailsStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.EnrollmentDetailsStore.String())
 		require.NoError(t, err)
@@ -864,7 +864,7 @@ func TestGetRunID(t *testing.T) {
 		}, nil, nil, multislogger.New(), multislogger.New())
 	}
 
-	t.Run("generates and returns same ID", func(t *testing.T) {
+	t.Run("generates and returns same ID", func(t *testing.T) { //nolint:paralleltest
 		runID = "" // reset global, otherwise test is a no-op
 		testKnapsack := newKnapsack()
 		runId := testKnapsack.GetRunID()
@@ -874,7 +874,7 @@ func TestGetRunID(t *testing.T) {
 
 	// Regression: GetRunID historically orphaned existing loggers
 	// by replacing the Logger pointers in knapsack.
-	t.Run("does not orphan existing sloggers", func(t *testing.T) {
+	t.Run("does not orphan existing sloggers", func(t *testing.T) { //nolint:paralleltest
 		runID = "" // reset global, otherwise test is a no-op
 		testKnapsack := newKnapsack()
 		slogger := testKnapsack.Slogger()

--- a/ee/agent/knapsack/knapsack_test.go
+++ b/ee/agent/knapsack/knapsack_test.go
@@ -852,3 +852,39 @@ func createTestEnrollSecret(t *testing.T, munemo string) string {
 
 	return signedTokenStr
 }
+
+// Retrieving a RunID should fetch a consistent ID. It also shouldn't replace the pointers
+// to our internal loggers which are exposed via APIs.
+func TestGetRunID(t *testing.T) {
+	newKnapsack := func() *knapsack {
+		enrollmentDetailsStore, err := storageci.NewStore(t, multislogger.NewNopLogger(), storage.EnrollmentDetailsStore.String())
+		require.NoError(t, err)
+		return New(map[storage.Store]types.KVStore{
+			storage.EnrollmentDetailsStore: enrollmentDetailsStore,
+		}, nil, nil, multislogger.New(), multislogger.New())
+	}
+
+	t.Run("generates and returns same ID", func(t *testing.T) {
+		runID = "" // reset global, otherwise test is a no-op
+		testKnapsack := newKnapsack()
+		runId := testKnapsack.GetRunID()
+		require.NotEmpty(t, runId)
+		require.Equal(t, runId, testKnapsack.GetRunID())
+	})
+
+	// Regression: GetRunID historically orphaned existing loggers
+	// by replacing the Logger pointers in knapsack.
+	t.Run("does not orphan existing sloggers", func(t *testing.T) {
+		runID = "" // reset global, otherwise test is a no-op
+		testKnapsack := newKnapsack()
+		slogger := testKnapsack.Slogger()
+		systemSlogger := testKnapsack.SystemSlogger()
+		require.NotNil(t, slogger)
+		require.NotNil(t, systemSlogger)
+
+		testKnapsack.GetRunID()
+
+		require.Equal(t, slogger, testKnapsack.Slogger())
+		require.Equal(t, systemSlogger, testKnapsack.SystemSlogger())
+	})
+}

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -52,7 +52,7 @@ func New(k types.Knapsack, baseLogger log.Logger) *LogShipper {
 	sender := newAuthHttpSender()
 
 	sendInterval := defaultSendInterval
-	sendBuffer := sendbuffer.New(sender, sendbuffer.WithSendInterval(sendInterval))
+	sendBuffer := sendbuffer.New(sender, sendbuffer.WithSendInterval(sendInterval), sendbuffer.WithLogger(baseLogger))
 
 	// setting a ulid as session_ulid allows us to follow a single run of launcher
 	shippingLogger := log.With(log.NewJSONLogger(sendBuffer), "caller", log.Caller(6), "session_ulid", ulid.New())


### PR DESCRIPTION
This PR follows a similar goal to #1869. We observe that some logs and attributes do not properly get shipped via logshipper. The prior PR succeeded, now allowing run_group logs to be shipped, but we're still missing others along with some attributes. 

I've identified a handful of places where we mishandle multiple loggers, drop slogger attributes, or orphan loggers. This PR fixes a few and adds a bit of obs.

Bugs addressed:
  * logshipper silently drops logs when configured storage values are exceeded due to an unconfigured `NopLogger`.
    * logshipper requires sendbuffer and a questionable refactor is needed to connect them.
  * `knapsack.GetRunID()` modified the pointer of its internal loggers, which effectively orphaned any previously retrieved sloggers.
    * This was a root cause of #1869, as rungroup setup preceded RunID initialization and logshipper setup. 
  * `runLauncher` juggled an orphaned slogger at the top-level, cloning it with `With`. I believe the cloned one only logged locally, though I'm not sure.
  
Enough logs are still not shipped that I'm certain these fixes aren't a smoking gun. But they're in the way of my investigation.