### PR TITLE
pkg/osquery: fix flaky secretless enrollment test

### DIFF
--- a/pkg/osquery/extension_test.go
+++ b/pkg/osquery/extension_test.go
@@ -1684,19 +1684,25 @@ func TestGetQueries_WorksWithSecretlessEnrollment(t *testing.T) {
 	assert.False(t, s.RequestEnrollmentFuncInvoked)
 	assert.False(t, s.RequestQueriesFuncInvoked)
 
-	// Now, fire off a bunch of sequential GetQueries requests, so that we'll (probably) have one
-	// processing while we simulate secretless enrollment completing
+	// Once the key is set, GetQueries rarely can be mid-evaluation of whether to enroll.
+	// It checks the key before it begins enrollment, and if it's there it stores it.
+	k.On("EnsureEnrollmentStored", testifymock.Anything).Return(nil).Maybe()
+
+	// Set the node key in the middle of our GetQueries calls, simulating secretless enrollment completing in a
+	// different goroutine.
+	nodekeyMockCall.Unset()
+	nodekeyMockCall = k.On("NodeKey", testifymock.Anything).Return("", nil).Times(10)
+	k.On("NodeKey", testifymock.Anything).Return(nodeKeyFromSecretlessEnrollment, nil).NotBefore(nodekeyMockCall)
+
+	// In parallel, hopefully running at different stages.
 	resultChan := make(chan struct{}, 100)
-	go func() {
-		for range 100 {
+	for range 100 {
+		go func() {
+			time.Sleep(time.Microsecond) // jitter from yielding more than sleeping
 			_, _ = e.GetQueries(t.Context())
 			resultChan <- struct{}{}
-		}
-	}()
-
-	// Now, set the node key, to simulate secretless enrollment completing in a different thread.
-	nodekeyMockCall.Unset()
-	k.On("NodeKey", testifymock.Anything).Return(nodeKeyFromSecretlessEnrollment, nil)
+		}()
+	}
 
 	// Wait for our previous queries to complete
 	for range 100 {


### PR DESCRIPTION
My PR #2804 is on its seventh "rerun failed jobs" due to flakes.

This PR fixes two flakes in `TestGetQueries_WorksWithSecretlessEnrollment`. The first flake I saw [here](https://github.com/kolide/launcher/actions/runs/33015756762/job/98334597603) and the second is easily reproducible locally.

The first is harder to hit, because the window is tiny. If `GetQueries` in `getQueriesWithReenroll` sees no nodeKey, it enters `Enroll`. In a very small time window the key can be set on the mock, and `Enroll` checks the nodeKey again and then tries to store it before returning. That causes this flake:
```
--- FAIL: TestGetQueries_WorksWithSecretlessEnrollment (60.10s)
    mock.go:361:
        assert: mock: I don't know what to return because the method call was unexpected.
        	Either do Mock.On("EnsureEnrollmentStored").Return(...) first, or remove the EnsureEnrollmentStored() call.
        	This method was unexpected:
        		EnsureEnrollmentStored(string)
        		0: "default"
        	at: [/home/runner/work/launcher/launcher/ee/agent/types/mocks/knapsack.go:1725 /home/runner/work/launcher/launcher/pkg/osquery/extension.go:344 /home/runner/work/launcher/launcher/pkg/osquery/extension.go:1051 /home/runner/work/launcher/launcher/pkg/osquery/extension.go:1026 /home/runner/work/launcher/launcher/pkg/osquery/extension_test.go:1692 /opt/hostedtoolcache/go/1.26.6/x64/src/runtime/asm_amd64.s:1771]
FAIL
coverage: 74.9% of statements
```

The second flake is a race when a `GetQueries` goroutine grabs the node key _after_ we `Unset` the mock, but before we set the new return value:
```
=== RUN   TestGetQueries_WorksWithSecretlessEnrollment
panic: no return value specified for NodeKey

goroutine 131 [running]:
github.com/kolide/launcher/v2/ee/agent/types/mocks.(*Knapsack).NodeKey(0xc0003d20f0, {0x1384343, 0x7})
        /home/billy/work/launcher/ee/agent/types/mocks/knapsack.go:3076 +0x338
github.com/kolide/launcher/v2/pkg/osquery.(*Extension).nodeKey(...)
        /home/billy/work/launcher/pkg/osquery/extension.go:520
github.com/kolide/launcher/v2/pkg/osquery.(*Extension).Enroll(0xc00043e000, {0x13e04f8, 0xc00038d7a0})
        /home/billy/work/launcher/pkg/osquery/extension.go:338 +0x2de
github.com/kolide/launcher/v2/pkg/osquery.(*Extension).getQueriesWithReenroll(0xc00043e000, {0x13e04f8, 0xc00038d6e0}, 0x1)
        /home/billy/work/launcher/pkg/osquery/extension.go:1051 +0x1ac
github.com/kolide/launcher/v2/pkg/osquery.(*Extension).GetQueries(0xc00043e000, {0x13e0530, 0xc0003d20a0})
        /home/billy/work/launcher/pkg/osquery/extension.go:1026 +0x289
github.com/kolide/launcher/v2/pkg/osquery.TestGetQueries_WorksWithSecretlessEnrollment.func2()
        /home/billy/work/launcher/pkg/osquery/extension_test.go:1692 +0x65
created by github.com/kolide/launcher/v2/pkg/osquery.TestGetQueries_WorksWithSecretlessEnrollment in goroutine 130
        /home/billy/work/launcher/pkg/osquery/extension_test.go:1690 +0x8eb
FAIL    github.com/kolide/launcher/v2/pkg/osquery       0.251s
```