### PR TITLE
Fix signal panic

### DIFF
--- a/cmd/launcher/signal_listener.go
+++ b/cmd/launcher/signal_listener.go
@@ -28,10 +28,6 @@ func newSignalListener(sigChannel chan os.Signal, cancel context.CancelFunc, slo
 func (s *signalListener) Execute() error {
 	signal.Notify(s.sigChannel, os.Interrupt, syscall.SIGTERM)
 	sig := <-s.sigChannel
-	// tell sender in `os/signal` package to stop sending on `s.sigChannel`
-	// to avoid panics for sending on a closed channel
-	// after we close the signal channel in `Interrupt`
-	defer signal.Stop(s.sigChannel)
 	s.slogger.Log(context.TODO(), slog.LevelInfo,
 		"beginning shutdown via signal",
 		"signal_received", sig,
@@ -45,6 +41,9 @@ func (s *signalListener) Interrupt(_ error) {
 		return
 	}
 
+	// tell sender in `os/signal` package to stop sending on `s.sigChannel`
+	// to avoid panics for sending on a closed channel
+	signal.Stop(s.sigChannel)
 	s.cancel()
 	close(s.sigChannel)
 }

--- a/cmd/launcher/signal_listener.go
+++ b/cmd/launcher/signal_listener.go
@@ -28,6 +28,10 @@ func newSignalListener(sigChannel chan os.Signal, cancel context.CancelFunc, slo
 func (s *signalListener) Execute() error {
 	signal.Notify(s.sigChannel, os.Interrupt, syscall.SIGTERM)
 	sig := <-s.sigChannel
+	// tell sender in `os/signal` package to stop sending on `s.sigChannel`
+	// to avoid panics for sending on a closed channel
+	// after we close the signal channel in `Interrupt`
+	defer signal.Stop(s.sigChannel)
 	s.slogger.Log(context.TODO(), slog.LevelInfo,
 		"beginning shutdown via signal",
 		"signal_received", sig,


### PR DESCRIPTION
Our basic e2e test suite in the monorepo is failing on Linux due to panics with stack traces similar to the following:

```
panic: send on closed channel
goroutine 26 [running]:
os/signal.process({0x1b0a590, 0x1b51f98})
	os/signal/signal.go:246 +0x185
os/signal.loop()
	os/signal/signal_unix.go:23 +0x29
created by os/signal.Notify.func1.1 in goroutine 23
	os/signal/signal.go:152 +0x1f
launcher.kolide-k2.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
launcher.kolide-k2.service: Failed with result 'exit-code'.
Stopped launcher.kolide-k2.service - The Kolide Launcher.
```

I was able to reproduce this on a physical System76 machine running Pop!_OS and an Ubuntu VM with a minimal version of the launcher code (just run group concept running the signal listener actor). If any actors in the run group return (whether the error is nil or non-nil), this triggers the `Interrupt` method of all actors. The signal listener's interrupt method closes the channel provided to `signal.Notify`. If the OS sends any further registered signals (`SIGINT`, `SIGTERM`), those are sent to the closed channel and cause a panic. The fix is to tell the channel sender (i.e. the `os/signal` package) to stop sending on the channel.