### PR TITLE
Use dbus => OpenURI to open URLs when possible

### DIFF
--- a/ee/desktop/user/menu/action_open_url_linux.go
+++ b/ee/desktop/user/menu/action_open_url_linux.go
@@ -6,12 +6,22 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/godbus/dbus/v5"
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
+	"github.com/kolide/launcher/v2/ee/desktop/user/notify"
 )
 
 // open opens the specified URL in the default browser of the user
 // See https://stackoverflow.com/a/39324149/1705598
 func open(url string) error {
+	// Try via dbus before falling back to xdg-open --
+	// we see improved behavior when using dbus.
+	if conn, err := dbus.SessionBus(); err == nil {
+		if err := notify.OpenViaDbus(conn, url); err == nil {
+			return nil
+		}
+	}
+
 	cmd, err := allowedcmd.XdgOpen.Cmd(context.TODO(), url)
 	if err != nil {
 		return fmt.Errorf("creating command: %w", err)

--- a/ee/desktop/user/menu/action_open_url_linux.go
+++ b/ee/desktop/user/menu/action_open_url_linux.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/godbus/dbus/v5"
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
 	"github.com/kolide/launcher/v2/ee/desktop/user/notify"
 )
@@ -16,15 +15,14 @@ import (
 func open(url string) error {
 	// Try via dbus before falling back to xdg-open --
 	// we see improved behavior when using dbus.
-	if conn, err := dbus.SessionBus(); err == nil {
-		if err := notify.OpenViaDbus(conn, url); err == nil {
-			return nil
-		}
+	dbusErr := notify.OpenViaDbus(url)
+	if dbusErr == nil {
+		return nil
 	}
 
 	cmd, err := allowedcmd.XdgOpen.Cmd(context.TODO(), url)
 	if err != nil {
-		return fmt.Errorf("creating command: %w", err)
+		return fmt.Errorf("falling back creating command (after dbus failure %v): %w", dbusErr, err)
 	}
 
 	return cmd.Start()

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -7,13 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
 )
 
@@ -30,17 +27,12 @@ type dbusNotifier struct {
 }
 
 const (
-	notificationServiceObj          = "/org/freedesktop/Notifications"
-	notificationServiceInterface    = "org.freedesktop.Notifications"
-	signalActionInvoked             = "org.freedesktop.Notifications.ActionInvoked"
-	desktopPortalPath               = "/org/freedesktop/portal/desktop"
-	desktopPortalName               = "org.freedesktop.portal.Desktop"
-	methodOpenUri                   = "org.freedesktop.portal.OpenURI.OpenURI"
-	portalRequestInterface          = "org.freedesktop.portal.Request"
-	desktopPortalRequestPathPattern = "/org/freedesktop/portal/desktop/request/%s/%s"
-	portalResponseSignal            = "org.freedesktop.portal.Request.Response"
-	portalResponseMember            = "Response"
-	portalResponseTimeout           = 5 * time.Second
+	notificationServiceObj       = "/org/freedesktop/Notifications"
+	notificationServiceInterface = "org.freedesktop.Notifications"
+	signalActionInvoked          = "org.freedesktop.Notifications.ActionInvoked"
+	desktopPortalPath            = "/org/freedesktop/portal/desktop"
+	desktopPortalName            = "org.freedesktop.portal.Desktop"
+	methodOpenUri                = "org.freedesktop.portal.OpenURI.OpenURI"
 )
 
 // We default to xdg-open first because, if available, it appears to be better at picking
@@ -289,6 +281,8 @@ func (d *dbusNotifier) sendNotificationViaNotifySend(n Notification) error {
 }
 
 // OpenViaDbus opens the given URI via call to XDG Desktop Portal's OpenURI method.
+// We do not check responses because we cannot distinguish between a failure and the user
+// simply closing the browser.
 // See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html
 func OpenViaDbus(uri string) error {
 	conn, err := dbus.ConnectSessionBus()
@@ -296,38 +290,6 @@ func OpenViaDbus(uri string) error {
 		return fmt.Errorf("connecting to dbus: %w", err)
 	}
 	defer conn.Close()
-
-	// Determine our sender identity so that we can match on responses to our request only.
-	names := conn.Names()
-	if len(names) == 0 {
-		return errors.New("connection has no unique name")
-	}
-	// Our request handle takes the following form: /org/freedesktop/portal/desktop/request/SENDER/TOKEN,
-	// where SENDER is our name, with the initial ':' removed and all '.' replaced by '_'".
-	// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request
-	sender := strings.ReplaceAll(strings.TrimPrefix(names[0], ":"), ".", "_")
-
-	// Generate the token:
-	handleToken := "kolide_" + ulid.New()
-	requestPath := fmt.Sprintf(desktopPortalRequestPathPattern, sender, handleToken)
-
-	// Now, prepare to receive response from calling OpenURI:
-	// First, subscribe to responses.
-	matchSignalOpts := []dbus.MatchOption{
-		dbus.WithMatchObjectPath(dbus.ObjectPath(requestPath)),
-		dbus.WithMatchInterface(portalRequestInterface),
-		dbus.WithMatchMember(portalResponseMember),
-		dbus.WithMatchSender(desktopPortalName),
-	}
-	if err := conn.AddMatchSignal(matchSignalOpts...); err != nil {
-		return fmt.Errorf("adding match signal for response from portal: %w", err)
-	}
-	defer conn.RemoveMatchSignal(matchSignalOpts...)
-
-	// Next, set up channel to receive responses on.
-	portalResponse := make(chan *dbus.Signal, 5)
-	conn.Signal(portalResponse)
-	defer conn.RemoveSignal(portalResponse)
 
 	// Prepare to call Desktop Portal's OpenURI:
 	desktopPortal := conn.Object(
@@ -338,47 +300,12 @@ func OpenViaDbus(uri string) error {
 	if err := desktopPortal.Call(
 		methodOpenUri,
 		0,
-		"",  // parent_window
-		uri, // uri
-		map[string]dbus.Variant{
-			"handle_token": dbus.MakeVariant(handleToken),
-		}, // options
+		"",                        // parent_window
+		uri,                       // uri
+		map[string]dbus.Variant{}, // options
 	).Store(&requestHandle); err != nil {
 		return fmt.Errorf("calling OpenURI: %w", err)
 	}
 
-	// Finally, await response until timeout
-	ctx, cancel := context.WithTimeout(context.Background(), portalResponseTimeout)
-	defer cancel()
-	for {
-		select {
-		case signal, open := <-portalResponse:
-			if !open {
-				return errors.New("dbus signal channel closed, cannot proceed")
-			}
-
-			if signal == nil || signal.Name != portalResponseSignal || signal.Path != requestHandle || signal.Sender != desktopPortalName {
-				// Not a signal, not a response signal, or not a response signal to _our_ request
-				continue
-			}
-
-			if len(signal.Body) < 1 {
-				return errors.New("received empty response")
-			}
-
-			responseCode, ok := signal.Body[0].(uint32)
-			if !ok {
-				return fmt.Errorf("unexpected response type %T", signal.Body[0])
-			}
-
-			// 0 is success; 1 is user cancelled
-			// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request-response
-			if responseCode == 0 || responseCode == 1 {
-				return nil
-			}
-			return fmt.Errorf("open failed: response code %d", responseCode)
-		case <-ctx.Done():
-			return fmt.Errorf("waiting for response: %w", ctx.Err())
-		}
-	}
+	return nil
 }

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -7,10 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/kolide/kit/ulid"
 	"github.com/kolide/launcher/v2/ee/allowedcmd"
 )
 
@@ -27,12 +30,17 @@ type dbusNotifier struct {
 }
 
 const (
-	notificationServiceObj       = "/org/freedesktop/Notifications"
-	notificationServiceInterface = "org.freedesktop.Notifications"
-	signalActionInvoked          = "org.freedesktop.Notifications.ActionInvoked"
-	desktopPortalPath            = "/org/freedesktop/portal/desktop"
-	desktopPortalName            = "org.freedesktop.portal.Desktop"
-	methodOpenUri                = "org.freedesktop.portal.OpenURI.OpenURI"
+	notificationServiceObj          = "/org/freedesktop/Notifications"
+	notificationServiceInterface    = "org.freedesktop.Notifications"
+	signalActionInvoked             = "org.freedesktop.Notifications.ActionInvoked"
+	desktopPortalPath               = "/org/freedesktop/portal/desktop"
+	desktopPortalName               = "org.freedesktop.portal.Desktop"
+	methodOpenUri                   = "org.freedesktop.portal.OpenURI.OpenURI"
+	portalRequestInterface          = "org.freedesktop.portal.Request"
+	desktopPortalRequestPathPattern = "/org/freedesktop/portal/desktop/request/%s/%s"
+	portalResponseSignal            = "org.freedesktop.portal.Request.Response"
+	portalResponseMember            = "Response"
+	portalResponseTimeout           = 5 * time.Second
 )
 
 // We default to xdg-open first because, if available, it appears to be better at picking
@@ -53,38 +61,11 @@ func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationP
 		localizationPath:    localizationPath,
 		slogger:             slogger.With("component", "desktop_notifier"),
 		conn:                conn,
-		signal:              make(chan *dbus.Signal),
+		signal:              make(chan *dbus.Signal, 5),
 		interrupt:           make(chan struct{}),
 		sentNotificationIds: make(map[uint32]bool),
 		lock:                sync.RWMutex{},
 	}
-}
-
-// OpenViaDbus opens the given URI via call to XDG Desktop Portal's OpenURI method.
-// We treat it as successful if the portal accepts; we do not wait for the response.
-// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html
-func OpenViaDbus(conn *dbus.Conn, uri string) error {
-	if conn == nil {
-		return errors.New("no connection available")
-	}
-
-	desktopPortal := conn.Object(
-		desktopPortalName,
-		desktopPortalPath,
-	)
-
-	var requestHandle dbus.ObjectPath
-	if err := desktopPortal.Call(
-		methodOpenUri,
-		0,
-		"",                        // parent_window
-		uri,                       // uri
-		map[string]dbus.Variant{}, // options
-	).Store(&requestHandle); err != nil {
-		return fmt.Errorf("calling OpenURI: %w", err)
-	}
-
-	return nil
 }
 
 func (d *dbusNotifier) Execute() error {
@@ -117,8 +98,16 @@ func (d *dbusNotifier) Execute() error {
 				continue
 			}
 
+			if len(signal.Body) < 2 {
+				// Malformed signal -- we expect notification ID + action URI
+				continue
+			}
+
 			// Confirm that this is a Kolide-originated notification by checking for known notification IDs
-			notificationId := signal.Body[0].(uint32)
+			notificationId, ok := signal.Body[0].(uint32)
+			if !ok {
+				continue
+			}
 			d.lock.RLock()
 			if _, found := d.sentNotificationIds[notificationId]; !found {
 				// This notification didn't come from us -- ignore it
@@ -128,11 +117,14 @@ func (d *dbusNotifier) Execute() error {
 			d.lock.RUnlock()
 
 			// Attempt to open a browser to the given URL
-			actionUri := signal.Body[1].(string)
+			actionUri, ok := signal.Body[1].(string)
+			if !ok {
+				continue
+			}
 
 			// Try via dbus before falling back to xdg-open and www-browser --
 			// we see improved behavior when using dbus.
-			err := OpenViaDbus(d.conn, actionUri)
+			err := OpenViaDbus(actionUri)
 			if err == nil {
 				continue
 			}
@@ -286,4 +278,99 @@ func (d *dbusNotifier) sendNotificationViaNotifySend(n Notification) error {
 	}
 
 	return nil
+}
+
+// OpenViaDbus opens the given URI via call to XDG Desktop Portal's OpenURI method.
+// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html
+func OpenViaDbus(uri string) error {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return fmt.Errorf("connecting to dbus: %w", err)
+	}
+	defer conn.Close()
+
+	// Determine our sender identity so that we can match on responses to our request only.
+	names := conn.Names()
+	if len(names) == 0 {
+		return errors.New("connection has no unique name")
+	}
+	// Our request handle takes the following form: /org/freedesktop/portal/desktop/request/SENDER/TOKEN,
+	// where SENDER is our name, with the initial ':' removed and all '.' replaced by '_'".
+	// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request
+	sender := strings.ReplaceAll(strings.TrimPrefix(names[0], ":"), ".", "_")
+
+	// Generate the token:
+	handleToken := "kolide_" + ulid.New()
+	requestPath := fmt.Sprintf(desktopPortalRequestPathPattern, sender, handleToken)
+
+	// Now, prepare to receive response from calling OpenURI:
+	// First, subscribe to responses.
+	matchSignalOpts := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(dbus.ObjectPath(requestPath)),
+		dbus.WithMatchInterface(portalRequestInterface),
+		dbus.WithMatchMember(portalResponseMember),
+		dbus.WithMatchSender(desktopPortalName),
+	}
+	if err := conn.AddMatchSignal(matchSignalOpts...); err != nil {
+		return fmt.Errorf("adding match signal for response from portal: %w", err)
+	}
+	defer conn.RemoveMatchSignal(matchSignalOpts...)
+
+	// Next, set up channel to receive responses on.
+	portalResponse := make(chan *dbus.Signal, 5)
+	conn.Signal(portalResponse)
+	defer conn.RemoveSignal(portalResponse)
+
+	// Prepare to call Desktop Portal's OpenURI:
+	desktopPortal := conn.Object(
+		desktopPortalName,
+		desktopPortalPath,
+	)
+	var requestHandle dbus.ObjectPath
+	if err := desktopPortal.Call(
+		methodOpenUri,
+		0,
+		"",  // parent_window
+		uri, // uri
+		map[string]dbus.Variant{
+			"handle_token": dbus.MakeVariant(handleToken),
+		}, // options
+	).Store(&requestHandle); err != nil {
+		return fmt.Errorf("calling OpenURI: %w", err)
+	}
+
+	// Finally, await response until timeout
+	ctx, cancel := context.WithTimeout(context.Background(), portalResponseTimeout)
+	defer cancel()
+	for {
+		select {
+		case signal, open := <-portalResponse:
+			if !open {
+				return errors.New("dbus signal channel closed, cannot proceed")
+			}
+
+			if signal == nil || signal.Name != portalResponseSignal || signal.Path != requestHandle || signal.Sender != desktopPortalName {
+				// Not a signal, not a response signal, or not a response signal to _our_ request
+				continue
+			}
+
+			if len(signal.Body) < 1 {
+				return errors.New("received empty response")
+			}
+
+			responseCode, ok := signal.Body[0].(uint32)
+			if !ok {
+				return fmt.Errorf("unexpected response type %T", signal.Body[0])
+			}
+
+			// 0 is success; 1 is user cancelled
+			// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request-response
+			if responseCode == 0 || responseCode == 1 {
+				return nil
+			}
+			return fmt.Errorf("open failed: response code %d", responseCode)
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for response: %w", ctx.Err())
+		}
+	}
 }

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -30,6 +30,9 @@ const (
 	notificationServiceObj       = "/org/freedesktop/Notifications"
 	notificationServiceInterface = "org.freedesktop.Notifications"
 	signalActionInvoked          = "org.freedesktop.Notifications.ActionInvoked"
+	desktopPortalPath            = "/org/freedesktop/portal/desktop"
+	desktopPortalName            = "org.freedesktop.portal.Desktop"
+	methodOpenUri                = "org.freedesktop.portal.OpenURI.OpenURI"
 )
 
 // We default to xdg-open first because, if available, it appears to be better at picking
@@ -55,6 +58,33 @@ func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationP
 		sentNotificationIds: make(map[uint32]bool),
 		lock:                sync.RWMutex{},
 	}
+}
+
+// OpenViaDbus opens the given URI via call to XDG Desktop Portal's OpenURI method.
+// We treat it as successful if the portal accepts; we do not wait for the response.
+// See: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html
+func OpenViaDbus(conn *dbus.Conn, uri string) error {
+	if conn == nil {
+		return errors.New("no connection available")
+	}
+
+	desktopPortal := conn.Object(
+		desktopPortalName,
+		desktopPortalPath,
+	)
+
+	var requestHandle dbus.ObjectPath
+	if err := desktopPortal.Call(
+		methodOpenUri,
+		0,
+		"",                        // parent_window
+		uri,                       // uri
+		map[string]dbus.Variant{}, // options
+	).Store(&requestHandle); err != nil {
+		return fmt.Errorf("calling OpenURI: %w", err)
+	}
+
+	return nil
 }
 
 func (d *dbusNotifier) Execute() error {
@@ -100,6 +130,17 @@ func (d *dbusNotifier) Execute() error {
 			// Attempt to open a browser to the given URL
 			actionUri := signal.Body[1].(string)
 
+			// Try via dbus before falling back to xdg-open and www-browser --
+			// we see improved behavior when using dbus.
+			err := OpenViaDbus(d.conn, actionUri)
+			if err == nil {
+				continue
+			}
+			d.slogger.Log(context.TODO(), slog.LevelWarn,
+				"couldn't open URI via dbus, falling back to exec",
+				"err", err,
+			)
+
 			for _, browserLauncher := range browserLaunchers {
 				cmd, err := browserLauncher.Cmd(context.TODO(), actionUri)
 				if err != nil {
@@ -137,10 +178,21 @@ func (d *dbusNotifier) Interrupt(err error) {
 
 	if d.conn != nil {
 		d.conn.RemoveSignal(d.signal)
-		d.conn.RemoveMatchSignal(
+		if err := d.conn.RemoveMatchSignal(
 			dbus.WithMatchObjectPath(notificationServiceObj),
 			dbus.WithMatchInterface(notificationServiceInterface),
-		)
+		); err != nil {
+			d.slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not remove match signal during shutdown",
+				"err", err,
+			)
+		}
+		if err := d.conn.Close(); err != nil {
+			d.slogger.Log(context.TODO(), slog.LevelWarn,
+				"could not close session bus connection during shutdown",
+				"err", err,
+			)
+		}
 	}
 }
 

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -62,14 +62,7 @@ func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationP
 
 func (d *dbusNotifier) Execute() error {
 	if d.conn != nil {
-		// Match on the sender as well as the path and interface: more than one connection can export
-		// /org/freedesktop/Notifications and emit ActionInvoked for the same click. Under GNOME, the
-		// shell emits it and a separate relay process that owns the org.freedesktop.Notifications name
-		// re-emits an identical copy, so without a sender match we handle one click twice and open two
-		// browser tabs. The bus resolves the well-known name to its current owner and keeps the rule up
-		// to date as ownership changes.
 		if err := d.conn.AddMatchSignal(
-			dbus.WithMatchSender(notificationServiceInterface),
 			dbus.WithMatchObjectPath(notificationServiceObj),
 			dbus.WithMatchInterface(notificationServiceInterface),
 		); err != nil {
@@ -170,7 +163,6 @@ func (d *dbusNotifier) Interrupt(err error) {
 	if d.conn != nil {
 		d.conn.RemoveSignal(d.signal)
 		if err := d.conn.RemoveMatchSignal(
-			dbus.WithMatchSender(notificationServiceInterface),
 			dbus.WithMatchObjectPath(notificationServiceObj),
 			dbus.WithMatchInterface(notificationServiceInterface),
 		); err != nil {

--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -70,7 +70,14 @@ func NewDesktopNotifier(slogger *slog.Logger, iconFilepath string, localizationP
 
 func (d *dbusNotifier) Execute() error {
 	if d.conn != nil {
+		// Match on the sender as well as the path and interface: more than one connection can export
+		// /org/freedesktop/Notifications and emit ActionInvoked for the same click. Under GNOME, the
+		// shell emits it and a separate relay process that owns the org.freedesktop.Notifications name
+		// re-emits an identical copy, so without a sender match we handle one click twice and open two
+		// browser tabs. The bus resolves the well-known name to its current owner and keeps the rule up
+		// to date as ownership changes.
 		if err := d.conn.AddMatchSignal(
+			dbus.WithMatchSender(notificationServiceInterface),
 			dbus.WithMatchObjectPath(notificationServiceObj),
 			dbus.WithMatchInterface(notificationServiceInterface),
 		); err != nil {
@@ -171,6 +178,7 @@ func (d *dbusNotifier) Interrupt(err error) {
 	if d.conn != nil {
 		d.conn.RemoveSignal(d.signal)
 		if err := d.conn.RemoveMatchSignal(
+			dbus.WithMatchSender(notificationServiceInterface),
 			dbus.WithMatchObjectPath(notificationServiceObj),
 			dbus.WithMatchInterface(notificationServiceInterface),
 		); err != nil {

--- a/ee/desktop/user/notify/notify_test.go
+++ b/ee/desktop/user/notify/notify_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// ioCompletionProcessor will continue to run forever until the process (go test in this case) exits,
-	// so we need goleak to ignore that one.
-	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/Microsoft/go-winio.ioCompletionProcessor"))
+	goleak.VerifyTestMain(m)
 }
 
 // TestInterrupt_Multiple confirms that Interrupt can be called multiple times without blocking;

--- a/ee/desktop/user/notify/notify_test.go
+++ b/ee/desktop/user/notify/notify_test.go
@@ -1,0 +1,62 @@
+package notify
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kolide/launcher/v2/pkg/threadsafebuffer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// ioCompletionProcessor will continue to run forever until the process (go test in this case) exits,
+	// so we need goleak to ignore that one.
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/Microsoft/go-winio.ioCompletionProcessor"))
+}
+
+// TestInterrupt_Multiple confirms that Interrupt can be called multiple times without blocking;
+// we require this for rungroup actors.
+func TestInterrupt_Multiple(t *testing.T) {
+	t.Parallel()
+
+	// Set up dependencies
+	var logBytes threadsafebuffer.ThreadSafeBuffer
+	slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	testNotifier := NewDesktopNotifier(slogger, "", "")
+
+	// Start and then interrupt
+	go testNotifier.Execute()
+	time.Sleep(3 * time.Second)
+	interruptStart := time.Now()
+	testNotifier.Interrupt(errors.New("test error"))
+
+	// Confirm we can call Interrupt multiple times without blocking
+	interruptComplete := make(chan struct{})
+	expectedInterrupts := 3
+	for range expectedInterrupts {
+		go func() {
+			testNotifier.Interrupt(nil)
+			interruptComplete <- struct{}{}
+		}()
+	}
+
+	receivedInterrupts := 0
+	for receivedInterrupts < expectedInterrupts {
+		select {
+		case <-interruptComplete:
+			receivedInterrupts += 1
+			continue
+		case <-time.After(5 * time.Second):
+			t.Errorf("could not call interrupt multiple times and return within 5 seconds -- interrupted at %s, received %d interrupts before timeout; logs: \n%s\n", interruptStart.String(), receivedInterrupts, logBytes.String())
+			t.FailNow()
+		}
+	}
+
+	require.Equal(t, expectedInterrupts, receivedInterrupts)
+}


### PR DESCRIPTION
Adding thanks to the suggestion on https://github.com/kolide/launcher/issues/1537 from @smlx.

I see improved behavior on Ubuntu 26.04 -- with previous options, opening URIs would not respect my default browser and open in Chrome instead.

Also added some connection cleanup in the notification handler that was missing before, and added the basic rungroup actor test + goleak detection.