### PR TITLE
Fix queries for kolide_keychain_ tables

### DIFF
--- a/pkg/osquery/table/platform_tables_darwin.go
+++ b/pkg/osquery/table/platform_tables_darwin.go
@@ -65,7 +65,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 
 	keychainAclsTable := osquery_user_exec_table.TablePlugin(
 		k, slogger, "kolide_keychain_acls",
-		currentOsquerydBinaryPath, keychainItemsQuery,
+		currentOsquerydBinaryPath, keychainAclsQuery,
 		[]table.ColumnDefinition{
 			table.TextColumn("keychain_path"),
 			table.TextColumn("authorizations"),
@@ -78,7 +78,7 @@ func platformSpecificTables(k types.Knapsack, slogger *slog.Logger, currentOsque
 
 	keychainItemsTable := osquery_user_exec_table.TablePlugin(
 		k, slogger, "kolide_keychain_items",
-		currentOsquerydBinaryPath, keychainAclsQuery,
+		currentOsquerydBinaryPath, keychainItemsQuery,
 		[]table.ColumnDefinition{
 			table.TextColumn("label"),
 			table.TextColumn("description"),


### PR DESCRIPTION
The queries for `kolide_keychain_acls` and `kolide_keychain_items` were swapped, leading to incorrect data returned by both tables -- both the wrong data was returned, and columns were null (type/modified/label/comment/created were all null for `kolide_keychain_items`, and authorizations/keychain_path/description were all null for `kolide_keychain_acls`).

This PR swaps the queries. After making this change, the data returned by each table is correct and complete, with all columns filled in.

@Micah-Kolide confirmed that these tables are not in use by Kolide, nor by any custom checks.