### PR TITLE
Ensure notifications don't auto-close very quickly on Linux

### DIFF
--- a/ee/desktop/user/notify/notify_linux.go
+++ b/ee/desktop/user/notify/notify_linux.go
@@ -209,15 +209,17 @@ func (d *dbusNotifier) sendNotificationViaDbus(n Notification) error {
 
 	notificationsService := conn.Object(notificationServiceInterface, notificationServiceObj)
 	call := notificationsService.Call("org.freedesktop.Notifications.Notify",
-		0,                         // no flags
-		"Kolide",                  // app_name
-		uint32(0),                 // replaces_id -- 0 means this notification won't replace any existing notifications
-		d.iconFilepath,            // app_icon
-		n.Title,                   // summary
-		n.Body,                    // body
-		actions,                   // actions
-		map[string]dbus.Variant{}, // hints
-		int32(0))                  // expire_timeout -- 0 means the notification will not expire
+		0,              // no flags
+		"Kolide",       // app_name
+		uint32(0),      // replaces_id -- 0 means this notification won't replace any existing notifications
+		d.iconFilepath, // app_icon
+		n.Title,        // summary
+		n.Body,         // body
+		actions,        // actions
+		map[string]dbus.Variant{
+			"urgency": dbus.MakeVariant(uint8(2)), // Without an urgency of "critical", the notification auto-closes extremely quickly
+		}, // hints
+		int32(0)) // expire_timeout -- 0 means the notification will not expire
 
 	if call.Err != nil {
 		d.slogger.Log(context.TODO(), slog.LevelError,
@@ -251,7 +253,8 @@ func (d *dbusNotifier) sendNotificationViaNotifySend(n Notification) error {
 		n.Body += " " + learnMoreLabel(d.localizationPath) + ": " + n.ActionUri
 	}
 
-	args := []string{n.Title, n.Body}
+	// We set an urgency of "critical" so that the notification does not auto-close quickly.
+	args := []string{n.Title, n.Body, "-u", "critical"}
 	if d.iconFilepath != "" {
 		args = append(args, "-i", d.iconFilepath)
 	}


### PR DESCRIPTION
Per https://specifications.freedesktop.org/notification/latest-single/#urgency-levels:

>  For low and normal urgencies, server implementations may display the notifications how they choose. They should, however, have a sane expiration timeout dependent on the urgency level.

> Critical notifications should not automatically expire, as they are things that the user will most likely want to know about. They should only be closed when the user dismisses them, for example, by clicking on the notification.

On multiple versions of Ubuntu for me, notifications auto-close _incredibly_ quickly, ignoring our `expire_timeout` value. Therefore, I am updating to set the urgency for notifications for "critical", which will give us the behavior that we want: the notification does not go away until the user dismisses it.