### PR TITLE
Use go-tuf/v2 in tufci (tests)

### DIFF
--- a/ee/tuf/ci/tuf_client.go
+++ b/ee/tuf/ci/tuf_client.go
@@ -1,38 +1,39 @@
 package tufci
 
 import (
-	"net/http"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/theupdateframework/go-tuf/client"
-	filejsonstore "github.com/theupdateframework/go-tuf/client/filejsonstore"
+	"github.com/theupdateframework/go-tuf/v2/metadata/config"
+	"github.com/theupdateframework/go-tuf/v2/metadata/updater"
 )
 
 // SeedLocalTufRepo creates a local TUF repo with a valid release under the given version `testTargetVersion`
 func SeedLocalTufRepo(t *testing.T, testTargetVersion string, testRootDir string) {
 	serverUrl, testRootJson := InitRemoteTufServer(t, testTargetVersion)
 
-	// Now set up local repo
 	localTufDir := filepath.Join(testRootDir, "tuf")
-	localStore, err := filejsonstore.NewFileJSONStore(localTufDir)
-	require.NoError(t, err, "could not set up local store")
+	localTargetsDir := filepath.Join(testRootDir, "updates")
 
-	// Set up our remote store i.e. tuf.kolide.com
-	remoteOpts := client.HTTPRemoteOptions{
-		MetadataPath: "/repository",
+	metadataUrl := strings.TrimSuffix(serverUrl, "/") + "/repository"
+	cfg, err := config.New(metadataUrl, testRootJson)
+	require.NoError(t, err)
+	cfg.LocalMetadataDir = localTufDir
+	cfg.LocalTargetsDir = localTargetsDir
+
+	up, err := updater.New(cfg)
+	require.NoError(t, err, "initializing updater")
+	require.NoError(t, up.Refresh(), "refreshing TUF metadata")
+
+	// The old version of go-tuf expects permissions at 0640 at most, but go-tuf/v2
+	// creates metadata files at 0644. So, re-chmod any metadata files added by
+	// the call to `Refresh`.
+	metadataFiles, err := filepath.Glob(filepath.Join(localTufDir, "*.json"))
+	require.NoError(t, err)
+	for _, metadataFile := range metadataFiles {
+		require.NoError(t, os.Chmod(metadataFile, 0640))
 	}
-	c := &http.Client{}
-	t.Cleanup(func() {
-		c.CloseIdleConnections()
-	})
-	remoteStore, err := client.HTTPRemoteStore(serverUrl, &remoteOpts, c)
-	require.NoError(t, err, "could not set up remote store")
-
-	metadataClient := client.NewClient(localStore, remoteStore)
-	require.NoError(t, err, metadataClient.Init(testRootJson), "failed to initialze TUF client")
-
-	_, err = metadataClient.Update()
-	require.NoError(t, err, "could not update TUF client")
 }

--- a/ee/tuf/ci/tuf_server.go
+++ b/ee/tuf/ci/tuf_server.go
@@ -145,20 +145,23 @@ func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL 
 
 	// Save metadata to filesystem dir
 	for _, name := range []string{"targets", "snapshot", "timestamp", "root"} {
+		filename := fmt.Sprintf("%s.json", name)
 		var err error
 		switch name {
 		case "targets":
-			filename := fmt.Sprintf("%d.%s.json", targets["targets"].Signed.Version, name)
-			err = targets["targets"].ToFile(filepath.Join(tufDir, "repository", filename), true)
+			require.NoError(t, targets["targets"].ToFile(filepath.Join(tufDir, "repository", filename), true))
+			versionedFilename := fmt.Sprintf("%d.%s.json", targets["targets"].Signed.Version, name)
+			require.NoError(t, targets["targets"].ToFile(filepath.Join(tufDir, "repository", versionedFilename), true))
 		case "snapshot":
-			filename := fmt.Sprintf("%d.%s.json", snapshot.Signed.Version, name)
-			err = snapshot.ToFile(filepath.Join(tufDir, "repository", filename), true)
+			require.NoError(t, snapshot.ToFile(filepath.Join(tufDir, "repository", filename), true))
+			versionedFilename := fmt.Sprintf("%d.%s.json", snapshot.Signed.Version, name)
+			require.NoError(t, snapshot.ToFile(filepath.Join(tufDir, "repository", versionedFilename), true))
 		case "timestamp":
-			filename := fmt.Sprintf("%s.json", name)
-			err = timestamp.ToFile(filepath.Join(tufDir, "repository", filename), true)
+			require.NoError(t, timestamp.ToFile(filepath.Join(tufDir, "repository", filename), true))
 		case "root":
-			filename := fmt.Sprintf("%d.%s.json", root.Signed.Version, name)
-			err = root.ToFile(filepath.Join(tufDir, "repository", filename), true)
+			require.NoError(t, root.ToFile(filepath.Join(tufDir, "repository", filename), true))
+			versionedFilename := fmt.Sprintf("%d.%s.json", root.Signed.Version, name)
+			require.NoError(t, root.ToFile(filepath.Join(tufDir, "repository", versionedFilename), true))
 		}
 		require.NoError(t, err)
 	}

--- a/ee/tuf/ci/tuf_server.go
+++ b/ee/tuf/ci/tuf_server.go
@@ -169,8 +169,11 @@ func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL 
 	// Quick validation that we set up the repo properly: metadata files should exist; targets should exist
 	require.DirExists(t, filepath.Join(tufDir, "repository"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "1.root.json")) // We only performed one commit, so we can assume version 1
+	require.FileExists(t, filepath.Join(tufDir, "repository", "root.json"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "1.snapshot.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "snapshot.json"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "1.targets.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "targets.json"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "timestamp.json")) // Timestamp file does not have versioning
 	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, arch, "stable", "release.json"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, arch, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)))

