### PR TITLE
ci: pin to shas tools fetched via tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,7 +25,7 @@ jobs:
           check-latest: true
           cache: false
       - name: install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
       - name: actionlint
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -433,7 +433,7 @@ jobs:
 
       - name: Install benchstat
         if: github.ref != 'refs/heads/main' && github.ref_type != 'tag' && steps.download-benchmark.outcome == 'success'
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@9e4b9ddef5b6a4371594ec978cb4b8088bec845d # untagged, unversioned
 
       - name: Compare performance against main
         if: github.ref != 'refs/heads/main' && github.ref_type != 'tag' && steps.download-benchmark.outcome == 'success'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
           cache: false
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@3e6f44f962742443c11ae2261f02e0c917aeb2bc # v1.5.0
         shell: bash
 
       # For false positives, filtering out in jq by `select(.osv != "GO-2024-3166")`


### PR DESCRIPTION
[KOL-786](https://1password.atlassian.net/browse/KOL-786)

GitHub hardening docs [recommend pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This repo looks fine? But pinning `go install`'d dependencies is a good practice too.

I couldn't make out anything to cut. The lack of deploys make this repo's actions seems pretty light by comparison.

Changes:
  - Pin 3 `go installs` to specific shas.
  - Add weekly GitHub action dependabot checking.