### PR TITLE
Preserve embedded datetime translations on localization updates

### DIFF
--- a/ee/control/consumers/localizationconsumer/localizationconsumer.go
+++ b/ee/control/consumers/localizationconsumer/localizationconsumer.go
@@ -74,7 +74,7 @@ func NewLocalizationConsumer(slogger *slog.Logger, kvStore types.KVStore) (*Loca
 		return nil, fmt.Errorf("failed to unmarshal localization data from store: %w", err)
 	}
 
-	maps.Copy(t.localizationData.Translations, localizationFromStore.Translations)
+	t.mergeTranslations(localizationFromStore.Translations)
 
 	// set the locale to the one from the store
 	t.localizationData.Locale = localizationFromStore.Locale
@@ -89,7 +89,7 @@ func (t *LocalizationConsumer) Update(data io.Reader) error {
 		return fmt.Errorf("failed to decode localization update: %w", err)
 	}
 
-	maps.Copy(t.localizationData.Translations, updatedLocalizationData.Translations)
+	t.mergeTranslations(updatedLocalizationData.Translations)
 	t.localizationData.Locale = updatedLocalizationData.Locale
 
 	// marshal updated localization data into a byte slice
@@ -104,6 +104,26 @@ func (t *LocalizationConsumer) Update(data io.Reader) error {
 	}
 
 	return nil
+}
+
+// mergeTranslations folds incoming per-locale translations into the current set,
+// section by section. The server only sends the sections it owns (e.g. the
+// notification "Learn More" label), so replacing a locale's whole entry would
+// blank out the datetime translations that ship in the embedded assets. Empty
+// incoming sections are left alone so the embedded values survive.
+func (t *LocalizationConsumer) mergeTranslations(incoming map[string]types.Translations) {
+	for locale, in := range incoming {
+		merged := t.localizationData.Translations[locale]
+
+		if in.Datetime != (types.Datetime{}) {
+			merged.Datetime = in.Datetime
+		}
+		if in.Notifications != (types.Notifications{}) {
+			merged.Notifications = in.Notifications
+		}
+
+		t.localizationData.Translations[locale] = merged
+	}
 }
 
 func (t *LocalizationConsumer) LocalizationData() types.LocalizationData {

--- a/ee/control/consumers/localizationconsumer/localizationconsumer_test.go
+++ b/ee/control/consumers/localizationconsumer/localizationconsumer_test.go
@@ -92,3 +92,36 @@ func TestLocalizationConsumer(t *testing.T) {
 		})
 	}
 }
+
+// TestLocalizationConsumer_NotificationsOnlyUpdate covers the shape of update the
+// server actually sends: a single locale carrying only the notification action
+// label. The embedded datetime translations for that locale must survive.
+func TestLocalizationConsumer_NotificationsOnlyUpdate(t *testing.T) {
+	t.Parallel()
+
+	slogger := slog.Default()
+	store := inmemory.NewStore()
+
+	consumer, err := NewLocalizationConsumer(slogger, store)
+	require.NoError(t, err)
+
+	embeddedXMinutes := consumer.localizationData.Translations["es-ES"].Datetime.DistanceInWords.XMinutes.Other
+	require.NotEmpty(t, embeddedXMinutes, "es-ES asset should ship datetime translations")
+
+	update := []byte(`{"locale":"es-ES","translations":{"es-ES":{"notifications":{"actions":{"learn_more":"Más información"}}}}}`)
+	require.NoError(t, consumer.Update(bytes.NewReader(update)))
+
+	esES := consumer.localizationData.Translations["es-ES"]
+	require.Equal(t, "Más información", esES.Notifications.Actions.LearnMore)
+	require.Equal(t, embeddedXMinutes, esES.Datetime.DistanceInWords.XMinutes.Other,
+		"notifications-only update should not blank embedded datetime translations")
+
+	// a restart reads the merged data back out of the store, which must also
+	// preserve the embedded datetime translations
+	consumer, err = NewLocalizationConsumer(slogger, store)
+	require.NoError(t, err)
+
+	esES = consumer.localizationData.Translations["es-ES"]
+	require.Equal(t, "Más información", esES.Notifications.Actions.LearnMore)
+	require.Equal(t, embeddedXMinutes, esES.Datetime.DistanceInWords.XMinutes.Other)
+}


### PR DESCRIPTION
## Summary

Localized devices were still showing English relative time in the menu bar app (e.g. `Last Menu Update: 5 Minutes Ago` on an `es-ES` device).

The control server only sends the localization sections it owns — currently just the notification "Learn More" label, see [`LocalizationsService`](https://github.com/kolide/k2/blob/main/app/services/agent_control/localizations_service.rb):

```json
{"locale":"es-ES","translations":{"es-ES":{"notifications":{"actions":{"learn_more":"Más información"}}}}}
```

But `LocalizationConsumer` merged that with `maps.Copy`, which replaces a locale's entire `Translations` entry rather than merging fields. So the `es-ES` entry ended up with the correct `learn_more` and every datetime string blanked to `""`, wiping the Spanish strings that ship in `assets/es-ES.json`. `PluralForms.Select` then returned `""`, and `relativeTimeLocalized` fell back to `relativeTimeDefault` (English).

Confirmed on a live device — `localization.json` on disk had `"x_minutes": {"other": ""}` for `es-ES` while the other 122 bundled locales were intact, since `es-ES` was the only one the server sent.

This merges section by section instead, leaving empty incoming sections alone. It also applies to the store-read path in `NewLocalizationConsumer`, so devices that already persisted a blanked entry recover on their next start rather than staying broken.

Only affects the launcher-controlled strings in scope for [KOL-213](https://1password.atlassian.net/browse/KOL-213). The rest of the menu (`About Kolide...`, `View Details...`, etc.) is server-rendered text from `kolide_desktop_menu` and is expected to follow k2's locale handling.

## Test plan

- [x] `TestLocalizationConsumer_NotificationsOnlyUpdate` uses the real payload shape and asserts the embedded datetime strings survive both an `Update` and a consumer restart. Verified it fails against the old behavior (`expected "%{count} minutos", actual ""`) and passes with the fix.
- [x] `go test ./ee/control/consumers/localizationconsumer/ ./ee/desktop/...` passes. (`TestDesktopUserProcessRunner_Execute` times out locally for me on a clean `main` as well — unrelated, it spawns real desktop processes.)
- [ ] Verify on a device with a non-English locale that the menu bar relative time renders localized.