### PR TITLE
osquery/runtime: fix osqueryinstance's WithStartFunc

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -233,6 +233,9 @@ func newInstance(enrollmentId string, knapsack types.Knapsack, logPublishClient 
 		runId:                   runId,
 		extensionManagerServers: make(map[string]*osquery.ExtensionManagerServer),
 		history:                 knapsack.OsqueryHistory(),
+		startFunc: func(cmd *exec.Cmd) error {
+			return cmd.Start()
+		},
 	}
 
 	for _, opt := range opts {
@@ -240,10 +243,6 @@ func newInstance(enrollmentId string, knapsack types.Knapsack, logPublishClient 
 	}
 
 	i.errgroup = errgroup.NewLoggedErrgroup(context.Background(), i.slogger)
-
-	i.startFunc = func(cmd *exec.Cmd) error {
-		return cmd.Start()
-	}
 
 	return i
 }


### PR DESCRIPTION
WithStartFunc doesn't work. We always clobber it with a default. It's only used by tests.

I have stared at this file, neck deep in a refactor, for over a day. I don't know if this had a negative effect on the sole test that used it, [`TestOsquerySlowStart`](https://github.com/brhoades/launcher/blob/0e5872d812ed59b2d5850730193a6fe8698a3bca/pkg/osquery/runtime/runtime_posix_test.go#L39), since it passed. It clearly couldn't do what it was trying to.


It upset me when I finally saw it, so it's worth fixing :+1:.