--- a/ee/tuf/ci/tuf_server.go
+++ b/ee/tuf/ci/tuf_server.go
@@ -1,7 +1,10 @@
 package tufci
 
 import (
+	"crypto"
+	"crypto/ed25519"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,9 +13,11 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/require"
-	"github.com/theupdateframework/go-tuf"
+	"github.com/theupdateframework/go-tuf/v2/metadata"
 )
 
 //go:embed testdata/*.tar.gz
@@ -34,24 +39,10 @@ func getTarballContents(t *testing.T, binary string) []byte {
 func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL string, rootJson []byte) {
 	tufDir := t.TempDir()
 
-	// Initialize repo with store
-	localStore := tuf.FileSystemStore(tufDir, nil)
-	repo, err := tuf.NewRepo(localStore)
-	require.NoError(t, err, "could not create new tuf repo")
-	require.NoError(t, repo.Init(false), "could not init new tuf repo")
-
-	// Gen keys
-	_, err = repo.GenKey("root")
-	require.NoError(t, err, "could not gen root key")
-	_, err = repo.GenKey("targets")
-	require.NoError(t, err, "could not gen targets key")
-	_, err = repo.GenKey("snapshot")
-	require.NoError(t, err, "could not gen snapshot key")
-	_, err = repo.GenKey("timestamp")
-	require.NoError(t, err, "could not gen timestamp key")
-
-	// Sign the root metadata file
-	require.NoError(t, repo.Sign("root.json"), "could not sign root metadata file")
+	// Initialize TUF targets
+	targets := map[string]*metadata.Metadata[metadata.TargetsType]{
+		"targets": metadata.Targets(time.Now().AddDate(0, 0, 7).UTC()),
+	}
 
 	arch := runtime.GOARCH
 	if runtime.GOOS == "darwin" {
@@ -62,35 +53,34 @@ func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL 
 	for _, b := range []string{"osqueryd", "launcher"} {
 		for _, v := range []string{NonReleaseVersion, "0.12.3-deadbeef", testReleaseVersion} {
 			binaryFileName := fmt.Sprintf("%s-%s.tar.gz", b, v)
+			binaryDir := filepath.Join(tufDir, "repository", "targets", b, runtime.GOOS, arch)
+			binaryFilepath := filepath.Join(binaryDir, binaryFileName)
 
 			// Create a valid test binary -- an archive of an executable with the proper directory structure
 			// that will actually run -- if this is the release version we care about. If this is not the
 			// release version we care about, then just create a small text file since it won't be downloaded
 			// and evaluated.
 			if v == testReleaseVersion {
-				// Create test binary and copy it to the staged targets directory
-				stagedTargetsDir := filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, arch)
-				require.NoError(t, os.MkdirAll(stagedTargetsDir, 0755))
+				// Create test binary and copy it to the targets directory
+				require.NoError(t, os.MkdirAll(binaryDir, 0755))
 
-				f, err := os.Create(filepath.Join(stagedTargetsDir, binaryFileName))
+				f, err := os.Create(binaryFilepath)
 				require.NoError(t, err)
 				_, err = f.Write(getTarballContents(t, b))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 			} else {
 				// Create a fake test binary
-				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, arch), 0777), "could not make staging directory")
-				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, arch, binaryFileName), []byte("I am a test target"), 0777)
+				require.NoError(t, os.MkdirAll(binaryDir, 0777), "could not make staging directory")
+				err := os.WriteFile(filepath.Join(tufDir, "repository", "targets", b, runtime.GOOS, arch, binaryFileName), []byte("I am a test target"), 0777)
 				require.NoError(t, err, "could not write test target binary to temp dir")
 			}
 
 			// Add the target
