### PR TITLE
added buffered transport to osquery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kolide/krypto v0.1.1-0.20251209172506-7738d1f5d7c1
 	github.com/mat/besticon v3.9.0+incompatible
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
-	github.com/osquery/osquery-go v0.0.0-20260226222546-0cc22f415e57
+	github.com/osquery/osquery-go v0.0.0-20260630173615-eb39ad3443df
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/osquery/osquery-go v0.0.0-20210622151333-99b4efa62ec5/go.mod h1:JKR5QhjsYdnIPY7hakgas5sxf8qlA/9wQnLqaMfWdcg=
-github.com/osquery/osquery-go v0.0.0-20260226222546-0cc22f415e57 h1:t6YJWPvNurotG1WBdjycKpVFdHsvL7QqWslqfimhBWA=
-github.com/osquery/osquery-go v0.0.0-20260226222546-0cc22f415e57/go.mod h1:4cBOmXSmmDULG4bTOq0EFvIy5NUMNJMKbLDBMg6lhJE=
+github.com/osquery/osquery-go v0.0.0-20260630173615-eb39ad3443df h1:GEa8SFf/OXRXSHU5EtjUxs4yPz8caf9UlHN/F89/OJA=
+github.com/osquery/osquery-go v0.0.0-20260630173615-eb39ad3443df/go.mod h1:/Nxgn14on72pNnpjn9Fbw9WQc8JKY1sVv5K+SRZknEk=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/pkg/osquery/interactive/interactive.go
+++ b/pkg/osquery/interactive/interactive.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/kolide/kit/fsutil"
 	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/v2/ee/agent/startupsettings"
@@ -177,6 +178,10 @@ func loadExtensionsAndStartServer(slogger *slog.Logger, socketPath string, plugi
 		socketPath,
 		osquery.ServerTimeout(10*time.Second),
 		osquery.WithClient(client),
+		// Buffer the extension transport so serializing large table results
+		// batches socket writes instead of issuing one write syscall per
+		// Thrift primitive. See osquery/osquery-go#136.
+		osquery.WithTransportFactory(thrift.NewTBufferedTransportFactory(16*1024)),
 	)
 	if err != nil {
 		return extensionManagerServer, fmt.Errorf("error creating extension manager server: %w", err)

--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -909,6 +909,10 @@ func (i *OsqueryInstance) StartOsqueryExtensionManagerServer(name string, client
 			i.paths.extensionSocketPath,
 			osquery.ServerTimeout(1*time.Minute),
 			osquery.WithClient(client),
+			// Buffer the extension transport so serializing large table results
+			// batches socket writes instead of issuing one write syscall per
+			// Thrift primitive. See osquery/osquery-go#136.
+			osquery.WithTransportFactory(thrift.NewTBufferedTransportFactory(16*1024)),
 		)
 		return newErr
 	}, socketOpenTimeout, socketOpenInterval); err != nil {


### PR DESCRIPTION
## Buffer the osquery extension transport

### What changed
Wrap the osquery extension manager server's Thrift transport in `thrift.NewTBufferedTransportFactory(16*1024)` (via osquery-go's new `WithTransportFactory` option), in both the runtime instance (`osqueryinstance.go`) and interactive mode (`interactive.go`).

### Why / expected impact
osquery-go's extension server serializes results with `TBinaryProtocol` over an **unbuffered** transport, so every Thrift primitive becomes its own `write(2)` to the extension socket. For large table results this means one write syscall per cell — tens of thousands to millions of tiny writes. Buffering coalesces those into ~16 KB socket writes, drastically cutting syscall count (and the associated context-switch/kernel overhead) with no change to the bytes on the wire.

### Measured impact
Built the launcher at this branch and at its parent, then counted `write(2)` syscalls to the **extension socket** on the launcher process while running fixed queries through `launcher interactive` (which loads the kolide tables and exercises the modified path). `count(*)` keeps osqueryd's own output tiny so the count reflects extension→osquery serialization.

| Query (`kolide_system_profiler` datatype) | rows | writes before | writes after | reduction |
|---|---|---|---|---|
| `SPHardwareDataType` ×5 | 13×5 | 2,624 | 17 | ~154× |
| `SPApplicationsDataType` | 3,244 | 113,717 | ~430 | ~265× |
| `SPFontsDataType` | 55,203 | 1,932,354 | 8,039 | ~240× |

Non-socket writes (logs, augeas, certs) were byte-identical between builds, and for results that fit in one write the socket byte totals matched to within 1 byte — confirming the change only affects how writes are batched, not the data sent.

### Trade-off: buffer size vs. socket send buffer
macOS Unix-domain sockets default to an **8 KB** send buffer (`net.local.stream.sendspace = 8192`). A 16 KB flush therefore often can't be accepted in one `write(2)` — the kernel takes ~8 KB and Go's poller writes the remainder, so a full flush can cost two syscalls instead of one. This is an accepted trade-off: even split in two, we're bounded by `total_bytes / send_buffer` writes instead of one-per-primitive, so the order-of-magnitude win stands.

### Why not size the buffer to the socket send buffer (8 KB)?
- **Negligible syscall gain.** The send buffer caps bytes-per-write, so an 8 KB buffer and a 16 KB buffer produce roughly the same number of actual writes; matching 8 KB would only shave the occasional partial-write retry.
- **Not portable.** 8 KB is a macOS default; Linux `AF_UNIX` send buffers are far larger (~200 KB) and Windows uses named pipes. Coupling the constant to a macOS sysctl would be wrong elsewhere.
- A fixed, generous 16 KB is simple and robust across platforms; the more effective lever for further reduction (raising `SO_SNDBUF`) lives in osquery-go and isn't worth it given the current win.

### How to reproduce
1. Build both binaries: build this branch, then `git stash` the change and build the parent (e.g. `launcher-new` / `launcher-old`).
2. Count socket `write(2)`s on the launcher process while it serializes a heavy result. Either:
   - **dtrace (macOS, needs sudo):** run `launcher interactive` under `dtrace`/`dtruss` counting `syscall::write*:entry` for the launcher pid, or
   - **no root:** `DYLD_INSERT_LIBRARIES` a small shim that interposes `write`/`writev` and counts only calls whose fd is a socket (`S_ISSOCK`).
3. Pipe a fixed query on stdin, e.g. `SELECT count(*) FROM kolide_system_profiler WHERE datatype='SPFontsDataType';`, and compare the socket-write totals between the two builds.