### PR TITLE
[do not merge] repro for CI-only Windows memory bug

### DIFF
--- a/.github/workflows/filewalker-gc-stress.yml
+++ b/.github/workflows/filewalker-gc-stress.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STRESS_ITERATIONS: "100"
-  STRESS_BUDGET_MINUTES: "240"
+  STRESS_ITERATIONS: "5"
+  STRESS_BUDGET_MINUTES: "5"
 
 jobs:
   gc_stress:

--- a/.github/workflows/filewalker-gc-stress.yml
+++ b/.github/workflows/filewalker-gc-stress.yml
@@ -2,12 +2,16 @@ name: filewalker-gc-stress
 
 # Stress-loops the ee/filewalker tests on Windows runners to reproduce rare
 # GC-integrity fatal errors seen in CI.
-# Variants for GC are included, per Claude:
-#   stock      -- default build (Green Tea GC on; the crashing config)
-#   nogreentea -- built with GOEXPERIMENT=nogreenteagc
-#   noavx512   -- stock build, run with GODEBUG disabling the AVX-512 features
-#                 gating Green Tea's span-scan path (VL/BW/DQ; avx512f is not
-#                 part of the gate and GODEBUG cpu toggles don't cascade)
+#
+# Findings so far: failures correlate with one host type -- Intel Xeon
+# Platinum 8573C (Emerald Rapids, AMX-capable) on Standard_D4ds_v6 -- and
+# reproduce with the Green Tea GC disabled, so GC variant and AVX-512 are
+# exonerated. Current suspect: Go async preemption (SuspendThread /
+# Get/SetThreadContext) mishandling extended CPU state on AMX hosts.
+# Variants:
+#   stock          -- default build and runtime config (the crashing config)
+#   asyncpreemptoff -- GODEBUG=asyncpreemptoff=1 at run time; if this passes
+#                      on an 8573C host, async preemption is implicated
 
 on:
   pull_request:
@@ -38,14 +42,9 @@ jobs:
           - windows-2025
         variant:
           - name: stock
-            goexperiment: ""
             godebug: ""
-          - name: nogreentea
-            goexperiment: "nogreenteagc"
-            godebug: ""
-          - name: noavx512
-            goexperiment: ""
-            godebug: "cpu.avx512vl=off,cpu.avx512bw=off,cpu.avx512dq=off"
+          - name: asyncpreemptoff
+            godebug: "asyncpreemptoff=1"
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -118,15 +117,15 @@ jobs:
           rm -rf gcstress-cpuinfo
 
           cpu_name=$(powershell -NoProfile -Command "(Get-CimInstance Win32_Processor).Name" | tr -d '\r' || true)
