### PR TITLE
Handle `ecdsa.PublicKey.X` and `ecdsa.PublicKey.Y` deprecation

### DIFF
--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -265,16 +265,10 @@ func (c *chain) validate(trustedKeys map[string]*ecdsa.PublicKey) error {
 		}
 	}
 
-	rootKey, ok := trustedKeys[c.Links[0].SignedBy]
+	// Get copy of root key
+	parentEcdsa, ok := trustedKeys[c.Links[0].SignedBy]
 	if !ok {
 		return fmt.Errorf("root key with kid %s not found in trusted keys", c.Links[0].SignedBy)
-	}
-
-	// make a copy of the root key so that we can reassign it
-	parentEcdsa := &ecdsa.PublicKey{
-		Curve: rootKey.Curve,
-		X:     rootKey.X, //nolint:staticcheck
-		Y:     rootKey.Y, //nolint:staticcheck
 	}
 
 	var currentPayload payload

--- a/ee/localserver/dt4a_auth_middleware.go
+++ b/ee/localserver/dt4a_auth_middleware.go
@@ -265,7 +265,7 @@ func (c *chain) validate(trustedKeys map[string]*ecdsa.PublicKey) error {
 		}
 	}
 
-	// Get copy of root key
+	// Get reference to root key
 	parentEcdsa, ok := trustedKeys[c.Links[0].SignedBy]
 	if !ok {
 		return fmt.Errorf("root key with kid %s not found in trusted keys", c.Links[0].SignedBy)

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -118,7 +118,7 @@ func Test_Dt4aAuthMiddleware(t *testing.T) {
 		pubcallerPubKey, _, err := box.GenerateKey(rand.Reader)
 		require.NoError(t, err)
 
-		chain, err := newChain(pubcallerPubKey, invalidKeys...)
+		chain, err := newChain(t, pubcallerPubKey, invalidKeys...)
 		require.NoError(t, err)
 
 		chainMarshalled, err := json.Marshal(chain)
@@ -146,7 +146,7 @@ func Test_Dt4aAuthMiddleware(t *testing.T) {
 		callerPubKey, callerPrivKey, err := box.GenerateKey(rand.Reader)
 		require.NoError(t, err)
 
-		chain, err := newChain(callerPubKey, validKeys...)
+		chain, err := newChain(t, callerPubKey, validKeys...)
 		require.NoError(t, err)
 
 		chainMarshalled, err := json.Marshal(chain)
@@ -200,7 +200,7 @@ func Test_ValidateCertChain(t *testing.T) {
 
 	t.Run("trusted root is nil", func(t *testing.T) {
 		t.Parallel()
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		chain.Links[0] = chainLink{}
@@ -218,7 +218,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("key not found", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		require.ErrorContains(t, chain.validate(make(map[string]*ecdsa.PublicKey)), "not found in trusted keys")
@@ -227,7 +227,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("bad sig last item in chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		// replace last item in chain
@@ -239,7 +239,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("invalid signature in chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		chain.Links[1].Payload = base64.URLEncoding.EncodeToString([]byte("ahhh"))
@@ -250,7 +250,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("invalid public encryption key", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		badPubEncryptionKey, _, err := box.GenerateKey(rand.Reader)
@@ -280,7 +280,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("handles expired chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		// get first payload
@@ -309,7 +309,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("valid chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(pubEncryptionKey, keys...)
+		chain, err := newChain(t, pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
 		// Get starting value of root key so we can confirm that our validation process does not change it
@@ -410,7 +410,7 @@ func Test_originIsAllowlisted(t *testing.T) {
 // newChain creates a new chain of keys, where each key signs the next key in the chain
 // leaving this in the _test file since we will always be receiving a chain of keys
 // so this is only needed for testing
-func newChain(counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.PrivateKey) (*chain, error) {
+func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.PrivateKey) (*chain, error) {
 	if len(ecdsaKeys) == 0 {
 		return nil, errors.New("no keys provided")
 	}
@@ -430,9 +430,9 @@ func newChain(counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.Privat
 		var err error
 
 		if i == len(ecdsaKeys)-1 {
-			childKey, err = toJWK(counterPartyPubEncryptionKey, "counter_party_pub_encryption_key")
+			childKey, err = toJWK(t, counterPartyPubEncryptionKey, "counter_party_pub_encryption_key")
 		} else {
-			childKey, err = toJWK(&ecdsaKeys[i+1].PublicKey, fmt.Sprint(i))
+			childKey, err = toJWK(t, &ecdsaKeys[i+1].PublicKey, fmt.Sprint(i))
 		}
 
 		if err != nil {
@@ -472,7 +472,7 @@ func newChain(counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.Privat
 
 // toJWK accepts either an *ecdsa.PublicKey or *[32]byte (for X25519)
 // along with an optional kid value and returns a jwk object
-func toJWK(key any, kid string) (*jwk, error) {
+func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
 	switch k := key.(type) {
 	case *ecdsa.PublicKey:
 		// determine curve
@@ -488,9 +488,18 @@ func toJWK(key any, kid string) (*jwk, error) {
 			return nil, fmt.Errorf("unsupported elliptic curve, %s", crv)
 		}
 
+		// Extract X and Y raw bytes from key
+		sec1Compressed, err := k.Bytes()
+		require.NoError(t, err)
+		coordinateLen := (k.Curve.Params().BitSize + 7) / 8
+
+		// Format of sec1Compressed is header 0x04, then X bytes, then Y bytes
+		xBytes := sec1Compressed[1 : coordinateLen+1]
+		yBytes := sec1Compressed[coordinateLen+1:]
+
 		// Encode x and y coordinates using base64 URL encoding (unpadded).
-		xStr := base64.RawURLEncoding.EncodeToString(k.X.Bytes()) //nolint:staticcheck
-		yStr := base64.RawURLEncoding.EncodeToString(k.Y.Bytes()) //nolint:staticcheck
+		xStr := base64.RawURLEncoding.EncodeToString(xBytes)
+		yStr := base64.RawURLEncoding.EncodeToString(yBytes)
 
 		return &jwk{
 			Curve: crv,

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -312,6 +312,12 @@ func Test_ValidateCertChain(t *testing.T) {
 		chain, err := newChain(pubEncryptionKey, keys...)
 		require.NoError(t, err)
 
+		// Get starting value of root key so we can confirm that our validation process does not change it
+		startingRootKey, ok := trustedKeysMap[chain.Links[0].SignedBy]
+		require.True(t, ok)
+		startingRootKeyBytes, err := startingRootKey.Bytes()
+		require.NoError(t, err)
+
 		require.NoError(t, chain.validate(trustedKeysMap),
 			"should be able to validate chain",
 		)
@@ -327,6 +333,13 @@ func Test_ValidateCertChain(t *testing.T) {
 		require.Equal(t, testUserId, chain.userUuid,
 			"user uuid should be set in validate",
 		)
+
+		postValidationRootKey, ok := trustedKeysMap[chain.Links[0].SignedBy]
+		require.True(t, ok)
+		postValidationRootKeyBytes, err := postValidationRootKey.Bytes()
+		require.NoError(t, err)
+
+		require.Equal(t, startingRootKeyBytes, postValidationRootKeyBytes)
 	})
 }
 

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -489,13 +489,13 @@ func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
 		}
 
 		// Extract X and Y raw bytes from key
-		sec1Compressed, err := k.Bytes()
+		sec1Uncompressed, err := k.Bytes()
 		require.NoError(t, err)
 		coordinateLen := (k.Curve.Params().BitSize + 7) / 8
 
-		// Format of sec1Compressed is header 0x04, then X bytes, then Y bytes
-		xBytes := sec1Compressed[1 : coordinateLen+1]
-		yBytes := sec1Compressed[coordinateLen+1:]
+		// Format of sec1Uncompressed is header 0x04, then X bytes, then Y bytes
+		xBytes := sec1Uncompressed[1 : coordinateLen+1]
+		yBytes := sec1Uncompressed[coordinateLen+1:]
 
 		// Encode x and y coordinates using base64 URL encoding (unpadded).
 		xStr := base64.RawURLEncoding.EncodeToString(xBytes)

--- a/ee/localserver/dt4a_auth_middleware_test.go
+++ b/ee/localserver/dt4a_auth_middleware_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -118,8 +117,7 @@ func Test_Dt4aAuthMiddleware(t *testing.T) {
 		pubcallerPubKey, _, err := box.GenerateKey(rand.Reader)
 		require.NoError(t, err)
 
-		chain, err := newChain(t, pubcallerPubKey, invalidKeys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubcallerPubKey, invalidKeys...)
 
 		chainMarshalled, err := json.Marshal(chain)
 		require.NoError(t, err)
@@ -146,8 +144,7 @@ func Test_Dt4aAuthMiddleware(t *testing.T) {
 		callerPubKey, callerPrivKey, err := box.GenerateKey(rand.Reader)
 		require.NoError(t, err)
 
-		chain, err := newChain(t, callerPubKey, validKeys...)
-		require.NoError(t, err)
+		chain := newChain(t, callerPubKey, validKeys...)
 
 		chainMarshalled, err := json.Marshal(chain)
 		require.NoError(t, err)
@@ -200,8 +197,7 @@ func Test_ValidateCertChain(t *testing.T) {
 
 	t.Run("trusted root is nil", func(t *testing.T) {
 		t.Parallel()
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		chain.Links[0] = chainLink{}
 
@@ -218,8 +214,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("key not found", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		require.ErrorContains(t, chain.validate(make(map[string]*ecdsa.PublicKey)), "not found in trusted keys")
 	})
@@ -227,8 +222,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("bad sig last item in chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		// replace last item in chain
 		chain.Links[len(chain.Links)-1].Signature = base64.URLEncoding.EncodeToString([]byte("bad sig"))
@@ -239,8 +233,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("invalid signature in chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		chain.Links[1].Payload = base64.URLEncoding.EncodeToString([]byte("ahhh"))
 
@@ -250,8 +243,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("invalid public encryption key", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		badPubEncryptionKey, _, err := box.GenerateKey(rand.Reader)
 		require.NoError(t, err)
@@ -280,8 +272,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("handles expired chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		// get first payload
 		payloadBytes, err := base64.URLEncoding.DecodeString(chain.Links[0].Payload)
@@ -309,8 +300,7 @@ func Test_ValidateCertChain(t *testing.T) {
 	t.Run("valid chain", func(t *testing.T) {
 		t.Parallel()
 
-		chain, err := newChain(t, pubEncryptionKey, keys...)
-		require.NoError(t, err)
+		chain := newChain(t, pubEncryptionKey, keys...)
 
 		// Get starting value of root key so we can confirm that our validation process does not change it
 		startingRootKey, ok := trustedKeysMap[chain.Links[0].SignedBy]
@@ -410,14 +400,8 @@ func Test_originIsAllowlisted(t *testing.T) {
 // newChain creates a new chain of keys, where each key signs the next key in the chain
 // leaving this in the _test file since we will always be receiving a chain of keys
 // so this is only needed for testing
-func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.PrivateKey) (*chain, error) {
-	if len(ecdsaKeys) == 0 {
-		return nil, errors.New("no keys provided")
-	}
-
-	if len(ecdsaKeys) == 1 {
-		return nil, errors.New("only one key provided")
-	}
+func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ...*ecdsa.PrivateKey) *chain {
+	require.Less(t, 1, len(ecdsaKeys), "require at least two keys")
 
 	// counterPartyPubEncryptionKey will be last link in links
 	links := make([]chainLink, len(ecdsaKeys))
@@ -427,16 +411,11 @@ func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ..
 		parentKey := ecdsaKeys[i]
 
 		var childKey *jwk
-		var err error
 
 		if i == len(ecdsaKeys)-1 {
-			childKey, err = toJWK(t, counterPartyPubEncryptionKey, "counter_party_pub_encryption_key")
+			childKey = toJWK(t, counterPartyPubEncryptionKey, "counter_party_pub_encryption_key")
 		} else {
-			childKey, err = toJWK(t, &ecdsaKeys[i+1].PublicKey, fmt.Sprint(i))
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to create jwk from public key: %w", err)
+			childKey = toJWK(t, &ecdsaKeys[i+1].PublicKey, fmt.Sprint(i))
 		}
 
 		thisPayload := payload{
@@ -449,16 +428,12 @@ func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ..
 		}
 
 		payloadBytes, err := json.Marshal(thisPayload)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(t, err)
 
 		payloadB64 := base64.URLEncoding.EncodeToString(payloadBytes)
 
 		sig, err := echelper.Sign(parentKey, []byte(payloadB64))
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(t, err)
 
 		links[i] = chainLink{
 			Payload:   payloadB64,
@@ -467,12 +442,12 @@ func newChain(t *testing.T, counterPartyPubEncryptionKey *[32]byte, ecdsaKeys ..
 		}
 	}
 
-	return &chain{Links: links}, nil
+	return &chain{Links: links}
 }
 
 // toJWK accepts either an *ecdsa.PublicKey or *[32]byte (for X25519)
 // along with an optional kid value and returns a jwk object
-func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
+func toJWK(t *testing.T, key any, kid string) *jwk {
 	switch k := key.(type) {
 	case *ecdsa.PublicKey:
 		// determine curve
@@ -485,7 +460,7 @@ func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
 		case elliptic.P521():
 			crv = curveP521
 		default:
-			return nil, fmt.Errorf("unsupported elliptic curve, %s", crv)
+			t.Fatalf("unsupported elliptic curve, %s", crv)
 		}
 
 		// Extract X and Y raw bytes from key
@@ -506,7 +481,7 @@ func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
 			X:     xStr,
 			Y:     yStr,
 			KeyID: kid,
-		}, nil
+		}
 
 	case *[32]byte: // Handle X25519 public key.
 		xStr := base64.RawURLEncoding.EncodeToString(k[:])
@@ -515,9 +490,10 @@ func toJWK(t *testing.T, key any, kid string) (*jwk, error) {
 			Curve: "X25519",
 			X:     xStr,
 			KeyID: kid,
-		}, nil
+		}
 
 	default:
-		return nil, errors.New("unsupported key type")
+		t.Fatal("unsupported key type")
+		return nil
 	}
 }

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -84,7 +84,7 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	// Finally, parse the pubkey. This will also validate that the key is on the curve.
 	pubKey, err := ecdsa.ParseUncompressedPublicKey(curve, buf)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid ECDSA public key: %w`, err)
+		return nil, fmt.Errorf("invalid ECDSA public key: %w", err)
 	}
 
 	return pubKey, nil

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -64,7 +64,7 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	// we need in the buffer. curve.Params().BitSize gives us the bitsize for the curve; we
 	// add 7 so that we don't miss any additional data for curve sizes that don't divide into 8
 	// evenly (e.g. for P-521, 521 / 8 = 65.125, which rounds to 65, so we may be missing data).
-	// This is how crypto/ellpitic performs this calculation. We expect 32 for P-256, 48 for P-384,
+	// This is how crypto/elliptic performs this calculation. We expect 32 for P-256, 48 for P-384,
 	// 66 for P-521.
 	coordinateLen := (curve.Params().BitSize + 7) / 8
 	if len(xBytes) != coordinateLen || len(yBytes) != coordinateLen {
@@ -81,17 +81,10 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 		buf[i+1+coordinateLen] = yBytes[i]
 	}
 
-	// Finally, parse the pubkey.
+	// Finally, parse the pubkey. This will also validate that the key is on the curve.
 	pubKey, err := ecdsa.ParseUncompressedPublicKey(curve, buf)
 	if err != nil {
 		return nil, fmt.Errorf(`invalid ECDSA public key: %w`, err)
-	}
-
-	// this is a little weird, but it's the recommended way to validate a public key,
-	// under the hood it calls Curve.IsOnCurve(...), but if you call that directly
-	// you get deprecated warnings
-	if _, err := pubKey.ECDH(); err != nil {
-		return nil, fmt.Errorf("invalid public key: %w", err)
 	}
 
 	return pubKey, nil

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"math/big"
 	"strings"
 )
 
@@ -46,7 +45,12 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	// Decode the x and y coordinates using base64 URL decoding (unpadded).
+	// We can't construct an ecdsa.PublicKey using j.X and j.Y directly, because direct access
+	// to those fields has been deprecated. Instead, we construct the SEC1 uncompressed
+	// encoding inside a buffer, and then pass that off to the ecdsa package to parse.
+	// See https://www.secg.org/sec1-v2.pdf 2.3.3.
+
+	// First, decode the x and y coordinates using base64 URL decoding (unpadded).
 	xBytes, err := base64.RawURLEncoding.DecodeString(j.X)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding x coordinate: %v", err)
@@ -56,15 +60,28 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 		return nil, fmt.Errorf("error decoding y coordinate: %v", err)
 	}
 
-	// Convert the bytes into big.Int values.
-	x := new(big.Int).SetBytes(xBytes)
-	y := new(big.Int).SetBytes(yBytes)
+	// Next, figure out how many bytes we need for each coordinate, so we know how many bytes
+	// we need in the buffer. curve.Params().BitSize gives us the bitsize for the curve; we
+	// add 7 so that we don't miss any additional data for curve sizes that don't divide into 8
+	// evenly (e.g. for P-521, 521 / 8 = 65.125, which rounds to 65, so we may be missing data).
+	// This is how crypto/ellpitic performs this calculation. We expect 32 for P-256, 48 for P-384,
+	// 66 for P-521.
+	coordinateLen := (curve.Params().BitSize + 7) / 8
 
-	// Construct the ECDSA public key.
-	pubKey := &ecdsa.PublicKey{
-		Curve: curve,
-		X:     x, //nolint:staticcheck
-		Y:     y, //nolint:staticcheck
+	// Now, construct the buffer:
+	// The first byte 0x04 indicates that point compression is off; then follows all of the
+	// bytes in X; then follows all of the bytes in Y.
+	buf := make([]byte, 1+2*coordinateLen)
+	buf[0] = 0x04
+	for i := range coordinateLen {
+		buf[i+1] = xBytes[i]
+		buf[i+1+coordinateLen] = yBytes[i]
+	}
+
+	// Finally, parse the pubkey.
+	pubKey, err := ecdsa.ParseUncompressedPublicKey(curve, buf)
+	if err != nil {
+		return nil, fmt.Errorf(`invalid ECDSA public key: %w`, err)
 	}
 
 	// this is a little weird, but it's the recommended way to validate a public key,

--- a/ee/localserver/jwk_keys.go
+++ b/ee/localserver/jwk_keys.go
@@ -67,6 +67,9 @@ func (j *jwk) ecdsaPubKey() (*ecdsa.PublicKey, error) {
 	// This is how crypto/ellpitic performs this calculation. We expect 32 for P-256, 48 for P-384,
 	// 66 for P-521.
 	coordinateLen := (curve.Params().BitSize + 7) / 8
+	if len(xBytes) != coordinateLen || len(yBytes) != coordinateLen {
+		return nil, fmt.Errorf("unexpected coordinate size: expected %d, got X len %d and Y len %d", coordinateLen, len(xBytes), len(yBytes))
+	}
 
 	// Now, construct the buffer:
 	// The first byte 0x04 indicates that point compression is off; then follows all of the

--- a/ee/localserver/jwk_keys_test.go
+++ b/ee/localserver/jwk_keys_test.go
@@ -1,0 +1,81 @@
+package localserver
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ecdsaPubKey(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		curve         string
+		mutate        func(x, y []byte) ([]byte, []byte)
+		errorExpected bool
+	}{
+		{name: "valid P-256", curve: curveP256},
+		{name: "valid P-384", curve: curveP384},
+		{name: "valid P-521", curve: curveP521},
+		{
+			name:          "coordinate one byte short",
+			curve:         curveP256,
+			mutate:        func(x, y []byte) ([]byte, []byte) { return x[1:], y },
+			errorExpected: true,
+		},
+		{
+			name:          "coordinate one byte long",
+			curve:         curveP256,
+			mutate:        func(x, y []byte) ([]byte, []byte) { return append([]byte{0x00}, x...), y },
+			errorExpected: true,
+		},
+		{
+			name:          "off-curve point",
+			curve:         curveP256,
+			mutate:        func(x, y []byte) ([]byte, []byte) { y[len(y)-1] ^= 0xff; return x, y },
+			errorExpected: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a key as described by the test case
+			curve, err := parseEllipticCurve(tt.curve)
+			require.NoError(t, err)
+			key, err := ecdsa.GenerateKey(curve, rand.Reader)
+			require.NoError(t, err)
+			encoded, err := key.PublicKey.Bytes()
+			require.NoError(t, err)
+
+			// Handle mutations (point is off the curve, coordinates are malformed)
+			coordinateLen := (curve.Params().BitSize + 7) / 8
+			x, y := encoded[1:1+coordinateLen], encoded[1+coordinateLen:]
+			if tt.mutate != nil {
+				x, y = tt.mutate(x, y)
+			}
+
+			// Now, convert to a jwk
+			testJwk := &jwk{
+				Curve: tt.curve,
+				X:     base64.RawURLEncoding.EncodeToString(x),
+				Y:     base64.RawURLEncoding.EncodeToString(y),
+			}
+
+			// Parse the pubkey
+			pubKey, err := testJwk.ecdsaPubKey()
+
+			if tt.errorExpected {
+				require.Error(t, err)
+				return
+			}
+
+			// Confirm we get back the same pubkey that we started with
+			require.NoError(t, err)
+			require.True(t, key.PublicKey.Equal(pubKey))
+		})
+	}
+}


### PR DESCRIPTION
Handles the following deprecation:

> (crypto/ecdsa.PublicKey).X has been deprecated since Go 1.26 and an alternative has been available since Go 1.25: modifying the raw coordinates can produce invalid keys, and may invalidate internal optimizations; moreover, [big.Int] methods are not suitable for operating on cryptographic values. To encode and decode PublicKey values, use [PublicKey.Bytes] and [ParseUncompressedPublicKey] or [crypto/x509.MarshalPKIXPublicKey] and [crypto/x509.ParsePKIXPublicKey]. For ECDH, use [crypto/ecdh]. For lower-level elliptic curve operations, use a third-party module like filippo.io/nistec. (staticcheck)

> (crypto/ecdsa.PublicKey).Y has been deprecated since Go 1.26 and an alternative has been available since Go 1.25: modifying the raw coordinates can produce invalid keys, and may invalidate internal optimizations; moreover, [big.Int] methods are not suitable for operating on cryptographic values. To encode and decode PublicKey values, use [PublicKey.Bytes] and [ParseUncompressedPublicKey] or [crypto/x509.MarshalPKIXPublicKey] and [crypto/x509.ParsePKIXPublicKey]. For ECDH, use [crypto/ecdh]. For lower-level elliptic curve operations, use a third-party module like filippo.io/nistec. (staticcheck)