-			require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s/%s", b, runtime.GOOS, arch, binaryFileName), nil), "could not add test target binary to tuf")
-
-			// Commit
-			require.NoError(t, repo.Snapshot(), "could not take snapshot")
-			require.NoError(t, repo.Timestamp(), "could not take timestamp")
-			require.NoError(t, repo.Commit(), "could not commit")
+			targetFileInfo, err := metadata.TargetFile().FromFile(binaryFilepath, "sha256")
+			require.NoError(t, err)
+			targetName := fmt.Sprintf("%s/%s/%s/%s", b, runtime.GOOS, arch, binaryFileName)
+			targets["targets"].Signed.Targets[targetName] = targetFileInfo
 
 			if v != testReleaseVersion {
 				continue
@@ -98,31 +88,87 @@ func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL 
 
 			// If this is our release version, also create and commit a test release file
 			for _, c := range []string{"stable", "beta", "nightly"} {
-				require.NoError(t, os.MkdirAll(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, arch, c), 0777), "could not make staging directory")
-				err = os.WriteFile(filepath.Join(tufDir, "staged", "targets", b, runtime.GOOS, arch, c, "release.json"), []byte("{}"), 0777)
+				releaseTargetFileDir := filepath.Join(tufDir, "repository", "targets", b, runtime.GOOS, arch, c)
+				releaseTargetFile := filepath.Join(releaseTargetFileDir, "release.json")
+				require.NoError(t, os.MkdirAll(releaseTargetFileDir, 0777), "could not make staging directory")
+				err = os.WriteFile(releaseTargetFile, []byte("{}"), 0777)
 				require.NoError(t, err, "could not write test target release file to temp dir")
-				customMetadata := fmt.Sprintf("{\"target\":\"%s/%s/%s/%s\"}", b, runtime.GOOS, arch, binaryFileName)
-				require.NoError(t, repo.AddTarget(fmt.Sprintf("%s/%s/%s/%s/release.json", b, runtime.GOOS, arch, c), []byte(customMetadata)), "could not add test target release file to tuf")
 
-				// Commit
-				require.NoError(t, repo.Snapshot(), "could not take snapshot")
-				require.NoError(t, repo.Timestamp(), "could not take timestamp")
-				require.NoError(t, repo.Commit(), "could not commit")
+				customMetadata, err := json.Marshal(map[string]string{
+					"target": targetName,
+				})
+				require.NoError(t, err)
+				rawCustomMetadata := json.RawMessage(customMetadata)
+
+				releaseFileInfo, err := metadata.TargetFile().FromFile(releaseTargetFile, "sha256")
+				require.NoError(t, err)
+				releaseFileInfo.Custom = &rawCustomMetadata
+
+				targets["targets"].Signed.Targets[fmt.Sprintf("%s/%s/%s/%s/release.json", b, runtime.GOOS, arch, c)] = releaseFileInfo
 			}
 		}
 	}
 
