### PR TITLE
actionqueue: fix Start/Stop race on actionqueue.cancel

### DIFF
--- a/ee/control/actionqueue/actionqueue.go
+++ b/ee/control/actionqueue/actionqueue.go
@@ -47,7 +47,7 @@ type ActionQueue struct {
 	oldNotificationsStore types.KVStore
 	slogger               *slog.Logger
 	actionCleanupInterval time.Duration
-	cancel                context.CancelFunc
+	done                  chan struct{}
 }
 
 type actionqueueOption func(*ActionQueue)
@@ -82,6 +82,7 @@ func New(k types.Knapsack, opts ...actionqueueOption) *ActionQueue {
 		actors:                make(map[string]actor, 0),
 		actionCleanupInterval: defaultCleanupInterval,
 		slogger:               k.Slogger().With("component", "actionqueue"),
+		done:                  make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -155,18 +156,17 @@ func (aq *ActionQueue) StartCleanup() error {
 }
 
 func (aq *ActionQueue) runCleanup() {
-	ctx, cancel := context.WithCancel(aq.ctx)
-	aq.cancel = cancel
-
 	t := time.NewTicker(aq.actionCleanupInterval)
 	defer t.Stop()
 
 	for {
 		select {
-		case <-ctx.Done():
-			aq.slogger.Log(context.TODO(), slog.LevelDebug,
+		case <-aq.ctx.Done():
+			aq.slogger.Log(aq.ctx, slog.LevelDebug,
 				"action cleanup stopped due to context cancel",
 			)
+			return
+		case <-aq.done:
 			return
 		case <-t.C:
 			aq.cleanupActions()
@@ -175,7 +175,11 @@ func (aq *ActionQueue) runCleanup() {
 }
 
 func (aq *ActionQueue) StopCleanup(err error) {
-	aq.cancel()
+	select {
+	case <-aq.done:
+	default:
+		close(aq.done)
+	}
 }
 
 func (aq *ActionQueue) storeActionRecord(actionToStore action) {

--- a/ee/control/actionqueue/actionqueue_test.go
+++ b/ee/control/actionqueue/actionqueue_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -246,10 +247,10 @@ func TestCleanup(t *testing.T) {
 	require.NotNil(t, newActionRecord, "new action was not seeded in db")
 	require.NoError(t, err)
 
-	// start clean up
-	go func() {
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		actionQueue.StartCleanup()
-	}()
+	})
 
 	// give it a chance to run
 	time.Sleep(500 * time.Millisecond)
@@ -263,13 +264,11 @@ func TestCleanup(t *testing.T) {
 	require.NotNil(t, newActionRecord, "new action was cleaned up but should not have been")
 	require.NoError(t, err)
 
-	// stop
 	actionQueue.StopCleanup(nil)
-	// give log a chance to log
-	time.Sleep(500 * time.Millisecond)
-	require.Contains(t, logBytes.String(), "cleanup")
+	wg.Wait() // cleanup should exit
 }
 
+// Consuming APIs expect that stop may be called multiple times.
 func TestStopCleanup_Multiple(t *testing.T) {
 	t.Parallel()
 
@@ -289,35 +288,19 @@ func TestStopCleanup_Multiple(t *testing.T) {
 	)
 	actionQueue.RegisterActor(testActorType, mockActor)
 
-	// start clean up
 	go actionQueue.StartCleanup()
-	time.Sleep(3 * time.Second)
-	interruptStart := time.Now()
+	time.Sleep(250 * time.Millisecond) // allow cleanup to run
 	actionQueue.StopCleanup(errors.New("test error"))
 
 	// Confirm we can call Interrupt multiple times without blocking
-	interruptComplete := make(chan struct{})
-	expectedInterrupts := 3
-	for i := 0; i < expectedInterrupts; i += 1 {
-		go func() {
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Go(func() {
 			actionQueue.StopCleanup(nil)
-			interruptComplete <- struct{}{}
-		}()
+		})
 	}
 
-	receivedInterrupts := 0
-	for receivedInterrupts < expectedInterrupts {
-		select {
-		case <-interruptComplete:
-			receivedInterrupts += 1
-			continue
-		case <-time.After(5 * time.Second):
-			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
-			t.FailNow()
-		}
-	}
-
-	require.Equal(t, expectedInterrupts, receivedInterrupts)
+	wg.Wait() // all the cleanups should come back
 }
 
 func TestActionQueue_HandlesMalformedActions(t *testing.T) {


### PR DESCRIPTION
# Summary

`actionqueue.StartCleanup` used to set a context cancel in a struct without ensuring exclusive access. A well-timed `actionqueue.StopCleanup` can execute that cancel unconditionally, which is a race. A single test does this in parallel already.

This PR:
  * Switches to a channel closure to signal stop.
  * Includes test cleanup, removing log inspection to determine the cleanup goroutine exited and using a waitgroup since I was in the area.

## Details

The race doesn't show in CI and I'm not sure why. Locally, it repros reliably for me.

```
==================
WARNING: DATA RACE
Read at 0x00c0003a01d8 by goroutine 14:
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).StopCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:178 +0x830
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:296 +0x823
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0x38

Previous write at 0x00c0003a01d8 by goroutine 16:
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).runCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:159 +0x77
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).StartCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:153 +0x2e
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple.gowrap1()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:293 +0xe

Goroutine 14 (running) created at:
  testing.(*T).Run()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2443 +0xf4b
  go.uber.org/goleak.VerifyTestMain()
      /home/billy/go/pkg/mod/go.uber.org/goleak@v1.3.0/testmain.go:53 +0x64
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestMain()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:25 +0x184
  main.main()
      _testmain.go:60 +0x16d

Goroutine 16 (running) created at:
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:293 +0x7b2
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0x38
==================
==================
WARNING: DATA RACE
Write at 0x00c0003a01f0 by goroutine 14:
  sync/atomic.CompareAndSwapInt32()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/runtime/race_amd64.s:361 +0xb
  sync/atomic.CompareAndSwapInt32()
      <autogenerated>:1 +0x18
  context.WithCancel.func1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/context/context.go:242 +0x52
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).StopCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:178 +0x841
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:296 +0x823
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0x38

Previous write at 0x00c0003a01f0 by goroutine 16:
  context.withCancel()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/context/context.go:277 +0x53
  context.WithCancel()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/context/context.go:241 +0x26
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).runCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:158 +0x51
  github.com/kolide/launcher/v2/ee/control/actionqueue.(*ActionQueue).StartCleanup()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue.go:153 +0x2e
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple.gowrap1()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:293 +0xe

Goroutine 14 (running) created at:
  testing.(*T).Run()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2443 +0xf4b
  go.uber.org/goleak.VerifyTestMain()
      /home/billy/go/pkg/mod/go.uber.org/goleak@v1.3.0/testmain.go:53 +0x64
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestMain()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:25 +0x184
  main.main()
      _testmain.go:60 +0x16d

Goroutine 16 (running) created at:
  github.com/kolide/launcher/v2/ee/control/actionqueue.TestStopCleanup_Multiple()
      /home/billy/work/launcher/ee/control/actionqueue/actionqueue_test.go:293 +0x7b2
  testing.tRunner()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /nix/store/wp6mr7ada9g75g026q523s34l346mid2-go-1.26.5/share/go/src/testing/testing.go:2101 +0x38
==================
=== NAME  TestStopCleanup_Multiple
    testing.go:1712: race detected during execution of test
--- FAIL: TestStopCleanup_Multiple (3.00s)
FAIL
FAIL	github.com/kolide/launcher/v2/ee/control/actionqueue	3.024s
FAIL

```