### PR TITLE
golangci lint 2.13.0 updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,11 @@ linters:
       - linters:
           - staticcheck
         text: QF1001
+      # Impossible comparison of interface value with untyped nil
+      # https://staticcheck.dev/docs/checks/#SA4023
+      - linters:
+          - staticcheck
+        text: SA4023
     paths:
       - test-cmds
       - third_party$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,11 +120,6 @@ linters:
       - linters:
           - staticcheck
         text: QF1001
-      # Impossible comparison of interface value with untyped nil
-      # https://staticcheck.dev/docs/checks/#SA4023
-      - linters:
-          - staticcheck
-        text: SA4023
     paths:
       - test-cmds
       - third_party$

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -217,8 +217,8 @@ func New(k types.Knapsack, messenger runnerserver.Messenger, opts ...desktopUser
 	runner.runnerServer = rs
 
 	if runtime.GOOS == "darwin" {
-		runner.osVersion, err = osversion()
-		if err != nil { //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
+		runner.osVersion, err = osversion() //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
+		if err != nil {                     //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
 			runner.slogger.Log(context.TODO(), slog.LevelError,
 				"getting os version",
 				"err", err,
@@ -1355,8 +1355,8 @@ func (r *DesktopUsersProcessesRunner) checkOsUpdate() {
 		return
 	}
 
-	currentOsVersion, err := osversion()
-	if err != nil { //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
+	currentOsVersion, err := osversion() //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
+	if err != nil {                      //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
 		r.slogger.Log(context.TODO(), slog.LevelError,
 			"getting os version",
 			"err", err,

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -218,7 +218,7 @@ func New(k types.Knapsack, messenger runnerserver.Messenger, opts ...desktopUser
 
 	if runtime.GOOS == "darwin" {
 		runner.osVersion, err = osversion()
-		if err != nil {
+		if err != nil { //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
 			runner.slogger.Log(context.TODO(), slog.LevelError,
 				"getting os version",
 				"err", err,
@@ -1356,7 +1356,7 @@ func (r *DesktopUsersProcessesRunner) checkOsUpdate() {
 	}
 
 	currentOsVersion, err := osversion()
-	if err != nil {
+	if err != nil { //nolint:staticcheck // Ignore SA4023 on Windows/Linux; this only runs on darwin, where err is not always nil
 		r.slogger.Log(context.TODO(), slog.LevelError,
 			"getting os version",
 			"err", err,

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -63,8 +63,8 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	// Construct the ECDSA public key.
 	pubKey := &ecdsa.PublicKey{
 		Curve: curve,
-		X:     x,
-		Y:     y,
+		X:     x, //nolint:staticcheck
+		Y:     y, //nolint:staticcheck
 	}
 
 	// this is a little weird, but it's the recommended way to validate a public key,

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -39,7 +39,7 @@ func parseEllipticCurve(str string) (elliptic.Curve, error) {
 	}
 }
 
-// ecdsaPubKey converts jwk in to ecdsa public key
+// ecdsaPubKey converts jwk into ecdsa public key
 func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	curve, err := parseEllipticCurve(j.Curve)
 	if err != nil {
@@ -77,7 +77,7 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	return pubKey, nil
 }
 
-// x25519PubKey converts jwk in to x25519 key (*[32]byte)
+// x25519PubKey converts jwk into x25519 key (*[32]byte)
 func (j *jwk) x25519PubKey() (*[32]byte, error) {
 	// Decode the "x" coordinate using base64 URL decoding (unpadded).
 	xBytes, err := base64.RawURLEncoding.DecodeString(j.X)

--- a/ee/nativemessaging/manifest.go
+++ b/ee/nativemessaging/manifest.go
@@ -161,13 +161,17 @@ func buildManifests(hostName string) (*chromeManifest, *firefoxManifest, error) 
 	slices.Sort(allowedChromeOrigins)
 	slices.Sort(allowedFirefoxExtensions)
 
-	return &chromeManifest{
-			manifest:       sharedManifest,
-			AllowedOrigins: allowedChromeOrigins,
-		}, &firefoxManifest{
-			manifest:          sharedManifest,
-			AllowedExtensions: allowedFirefoxExtensions,
-		}, nil
+	chrome := &chromeManifest{
+		manifest:       sharedManifest,
+		AllowedOrigins: allowedChromeOrigins,
+	}
+	firefox := &firefoxManifest{
+		manifest:          sharedManifest,
+		AllowedExtensions: allowedFirefoxExtensions,
+	}
+
+	return chrome, firefox, nil
+
 }
 
 func RemoveNativeMessagingManifest(rootDir string, identifier string) error {

--- a/ee/powereventwatcher/power_event_watcher_windows.go
+++ b/ee/powereventwatcher/power_event_watcher_windows.go
@@ -198,7 +198,7 @@ func New(ctx context.Context, slogger *slog.Logger, pes powerEventSubscriber) (*
 
 	// EvtSubscribe: https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe
 	// Flags: https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_subscribe_flags
-	subscriptionHandle, _, err := p.subscribeProcedure.Call(
+	subscriptionHandle, _, err := p.subscribeProcedure.Call( //nolint:staticcheck // Ignore SA4023
 		0,                                    // Session -- NULL because we're querying the local computer
 		0,                                    // SignalEvent -- NULL because we're setting a callback
 		uintptr(unsafe.Pointer(channelPath)), // ChannelPath -- the channel in the event log
@@ -268,7 +268,7 @@ func (p *powerEventWatcher) onPowerEvent(action uint32, _ uintptr, eventHandle u
 	buf := make([]byte, bufferSize)
 	var bufUsed uint32
 	var propertyCount uint32
-	_, _, err := p.renderEventLogProcedure.Call(
+	_, _, err := p.renderEventLogProcedure.Call( //nolint:staticcheck // Ignore SA4023
 		0,                                       // Context -- unused
 		eventHandle,                             // Fragment -- the event handle
 		uintptr(uint32(1)),                      // Flags -- EvtRenderEventXml has value 1

--- a/ee/powereventwatcher/power_event_watcher_windows.go
+++ b/ee/powereventwatcher/power_event_watcher_windows.go
@@ -208,7 +208,7 @@ func New(ctx context.Context, slogger *slog.Logger, pes powerEventSubscriber) (*
 		syscall.NewCallback(p.onPowerEvent),  // Callback -- executed every time an event matching our query occurs
 		uintptr(uint32(1)),                   // Flags -- EvtSubscribeToFutureEvents has value 1
 	)
-	if err != nil && err.Error() != operationSuccessfulMsg {
+	if err != nil && err.Error() != operationSuccessfulMsg { //nolint:staticcheck // Ignore SA4023; the operationSuccessfulMsg check here is sufficient
 		return nil, fmt.Errorf("could not subscribe to future power events: %w", err)
 	}
 
@@ -277,7 +277,7 @@ func (p *powerEventWatcher) onPowerEvent(action uint32, _ uintptr, eventHandle u
 		uintptr(unsafe.Pointer(&bufUsed)),       // BufferUsed -- modified by call: the size, in bytes, of buffer used
 		uintptr(unsafe.Pointer(&propertyCount)), // PropertyCount -- modified by call: only matters if we used EvtRenderEventValues
 	)
-	if err != nil && err.Error() != operationSuccessfulMsg {
+	if err != nil && err.Error() != operationSuccessfulMsg { //nolint:staticcheck // Ignore SA4023; the operationSuccessfulMsg check here is sufficient
 		p.slogger.Log(context.TODO(), slog.LevelWarn,
 			"error calling EvtRender to get event details",
 			"last_err", err,

--- a/pkg/windows/oleconv/oleconv.go
+++ b/pkg/windows/oleconv/oleconv.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 // Package oleconv provides functions to convert from ole.VARIANT to
 // expected types.
 //

--- a/pkg/windows/windowsupdate/icategory.go
+++ b/pkg/windows/windowsupdate/icategory.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iimageinformation.go
+++ b/pkg/windows/windowsupdate/iimageinformation.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iinstallationbehavior.go
+++ b/pkg/windows/windowsupdate/iinstallationbehavior.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/isearchresult.go
+++ b/pkg/windows/windowsupdate/isearchresult.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/istringcollection.go
+++ b/pkg/windows/windowsupdate/istringcollection.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdate.go
+++ b/pkg/windows/windowsupdate/iupdate.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdatedownloadcontent.go
+++ b/pkg/windows/windowsupdate/iupdatedownloadcontent.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdateexception.go
+++ b/pkg/windows/windowsupdate/iupdateexception.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdatehistoryentry.go
+++ b/pkg/windows/windowsupdate/iupdatehistoryentry.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdateidentity.go
+++ b/pkg/windows/windowsupdate/iupdateidentity.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/iupdatesearcher.go
+++ b/pkg/windows/windowsupdate/iupdatesearcher.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (

--- a/pkg/windows/windowsupdate/session.go
+++ b/pkg/windows/windowsupdate/session.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package windowsupdate
 
 import (


### PR DESCRIPTION
### SA4023: Impossible comparison of interface value with untyped nil

This check isn't working well cross-platform. For example, here's a Windows failure:

```
 Error: ee\desktop\runner\runner.go:220:3: SA4023(related information): the lhs of the comparison is the 2nd return value of this function call (staticcheck)
		runner.osVersion, err = osversion()
		^
Error: ee\desktop\runner\runner.go:221:6: SA4023: this comparison is always true (staticcheck)
		if err != nil {
		   ^
Error: ee\desktop\runner\runner.go:1358:2: SA4023(related information): the lhs of the comparison is the 2nd return value of this function call (staticcheck)
	currentOsVersion, err := osversion()
```

https://github.com/kolide/launcher/blob/main/ee/desktop/runner/runner.go#L220
https://github.com/kolide/launcher/blob/main/ee/desktop/runner/runner.go#L1358

`osversion` does indeed always return an error on Windows (https://github.com/kolide/launcher/blob/main/ee/desktop/runner/runner_windows.go#L69) -- but it does not on macOS (https://github.com/kolide/launcher/blob/main/ee/desktop/runner/runner_darwin.go#L64). So while it may be a technically correct error when running golangci-lint on Windows, it is not correct for our cross-platform application.

For now, I have `nolint`ed or added build directives where reasonable to ignore these errors. If they get too numerous in the future, we can exclude this check via the config instead.

### SA1019: Using a deprecated function, variable, constant or field

I am continuing to punt on our `(crypto/ecdsa.PublicKey).X` and `(crypto/ecdsa.PublicKey).Y` deprecation for now, since it's going to be more of a pain to untangle. I filed KOL-1205 to handle this later.

```
Error: ee\localserver\jwk_keys.go:66:3: SA1019: (crypto/ecdsa.PublicKey).X has been deprecated since Go 1.26 and an alternative has been available since Go 1.25: modifying the raw coordinates can produce invalid keys, and may invalidate internal optimizations; moreover, [big.Int] methods are not suitable for operating on cryptographic values. To encode and decode PublicKey values, use [PublicKey.Bytes] and [ParseUncompressedPublicKey] or [crypto/x509.MarshalPKIXPublicKey] and [crypto/x509.ParsePKIXPublicKey]. For ECDH, use [crypto/ecdh]. For lower-level elliptic curve operations, use a third-party module like filippo.io/nistec. (staticcheck)
```