### PR TITLE
Remove reported errors

### DIFF
--- a/pkg/log/multislogger/multislogger.go
+++ b/pkg/log/multislogger/multislogger.go
@@ -91,7 +91,6 @@ func (m *MultiSlogger) AddHandler(handler ...slog.Handler) {
 			Pipe(slogmulti.NewHandleInlineMiddleware(utcTimeMiddleware)).
 			Pipe(slogmulti.NewHandleInlineMiddleware(ctxValuesMiddleWare)).
 			Pipe(m.dedupEngine.NewMiddleware()).
-			Pipe(slogmulti.NewHandleInlineMiddleware(reportedErrorMiddleware)).
 			Handler(slogmulti.Fanout(m.handlers...)),
 	)
 
@@ -219,30 +218,6 @@ func ctxValuesMiddleWare(ctx context.Context, record slog.Record, next func(cont
 			})
 		}
 	}
-
-	return next(ctx, record)
-}
-
-func reportedErrorMiddleware(ctx context.Context, record slog.Record, next func(context.Context, slog.Record) error) error {
-	if record.Level != slog.LevelError {
-		return next(ctx, record)
-	}
-
-	// We tag LevelError logs for GCP.
-	// See: https://cloud.google.com/error-reporting/docs/formatting-error-messages
-	record.AddAttrs(
-		// We must set @type so that GCP knows it's a ReportedError
-		slog.Attr{
-			Key:   "@type",
-			Value: slog.StringValue("type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"),
-		},
-		// GCP must have a "message", "stack_trace", or "exception" field, none of which we're guaranteed here
-		// (we report up record.Message under key "msg"). Duplicate record.Message to key "message" so the error will be recorded.
-		slog.Attr{
-			Key:   "message",
-			Value: slog.StringValue(record.Message),
-		},
-	)
 
 	return next(ctx, record)
 }


### PR DESCRIPTION
Removes the `reportedErrorMiddleware` from the `multislogger`. This middleware only occurs in `AddHandler` in the `multislogger` package.