-	// Quick validation that we set up the repo properly: key and metadata files should exist; targets should exist
-	require.DirExists(t, filepath.Join(tufDir, "keys"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "root.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "snapshot.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "targets.json"))
-	require.FileExists(t, filepath.Join(tufDir, "keys", "timestamp.json"))
+	// Initialize our other TUF roles
+	snapshot := metadata.Snapshot(time.Now().AddDate(0, 0, 7).UTC())
+	timestamp := metadata.Timestamp(time.Now().AddDate(0, 0, 1).UTC())
+	root := metadata.Root(time.Now().AddDate(0, 0, 365).UTC())
+
+	// Generate keys so we can sign metadata
+	keys := make(map[string]ed25519.PrivateKey)
+	for _, name := range []string{"targets", "snapshot", "timestamp", "root"} {
+		_, private, err := ed25519.GenerateKey(nil)
+		require.NoError(t, err)
+		keys[name] = private
+		key, err := metadata.KeyFromPublicKey(private.Public())
+		require.NoError(t, err)
+		root.Signed.AddKey(key, name)
+	}
+
+	// Sign metadata
+	for _, name := range []string{"targets", "snapshot", "timestamp", "root"} {
+		key := keys[name]
+		signer, err := signature.LoadSigner(key, crypto.Hash(0))
+		require.NoError(t, err)
+		switch name {
+		case "targets":
+			_, err = targets["targets"].Sign(signer)
+		case "snapshot":
+			_, err = snapshot.Sign(signer)
+		case "timestamp":
+			_, err = timestamp.Sign(signer)
+		case "root":
+			_, err = root.Sign(signer)
+		}
+		require.NoError(t, err)
+	}
+
+	// Save metadata to filesystem dir
+	for _, name := range []string{"targets", "snapshot", "timestamp", "root"} {
+		var err error
+		switch name {
+		case "targets":
+			filename := fmt.Sprintf("%d.%s.json", targets["targets"].Signed.Version, name)
+			err = targets["targets"].ToFile(filepath.Join(tufDir, "repository", filename), true)
+		case "snapshot":
+			filename := fmt.Sprintf("%d.%s.json", snapshot.Signed.Version, name)
+			err = snapshot.ToFile(filepath.Join(tufDir, "repository", filename), true)
+		case "timestamp":
+			filename := fmt.Sprintf("%s.json", name)
+			err = timestamp.ToFile(filepath.Join(tufDir, "repository", filename), true)
+		case "root":
+			filename := fmt.Sprintf("%d.%s.json", root.Signed.Version, name)
+			err = root.ToFile(filepath.Join(tufDir, "repository", filename), true)
+		}
+		require.NoError(t, err)
+	}
+
+	// Quick validation that we set up the repo properly: metadata files should exist; targets should exist
 	require.DirExists(t, filepath.Join(tufDir, "repository"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "root.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "snapshot.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "timestamp.json"))
-	require.FileExists(t, filepath.Join(tufDir, "repository", "targets.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "1.root.json")) // We only performed one commit, so we can assume version 1
+	require.FileExists(t, filepath.Join(tufDir, "repository", "1.snapshot.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "1.targets.json"))
+	require.FileExists(t, filepath.Join(tufDir, "repository", "timestamp.json")) // Timestamp file does not have versioning
 	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, arch, "stable", "release.json"))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "launcher", runtime.GOOS, arch, fmt.Sprintf("launcher-%s.tar.gz", testReleaseVersion)))
 	require.FileExists(t, filepath.Join(tufDir, "repository", "targets", "osqueryd", runtime.GOOS, arch, "stable", "release.json"))
