### PR TITLE
Use Cloudsmith in more places, where possible

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -887,6 +887,27 @@ jobs:
         with:
           egress-policy: audit # Audit network and disk activity
 
+      - name: Setup Cloudsmith CLI # Exports CLOUDSMITH_API_KEY
+        uses: step-security/cloudsmith-cli-action@dd1da513017145043c2d29a38b3b85c2b609b5ad # v2.0.3
+        # We don't distribute package_builder via these artifacts, but nonetheless use Cloudsmith where we can (main and tagged builds).
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        with:
+          oidc-auth-only: 'true' # Just the auth, don't need the CLI installed in CI
+          oidc-namespace: '1password'
+          oidc-service-slug: 'ga-kolide-launcher'
+
+      - name: Configure GOPROXY
+        # We don't distribute package_builder via these artifacts, but nonetheless use Cloudsmith where we can (main and tagged builds).
+        # cloudsmith-cli-action should mask the API key, but we add additional masks just to be safe.
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        shell: bash
+        run: |
+          echo "::add-mask::${CLOUDSMITH_API_KEY}"
+          [ -z "${CLOUDSMITH_API_KEY:-}" ] && exit 1
+          goproxy="https://token:${CLOUDSMITH_API_KEY}@golang.cloudsmith.io/1password/op-golang/"
+          echo "::add-mask::$goproxy"
+          echo "GOPROXY=$goproxy" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need a full checkout for `git describe`

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -872,6 +872,7 @@ jobs:
   package_builder_test:
     permissions:
       contents: read
+      id-token: write # Required to create an OIDC token for Cloudsmith auth
     name: package_builder
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,6 +132,27 @@ jobs:
         with:
           egress-policy: audit # Audit network and disk activity
 
+      - name: Setup Cloudsmith CLI # Exports CLOUDSMITH_API_KEY
+        uses: step-security/cloudsmith-cli-action@dd1da513017145043c2d29a38b3b85c2b609b5ad # v2.0.3
+        # We don't distribute the results of running table specs here, but we use Cloudsmith where we can (main and tags) nonetheless.
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        with:
+          oidc-auth-only: 'true' # Just the auth, don't need the CLI installed in CI
+          oidc-namespace: '1password'
+          oidc-service-slug: 'ga-kolide-launcher'
+
+      - name: Configure GOPROXY
+        # We don't distribute the results of running table specs here, but we use Cloudsmith where we can (main and tags) nonetheless.
+        # cloudsmith-cli-action should mask the API key, but we add additional masks just to be safe.
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        shell: bash
+        run: |
+          echo "::add-mask::${CLOUDSMITH_API_KEY}"
+          [ -z "${CLOUDSMITH_API_KEY:-}" ] && exit 1
+          goproxy="https://token:${CLOUDSMITH_API_KEY}@golang.cloudsmith.io/1password/op-golang/"
+          echo "::add-mask::$goproxy"
+          echo "GOPROXY=$goproxy" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
   govulncheck:
     permissions:
       contents: read
+      id-token: write # Required to create an OIDC token for Cloudsmith auth
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +66,7 @@ jobs:
 
       - name: Setup Cloudsmith CLI # Exports CLOUDSMITH_API_KEY
         uses: step-security/cloudsmith-cli-action@dd1da513017145043c2d29a38b3b85c2b609b5ad # v2.0.3
-        # For now, we only use Cloudsmith on builds we're going to distribute: refs/head/main for nightly builds, and 'tag' for stable builds
+        # We don't distribute any artifacts from this job, but we still use Cloudsmith where we can (main and tags).
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         with:
           oidc-auth-only: 'true' # Just the auth, don't need the CLI installed in CI
@@ -73,7 +74,7 @@ jobs:
           oidc-service-slug: 'ga-kolide-launcher'
 
       - name: Configure GOPROXY
-        # For now, we only use Cloudsmith on builds we're going to distribute: refs/head/main for nightly builds, and 'tag' for stable builds.
+        # We don't distribute any artifacts from this job, but we still use Cloudsmith where we can (main and tags).
         # cloudsmith-cli-action should mask the API key, but we add additional masks just to be safe.
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         shell: bash
@@ -120,6 +121,7 @@ jobs:
   table_specs:
     permissions:
       contents: read
+      id-token: write # Required to create an OIDC token for Cloudsmith auth
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,6 +63,27 @@ jobs:
         with:
           egress-policy: audit # Audit network and disk activity
 
+      - name: Setup Cloudsmith CLI # Exports CLOUDSMITH_API_KEY
+        uses: step-security/cloudsmith-cli-action@dd1da513017145043c2d29a38b3b85c2b609b5ad # v2.0.3
+        # For now, we only use Cloudsmith on builds we're going to distribute: refs/head/main for nightly builds, and 'tag' for stable builds
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        with:
+          oidc-auth-only: 'true' # Just the auth, don't need the CLI installed in CI
+          oidc-namespace: '1password'
+          oidc-service-slug: 'ga-kolide-launcher'
+
+      - name: Configure GOPROXY
+        # For now, we only use Cloudsmith on builds we're going to distribute: refs/head/main for nightly builds, and 'tag' for stable builds.
+        # cloudsmith-cli-action should mask the API key, but we add additional masks just to be safe.
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        shell: bash
+        run: |
+          echo "::add-mask::${CLOUDSMITH_API_KEY}"
+          [ -z "${CLOUDSMITH_API_KEY:-}" ] && exit 1
+          goproxy="https://token:${CLOUDSMITH_API_KEY}@golang.cloudsmith.io/1password/op-golang/"
+          echo "::add-mask::$goproxy"
+          echo "GOPROXY=$goproxy" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/pull/2784

Uses Cloudsmith for govulncheck, linting the schema, and testing package builder. These are less critical paths (we do not produce artifacts that we use from any of these jobs), but they are updated in this PR for the sake of completeness.