### PR TITLE
launcher: log on Windows options parsing, better handle path overrides

### DIFF
--- a/cmd/launcher/desktop.go
+++ b/cmd/launcher/desktop.go
@@ -29,6 +29,10 @@ import (
 	"github.com/peterbourgon/ff/v3"
 )
 
+// runDesktop executes the userland, unprivileged launcher in the background
+// which surfaces notifications and provides a tray icon. It bypasses launcher
+// proper's option parsing and its arguments are set explicitly by the parent
+// process.
 func runDesktop(_ *multislogger.MultiSlogger, args []string) error {
 	var (
 		flagset = flag.NewFlagSet("kolide desktop", flag.ExitOnError)

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -21,7 +21,7 @@ func runDoctor(systemMultiSlogger *multislogger.MultiSlogger, args []string) err
 	launcher.DefaultAutoupdate = true
 	launcher.SetDefaultPaths()
 
-	opts, err := launcher.ParseOptions("doctor", os.Args[2:])
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "doctor", os.Args[2:])
 	if err != nil {
 		return err
 	}

--- a/cmd/launcher/doctor.go
+++ b/cmd/launcher/doctor.go
@@ -21,23 +21,24 @@ func runDoctor(systemMultiSlogger *multislogger.MultiSlogger, args []string) err
 	launcher.DefaultAutoupdate = true
 	launcher.SetDefaultPaths()
 
-	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "doctor", os.Args[2:])
-	if err != nil {
-		return err
-	}
-
-	fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
-
-	slogLevel := slog.LevelInfo
-	if opts.Debug {
-		slogLevel = slog.LevelDebug
-	}
-
+	slogLevel := new(slog.LevelVar)
+	slogLevel.Set(slog.LevelInfo)
 	// Add handler to write to stdout
 	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slogLevel,
 		AddSource: true,
 	}))
+
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "doctor", os.Args[2:])
+	if err != nil {
+		return err
+	}
+
+	if opts.Debug {
+		slogLevel.Set(slog.LevelDebug)
+	}
+
+	fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
 
 	flagController := flags.NewFlagController(systemMultiSlogger.Logger, nil, fcOpts...)
 	k := knapsack.New(nil, flagController, nil, nil, nil)

--- a/cmd/launcher/enroll.go
+++ b/cmd/launcher/enroll.go
@@ -34,7 +34,7 @@ func runEnroll(systemMultiSlogger *multislogger.MultiSlogger, args []string) err
 	if err := ff.Parse(flagset, args); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
-	opts, err := launcher.ParseOptions("enroll", []string{"-config", *flConfigFilePath})
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "enroll", []string{"-config", *flConfigFilePath})
 	if err != nil {
 		return fmt.Errorf("parsing options for subcommand enroll: %w", err)
 	}

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -44,7 +44,7 @@ func runFlare(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	opts, err := launcher.ParseOptions("flare", []string{"-config", *flConfigFilePath})
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "flare", []string{"-config", *flConfigFilePath})
 	if err != nil {
 		return err
 	}

--- a/cmd/launcher/flare.go
+++ b/cmd/launcher/flare.go
@@ -38,7 +38,15 @@ func runFlare(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		flOutputDir        = flagset.String("output_dir", ".", "path to directory to save flare output")
 		flUploadRequestURL = flagset.String("upload_request_url", "https://api.kolide.com/api/agent/flare", "URL to request a signed upload URL")
 		flConfigFilePath   = flagset.String("config", launcher.DefaultConfigFilePath, "config file to parse options from (optional)")
+		slogLevel          = new(slog.LevelVar)
 	)
+	slogLevel.Set(slog.LevelInfo)
+
+	// Add handler to write to stdout
+	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     slogLevel,
+		AddSource: true,
+	}))
 
 	if err := ff.Parse(flagset, args); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
@@ -49,16 +57,9 @@ func runFlare(systemMultiSlogger *multislogger.MultiSlogger, args []string) erro
 		return err
 	}
 
-	slogLevel := slog.LevelInfo
 	if opts.Debug {
-		slogLevel = slog.LevelDebug
+		slogLevel.Set(slog.LevelDebug)
 	}
-
-	// Add handler to write to stdout
-	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level:     slogLevel,
-		AddSource: true,
-	}))
 
 	fcOpts := []flags.Option{flags.WithCmdLineOpts(opts)}
 	flagController := flags.NewFlagController(systemMultiSlogger.Logger, inmemory.NewStore(), fcOpts...)

--- a/cmd/launcher/interactive.go
+++ b/cmd/launcher/interactive.go
@@ -20,7 +20,7 @@ import (
 )
 
 func runInteractive(systemMultiSlogger *multislogger.MultiSlogger, args []string) error {
-	opts, err := launcher.ParseOptions("interactive", args)
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "interactive", args)
 	if err != nil {
 		return err
 	}

--- a/cmd/launcher/launcher_test.go
+++ b/cmd/launcher/launcher_test.go
@@ -60,7 +60,7 @@ func Test_runLauncher(t *testing.T) {
 			})
 			downloadOnceFunc() // get an osquery binary
 			require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
