### PR TITLE
rearrange filewalker filter checks to optimize regexp calls

### DIFF
--- a/ee/filewalker/filewalker.go
+++ b/ee/filewalker/filewalker.go
@@ -192,19 +192,20 @@ func (f *filewalker) Filewalk(ctx context.Context) {
 					return nil
 				}
 
-				// Check to see if we're in a directory that should be skipped
-				if f.shouldSkip(path) {
-					return fs.SkipDir
-				}
-
-				// If our config restricts file type, check that
+				// If our config restricts file type, check that first as it is the cheapest filter (checking a single bit for dir or filemode)
 				if f.fileTypeFilter != nil && !f.fileTypeFilter.matches(d.Type()) {
 					return nil
 				}
 
-				// Finally, check for the file name regex
+				// Now check for the file name regex. We do this check next even if it might be filtered
+				// by skipDirs later because it is a single regex match that, vs the current avg of ~20 skipDirs
 				if f.fileNameRegex != nil && !f.fileNameRegex.MatchString(filepath.Base(path)) {
 					return nil
+				}
+
+				// Finally, check to see if we're in a directory that should be skipped
+				if f.shouldSkip(path) {
+					return fs.SkipDir
 				}
 
 				// Add this file to our results


### PR DESCRIPTION
We're seeing a device with launcher utilizing excessive CPU, the cpuprofile points to the filewalker logic. The majority of the cycles are coming from syscalls and I think we'll need to address another way (behavior looks expected depending on the number of files for this device), but the regexp matching can also be expensive and this seemed like an easier win for now.

Because all of the filters have to pass for us to retain a filepath entry, and we're sending down ~20 skipDirs per filwalk config, I think it makes sense to do the cheaper checks first. In many cases the files will not match the `fileNameRegex` anyway and we can avoid doing the more costly 20 regexp checks later