### PR TITLE
Don't call Ping if logshipper hasn't been initialized

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -409,7 +409,10 @@ func runLauncher(ctx context.Context, cancel func(), multiSlogger, systemMultiSl
 		// getOsqEnrollDetails has a 12-second timeout for performing the query, so we set our retry interval
 		// to slightly longer than that.
 		osquery.CollectAndSetEnrollmentDetails(ctx, slogger, k, 120*time.Second, 15*time.Second)
-		logShipper.Ping() // Let the logshipper know about the updated serial number
+		// Let the logshipper know about the updated serial number
+		if logShipper != nil {
+			logShipper.Ping()
+		}
 	})
 
 	// init osquery instance history


### PR DESCRIPTION
Fixes e.g.:

```
{
"time":"2026-08-20T13:59:33.236994Z",
"level":"ERROR",
"source":{"function":"github.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction.func1.1","file":"github.com/kolide/launcher/v2/ee/gowrapper/goroutine.go","line":24},
"msg":"panic occurred in goroutine",
"err":"runtime error: invalid memory address or nil pointer dereference"
}
{
"time":"2026-08-20T13:59:33.237231Z",
"level":"ERROR",
"source":{"function":"github.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction.func1.1","file":"github.com/kolide/launcher/v2/ee/gowrapper/goroutine.go","line":29},
"msg":"panic stack trace",
"stack_trace":"runtime error: invalid memory address or nil pointer dereference\ngithub.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction.func1.1\n\tgithub.com/kolide/launcher/v2/ee/gowrapper/goroutine.go:31\nruntime.gopanic\n\truntime/panic.go:860\nruntime.panicmem\n\truntime/panic.go:336\nruntime.sigpanic\n\truntime/signal_unix.go:931\ngithub.com/kolide/launcher/v2/pkg/log/logshipper.(*LogShipper).updateLogShippingLevel\n\tgithub.com/kolide/launcher/v2/pkg/log/logshipper/logshipper.go:323\ngithub.com/kolide/launcher/v2/pkg/log/logshipper.(*LogShipper).Ping\n\tgithub.com/kolide/launcher/v2/pkg/log/logshipper/logshipper.go:94\nmain.runLauncher.func5\n\tgithub.com/kolide/launcher/v2/cmd/launcher/launcher.go:412\ngithub.com/kolide/launcher/v2/ee/gowrapper.GoWithRecoveryAction.func1\n\tgithub.com/kolide/launcher/v2/ee/gowrapper/goroutine.go:39\nruntime.goexit\n\truntime/asm_arm64.s:1447"
}
```

In practice, we shouldn't see this panic: the logshipper is only left uninitialized if the control server URL is not set, and the control server should always be set for a Kolide installation. Nevertheless, the panic should be fixed.