-			defaultOpts, err := launcher.ParseOptions("launcher", []string{
+			defaultOpts, err := launcher.ParseOptions(multislogger.NewNopLogger(), "launcher", []string{
 				"--root_directory", testRootDir,
 				"--osqueryd_path", testOsqueryBinary,
 			})

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -83,7 +83,7 @@ func runMain() int {
 
 	// create initial logger. As this is prior to options parsing,
 	// use the environment to determine verbosity.  It will be
-	// re-leveled during options parsing.
+	// re-leveled after options parsing.
 	logger := logutil.NewServerLogger(env.Bool("LAUNCHER_DEBUG", false))
 	ctx = ctxlog.NewContext(ctx, logger)
 
@@ -148,7 +148,7 @@ func runMain() int {
 	}
 
 	// Fall back to running launcher
-	opts, err := launcher.ParseOptions("", os.Args[1:])
+	opts, err := launcher.ParseOptions(systemSlogger.Logger, "", os.Args[1:])
 	if err != nil {
 		if launcher.IsInfoCmd(err) {
 			return 0

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -134,8 +134,9 @@ func runMain() int {
 		}
 	}
 
-	// if the launcher is being ran with a positional argument,
-	// handle that argument.
+	// if the launcher is being run with a positional argument, we
+	// bypass launcher proper's option parsing and let the subcommand
+	// figure it out.
 	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], `-`) {
 		if err := runSubcommands(systemSlogger); err != nil {
 			systemSlogger.Log(ctx, slog.LevelError,
@@ -147,7 +148,7 @@ func runMain() int {
 		return 0
 	}
 
-	// Fall back to running launcher
+	// Default to running launcher proper with its extensive set of options.
 	opts, err := launcher.ParseOptions(systemSlogger.Logger, "", os.Args[1:])
 	if err != nil {
 		if launcher.IsInfoCmd(err) {
@@ -160,7 +161,7 @@ func runMain() int {
 		return 0
 	}
 
-	// recreate the logger with  the appropriate level.
+	// recreate the logger with the appropriate level.
 	logger = logutil.NewServerLogger(opts.Debug)
 
 	// set up slogger for internal launcher logging

--- a/cmd/launcher/run_compactdb.go
+++ b/cmd/launcher/run_compactdb.go
@@ -39,19 +39,19 @@ func runCompactDb(systemMultiSlogger *multislogger.MultiSlogger, args []string) 
 		launcherOptions = append(launcherOptions, "-config", *flConfigFilePath)
 	}
 
-	opts, err := launcher.ParseOptions("compactdb", launcherOptions)
+	// Add handler to write to stdout
+	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	}))
+
+	opts, err := launcher.ParseOptions(systemMultiSlogger.Logger, "compactdb", launcherOptions)
 	if err != nil {
 		return fmt.Errorf("parsing launcher options: %w", err)
 	}
 	if opts.RootDirectory == "" {
 		return errors.New("no root directory specified")
 	}
-
-	// Add handler to write to stdout
-	systemMultiSlogger.AddHandler(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level:     slog.LevelDebug,
-		AddSource: true,
-	}))
 
 	boltPath := filepath.Join(opts.RootDirectory, "launcher.db")
 	if *flDbFileName != "" {

--- a/cmd/launcher/svc_windows.go
+++ b/cmd/launcher/svc_windows.go
@@ -46,7 +46,7 @@ func runWindowsSvc(systemSlogger *multislogger.MultiSlogger, args []string) erro
 		"version", version.Version().Version,
 	)
 
-	opts, err := launcher.ParseOptions("", os.Args[2:])
+	opts, err := launcher.ParseOptions(systemSlogger.Logger, "", os.Args[2:])
 	if err != nil {
 		systemSlogger.Log(context.TODO(), slog.LevelInfo,
 			"error parsing options",
@@ -141,7 +141,7 @@ func runWindowsSvcForeground(systemSlogger *multislogger.MultiSlogger, args []st
 	localSlogger.AddHandler(handler)
 	systemSlogger.AddHandler(handler)
 
-	opts, err := launcher.ParseOptions("", os.Args[2:])
+	opts, err := launcher.ParseOptions(systemSlogger.Logger, "", os.Args[2:])
 	if err != nil {
 		level.Info(logger).Log("err", err)
 		return fmt.Errorf("parsing options: %w", err)

--- a/cmd/launcher/uninstall.go
+++ b/cmd/launcher/uninstall.go
@@ -37,7 +37,7 @@ func runUninstall(_ *multislogger.MultiSlogger, args []string) error {
 		launcherOptions = append(launcherOptions, "-config", *flConfigFilePath)
 	}
 
-	opts, err := launcher.ParseOptions("uninstall", launcherOptions)
+	opts, err := launcher.ParseOptions(multislogger.NewNopLogger(), "uninstall", launcherOptions)
 	if err != nil {
 		return fmt.Errorf("parsing launcher options: %w", err)
 	}

--- a/ee/debug/checkups/launcher_flags.go
+++ b/ee/debug/checkups/launcher_flags.go
@@ -50,7 +50,7 @@ func (lf *launcherFlags) Run(_ context.Context, extraFh io.Writer) error {
 		return nil
 	}
 
-	if _, err := launcher.ParseOptions("", []string{fmt.Sprintf("--config=%s", configFilePath)}); err != nil {
+	if _, err := launcher.ParseOptions(lf.k.Slogger(), "", []string{fmt.Sprintf("--config=%s", configFilePath)}); err != nil {
 		lf.summary = fmt.Sprintf("failed to parse flags: %s", err)
 		return nil
 	}

--- a/ee/desktop/runner/runner.go
+++ b/ee/desktop/runner/runner.go
@@ -1,4 +1,5 @@
-// runner handles multiuser process management for launcher desktop
+// runner spawns child processes to run the unprivileged launcher for all users
+// logged in.
 package runner
 
 import (
@@ -1159,8 +1160,10 @@ func (r *DesktopUsersProcessesRunner) writeLocalizationFile() error {
 	return nil
 }
 
-// desktopCommand invokes the launcher desktop executable with the appropriate env vars
+// desktopCommand invokes the launcher desktop executable with configuration
+// to interface with this process over a socket and URL
 func (r *DesktopUsersProcessesRunner) desktopCommand(uid, socketPath, menuPath string) (*allowedcmd.TracedCmd, error) {
+	// desktop subcommand runs the more limited desktop launcher
 	cmd, err := allowedcmd.Launcher.Cmd(context.TODO(), "desktop")
 	if err != nil {
 		return nil, fmt.Errorf("creating launcher desktop command: %w", err)
@@ -1199,7 +1202,7 @@ func (r *DesktopUsersProcessesRunner) desktopCommand(uid, socketPath, menuPath s
 		// Set GOMAXPROCS for the desktop subprocess (Go respects this natively).
 		// This overrides the GOMAXPROCS value set by allowedcmd.
 		fmt.Sprintf("GOMAXPROCS=%d", r.knapsack.DesktopGoMaxProcs()),
-		"LAUNCHER_SKIP_UPDATES=true", // We already know that we want to run the version of launcher in `executablePath`, so there's no need to perform lookups
+		"LAUNCHER_SKIP_UPDATES=true", // run the _exact_ binary that we run and dodge cross-version incompatibility
 	}
 
 	stdErr, err := cmd.StderrPipe()

--- a/ee/tuf/library_lookup.go
+++ b/ee/tuf/library_lookup.go
@@ -49,7 +49,7 @@ func CheckOutLatestWithoutConfig(binary autoupdatableBinary, slogger *slog.Logge
 	}
 
 	// check for old root directories before returning final config in case we've stomped over with windows MSI install
-	updatedRootDirectory := launcher.DetermineRootDirectoryOverride(cfg.rootDirectory, cfg.hostname, cfg.identifier)
+	updatedRootDirectory := launcher.DetermineRootDirectoryOverride(slogger, cfg.rootDirectory, cfg.hostname, cfg.identifier)
 	if updatedRootDirectory != cfg.rootDirectory {
 		slogger.Log(context.TODO(), slog.LevelInfo,
 			"old root directory contents detected, overriding for autoupdate config",

--- a/ee/watchdog/watchdog_task_windows.go
+++ b/ee/watchdog/watchdog_task_windows.go
@@ -35,7 +35,7 @@ func RunWatchdogTask(systemSlogger *multislogger.MultiSlogger, args []string) er
 	ff.Parse(flagset, args)
 
 	// pass the config file through our standard options parsing to get all default options
-	opts, err := launcher.ParseOptions("watchdog", []string{"-config", *flConfigFilePath})
+	opts, err := launcher.ParseOptions(systemSlogger.Logger, "watchdog", []string{"-config", *flConfigFilePath})
 	if err != nil {
 		return fmt.Errorf("parsing watchdog options: %w", err)
 	}

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -1,10 +1,12 @@
 package launcher
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/version"
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/peterbourgon/ff/v3"
 )
 
@@ -185,7 +188,7 @@ func (i *ArrayFlags) Set(value string) error {
 // ParseOptions parses the options that may be configured via command-line flags
 // and/or environment variables, determines order of precedence and returns a
 // typed struct of options for further application use
-func ParseOptions(subcommandName string, args []string) (*Options, error) {
+func ParseOptions(logger *slog.Logger, subcommandName string, args []string) (*Options, error) {
 	flagsetName := "launcher"
 	if subcommandName != "" {
 		flagsetName = fmt.Sprintf("launcher %s", subcommandName)
@@ -195,6 +198,9 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 		flagset.Usage = func() { usage(flagset) }
 	} else {
 		flagset.Usage = commandUsage(flagset, flagsetName)
+	}
+	if logger == nil {
+		logger = multislogger.NewNopLogger()
 	}
 
 	var (
@@ -312,6 +318,10 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 
 	// On windows, we should make sure osquerydPath ends in .exe
 	if runtime.GOOS == "windows" && !strings.HasSuffix(osquerydPath, ".exe") {
+		logger.Log(context.TODO(), slog.LevelInfo,
+			"appending missing file extension to osqueryd path",
+			"original_path", osquerydPath,
+		)
 		osquerydPath = osquerydPath + ".exe"
 	}
 
@@ -378,10 +388,7 @@ func ParseOptions(subcommandName string, args []string) (*Options, error) {
 
 	if runtime.GOOS == "windows" {
 		// check for old root directories before returning the configured option in case we've stomped over with windows MSI install
-		updatedRootDirectory := DetermineRootDirectoryOverride(*flRootDirectory, *flKolideServerURL, *flPackageIdentifier)
-		if updatedRootDirectory != *flRootDirectory {
-			*flRootDirectory = updatedRootDirectory
-		}
+		*flRootDirectory = DetermineRootDirectoryOverride(logger, *flRootDirectory, *flKolideServerURL, *flPackageIdentifier)
 	}
 
 	opts := &Options{

--- a/pkg/launcher/options.go
+++ b/pkg/launcher/options.go
@@ -185,9 +185,13 @@ func (i *ArrayFlags) Set(value string) error {
 	return nil
 }
 
-// ParseOptions parses the options that may be configured via command-line flags
-// and/or environment variables, determines order of precedence and returns a
-// typed struct of options for further application use
+// ParseOptions handles flags, environment variable overrides, and
+// their order of precedence for launcher. These generally apply
+// to the proper launcher runtime that communicates with a
+// controlserver and runs osquery. A parsed set of options is
+// returned.
+//
+// Launcher subcommands may opt-in to these flags, but most do not.
 func ParseOptions(logger *slog.Logger, subcommandName string, args []string) (*Options, error) {
 	flagsetName := "launcher"
 	if subcommandName != "" {

--- a/pkg/launcher/options_test.go
+++ b/pkg/launcher/options_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kolide/kit/stringutil"
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -90,7 +91,7 @@ func TestOptionsFromFlags(t *testing.T) { //nolint:paralleltest
 		}
 	}
 
-	opts, err := ParseOptions("", testFlags)
+	opts, err := ParseOptions(multislogger.NewNopLogger(), "", testFlags)
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -112,7 +113,7 @@ func TestOptionsFromEnv(t *testing.T) { //nolint:paralleltest
 		name := fmt.Sprintf("KOLIDE_LAUNCHER_%s", strings.ToUpper(strings.TrimLeft(k, "-")))
 		t.Setenv(name, val)
 	}
-	opts, err := ParseOptions("", []string{})
+	opts, err := ParseOptions(multislogger.NewNopLogger(), "", []string{})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -143,7 +144,7 @@ func TestOptionsFromFile(t *testing.T) { // nolint:paralleltest
 
 	require.NoError(t, flagFile.Close())
 
-	opts, err := ParseOptions("", []string{"-config", flagFile.Name()})
+	opts, err := ParseOptions(multislogger.NewNopLogger(), "", []string{"-config", flagFile.Name()})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -178,7 +179,7 @@ func TestAutoupdateDownloadSPlayCanBeDisabledFromFlagsFile(t *testing.T) { //nol
 
 	require.NoError(t, flagFile.Close())
 
-	opts, err := ParseOptions("", []string{"-config", flagFile.Name()})
+	opts, err := ParseOptions(multislogger.NewNopLogger(), "", []string{"-config", flagFile.Name()})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -215,7 +216,7 @@ func TestOsqueryLogPublishFlags(t *testing.T) { //nolint:paralleltest
 
 	require.NoError(t, flagFile.Close())
 
-	opts, err := ParseOptions("", []string{"-config", flagFile.Name()})
+	opts, err := ParseOptions(multislogger.NewNopLogger(), "", []string{"-config", flagFile.Name()})
 	require.NoError(t, err)
 	require.Equal(t, expectedOpts, opts)
 }
@@ -313,7 +314,7 @@ func TestOptionsSetControlServerHost(t *testing.T) { // nolint:paralleltest
 	for _, tt := range testCases { // nolint:paralleltest
 		os.Clearenv()
 		t.Run(tt.testName, func(t *testing.T) {
-			opts, err := ParseOptions("", tt.testFlags)
+			opts, err := ParseOptions(multislogger.NewNopLogger(), "", tt.testFlags)
 			require.NoError(t, err, "could not parse options")
 			require.Equal(t, tt.expectedControlServer, opts.ControlServerURL, "incorrect control server")
 			require.Equal(t, tt.expectedInsecureControlTLS, opts.InsecureControlTLS, "incorrect insecure TLS")

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -112,7 +112,6 @@ func DetermineRootDirectoryOverride(logger *slog.Logger, optsRootDirectory, koli
 
 	elevated, err := runningElevated() //nolint:staticcheck // Linux/MacOS unreachable, always errors
 	if err != nil {                    //nolint:staticcheck
-
 		logger.Log(context.TODO(), slog.LevelWarn,
 			"failed to check if process is elevated, returning passed root directory",
 			"root_directory", optsRootDirectory,

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -113,12 +113,11 @@ func DetermineRootDirectoryOverride(logger *slog.Logger, optsRootDirectory, koli
 	elevated, err := runningElevated() //nolint:staticcheck // Linux/MacOS unreachable, always errors
 	if err != nil {                    //nolint:staticcheck
 		logger.Log(context.TODO(), slog.LevelWarn,
-			"failed to check if process is elevated, returning passed root directory",
-			"root_directory", optsRootDirectory,
+			"failed to check if process is elevated, assuming privileged",
 			"err", err,
 		)
-
-		return optsRootDirectory
+		// historically we never checked privileges here, so fall through
+		elevated = true
 	}
 
 	return rootDirectoryOverride(optsRootDirectory, rootDirOverrideOpts{

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -166,10 +166,10 @@ func rootDirectoryOverride(rootDirectory string, opts rootDirOverrideOpts) strin
 		return rootDirectory
 	}
 
-	// override paths are not usable for unprivileged users
+	// unprivileged launcher cannot utilize system-owned override paths
 	if !opts.isPrivileged {
 		logger.Log(context.TODO(), slog.LevelWarn,
-			"not running elevated, initializing launcher at configured root path and skipping well-known override locations",
+			"not running elevated, initializing launcher at configured root path and skipping evaluation of well-known overrides",
 			"root_directory", rootDirectory,
 		)
 		return rootDirectory

--- a/pkg/launcher/paths.go
+++ b/pkg/launcher/paths.go
@@ -1,11 +1,15 @@
 package launcher
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 )
 
 var (
@@ -90,67 +94,126 @@ func DefaultPath(path defaultPath) string {
 	}
 }
 
+type rootDirOverrideOpts struct {
+	logger            *slog.Logger
+	kolideServerURL   string
+	packageIdentifier string
+	isPrivileged      bool
+	wellKnownRootDirs []string
+}
+
 // DetermineRootDirectoryOverride is used specifically for windows deployments to override the
-// configured root directory if another well known location containing a launcher DB already exists
-// This is used by ParseOptions which doesn't have access to a logger, we should add more logging here
-// when we have that available
-func DetermineRootDirectoryOverride(optsRootDirectory, kolideServerURL, packageIdentifier string) string {
+// configured root directory if a well-known location we have access to containing a launcher DB already exists,
+// and the configured root directory lacks a database. Always returns a directory.
+func DetermineRootDirectoryOverride(logger *slog.Logger, optsRootDirectory, kolideServerURL, packageIdentifier string) string {
 	if runtime.GOOS != "windows" {
 		return optsRootDirectory
 	}
 
-	// don't mess with the path if this installation isn't pointing to a kolide server URL
-	if !IsKolideHostedServerURL(kolideServerURL) {
+	elevated, err := runningElevated() //nolint:staticcheck // Linux/MacOS unreachable, always errors
+	if err != nil {                    //nolint:staticcheck
+
+		logger.Log(context.TODO(), slog.LevelWarn,
+			"failed to check if process is elevated, returning passed root directory",
+			"root_directory", optsRootDirectory,
+			"err", err,
+		)
+
 		return optsRootDirectory
 	}
 
-	// assume the default identifier if none is provided
-	if strings.TrimSpace(packageIdentifier) == "" {
-		packageIdentifier = DefaultLauncherIdentifier
+	return rootDirectoryOverride(optsRootDirectory, rootDirOverrideOpts{
+		logger:            logger,
+		kolideServerURL:   kolideServerURL,
+		packageIdentifier: packageIdentifier,
+		isPrivileged:      elevated,
+		wellKnownRootDirs: likelyWindowsRootDirPaths,
+	})
+}
+
+// rootDirectoryOverride holds the logic behind DetermineRootDirectoryOverride with stubs for testing.
+// Only rootDirectory is required, every opts field defaults to the passthrough answer.
+func rootDirectoryOverride(rootDirectory string, opts rootDirOverrideOpts) string {
+	logger := opts.logger
+	if logger == nil {
+		logger = multislogger.NewNopLogger()
 	}
 
-	optsDBLocation := filepath.Join(optsRootDirectory, "launcher.db")
-	dbExists, err := nonEmptyFileExists(optsDBLocation)
+	// don't mess with the path if this installation isn't pointing to a kolide server URL
+	if !IsKolideHostedServerURL(opts.kolideServerURL) {
+		return rootDirectory
+	}
+
+	// assume the default identifier if none is provided
+	if strings.TrimSpace(opts.packageIdentifier) == "" {
+		opts.packageIdentifier = DefaultLauncherIdentifier
+	}
+
+	dbLocation := filepath.Join(rootDirectory, "launcher.db")
+	dbExists, err := nonEmptyFileExists(dbLocation)
 	// If we get an unknown error, back out from making any options changes. This is an
 	// unlikely path but doesn't feel right updating the rootDirectory without knowing what's going
 	// on here
 	if err != nil {
-		// we should add logs here when available - revisit with https://github.com/kolide/launcher/issues/1698
-		return optsRootDirectory
+		logger.Log(context.TODO(), slog.LevelWarn,
+			"failed to determine if an existing database is present in the root directory",
+			"database", dbLocation,
+			"err", err,
+		)
+		return rootDirectory
 	}
 
-	// database already exists in configured root directory, keep that
+	// database exists in configured path: not a fresh install, keep it
 	if dbExists {
-		return optsRootDirectory
+		return rootDirectory
+	}
+
+	// override paths are not usable for unprivileged users
+	if !opts.isPrivileged {
+		logger.Log(context.TODO(), slog.LevelWarn,
+			"not running elevated, initializing launcher at configured root path and skipping well-known override locations",
+			"root_directory", rootDirectory,
+		)
+		return rootDirectory
 	}
 
 	// we know this is a fresh install with no launcher.db in the configured root directory,
 	// check likely locations and return updated rootDirectory if found
-	for _, path := range likelyWindowsRootDirPaths {
-		if path == optsRootDirectory { // we already know this does not contain an enrolled DB
+	for _, path := range opts.wellKnownRootDirs {
+		if path == rootDirectory { // we already know this does not contain an enrolled DB
 			continue
 		}
 
-		// the fallaback path MUST contain the identifier
-		if !strings.Contains(path, packageIdentifier) {
+		// a valid fallback path contains our identifier
+		if !strings.Contains(path, opts.packageIdentifier) {
 			continue
 		}
 
 		testingLocation := filepath.Join(path, "launcher.db")
 		dbExists, err := nonEmptyFileExists(testingLocation)
-		if err == nil && dbExists {
-			return path
-		}
-
 		if err != nil {
-			// we should add logs here when available - revisit with https://github.com/kolide/launcher/issues/1698
+			logger.Log(context.TODO(), slog.LevelWarn,
+				"failed to determine if an existing database was present in a well-known location",
+				"database", testingLocation,
+				"err", err,
+			)
 			continue
 		}
+
+		if !dbExists {
+			continue
+		}
+
+		logger.Log(context.TODO(), slog.LevelWarn,
+			"overriding root directory to a well-known location",
+			"original_root", rootDirectory,
+			"new_root", path,
+		)
+		return path
 	}
 
-	// if all else fails, return the originally configured rootDirectory -
-	// this is expected for devices that are truly installing from MSI for the first time
-	return optsRootDirectory
+	// expected for devices that are truly installing from MSI for the first time
+	return rootDirectory
 }
 
 func nonEmptyFileExists(path string) (bool, error) {

--- a/pkg/launcher/paths_other.go
+++ b/pkg/launcher/paths_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package launcher
+
+import "errors"
+
+// Unreachable on non-Windows, included for compilation.
+func runningElevated() (bool, error) {
+	return false, errors.New("OS does not support elevation check")
+}

--- a/pkg/launcher/paths_other_test.go
+++ b/pkg/launcher/paths_other_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetermineRootDirectoryOverride(t *testing.T) {
+func TestDetermineRootDirectoryOverride_NonWindowsPassthrough(t *testing.T) {
 	t.Parallel()
 
 	// On non-Windows OSes, we don't override the root directory -- confirm we always return

--- a/pkg/launcher/paths_other_test.go
+++ b/pkg/launcher/paths_other_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,5 +16,5 @@ func TestDetermineRootDirectoryOverride_NonWindowsPassthrough(t *testing.T) {
 	// On non-Windows OSes, we don't override the root directory -- confirm we always return
 	// optsRootDir instead of an override
 	optsRootDir := filepath.Join("some", "dir", "somewhere")
-	require.Equal(t, optsRootDir, DetermineRootDirectoryOverride(optsRootDir, "", ""))
+	require.Equal(t, optsRootDir, DetermineRootDirectoryOverride(multislogger.NewNopLogger(), optsRootDir, "", ""))
 }

--- a/pkg/launcher/paths_test.go
+++ b/pkg/launcher/paths_test.go
@@ -1,0 +1,127 @@
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kolide/launcher/v2/pkg/log/multislogger"
+	"github.com/stretchr/testify/require"
+)
+
+const kolideServerURLForTest = "k2device.kolide.com"
+
+func TestDetermineRootDirectoryOverride(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName string
+		// setup preps and returns the provided dir and opts, plus the expected result
+		setup func(t *testing.T) (rootDir string, opts rootDirOverrideOpts, expectedRootDir string)
+	}{
+		{
+			testCaseName: "non-kolide server url passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				opts := testOverrideOpts(wellKnownDir(t, "launcher db contents"))
+				opts.kolideServerURL = "https://example.com"
+
+				rootDir := filepath.Join("some", "dir", "somewhere")
+				return rootDir, opts, rootDir
+			},
+		},
+		{
+			testCaseName: "database already in passed directory passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				rootDir := t.TempDir()
+				writeDB(t, rootDir, "launcher db contents")
+
+				return rootDir, testOverrideOpts(wellKnownDir(t, "launcher db contents")), rootDir
+			},
+		},
+		{
+			testCaseName: "root directory cannot be checked passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				// the NUL byte makes os.Stat fail with EINVAL rather than a not-exist error
+				rootDir := filepath.Join(t.TempDir(), "root\x00dir")
+
+				return rootDir, testOverrideOpts(wellKnownDir(t, "launcher db contents")), rootDir
+			},
+		},
+		{
+			testCaseName: "all well-known empty databases passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				rootDir := filepath.Join(t.TempDir(), "does-not-exist")
+
+				return rootDir, testOverrideOpts(wellKnownDir(t, "")), rootDir
+			},
+		},
+		{
+			testCaseName: "well-known databases absent passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				rootDir := filepath.Join(t.TempDir(), "does-not-exist")
+
+				return rootDir, testOverrideOpts(wellKnownDirNoDB(t)), rootDir
+			},
+		},
+		{
+			testCaseName: "unprivileged passthrough",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				opts := testOverrideOpts(wellKnownDir(t, "launcher db contents"))
+				opts.isPrivileged = false
+
+				rootDir := filepath.Join(t.TempDir(), "does-not-exist")
+				return rootDir, opts, rootDir
+			},
+		},
+		{
+			testCaseName: "well-known database works returns override",
+			setup: func(t *testing.T) (string, rootDirOverrideOpts, string) {
+				overrideDir := wellKnownDir(t, "launcher db contents")
+
+				return filepath.Join(t.TempDir(), "does-not-exist"), testOverrideOpts(overrideDir), overrideDir
+			},
+		},
+	} {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			rootDir, opts, expectedRootDir := tt.setup(t)
+
+			require.Equal(
+				t,
+				expectedRootDir,
+				rootDirectoryOverride(rootDir, opts),
+				"incorrect root directory",
+			)
+		})
+	}
+}
+
+// testOverrideOpts defaults to the privileged kolide-hosted case, so that each test case
+// only has to state how it differs from one that would produce an override.
+func testOverrideOpts(wellKnownRootDirs ...string) rootDirOverrideOpts {
+	return rootDirOverrideOpts{
+		logger:            multislogger.NewNopLogger(),
+		kolideServerURL:   kolideServerURLForTest,
+		isPrivileged:      true,
+		wellKnownRootDirs: wellKnownRootDirs,
+	}
+}
+
+// wellKnownDirNoDB returns a stand-in for one of the likelyWindowsRootDirPaths -- the
+// package identifier must appear in the path for it to be considered a candidate.
+func wellKnownDirNoDB(t *testing.T) string {
+	dir := filepath.Join(t.TempDir(), "Kolide", "Launcher-"+DefaultLauncherIdentifier, "data")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	return dir
+}
+
+func wellKnownDir(t *testing.T, dbContents string) string {
+	dir := wellKnownDirNoDB(t)
+	writeDB(t, dir, dbContents)
+	return dir
+}
+
+func writeDB(t *testing.T, dir string, contents string) {
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "launcher.db"), []byte(contents), 0644))
+}

--- a/pkg/launcher/paths_windows.go
+++ b/pkg/launcher/paths_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package launcher
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Detects UAC elevation or when running as LocalSystem.
+// Impl is copied from windows.Token.IsElevated, but exposes the error
+// on a failure to check.
+func runningElevated() (bool, error) {
+	var elevation uint32
+	var outLen uint32
+	if err := windows.GetTokenInformation(
+		windows.GetCurrentProcessToken(),
+		windows.TokenElevation,
+		(*byte)(unsafe.Pointer(&elevation)),
+		uint32(unsafe.Sizeof(elevation)),
+		&outLen,
+	); err != nil {
+		return false, fmt.Errorf("failed to detect if process is running elevated: %w", err)
+	}
+
+	return outLen == uint32(unsafe.Sizeof(elevation)) && elevation != 0, nil
+}


### PR DESCRIPTION
Plumbs and uses a logger in launcher options parsing. Previously on Windows, options parsing quietly overrode the configured root directory if a well-known database location existed. This is made more confusing by privileged Windows launchers not logging options parsing _at all_.

Changes on Windows:
  - Log on root directory overrides.
  - Unprivileged processes no longer use restricted override folders.

I'm not very familiar with the history of why this is present, but I believe this is backwards compatible with solving the MSI issue? Please let me know.

## Testing - Unprivileged
Command:
```ps1
Start-Process -FilePath ./launcher.exe -ArgumentList "--config=launcher.flags" -Wait -NoNewWindow -RedirectStandardOutput .\20260824.stdout.log -RedirectStandardError .\20260824.stderr.log
```

### Fresh Run
```jsonl
{"time":"2026-08-24T18:44:29.5801767Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:44:29.5801767Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
{"time":"2026-08-24T18:44:29.5801767Z","level":"INFO","msg":"got new version of launcher to run","old_version":"unknown","new_binary_version":"","new_binary_path":"C:\\Users\\billy\\kolide-2\\launcher.exe"}
{"time":"2026-08-24T18:44:29.5801767Z","level":"INFO","msg":"found newer version of launcher to run","new_binary":"C:\\Users\\billy\\kolide-2\\launcher.exe"}
{"time":"2026-08-24T18:44:29.5801767Z","level":"INFO","msg":"preparing to run command","cmd":"C:\\Users\\billy\\kolide-2\\launcher.exe --config launcher.flags","component":"execwrapper"}
{"time":"2026-08-24T18:44:33.4751211Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:44:33.4787187Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
{"time":"2026-08-24T18:44:33.4808552Z","level":"WARN","msg":"not running elevated, initializing launcher at configured root path and skipping well-known override locations","root_directory":"C:\\Users\\billy\\kolide-2\\"}
{"time":"2026-08-24T18:44:33.7710365Z","level":"ERROR","msg":"{\"caller\":\"logshipper.go:97\",\"component\":\"logshipper\",\"err\":\"no token found\",\"msg\":\"updating auth token\",\"run_id\":\"01M0THDBAAVQ8JFM33AR3KY1GK\",\"session_pid\":8648,\"severity\":\"debug\",\"ts\":\"2026-08-24T18:44:33.7705801Z\"}","cmd":"C:\\Users\\billy\\kolide-2\\launcher.exe --config launcher.flags","component":"execwrapper","subcomponent":"cmd_stderr"}
{"time":"2026-08-24T18:44:33.8957153Z","level":"INFO","msg":"started kolide launcher","version":"unknown","build":"unknown","span_id":"189273e3c87cc764","trace_id":"c1e598bd21ef6f6974a6435e2cf8d689","trace_sampled":true}
```

### Second Run
```jsonl
{"time":"2026-08-24T18:44:47.5153092Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:44:47.5153092Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
{"time":"2026-08-24T18:44:47.5153092Z","level":"INFO","msg":"got new version of launcher to run","old_version":"unknown","new_binary_version":"","new_binary_path":"C:\\Users\\billy\\kolide\\launcher.exe"}
{"time":"2026-08-24T18:44:47.5153092Z","level":"INFO","msg":"found newer version of launcher to run","new_binary":"C:\\Users\\billy\\kolide\\launcher.exe"}
{"time":"2026-08-24T18:44:47.5153092Z","level":"INFO","msg":"preparing to run command","cmd":"C:\\Users\\billy\\kolide\\launcher.exe --config launcher.flags","component":"execwrapper"}
{"time":"2026-08-24T18:44:47.6925156Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:44:47.6925156Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
```

### Flare
```
{"time":"2026-08-24T18:39:32.5710052Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:39:32.5710052Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
{"time":"2026-08-24T18:39:32.5710052Z","level":"INFO","msg":"appending missing file extension to osqueryd path","original_path":"C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\osqueryd"}
time=2026-08-24T18:39:32.571Z level=INFO source=/home/billy/work/launcher/pkg/launcher/options.go:321 msg="appending missing file extension to osqueryd path" original_path="C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\osqueryd"
{"time":"2026-08-24T18:40:54.2768528Z","level":"INFO","msg":"flare creation complete","status":"flare uploaded successfully","file":"2026/08/24/01M0TH472WE31TKBSBZZH7Q7D2.zip","config_path":"C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf\\launcher.flags"}
time=2026-08-24T18:40:54.276Z level=INFO source=/home/billy/work/launcher/cmd/launcher/flare.go:103 msg="flare creation complete" status="flare uploaded successfully" file=2026/08/24/01M0TH472WE31TKBSBZZH7Q7D2.zip config_path="C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf\\launcher.flags"
Press enter to return to your terminal
```

### Doctor
```
{"time":"2026-08-24T18:39:07.4323925Z","level":"INFO","msg":"launcher running on windows without elevated permissions, using default stdout instead of eventlog"}
{"time":"2026-08-24T18:39:07.4323925Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
{"time":"2026-08-24T18:39:07.4323925Z","level":"INFO","msg":"appending missing file extension to osqueryd path","original_path":"C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\osqueryd"}
        Platform: platform: windows, architecture: amd64
        Host Info: hostname: DESKTOP-1P62ADB, uptime: 24 days, 2 hours, 14 minutes, 49 seconds
X       Launcher Version: (unknown) Invalid Semantic Version
X       Process Report: found 0 kolide processes, none running as root or system
OK      Root directory contents: root directory (C:\ProgramData\Kolide\Launcher-kolide-k2\data) contains 34 files
OK      Check communication with Kolide: successfully connected to device and control server
OK      Logs: debug.json is 894443 bytes, and was last modified at 2026-08-24 11:38:52.5358485 -0700 PDT
OK      Binary directory contents: binary directory (C:\Program Files\Kolide\Launcher-kolide-k2\bin) contains 2 files
        Enrollment Secret: permission denied (might be running as user)
OK      Network Report: launcher can listen on local network
X       Service Report: failed to run: connecting to service manager: Access is denied.
OK      Osquery: osqueryd.exe version 5.23.1
OK      Launcher Flags: launcher.flags exists and is parsable
OK      Quarantine: no files found in quarantine directories or with quarantine attributes set
OK      System Time: system time is within 5.000000 minutes of server date header, delta = 0.004413 minutes
OK      DNS Resolution: successfully resolved 5/5 hosts
OK      TUF: Successfully gathered release version launcher/windows/amd64/launcher-2.4.1.tar.gz from https://tuf.kolide.com:443/repository/targets.json
OK      Osquery Conflicts: No notable directories were detected
OK      Osquery Data: os_name: Microsoft Windows 11 Pro N, os_version: 10.0.22621, hardware_model: Standard PC (Q35 + ICH9, 2009), hardware_serial: , hardware_uuid: 0E108654-B696-4A1A-93BE-0E9942480F97, hardware_vendor: QEMU, os_build: 22621
        Osquery Restarts: No osquery restart history instances available

Checkups with failures:
        * Launcher Version
        * Process Report
        * Service Report

Press enter to return to your terminal
```

## Testing - Privileged
### System Service
```
   Index Time          EntryType   Source                 InstanceID Message
   ----- ----          ---------   ------                 ---------- -------
   44986 Aug 24 09:38  Information Software Protecti...   3221241866 Offline downlevel migration succeeded.
   44985 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:16.9945714Z","level":"INFO","msg":"launcher starting up","version":"2.4.1","revision":"cec05ddfe723213c184f27d474dce6fa9190e8b5"}...
   44984 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:16.5751163Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}...
   44983 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:16.2461223Z","level":"INFO","msg":"started kolide launcher","version":"unknown","build":"unknown","span_id":"0d6892fe22faf315","trace_id":"bb29cc685f18b2587320ed3a70fbee1a","trace_sampl...
   44982 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:15.8037747Z","level":"INFO","msg":"windows service starting"}...
   44981 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:15.7958907Z","level":"INFO","msg":"launching service","version":"unknown"}...
   44980 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:15.7958907Z","level":"INFO","msg":"appending missing file extension to osqueryd path","original_path":"C:\\Program Files\\Kolide\\Launcher-kolide-k2\\bin\\osqueryd"}...
   44979 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:15.7958907Z","level":"INFO","msg":"service start requested","version":"unknown"}...
   44978 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:15.7958907Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}...
   44977 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:06.6741401Z","level":"INFO","msg":"preparing to run command","cmd":"C:\\launcher.exe svc -config C:\\Program Files\\Kolide\\Launcher-kolide-k2\\conf\\launcher.flags","component":"execwr...
   44976 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:06.6734993Z","level":"INFO","msg":"found newer version of launcher to run","new_binary":"C:\\launcher.exe"}...
   44975 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:06.6734993Z","level":"INFO","msg":"got new version of launcher to run","old_version":"unknown","new_binary_version":"","new_binary_path":"C:\\launcher.exe"}...
   44974 Aug 24 09:38  Information launcher                        1 {"time":"2026-08-24T16:38:06.6717888Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}...
```

### Privileged Shell - Fresh
Windows intentionally skips attaching stdout logging, so we get logs after options parsing in this case and only in debug.json/system log. They point to the right files being used.

```
{"time":"2026-08-24T18:47:31.5390955Z","level":"DEBUG","source":{"function":"main.runLauncher","file":"/home/billy/work/launcher/cmd/launcher/launcher.go","line":121},"msg":"runLauncher starting","span_id":"9520211e05f6e6c0","trace_id":"d08ebb08fc4ec3fcc18f39662d561d9d","trace_sampled":true}
{"time":"2026-08-24T18:47:31.6101692Z","level":"DEBUG","source":{"function":"github.com/kolide/launcher/v2/ee/agent/storage/bbolt.UseBackupDbIfNeeded","file":"/home/billy/work/launcher/ee/agent/storage/bbolt/backup.go","line":173},"msg":"launcher.db exists, no need to use backup","db_location":"C:\\ProgramData\\Kolide\\Launcher-kolide-k2\\data\\launcher.db"}
{"time":"2026-08-24T18:47:31.8276928Z","level":"DEBUG","source":{"function":"main.gomaxprocsLimiter.func1","file":"/home/billy/work/launcher/cmd/launcher/gomaxprocs_observer.go","line":54},"msg":"captured initial GOMAXPROCS","run_id":"01M0THJS7KADCT0S4GQ3W1MT06","value":16,"span_id":"9520211e05f6e6c0","trace_id":"d08ebb08fc4ec3fcc18f39662d561d9d","trace_sampled":true}
{"time":"2026-08-24T18:47:31.8276928Z","level":"INFO","source":{"function":"main.gomaxprocsLimiter","file":"/home/billy/work/launcher/cmd/launcher/gomaxprocs_observer.go","line":73},"msg":"changing GOMAXPROCS","run_id":"01M0THJS7KADCT0S4GQ3W1MT06","from":16,"to":8,"span_id":"9520211e05f6e6c0","trace_id":"d08ebb08fc4ec3fcc18f39662d561d9d","trace_sampled":true}
{"time":"2026-08-24T18:47:31.840095Z","level":"INFO","source":{"function":"github.com/kolide/launcher/v2/ee/agent/flags.(*FlagController).overrideFlag","file":"/home/billy/work/launcher/ee/agent/flags/flag_controller.go","line":177},"msg":"overriding flag","component":"flag_controller","key":"log_shipping_level","value":"debug","duration":600000000000,"span_id":"683b4a23036c99d2","trace_id":"040e1b4c8b576cf2691135ef6d2c66ea","trace_sampled":true}
{"time":"2026-08-24T18:47:31.8403339Z","level":"INFO","source":{"function":"github.com/kolide/launcher/v2/pkg/log/logshipper.(*LogShipper).updateLogShippingLevel","file":"/home/billy/work/launcher/pkg/log/logshipper/logshipper.go","line":346},"msg":"log shipping level changed","run_id":"01M0THJS7KADCT0S4GQ3W1MT06","old_log_level":"INFO","new_log_level":"DEBUG","send_interval":"5s"}
```

### Doctor
```
        Platform: platform: windows, architecture: amd64
        Host Info: hostname: DESKTOP-1P62ADB, uptime: 24 days, 2 hours, 25 minutes, 38 seconds
X       Launcher Version: (unknown) Invalid Semantic Version
X       Process Report: found 0 kolide processes, none running as root or system
OK      Root directory contents: root directory (C:\ProgramData\Kolide\Launcher-kolide-k2\data) contains 32 files
OK      Check communication with Kolide: successfully connected to device and control server
OK      Logs: debug.json is 570970 bytes, and was last modified at 2026-08-24 11:49:47.5290444 -0700 PDT
OK      Binary directory contents: binary directory (C:\Program Files\Kolide\Launcher-kolide-k2\bin) contains 2 files
OK      Enrollment Secret: claim for nafijo
OK      Network Report: launcher can listen on local network
X       Service Report: found Kolide service in state 1 (SERVICE_STOPPED)
OK      Osquery: osqueryd.exe version 5.23.1
OK      Launcher Flags: launcher.flags exists and is parsable
OK      Quarantine: no files found in quarantine directories or with quarantine attributes set
OK      System Time: system time is within 5.000000 minutes of server date header, delta = 0.013619 minutes
OK      DNS Resolution: successfully resolved 5/5 hosts
OK      TUF: Successfully gathered release version launcher/windows/amd64/launcher-2.4.1.tar.gz from https://tuf.kolide.com:443/repository/targets.json
OK      Osquery Conflicts: No notable directories were detected
OK      Osquery Data: hardware_vendor: QEMU, os_build: 22621, os_name: Microsoft Windows 11 Pro N, os_version: 10.0.22621, hardware_model: Standard PC (Q35 + ICH9, 2009), hardware_serial: , hardware_uuid: 0E108654-B696-4A1A-93BE-0E9942480F97
        Osquery Restarts: No osquery restart history instances available

Checkups with failures:
        * Launcher Version
        * Process Report
        * Service Report

Press enter to return to your terminal
```