### PR TITLE
logshipper: increase buffer/batch size, fix potential client race, add sendbuffer draining

### DIFF
--- a/pkg/log/logshipper/authedhttpsender.go
+++ b/pkg/log/logshipper/authedhttpsender.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/kolide/launcher/v2/pkg/atomic"
 )
 
 type authedHttpSender struct {
-	endpoint  string
-	authtoken string
+	endpoint  atomic.String
+	authtoken atomic.String
 	client    *http.Client
 }
 
@@ -25,12 +27,12 @@ func newAuthHttpSender() *authedHttpSender {
 }
 
 func (a *authedHttpSender) Send(ctx context.Context, r io.Reader) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint, r)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint.Load(), r)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("authorization", a.authtoken)
+	req.Header.Set("authorization", a.authtoken.Load())
 
 	resp, err := a.client.Do(req)
 	if err != nil {

--- a/pkg/log/logshipper/authedhttpsender.go
+++ b/pkg/log/logshipper/authedhttpsender.go
@@ -15,6 +15,7 @@ type authedHttpSender struct {
 	client    *http.Client
 }
 
+// Creates a generic HTTP client with an overall 30s timeout.
 func newAuthHttpSender() *authedHttpSender {
 	return &authedHttpSender{
 		client: &http.Client{
@@ -23,10 +24,7 @@ func newAuthHttpSender() *authedHttpSender {
 	}
 }
 
-func (a *authedHttpSender) Send(r io.Reader) error {
-	ctx, cancel := context.WithTimeout(context.Background(), a.client.Timeout)
-	defer cancel()
-
+func (a *authedHttpSender) Send(ctx context.Context, r io.Reader) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint, r)
 	if err != nil {
 		return err

--- a/pkg/log/logshipper/authedhttpsender.go
+++ b/pkg/log/logshipper/authedhttpsender.go
@@ -41,7 +41,7 @@ func (a *authedHttpSender) Send(r io.Reader) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		bodyData, err := io.ReadAll(resp.Request.Body)
+		bodyData, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("received non 200 http status code: %d, error reading body response body %w", resp.StatusCode, err)
 		}

--- a/pkg/log/logshipper/authedhttpsender_test.go
+++ b/pkg/log/logshipper/authedhttpsender_test.go
@@ -2,6 +2,7 @@ package logshipper
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -40,7 +41,7 @@ func Test_authedHttpSender_Send(t *testing.T) {
 			authedSender := newAuthHttpSender()
 			authedSender.endpoint = ts.URL
 			authedSender.authtoken = token
-			authedSender.Send(bytes.NewBuffer(dataToSend))
+			authedSender.Send(context.Background(), bytes.NewBuffer(dataToSend))
 
 			wg.Wait()
 		})

--- a/pkg/log/logshipper/authedhttpsender_test.go
+++ b/pkg/log/logshipper/authedhttpsender_test.go
@@ -39,8 +39,8 @@ func Test_authedHttpSender_Send(t *testing.T) {
 			defer ts.Close()
 
 			authedSender := newAuthHttpSender()
-			authedSender.endpoint = ts.URL
-			authedSender.authtoken = token
+			authedSender.endpoint.Store(ts.URL)
+			authedSender.authtoken.Store(token)
 			authedSender.Send(context.Background(), bytes.NewBuffer(dataToSend))
 
 			wg.Wait()

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -30,6 +30,7 @@ const (
 	truncatedFormatString = "%s[TRUNCATED]"
 	defaultSendInterval   = 1 * time.Minute
 	debugSendInterval     = 5 * time.Second
+	maxDrainTimeout       = 5 * time.Second
 )
 
 type LogShipper struct {
@@ -152,6 +153,18 @@ func (ls *LogShipper) Stop(_ error) {
 
 	if ls.stopFunc != nil {
 		ls.stopFunc()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), maxDrainTimeout)
+	defer cancel()
+
+	// Try to send any buffered logs without blocking process exit for too long.
+	if err := ls.sendBuffer.Drain(ctx); err != nil {
+		ls.knapsack.Slogger().Log(context.Background(), slog.LevelError,
+			"draining buffered logs errored",
+			"err",
+			err,
+		)
 	}
 }
 

--- a/pkg/log/logshipper/logshipper.go
+++ b/pkg/log/logshipper/logshipper.go
@@ -299,7 +299,7 @@ func (ls *LogShipper) updateSenderAuthToken() error {
 		return errors.New("no token found")
 	}
 
-	ls.sender.authtoken = string(token)
+	ls.sender.authtoken.Store(string(token))
 	return nil
 }
 
@@ -311,11 +311,11 @@ func (ls *LogShipper) updateLogIngestURL() error {
 	}
 
 	if parsedUrl == nil || parsedUrl.String() == "" {
-		ls.sender.endpoint = ""
+		ls.sender.endpoint.Store("")
 		return errors.New("log ingest url is empty")
 	}
 
-	ls.sender.endpoint = parsedUrl.String()
+	ls.sender.endpoint.Store(parsedUrl.String())
 	return nil
 }
 

--- a/pkg/log/logshipper/logshipper_test.go
+++ b/pkg/log/logshipper/logshipper_test.go
@@ -60,7 +60,7 @@ func TestLogShipper(t *testing.T) {
 			knapsack.On("LogIngestServerURL").Return("").Once()
 			ls.Ping()
 			require.False(t, ls.isShippingStarted.Load(), "shipping should not have stared since there is no ingest server url")
-			require.Equal(t, authToken, ls.sender.authtoken)
+			require.Equal(t, authToken, ls.sender.authtoken.Load())
 
 			// no device identifying attributes
 			logIngestUrl := "https://example.com"
@@ -68,8 +68,8 @@ func TestLogShipper(t *testing.T) {
 			knapsack.On("ServerProvidedDataStore").Return(storageci.NewStore(t, multislogger.NewNopLogger(), "test")).Once()
 			ls.Ping()
 			require.False(t, ls.isShippingStarted.Load(), "shipping should not have stared since there are no device identifying attributes")
-			require.Equal(t, authToken, ls.sender.authtoken)
-			require.Equal(t, logIngestUrl, ls.sender.endpoint)
+			require.Equal(t, authToken, ls.sender.authtoken.Load())
+			require.Equal(t, logIngestUrl, ls.sender.endpoint.Load())
 
 			// happy path
 
@@ -85,8 +85,8 @@ func TestLogShipper(t *testing.T) {
 			})
 			ls.Ping()
 			require.True(t, ls.isShippingStarted.Load(), "shipping should now be enabled")
-			require.Equal(t, authToken, ls.sender.authtoken)
-			require.Equal(t, logIngestUrl, ls.sender.endpoint)
+			require.Equal(t, authToken, ls.sender.authtoken.Load())
+			require.Equal(t, logIngestUrl, ls.sender.endpoint.Load())
 
 			// make sure attributes are added to logs in send buffer
 			ls.sendBuffer.UpdateData(func(in io.Reader, out io.Writer) error {
@@ -109,24 +109,24 @@ func TestLogShipper(t *testing.T) {
 			authToken = ulid.New()
 			tokenStore.Set(storage.ObservabilityIngestAuthTokenKey, []byte(authToken))
 			ls.Ping()
-			require.Equal(t, authToken, ls.sender.authtoken, "auth token should update")
-			require.Equal(t, logIngestUrl, ls.sender.endpoint)
+			require.Equal(t, authToken, ls.sender.authtoken.Load(), "auth token should update")
+			require.Equal(t, logIngestUrl, ls.sender.endpoint.Load())
 
 			// update shipping level
 			knapsack.On("LogShippingLevel").Return("debug")
 			knapsack.On("Slogger").Return(multislogger.NewNopLogger())
 			ls.Ping()
 			require.Equal(t, slog.LevelDebug.Level(), ls.slogLevel.Level(), "log shipper should set to debug")
-			require.Equal(t, authToken, ls.sender.authtoken)
-			require.Equal(t, logIngestUrl, ls.sender.endpoint)
+			require.Equal(t, authToken, ls.sender.authtoken.Load())
+			require.Equal(t, logIngestUrl, ls.sender.endpoint.Load())
 
 			// update log ingest url
 			logIngestUrl = "https://example.com/new"
 			knapsack.On("LogIngestServerURL").Return(logIngestUrl)
 			ls.Ping()
 			require.Equal(t, slog.LevelDebug.Level(), ls.slogLevel.Level(), "log shipper should set to debug")
-			require.Equal(t, authToken, ls.sender.authtoken)
-			require.Equal(t, logIngestUrl, ls.sender.endpoint)
+			require.Equal(t, authToken, ls.sender.authtoken.Load())
+			require.Equal(t, logIngestUrl, ls.sender.endpoint.Load())
 		})
 	}
 }

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -13,7 +13,7 @@ import (
 )
 
 type sender interface {
-	Send(r io.Reader) error
+	Send(ctx context.Context, r io.Reader) error
 }
 
 var (
@@ -148,7 +148,7 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 	}()
 
 	for {
-		if err := sb.sendAndPurge(); err != nil {
+		if err := sb.sendAndPurge(ctx); err != nil {
 			sb.logger.Log("msg", "failed to send and purge", "err", err)
 		}
 
@@ -266,7 +266,7 @@ func (sb *SendBuffer) DeleteAllData() {
 	sb.size = 0
 }
 
-func (sb *SendBuffer) sendAndPurge() error {
+func (sb *SendBuffer) sendAndPurge(ctx context.Context) error {
 	if !sb.sendMutex.TryLock() {
 		sb.logger.Log("msg", "could not get lock on send mutex, will retry")
 		return nil
@@ -283,7 +283,7 @@ func (sb *SendBuffer) sendAndPurge() error {
 		return nil
 	}
 
-	if err := sb.sender.Send(toSendBuff); err != nil {
+	if err := sb.sender.Send(ctx, toSendBuff); err != nil {
 		sb.logger.Log("msg", "failed to send, will retry", "err", err)
 		return nil
 	}

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -290,7 +290,7 @@ func (sb *SendBuffer) sendAndPurge(ctx context.Context) error {
 
 	if err := sb.sender.Send(ctx, toSendBuff); err != nil {
 		sb.logger.Log("msg", "failed to send, will retry", "err", err)
-		return nil
+		return err
 	}
 
 	// testing on a new enrollment in debug mode, log size hit 130K bytes

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -302,17 +302,17 @@ func (sb *SendBuffer) Drain(ctx context.Context) error {
 		defer sb.writeMutex.Unlock()
 		return len(sb.logs)
 	}
-	initialLines, i := storedLines(), 0
+	linesRemaining, i := storedLines(), 0
 
-	for i = 0; i < sb.maxDrainSends && initialLines > 0 && storedLines() > 0; i += 1 {
+	for i = 0; i < sb.maxDrainSends && linesRemaining > 0 && storedLines() > 0; i += 1 {
 		cnt, err := sb.sendAndPurge(ctx)
-		initialLines -= cnt
+		linesRemaining -= cnt
 		switch {
 		case err != nil:
 			return fmt.Errorf("draining sendbuffer failed on send and purge: %w", err)
 		case cnt == 0:
 			return nil
-		case initialLines <= 0:
+		case linesRemaining <= 0:
 			return nil
 		}
 
@@ -324,7 +324,7 @@ func (sb *SendBuffer) Drain(ctx context.Context) error {
 	}
 
 	if i >= sb.maxDrainSends {
-		return fmt.Errorf("failed to drain sendbuffer after the maximum of %d sends with %d lines remaining", sb.maxDrainSends, initialLines)
+		return fmt.Errorf("failed to drain sendbuffer after the maximum of %d sends with %d lines remaining", sb.maxDrainSends, linesRemaining)
 	}
 	return nil
 }

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -25,30 +26,38 @@ var (
 	defaultSendInterval = 1 * time.Minute
 	// discards a write which exceeds this amount
 	maxWriteBytes = 8 * 1024
+	// maximum number of times to send during draining
+	defaultMaxDrainSends = 5
+	// drain wait duration between multiple sends
+	defaultDrainSendWait = 300 * time.Millisecond
 )
 
 type SendBuffer struct {
-	logs                                        [][]byte
-	size, maxStorageSizeBytes, maxSendSizeBytes int
-	sendMutex                                   sync.Mutex
-	writeMutex                                  sync.RWMutex
-	logger                                      log.Logger
-	sender                                      sender
-	sendTicker                                  *time.Ticker
-	isSending                                   bool
-
+	logs       [][]byte
+	sendMutex  sync.Mutex
+	writeMutex sync.RWMutex
+	sender     sender
+	sendTicker *time.Ticker
+	isSending  bool
 	// logsJustPurged is used to prevent attempting to delete logs that were just purged
 	logsJustPurged bool
+
+	// configurables
+	logger                                                     log.Logger
+	size, maxStorageSizeBytes, maxSendSizeBytes, maxDrainSends int
+	drainSendWait                                              time.Duration
 }
 
 type option func(*SendBuffer)
 
+// The maximum amount of data to buffer in bytes.
 func WithMaxStorageSizeBytes(maxSize int) option {
 	return func(sb *SendBuffer) {
 		sb.maxStorageSizeBytes = maxSize
 	}
 }
 
+// The maximum size of a single Read call to the provided sender.
 func WithMaxSendSizeBytes(sendSize int) option {
 	return func(sb *SendBuffer) {
 		sb.maxSendSizeBytes = sendSize
@@ -61,6 +70,21 @@ func WithLogger(logger log.Logger) option {
 	}
 }
 
+// When draining, stops early with an error if more than the provided sends are
+// necessary.
+func WithMaxDrainSends(cnt int) option {
+	return func(sb *SendBuffer) {
+		sb.maxDrainSends = cnt
+	}
+}
+
+// When draining, wait the provided duration between sends if multiple are required.
+func WithDrainSendWait(wait time.Duration) option {
+	return func(sb *SendBuffer) {
+		sb.drainSendWait = wait
+	}
+}
+
 // WithSendInterval sets the interval at which the buffer will send data.
 func WithSendInterval(sendInterval time.Duration) option {
 	return func(sb *SendBuffer) {
@@ -70,12 +94,15 @@ func WithSendInterval(sendInterval time.Duration) option {
 
 func New(sender sender, opts ...option) *SendBuffer {
 	sb := &SendBuffer{
+		sender:     sender,
+		sendTicker: time.NewTicker(defaultSendInterval),
+		isSending:  false,
+
 		maxStorageSizeBytes: defaultMaxSizeBytes,
 		maxSendSizeBytes:    defaultSendSizeBytes,
-		sender:              sender,
-		sendTicker:          time.NewTicker(defaultSendInterval),
+		maxDrainSends:       defaultMaxDrainSends,
+		drainSendWait:       defaultDrainSendWait,
 		logger:              log.NewNopLogger(),
-		isSending:           false,
 	}
 
 	for _, opt := range opts {
@@ -154,7 +181,7 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 	}()
 
 	for {
-		if err := sb.sendAndPurge(ctx); err != nil {
+		if _, err := sb.sendAndPurge(ctx); err != nil {
 			sb.logger.Log("msg", "failed to send and purge", "err", err)
 		}
 
@@ -266,31 +293,64 @@ func (sb *SendBuffer) DeleteAllData() {
 	sb.size = 0
 }
 
-// Attempts to drain the send buffer.
+// Attempts to drain the send buffer, sending everything present through its configured
+// sender until empty, ctx is done, or it drains at least the number of logs originally
+// present at call.
 func (sb *SendBuffer) Drain(ctx context.Context) error {
-	return sb.sendAndPurge(ctx)
+	storedLines := func() int {
+		sb.writeMutex.Lock()
+		defer sb.writeMutex.Unlock()
+		return len(sb.logs)
+	}
+	initialLines, i := storedLines(), 0
+
+	for i = 0; i < sb.maxDrainSends && initialLines > 0 && storedLines() > 0; i += 1 {
+		cnt, err := sb.sendAndPurge(ctx)
+		initialLines -= cnt
+		switch {
+		case err != nil:
+			return fmt.Errorf("draining sendbuffer failed on send and purge: %w", err)
+		case cnt == 0:
+			return nil
+		case initialLines <= 0:
+			return nil
+		}
+
+		select {
+		case <-time.After(sb.drainSendWait):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	if i >= sb.maxDrainSends {
+		return fmt.Errorf("failed to drain sendbuffer after the maximum of %d sends with %d lines remaining", sb.maxDrainSends, initialLines)
+	}
+	return nil
 }
 
-func (sb *SendBuffer) sendAndPurge(ctx context.Context) error {
+// Sends from the buffer if anything is present, returning the number of entries sent
+// or an error.
+func (sb *SendBuffer) sendAndPurge(ctx context.Context) (int, error) {
 	if !sb.sendMutex.TryLock() {
 		sb.logger.Log("msg", "could not get lock on send mutex, will retry")
-		return nil
+		return 0, nil
 	}
 	defer sb.sendMutex.Unlock()
 
 	toSendBuff := &bytes.Buffer{}
 	lastKey, err := sb.copyLogs(toSendBuff, sb.maxSendSizeBytes)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if toSendBuff.Len() == 0 {
-		return nil
+		return 0, nil
 	}
 
 	if err := sb.sender.Send(ctx, toSendBuff); err != nil {
 		sb.logger.Log("msg", "failed to send, will retry", "err", err)
-		return err
+		return 0, err
 	}
 
 	// testing on a new enrollment in debug mode, log size hit 130K bytes
@@ -304,12 +364,12 @@ func (sb *SendBuffer) sendAndPurge(ctx context.Context) error {
 	// to send the logs. To live with this, we just verify that the logs didn't just get purged.
 	if sb.logsJustPurged {
 		sb.logsJustPurged = false
-		return nil
+		return 0, nil
 	}
 
 	sb.deleteLogs(lastKey)
 
-	return nil
+	return lastKey, nil
 }
 
 // copyLogs writes to the provided writer, peeking at the size of each log

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -156,12 +156,6 @@ func (sb *SendBuffer) Run(ctx context.Context) error {
 		case <-sb.sendTicker.C:
 			continue
 		case <-ctx.Done():
-			// Send one final batch, if possible, so that we can get logs related to shutdowns.
-			// Sleep for one second first to allow any shutdown-related logs to be written.
-			time.Sleep(1 * time.Second)
-			if err := sb.sendAndPurge(); err != nil {
-				sb.logger.Log("msg", "failed to send final batch of logs on shutdown", "err", err)
-			}
 			return nil
 		}
 	}
@@ -264,6 +258,11 @@ func (sb *SendBuffer) DeleteAllData() {
 	defer sb.writeMutex.Unlock()
 	sb.logs = nil
 	sb.size = 0
+}
+
+// Attempts to drain the send buffer.
+func (sb *SendBuffer) Drain(ctx context.Context) error {
+	return sb.sendAndPurge(ctx)
 }
 
 func (sb *SendBuffer) sendAndPurge(ctx context.Context) error {

--- a/pkg/sendbuffer/sendbuffer.go
+++ b/pkg/sendbuffer/sendbuffer.go
@@ -17,8 +17,14 @@ type sender interface {
 }
 
 var (
-	defaultMaxSizeBytes  = 512 * 1024
-	defaultSendSizeBytes = 8 * 1024
+	// default bytes buffered before dropping incoming data
+	defaultMaxSizeBytes = 1024 * 1024
+	// default bytes sent at one time per send tick
+	defaultSendSizeBytes = 512 * 1024
+	// default interval at which to send
+	defaultSendInterval = 1 * time.Minute
+	// discards a write which exceeds this amount
+	maxWriteBytes = 8 * 1024
 )
 
 type SendBuffer struct {
@@ -67,7 +73,7 @@ func New(sender sender, opts ...option) *SendBuffer {
 		maxStorageSizeBytes: defaultMaxSizeBytes,
 		maxSendSizeBytes:    defaultSendSizeBytes,
 		sender:              sender,
-		sendTicker:          time.NewTicker(1 * time.Minute),
+		sendTicker:          time.NewTicker(defaultSendInterval),
 		logger:              log.NewNopLogger(),
 		isSending:           false,
 	}
@@ -94,13 +100,13 @@ func (sb *SendBuffer) Write(in []byte) (int, error) {
 		return len(in), nil
 	}
 
-	// if the single data piece is larger than the max send size, drop it and log
-	if len(in) > sb.maxSendSizeBytes {
+	// if the single data piece is excessively large, drop it and log
+	if len(in) > maxWriteBytes {
 		sb.logger.Log(
-			"msg", "dropped data because element greater than max send size",
+			"msg", "dropped data that exceeds maximum write bytes",
 			"method", "Write",
 			"size_of_data_bytes", len(in),
-			"max_send_size_bytes", sb.maxSendSizeBytes,
+			"max_write_size", maxWriteBytes,
 			"head", string(in)[0:minInt(len(in), 100)],
 		)
 		return len(in), nil
@@ -128,7 +134,7 @@ func (sb *SendBuffer) Write(in []byte) (int, error) {
 	}
 
 	// If we don't make a copy of the data, we get data loss in the logs array.
-	// It seems the input gets concurrenlty overridden somewhere under the hood.
+	// It seems the input gets concurrently overridden somewhere under the hood.
 	data := make([]byte, len(in))
 	copy(data, in)
 

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -2,6 +2,7 @@ package sendbuffer
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -94,7 +95,7 @@ func TestSendBuffer(t *testing.T) {
 			}
 
 			for i := 0; i < len(tt.expectedReceives); i++ {
-				require.NoError(t, sb.sendAndPurge())
+				require.NoError(t, sb.sendAndPurge(context.Background()))
 
 				for {
 					// wait for the send to finish
@@ -138,7 +139,7 @@ func TestSendAndPurgeHandlesLogBufferFullPurge(t *testing.T) {
 	go func() {
 		for !testCompleted.Load() {
 			time.Sleep(50 * time.Millisecond)
-			sb.sendAndPurge()
+			sb.sendAndPurge(context.Background())
 		}
 	}()
 
@@ -504,7 +505,7 @@ type testSender struct {
 	allReceived  [][]byte
 }
 
-func (s *testSender) Send(r io.Reader) error {
+func (s *testSender) Send(_ context.Context, r io.Reader) error {
 	s.lastReceived.Reset()
 	data, err := io.ReadAll(r)
 	require.NoError(s.t, err)

--- a/pkg/sendbuffer/sendbuffer_test.go
+++ b/pkg/sendbuffer/sendbuffer_test.go
@@ -58,10 +58,10 @@ func TestSendBuffer(t *testing.T) {
 			expectedReceives: nil,
 		},
 		{
-			name:             "does not exceed max send size",
-			maxStorageSize:   1000,
-			maxSendSize:      4,
-			writes:           []string{"hello"},
+			name:             "does not exceed max write size",
+			maxStorageSize:   2 * maxWriteBytes,
+			maxSendSize:      2 * maxWriteBytes,
+			writes:           []string{strings.Repeat("a", maxWriteBytes+1)},
 			expectedReceives: nil,
 		},
 		{
@@ -95,7 +95,8 @@ func TestSendBuffer(t *testing.T) {
 			}
 
 			for i := 0; i < len(tt.expectedReceives); i++ {
-				require.NoError(t, sb.sendAndPurge(context.Background()))
+				_, err := sb.sendAndPurge(context.Background())
+				require.NoError(t, err)
 
 				for {
 					// wait for the send to finish
@@ -522,4 +523,175 @@ func (s *testSender) aggregateAllReceived() []byte {
 		aggregated = append(aggregated, data...)
 	}
 	return aggregated
+}
+
+// thread-safe sender for tests that tracks stats/sent bytes
+type drainTestSender struct {
+	mu       sync.Mutex
+	sends    int
+	received []byte
+	err      error
+}
+
+func (s *drainTestSender) Send(_ context.Context, r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sends++
+	if s.err != nil {
+		return s.err
+	}
+
+	s.received = append(s.received, data...)
+	return nil
+}
+
+func (s *drainTestSender) sendCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sends
+}
+
+func (s *drainTestSender) receivedData() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.received)
+}
+
+func TestDrain(t *testing.T) {
+	t.Parallel()
+
+	writeLines := func(t *testing.T, sb *SendBuffer, lines ...string) {
+		t.Helper()
+		for _, line := range lines {
+			_, err := sb.Write([]byte(line))
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("drains everything in multiple sends", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1), // one line per send
+			WithMaxDrainSends(5),
+			WithDrainSendWait(time.Nanosecond),
+		)
+		writeLines(t, sb, "0", "1", "2")
+
+		require.NoError(t, sb.Drain(t.Context()))
+
+		require.Equal(t, 3, sender.sendCount())
+		require.Equal(t, "012", sender.receivedData())
+		require.Empty(t, sb.logs)
+		require.Zero(t, sb.size)
+	})
+
+	t.Run("calls sender once when one send suffices", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1000), // everything fits in a single send
+			WithMaxDrainSends(5),
+			WithDrainSendWait(time.Microsecond),
+		)
+		writeLines(t, sb, "0", "1", "2")
+
+		require.NoError(t, sb.Drain(t.Context()))
+
+		require.Equal(t, 1, sender.sendCount())
+		require.Equal(t, "012", sender.receivedData())
+		require.Empty(t, sb.logs)
+		require.Zero(t, sb.size)
+	})
+
+	t.Run("errors after exceeding max drain sends", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1), // one line per send, so 5 lines need 5 sends
+			WithMaxDrainSends(2),
+			WithDrainSendWait(time.Microsecond),
+		)
+		writeLines(t, sb, "0", "1", "2", "3", "4")
+
+		err := sb.Drain(t.Context())
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to drain sendbuffer after the maximum")
+		require.Equal(t, 2, sender.sendCount())
+		require.Len(t, sb.logs, 3) // only 2 of 5 drained
+	})
+
+	t.Run("aborts and preserves data on send error", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{err: errors.New("boom")}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1),
+			WithMaxDrainSends(5),
+			WithDrainSendWait(time.Microsecond),
+		)
+		writeLines(t, sb, "0", "1", "2")
+
+		err := sb.Drain(t.Context())
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "draining sendbuffer failed on send and purge")
+		require.Equal(t, 1, sender.sendCount())
+		require.Len(t, sb.logs, 3) // nothing deleted on send failure
+		require.Equal(t, 3, sb.size)
+	})
+
+	t.Run("stops and returns when context is cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1),
+			WithMaxDrainSends(5),
+			WithDrainSendWait(10*time.Second), // long, so context wins
+		)
+		writeLines(t, sb, "0", "1", "2")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := sb.Drain(ctx)
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, sender.sendCount()) // one send, then bailed on the wait
+		require.Len(t, sb.logs, 2)
+	})
+
+	t.Run("waits drainSendWait between sends", func(t *testing.T) {
+		t.Parallel()
+
+		sender := &drainTestSender{}
+		sb := New(sender,
+			WithMaxSendSizeBytes(1), // one line per send, so a wait is required between them
+			WithMaxDrainSends(5),
+			WithDrainSendWait(2*time.Second),
+		)
+		writeLines(t, sb, "0", "1", "2")
+
+		go sb.Drain(t.Context())
+
+		// the first send happens immediately
+		require.Eventually(t, func() bool {
+			return sender.sendCount() == 1
+		}, 2*time.Second, 5*time.Millisecond)
+
+		// ...but the second is waiting, so nothing follows
+		time.Sleep(50 * time.Millisecond)
+		require.Equal(t, 1, sender.sendCount())
+	})
 }


### PR DESCRIPTION
PR continues log shipping-related fixes from #2751. It chiefly introduces draining to sendbuffer; without it, local testing consistently dropped logs on the floor.

I separated fixes by commit and it should be easier to review that way.

Summary:
  * `authedHttpSender`:
    * Fix potential race in setting token/endpoint
    * Errors now display the _response_ body instead of the request.
  * `SendBuffer`:
    * Tweak and document batch parameters: max buffer 512 KiB -> 1 MiB, max send size 8 KiB -> 512 KiB.
    * Allow context to cancel in flight HTTP requests ( `sender` now plumbs context).
    * Add `Drain` with config, it drains the buffer on `LogShipper.Stop`:
      * Attempts up to 5 sends, waiting 300 ms in between.
      * Does not keep calling if additional logs appear after sending.
      * Is timed out by `LogShipper.Stop` after 5 seconds.

The Drain logic and tests is the bulk of the PR and contained in the final commit. I'm definitely open to feedback on the durations involved: 5 seconds seemed fairly reasonable, but I'm not married to it.