### PR TITLE
Ignore android:apk-key-hash from generic-api-key findings

### DIFF
--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -33,6 +33,11 @@ description = "Ignore key algorithms supported by AWS Certificate Manager (https
 condition = "AND"
 # Values retrieved from https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateDetail.html
 stopwords = ["RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096", "EC_prime256v1", "EC_secp384r1", "EC_secp521r1"]
+[[rules.allowlists]]
+description = "Ignore base64-encoded SHA256 hashes of APK signing certificates"
+condition = "AND"
+regexTarget = "line"
+regexes = ['''.*android:apk-key-hash:.*''']
 
 [[rules]]
 id = "private-key"

--- a/ee/tables/secretscan/config.toml
+++ b/ee/tables/secretscan/config.toml
@@ -37,7 +37,7 @@ stopwords = ["RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096", "EC_prime256v1", "E
 description = "Ignore base64-encoded SHA256 hashes of APK signing certificates"
 condition = "AND"
 regexTarget = "line"
-regexes = ['''.*android:apk-key-hash:.*''']
+regexes = ['''android:apk-key-hash:''']
 
 [[rules]]
 id = "private-key"

--- a/ee/tables/secretscan/table_test.go
+++ b/ee/tables/secretscan/table_test.go
@@ -600,6 +600,16 @@ MC4CAQAwBQYDK2VwBCIEIALEbo1EFnWFqBK/wC+hhypG/8hXEerwdNetAoFoFVdv
 			rawData:         `1prk-25qx-vsex-bgmd-7cen-6yjn-java-drq3-dh2b-oic4-st4f-clua-bufs-vrna`,
 			expectedFinding: false,
 		},
+		{
+			testCaseName:    "APK key hash",
+			rawData:         `android:apk-key-hash:H9aaJx3lOZCaxVnsZU5__AZkVjXJALA11rtegEE0Ldc`,
+			expectedFinding: false,
+		},
+		{
+			testCaseName:    "APK key hash, middle of string",
+			rawData:         `TEST=android:apk-key-hash:H9aaJx3lOZCaxVnsZU5__AZkVjXJALA11rtegEE0Ldc`,
+			expectedFinding: false,
+		},
 	} {
 		t.Run(tt.testCaseName, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
As far as I can tell, this is not a sensitive value.