-          microcode=$(reg query "HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" /v "Update Revision" 2>/dev/null | awk '/Update Revision/ {print $NF}' || true)
+          # No /v flag: Git Bash's MSYS path conversion mangles it into a file path.
+          # $1/$2 match excludes the "Previous Update Revision" line.
+          microcode=$(reg query "HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" 2>/dev/null | awk '$1=="Update" && $2=="Revision" {print $NF}' | tr -d '\r' || true)
           vm_size=$(curl -s --connect-timeout 5 -H "Metadata:true" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text" || echo "unknown")
           avx512=$(grep "AVX512" cpuflags.txt | sed 's/^Has//;s/=true/:1/;s/=false/:0/' | paste -sd' ' - || true)
           echo "**${MATRIX_OS} / ${VARIANT_NAME}**: ${cpu_name} | ucode ${microcode:-?} | ${vm_size} | AVX512 ${avx512}" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Compile test binary
         shell: bash
-        env:
-          GOEXPERIMENT: ${{ matrix.variant.goexperiment }}
         run: |
           go version
           go test -c -race -cover -o filewalker.test.exe ./ee/filewalker/

--- a/.github/workflows/filewalker-gc-stress.yml
+++ b/.github/workflows/filewalker-gc-stress.yml
@@ -1,0 +1,124 @@
+name: filewalker-gc-stress
+
+# Stress-loops the ee/filewalker tests on Windows runners to reproduce rare
+# GC-integrity fatal errors seen in CI.
+# Variants for GC are included, per Claude:
+#   stock      -- default build (Green Tea GC on; the crashing config)
+#   nogreentea -- built with GOEXPERIMENT=nogreenteagc
+#   noavx512   -- stock build, run with GODEBUG disabling the AVX-512 features
+#                 gating Green Tea's span-scan path (VL/BW/DQ; avx512f is not
+#                 part of the gate and GODEBUG cpu toggles don't cascade)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  STRESS_ITERATIONS: "100"
+  STRESS_BUDGET_MINUTES: "240"
+
+jobs:
+  gc_stress:
+    permissions:
+      contents: read
+    name: gc-stress (${{ matrix.os }}, ${{ matrix.variant.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+          - windows-2025
+        variant:
+          - name: stock
+            goexperiment: ""
+            godebug: ""
+          - name: nogreentea
+            goexperiment: "nogreenteagc"
+            godebug: ""
+          - name: noavx512
+            goexperiment: ""
+            godebug: "cpu.avx512vl=off,cpu.avx512bw=off,cpu.avx512dq=off"
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          check-latest: false
+          cache: false
+
+      - name: Compile test binary
+        shell: bash
+        env:
+          GOEXPERIMENT: ${{ matrix.variant.goexperiment }}
+        run: |
+          go version
+          go test -c -race -cover -o filewalker.test.exe ./ee/filewalker/
+
+      - name: Stress loop
+        shell: bash
+        env:
+          GOGC: "1"
+          GOTRACEBACK: system
+          GODEBUG: ${{ matrix.variant.godebug }}
+        run: |
+          mkdir -p failures
+          start=$(date +%s)
+          budget_secs=$(( STRESS_BUDGET_MINUTES * 60 ))
+          completed=0
+          fail=0
+
+          for (( i = 1; i <= STRESS_ITERATIONS; i++ )); do
+            if (( $(date +%s) - start >= budget_secs )); then
+              echo "hit ${STRESS_BUDGET_MINUTES}m budget after ${completed} iterations; stopping"
+              break
+            fi
+
+            iter_start=$(date +%s)
+            if ./filewalker.test.exe -test.count=1 -test.timeout=10m > iter.log 2>&1; then
+              rc=0
+            else
+              rc=$?
+            fi
+            dur=$(( $(date +%s) - iter_start ))
+            completed=$(( completed + 1 ))
+
+            if (( rc == 0 )); then
+              echo "iter ${i}: PASS (${dur}s)"
+              rm -f iter.log
+            else
+              fail=$(( fail + 1 ))
+              echo "iter ${i}: FAIL rc=${rc} (${dur}s) -- last lines:"
+              tail -n 30 iter.log
+              mv iter.log "failures/iter-$(printf '%03d' "$i")-rc${rc}.log"
+            fi
+          done
+
+          echo "${completed} iterations: $(( completed - fail )) passed, ${fail} failed" | tee -a "$GITHUB_STEP_SUMMARY"
+
+          if (( fail > 0 )); then
+            exit 1
+          fi
+
+      - name: Upload failure logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: filewalker-gc-stress-failures-${{ matrix.os }}-${{ matrix.variant.name }}
+          path: failures/
+          if-no-files-found: ignore

--- a/.github/workflows/filewalker-gc-stress.yml
+++ b/.github/workflows/filewalker-gc-stress.yml
@@ -62,6 +62,67 @@ jobs:
           check-latest: false
           cache: false
 
+      # No GODEBUG here on purpose: this reports the raw hardware view.
+      - name: Host and CPU info
+        shell: bash
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          VARIANT_NAME: ${{ matrix.variant.name }}
+        run: |
+          echo "=== runner env ==="
+          echo "COMPUTERNAME=${COMPUTERNAME:-} RUNNER_NAME=${RUNNER_NAME:-}"
+          echo "ImageOS=${ImageOS:-} ImageVersion=${ImageVersion:-}"
+          echo "PROCESSOR_IDENTIFIER=${PROCESSOR_IDENTIFIER:-} PROCESSOR_REVISION=${PROCESSOR_REVISION:-} NUMBER_OF_PROCESSORS=${NUMBER_OF_PROCESSORS:-}"
+
+          echo "=== CPU (CIM) ==="
+          powershell -NoProfile -Command "Get-CimInstance Win32_Processor | Format-List Name,Manufacturer,Description,Family,Stepping,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed,L2CacheSize,L3CacheSize,ProcessorId" || true
+
+          echo "=== CPU (registry, incl. microcode Update Revision) ==="
+          reg query "HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" || true
+
+          echo "=== OS build ==="
+          powershell -NoProfile -Command "Get-CimInstance Win32_OperatingSystem | Format-List Caption,Version,BuildNumber,OSArchitecture" || true
+          powershell -NoProfile -Command "Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' | Format-List DisplayVersion,CurrentBuildNumber,UBR" || true
+
+          echo "=== system / hypervisor / BIOS ==="
+          powershell -NoProfile -Command "Get-CimInstance Win32_ComputerSystem | Format-List Manufacturer,Model,TotalPhysicalMemory,NumberOfProcessors,HypervisorPresent" || true
+          powershell -NoProfile -Command "Get-CimInstance Win32_BIOS | Format-List Manufacturer,SMBIOSBIOSVersion,ReleaseDate" || true
+
+          echo "=== Azure IMDS (VM SKU) ==="
+          curl -s --connect-timeout 5 -H "Metadata:true" "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" || echo "IMDS unavailable"
+          echo ""
+
+          echo "=== CPUID feature flags (golang.org/x/sys/cpu) ==="
+          mkdir -p gcstress-cpuinfo
+          cat > gcstress-cpuinfo/main.go <<'EOF'
+          package main
+
+          import (
+          	"fmt"
+          	"reflect"
+
+          	"golang.org/x/sys/cpu"
+          )
+
+          func main() {
+          	v := reflect.ValueOf(cpu.X86)
+          	t := v.Type()
+          	for i := 0; i < t.NumField(); i++ {
+          		if t.Field(i).Type.Kind() == reflect.Bool {
+          			fmt.Printf("%s=%v\n", t.Field(i).Name, v.Field(i).Bool())
+          		}
+          	}
+          }
+          EOF
+          go run ./gcstress-cpuinfo | tee cpuflags.txt || true
+          rm -rf gcstress-cpuinfo
+
+          cpu_name=$(powershell -NoProfile -Command "(Get-CimInstance Win32_Processor).Name" | tr -d '\r' || true)
+          microcode=$(reg query "HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" /v "Update Revision" 2>/dev/null | awk '/Update Revision/ {print $NF}' || true)
+          vm_size=$(curl -s --connect-timeout 5 -H "Metadata:true" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text" || echo "unknown")
+          avx512=$(grep "AVX512" cpuflags.txt | sed 's/^Has//;s/=true/:1/;s/=false/:0/' | paste -sd' ' - || true)
+          echo "**${MATRIX_OS} / ${VARIANT_NAME}**: ${cpu_name} | ucode ${microcode:-?} | ${vm_size} | AVX512 ${avx512}" | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Compile test binary
         shell: bash
         env:


### PR DESCRIPTION
A one-off stress test to try to repro Windows memory-related crashes. You can see an example crash here:
https://github.com/kolide/launcher/actions/runs/29606158269/job/88468298622

Cannot repro locally.