### PR TITLE
Upgrade to go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/go-ole/go-ole v1.3.0 => github.com/kolide/go-ole v0.0.0-20241008210444-65130153c767


### PR DESCRIPTION
Resolves govulncheck failures in https://github.com/kolide/launcher/actions/runs/31814153917/job/94811674689?pr=2794:

* https://pkg.go.dev/vuln/GO-2026-6218
* https://pkg.go.dev/vuln/GO-2026-6091
* https://pkg.go.dev/vuln/GO-2026-6090
* https://pkg.go.dev/vuln/GO-2026-6089
* https://pkg.go.dev/vuln/GO-2026-6088
* https://pkg.go.dev/vuln/GO-2026-5972
* https://pkg.go.dev/vuln/GO-2026-5026