### PR TITLE
Improve performance of kolide_xml table

### DIFF
--- a/ee/dataflatten/xml.go
+++ b/ee/dataflatten/xml.go
@@ -1,6 +1,7 @@
 package dataflatten
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 
@@ -8,11 +9,17 @@ import (
 )
 
 func XmlFile(file string, opts ...FlattenOpts) ([]Row, error) {
-	rdr, err := os.Open(file)
+	f, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
-	defer rdr.Close()
+	defer f.Close()
+
+	// Wrap the file in a bufio.Reader before handing it to mxj. mxj wraps any
+	// reader that isn't an io.ByteReader in a helper whose ReadByte issues a
+	// separate one-byte read syscall per byte; using bufio.Reader here avoids these
+	// extra syscalls.
+	rdr := bufio.NewReader(f)
 
 	mv, err := mxj.NewMapXmlReader(rdr)
 	if err != nil {


### PR DESCRIPTION
While benchmarking tables for https://github.com/kolide/launcher/pull/2775, Claude flagged that `kolide_xml` is slow, and surfaced the fix in this PR. The `mxj` package's reader wrapper does unnecessary work; wrapping our reader in a bufio reader prevents using the `mxj` reader. (See: https://github.com/clbanning/mxj/blob/master/xml.go#L106.)

Benchmarking:

before change: 23166839875 ns/op => 23 seconds

after change: 2299419792 ns/op => 2.3 seconds