### PR TITLE
fix kolide_macos_software_update panic for macos 27 builds

### DIFF
--- a/ee/tables/macos_software_update/sus.m
+++ b/ee/tables/macos_software_update/sus.m
@@ -97,9 +97,12 @@ void getSoftwareUpdateConfiguration(
           : [manager doesAutomaticCriticalUpdateInstall];
   *doesAutomaticCriticalUpdateInstall = value ? 1 : 0;
 
-  NSDate* lastCheckSuccessfulDate =
-      os_framework ? (NSDate*)[settings latestSuccessfulScanDate]
-                   : (NSDate*)[manager lastCheckSuccessfulDate];
+  // MacOS 27 (build version 26) removed [SUOSUShimController
+  // latestSuccessfulScanDate]. On MacOS 26 that method just forwarded to
+  // [SUPreferenceManager lastScanSuccessfulDate] (also removed in 27), which
+  // reads the same LastSuccessfulDate preference that SUSharedPrefs reads, so
+  // we now just read it directly via SUSharedPrefs on every version.
+  NSDate* lastCheckSuccessfulDate = (NSDate*)[manager lastCheckSuccessfulDate];
   *lastCheckTimestamp = [lastCheckSuccessfulDate timeIntervalSince1970];
 
   [settings dealloc];


### PR DESCRIPTION
macOS 27 removed `[SUOSUShimController latestSuccessfulScanDate]`, which we
called on macOS 15+. Calling it in the new macos 27 builds raises an exception resulting in a panic:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[SUOSUShimController latestSuccessfulScanDate]: unrecognized selector sent to instance 0x74a893c280'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000188c86754 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x00000001886e4654 objc_exception_throw + 88
	2   CoreFoundation                      0x0000000188d4ead0 -[NSObject(NSObject) __retain_OA] + 0
	3   CoreFoundation                      0x0000000188bf3e70 ___forwarding___ + 1504
	4   CoreFoundation                      0x0000000188bf37d0 __forwarding_prep_0___ + 96
	5   launcher                            0x0000000105bcd1ac getSoftwareUpdateConfiguration + 316
	6   launcher                            0x0000000105bcd064 _cgo_1db0497f87e6_Cfunc_getSoftwareUpdateConfiguration + 56
	7   launcher                            0x0000000104cf892c launcher + 575788
)
libc++abi: terminating due to uncaught exception of type NSException
SIGABRT: abort
PC=0x188b19650 m=9 sigcode=0
signal arrived during cgo execution

goroutine 884 gp=0x67944c110000 m=9 mp=0x67944b738008 [syscall]:
runtime.cgocall(0x105bcd02c, 0x67944bd4fd78)
	runtime/cgocall.go:167 +0x44 fp=0x67944bd4fd40 sp=0x67944bd4fd00 pc=0x104ced4b4
github.com/kolide/launcher/v2/ee/tables/macos_software_update._Cfunc_getSoftwareUpdateConfiguration(0x1b, 0x67944c2a4230, 0x67944c2a4234, 0x67944c2a4238, 0x67944c2a423c, 0x67944c2a4240, 0x67944c2a4244, 0x67944c2a4248, 0x67944c2a424c, 0x67944c2a4250, ...)
	_cgo_gotypes.go:83 +0x2c fp=0x67944bd4fd70 sp=0x67944bd4fd40 pc=0x10575e75c
github.com/kolide/launcher/v2/ee/tables/macos_software_update.(*osUpdateTable).generateMacUpdate(0x67944be7e380, {0x106ee5698?, 0x67944ba9c660?}, {0x104fddda8?})
	github.com/kolide/launcher/v2/ee/tables/macos_software_update/software_update_table.go:75 +0x1e4 fp=0x67944bd4fea0 sp=0x67944bd4fd70 pc=0x10575fed4
github.com/kolide/launcher/v2/ee/tables/macos_software_update.(*osUpdateTable).generateMacUpdate-fm({0x106ee5698?, 0x67944ba9c660?}, {0x67944c3b6e68?})
	<autogenerated>:1 +0x38 fp=0x67944bd4fed0 sp=0x67944bd4fea0 pc=0x1057607e8
github.com/kolide/launcher/v2/ee/tables/tablewrapper.(*wrappedTable).generate.func2.1()
	github.com/kolide/launcher/v2/ee/tables/tablewrapper/tablewrapper.go:174 +0x6c fp=0x67944bd4ff80 sp=0x67944bd4fed0 pc=0x1054f019c
github.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction.func1()
	github.com/kolide/launcher/v2/ee/gowrapper/goroutine.go:39 +0x58 fp=0x67944bd4ffd0 sp=0x67944bd4ff80 pc=0x1050976a8
runtime.goexit({})
	runtime/asm_arm64.s:1447 +0x4 fp=0x67944bd4ffd0 sp=0x67944bd4ffd0 pc=0x104cf8b34
created by github.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction in goroutine 801
	github.com/kolide/launcher/v2/ee/gowrapper/goroutine.go:21 +0x94
```

There is no replacement in the OSUpdate framework, nothing in the macOS 27
class dump exposes a scan date. Disassembling the old method on macOS 26 shows it was a one-line forward:
```
    return [[SUPreferenceManager defaultManager] lastScanSuccessfulDate];
```
and that in turn just reads the `LastSuccessfulDate` key from the any-user `com.apple.SoftwareUpdate` domain. 
The method we already used on pre-macOS 15 (`[SUSharedPrefs lastCheckSuccessfulDate]`) reads that same key directly, and still exists on macOS 27. So we drop the version branch for this field and read it via SUSharedPrefs on every version.

This is only verified on macOS 26 so far- the old and new paths return the identical timestamp.
We also know the underlying key is still populated on a macOS 27 beta device (proven via customer running `defaults read /Library/Preferences/com.apple.SoftwareUpdate LastSuccessfulDate` with a successful recent run date after the macos27 upgrade), but we'll need to get access to a machine running macos 27 to test this more thoroughly

additional details recorded in KOL-1197