@@ -155,10 +201,9 @@ func InitRemoteTufServer(t *testing.T, testReleaseVersion string) (tufServerURL 
 
 	tufServerURL = testMetadataServer.URL
 
-	metadata, err := repo.GetMeta()
-	require.NoError(t, err, "could not get metadata from test TUF repo")
-	require.Contains(t, metadata, "root.json")
-	rootJson = metadata["root.json"]
+	var err error
+	rootJson, err = root.ToBytes(false)
+	require.NoError(t, err, "generating root json")
 
 	return tufServerURL, rootJson
 }

--- a/ee/tuf/library_lookup_test.go
+++ b/ee/tuf/library_lookup_test.go
@@ -2,6 +2,7 @@ package tuf
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	agentsqlite "github.com/kolide/launcher/v2/ee/agent/storage/sqlite"
 	tufci "github.com/kolide/launcher/v2/ee/tuf/ci"
 	"github.com/kolide/launcher/v2/pkg/log/multislogger"
+	"github.com/kolide/launcher/v2/pkg/threadsafebuffer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,11 +67,16 @@ func TestCheckOutLatest_withTufRepository(t *testing.T) {
 			tufci.CopyBinary(t, tooRecentPath)
 			require.NoError(t, os.Chmod(tooRecentPath, 0755))
 
+			var logBytes threadsafebuffer.ThreadSafeBuffer
+			slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+
 			// Check it
-			latest, err := CheckOutLatest(t.Context(), binary, rootDir, "", "", "nightly", multislogger.NewNopLogger())
-			require.NoError(t, err, "unexpected error on checking out latest")
-			require.Equal(t, executablePath, latest.Path)
-			require.Equal(t, executableVersion, latest.Version)
+			latest, err := CheckOutLatest(t.Context(), binary, rootDir, "", "", "nightly", slogger)
+			require.NoError(t, err, "unexpected error on checking out latest", logBytes.String())
+			require.Equal(t, executablePath, latest.Path, "wrong path", logBytes.String())
+			require.Equal(t, executableVersion, latest.Version, "wrong version", logBytes.String())
 		})
 	}
 }
@@ -106,11 +113,16 @@ func TestCheckOutLatest_withTufRepository_withPinnedVersion(t *testing.T) {
 			tufci.CopyBinary(t, releaseTargetPath)
 			require.NoError(t, os.Chmod(releaseTargetPath, 0755))
 
+			var logBytes threadsafebuffer.ThreadSafeBuffer
+			slogger := slog.New(slog.NewTextHandler(&logBytes, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+
 			// Check it
-			latest, err := CheckOutLatest(t.Context(), binary, rootDir, "", pinnedVersion, "nightly", multislogger.NewNopLogger())
-			require.NoError(t, err, "unexpected error on checking out latest")
-			require.Equal(t, executablePath, latest.Path)
-			require.Equal(t, executableVersion, latest.Version)
+			latest, err := CheckOutLatest(t.Context(), binary, rootDir, "", pinnedVersion, "nightly", slogger)
+			require.NoError(t, err, "unexpected error on checking out latest", logBytes.String())
+			require.Equal(t, executablePath, latest.Path, "wrong path", logBytes.String())
+			require.Equal(t, executableVersion, latest.Version, "wrong version", logBytes.String())
 		})
 	}
 }


### PR DESCRIPTION
As a preliminary part of our effort to migrate to `go-tuf/v2`, this PR updates our isolated `tufci` package to use the new version.

`go-tuf/v2` does not provide a repository implementation or backing store like `tuf.FileSystemStore`, so the setup in the test server is a little more verbose than it was previously.

This update highlights a small difference between the old and new versions: `go-tuf/v2` creates metadata files with permissions 0644, whereas `go-tuf/v0.7.0` rejects metadata files with permissions in excess of 0640. We should plan to handle this change when migrating to `go-tuf/v2` so that we don't have any issues if we need to roll back from `go-tuf/v2` to `go-tuf/v0.7.0`.