### PR TITLE
osquery/runtime: fix common test flake from `os.Stat` on Windows

### DIFF
--- a/pkg/osquery/runtime/osqueryinstance.go
+++ b/pkg/osquery/runtime/osqueryinstance.go
@@ -49,16 +49,13 @@ const (
 
 	katcExtensionName = "katc"
 
-	// How long to wait before erroring because the osquery process has not started up successfully.
+	// How long to wait before failing when the osquery client fails to connect.
 	// This is a generous timeout -- the average osquery startup takes just over a second, and the
 	// 95th percentile startup takes just over two seconds. We rounded up to 10 seconds to give
 	// extra time for our outliers. 10 seconds also matches rungroup.InterruptTimeout, ensuring
 	// we don't leave behind osquery processes still trying to start up after exiting launcher.
 	// See writeup in https://github.com/kolide/launcher/pull/2041 for data and details.
 	osqueryStartupTimeout = 10 * time.Second
-
-	// How often to check whether the osquery process has started up successfully
-	osqueryStartupRecheckInterval = 1 * time.Second
 
 	// How long to wait before erroring because we cannot open the osquery
 	// extension socket.
@@ -463,21 +460,6 @@ func (i *OsqueryInstance) Launch() error {
 		return fmt.Errorf("starting osqueryd process: %w", err)
 	}
 
-	if i.history == nil {
-		i.slogger.Log(ctx, slog.LevelWarn,
-			"osquery history is not initialized in knapsack, unable to record stats",
-			"err", err,
-		)
-	} else {
-		err := i.history.NewInstance(i.enrollmentId, i.runId)
-		if err != nil {
-			i.slogger.Log(ctx, slog.LevelWarn,
-				"could not create new osquery instance history",
-				"err", err,
-			)
-		}
-	}
-
 	// This loop runs in the background when the process was
 	// successfully started. ("successful" is independent of exit
 	// code. eg: this runs if we could exec. Failure to exec is above.)
@@ -504,13 +486,29 @@ func (i *OsqueryInstance) Launch() error {
 	})
 
 	// Start an extension manager for the extensions that osquery
-	// needs for config/log/etc.
+	// needs for config/log/etc. Serves as a health check.
 	i.extensionManagerClient, err = i.StartOsqueryClient()
 	if err != nil {
 		observability.SetError(span, fmt.Errorf("could not create an extension client: %w", err))
 		return fmt.Errorf("could not create an extension client: %w", err)
 	}
 	span.AddEvent("extension_client_created")
+	i.slogger.Log(ctx, slog.LevelDebug, "osquery socket created")
+
+	// historically, we only logged initialize once we could connect to the extension
+	if i.history == nil {
+		i.slogger.Log(ctx, slog.LevelWarn,
+			"osquery history is not initialized in knapsack, unable to record stats",
+		)
+	} else {
+		err := i.history.NewInstance(i.enrollmentId, i.runId)
+		if err != nil {
+			i.slogger.Log(ctx, slog.LevelWarn,
+				"could not create new osquery instance history",
+				"err", err,
+			)
+		}
+	}
 
 	kolideSaasPlugins := []osquery.OsqueryPlugin{
 		config.NewPlugin(KolideSaasExtensionName, i.saasExtension.GenerateConfigs),
@@ -570,8 +568,7 @@ func (i *OsqueryInstance) Launch() error {
 	return nil
 }
 
-// startOsquerydProcess starts the osquery instance's `cmd` and waits for the osqueryd process
-// to create a socket file, indicating it's started up successfully.
+// startOsquerydProcess starts the osquery instance's `cmd` in the background
 func (i *OsqueryInstance) startOsquerydProcess(ctx context.Context) error {
 	ctx, span := observability.StartSpan(ctx)
 	defer span.End()
@@ -603,29 +600,6 @@ func (i *OsqueryInstance) startOsquerydProcess(ctx context.Context) error {
 	i.slogger.Log(ctx, slog.LevelInfo,
 		"launched osquery process",
 		"osqueryd_pid", i.cmd.Process.Pid,
-	)
-
-	// wait for osquery to create the socket before moving on,
-	// this is intended to serve as a kind of health check
-	// for osquery, if it's started successfully it will create
-	// a socket
-	if err := backoff.WaitFor(func() error {
-		_, err := os.Stat(i.paths.extensionSocketPath)
-		if err != nil {
-			i.slogger.Log(ctx, slog.LevelDebug,
-				"osquery extension socket not created yet ... will retry",
-				"path", i.paths.extensionSocketPath,
-			)
-		}
-		return err
-	}, osqueryStartupTimeout, osqueryStartupRecheckInterval); err != nil {
-		observability.SetError(span, fmt.Errorf("timeout waiting for osqueryd to create socket at %s: %w", i.paths.extensionSocketPath, err))
-		return fmt.Errorf("timeout waiting for osqueryd to create socket at %s: %w", i.paths.extensionSocketPath, err)
-	}
-
-	span.AddEvent("socket_created")
-	i.slogger.Log(ctx, slog.LevelDebug,
-		"osquery socket created",
 	)
 
 	return nil
@@ -878,15 +852,17 @@ func (i *OsqueryInstance) createOsquerydCommand(osquerydBinary string) (*exec.Cm
 }
 
 // StartOsqueryClient will create and return a new osquery client with a connection
-// over the socket at the provided path. It will retry for up to 10 seconds to create
-// the connection in the event of a failure.
+// over the socket at the provided path. It will retry the connection on failure.
 func (i *OsqueryInstance) StartOsqueryClient() (*osquery.ExtensionManagerClient, error) {
 	var client *osquery.ExtensionManagerClient
 	if err := backoff.WaitFor(func() error {
 		var newErr error
 		client, newErr = osquery.NewClient(i.paths.extensionSocketPath, socketOpenTimeout/2, osquery.DefaultWaitTime(1*time.Second), osquery.MaxWaitTime(maxSocketWaitTime))
 		return newErr
-	}, socketOpenTimeout, socketOpenInterval); err != nil {
+	},
+		socketOpenTimeout+osqueryStartupTimeout, // the client serves as a startup signal
+		socketOpenInterval,
+	); err != nil {
 		return nil, fmt.Errorf("could not create an extension client: %w", err)
 	}
 

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -3,9 +3,10 @@
 package runtime
 
 import (
-	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -33,9 +34,23 @@ func hasPermissionsToRunTest() bool {
 	return true
 }
 
-// TestOsquerySlowStart tests that launcher can handle a slow-starting osqueryd process.
-// This this is only enabled on non-Windows platforms because we have not yet figured
-// out how to suspend and resume a process on Windows via golang.
+// delayOsqueryd wraps the configured osqueryd invocation in a sleep script.
+func delayOsqueryd(t *testing.T, delay time.Duration) OsqueryInstanceOption {
+	script := filepath.Join(t.TempDir(), "delay.sh")
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\nsleep \"$1\"\nshift\nexec \"$@\"\n"), 0755))
+
+	return WithStartFunc(func(cmd *exec.Cmd) error {
+		sh, err := exec.LookPath("sh")
+		require.NoError(t, err)
+
+		cmd.Args = append([]string{"sh", script, strconv.Itoa(int(delay.Seconds())), cmd.Path}, cmd.Args[1:]...)
+		cmd.Path = sh
+
+		return cmd.Start()
+	})
+}
+
+// runner should wait out wait out a slow-starting osqueryd.
 func TestOsquerySlowStart(t *testing.T) {
 	t.Parallel()
 	requirePermissions(t)
@@ -43,74 +58,30 @@ func TestOsquerySlowStart(t *testing.T) {
 	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
 	setupOnceFunc()
 
-	rootDirectory := testRootDirectory(t)
+	for _, tt := range []struct {
+		name  string
+		delay time.Duration
+	}{
+		{"slow", osqueryStartupTimeout / 2},
+		// longer than we used to wait for the socket alone, so this only passes
+		// if the extension client is allowed the full startup budget
+		{"slower", osqueryStartupTimeout + socketOpenTimeout/2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	logBytes, slogger := setUpTestSlogger()
+			runner, logBytes, osqHistory := newTestRunner(t, delayOsqueryd(t, tt.delay))
+			ensureShutdownOnCleanup(t, runner, logBytes)
+			go runner.Run()
 
-	k := typesMocks.NewKnapsack(t)
-	k.On("EnrollmentIDs").Return([]string{types.DefaultEnrollmentID})
-	// OsqueryHealthcheckStartupDelay defaults to ten minutes, which is too long for tests.
-	// We don't want an extremely short interval, though, because we need to give the osquery instance
-	// time to actually start before we begin healthchecking it. So, we wait for at least the
-	// amount of time that we give for the socket to appear.
-	k.On("OsqueryHealthcheckStartupDelay").Return(socketOpenTimeout).Maybe()
-	k.On("WatchdogEnabled").Return(false)
-	k.On("RootDirectory").Return(rootDirectory).Maybe()
-	k.On("OsqueryVerbose").Return(true).Maybe()
-	k.On("OsqueryFlags").Return([]string{}).Maybe()
-	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	k.On("Slogger").Return(slogger)
-	k.On("LatestOsquerydPath", mock.Anything).Return(testOsqueryBinary)
-	k.On("LoggingInterval").Return(5 * time.Minute).Maybe()
-	k.On("LogMaxBytesPerBatch").Return(0).Maybe()
-	k.On("ReadEnrollSecret").Return("", nil).Maybe()
-	k.On("NodeKey", types.DefaultEnrollmentID).Return(ulid.New(), nil).Maybe()
-	k.On("EnsureEnrollmentStored", types.DefaultEnrollmentID).Return(nil).Maybe()
-	k.On("InModernStandby").Return(false).Maybe()
-	k.On("RegisterChangeObserver", mock.Anything, keys.UpdateChannel).Maybe()
-	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedLauncherVersion).Maybe()
-	k.On("RegisterChangeObserver", mock.Anything, keys.PinnedOsquerydVersion).Maybe()
-	k.On("UpdateChannel").Return("stable").Maybe()
-	k.On("PinnedLauncherVersion").Return("").Maybe()
-	k.On("PinnedOsquerydVersion").Return("").Maybe()
-	k.On("TableGenerateTimeout").Return(4 * time.Minute).Maybe()
-	k.On("RegisterChangeObserver", mock.Anything, keys.TableGenerateTimeout).Return().Maybe()
-	k.On("GetEnrollmentDetails").Return(types.EnrollmentDetails{OSVersion: "1", Hostname: "test"}, nil).Maybe()
-	k.On("DistributedForwardingInterval").Maybe().Return(60 * time.Second)
-	k.On("RegisterChangeObserver", mock.Anything, mock.Anything, mock.Anything).Maybe().Return()
-	k.On("DeregisterChangeObserver", mock.Anything).Maybe().Return()
-	k.On("UseCachedDataForScheduledQueries").Return(true).Maybe()
-	setUpMockStores(t, k)
-	osqHistory := setupHistory(t, k)
-	testServer := setupMockDeviceServer(t)
-	k.On("KolideServerURL").Return(testServer).Maybe()
-	k.On("InsecureTransportTLS").Return(true).Maybe()
+			// nothing can be healthy before the delay elapses, and waiting here keeps
+			// waitHealthy's deadline from overlapping the instance's own startup budget
+			time.Sleep(tt.delay)
+			waitHealthy(t, runner, logBytes, osqHistory)
 
-	s := settingsstoremock.NewSettingsStoreWriter(t)
-	s.On("WriteSettings").Return(nil).Maybe()
-	lpc := makeTestOsqLogPublisher(t, k)
-
-	runner := New(k, lpc, s, WithStartFunc(func(cmd *exec.Cmd) error {
-		err := cmd.Start()
-		if err != nil {
-			return fmt.Errorf("unexpected error starting command: %w", err)
-		}
-		// suspend the process right away
-		cmd.Process.Signal(syscall.SIGTSTP)
-		go func() {
-			// wait a while before resuming the process
-			time.Sleep(3 * time.Second)
-			cmd.Process.Signal(syscall.SIGCONT)
-		}()
-		return nil
-	}))
-	ensureShutdownOnCleanup(t, runner, logBytes)
-	go runner.Run()
-	waitHealthy(t, runner, logBytes, osqHistory)
-
-	// ensure that we actually had to wait on the socket
-	require.Contains(t, logBytes.String(), "osquery extension socket not created yet")
-	waitShutdown(t, runner, logBytes)
+			waitShutdown(t, runner, logBytes)
+		})
+	}
 }
 
 // TestExtensionSocketPath tests that the launcher can start osqueryd with a custom extension socket path.

--- a/pkg/osquery/runtime/runtime_posix_test.go
+++ b/pkg/osquery/runtime/runtime_posix_test.go
@@ -50,40 +50,6 @@ func delayOsqueryd(t *testing.T, delay time.Duration) OsqueryInstanceOption {
 	})
 }
 
-// runner should wait out wait out a slow-starting osqueryd.
-func TestOsquerySlowStart(t *testing.T) {
-	t.Parallel()
-	requirePermissions(t)
-	downloadOnceFunc()
-	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
-	setupOnceFunc()
-
-	for _, tt := range []struct {
-		name  string
-		delay time.Duration
-	}{
-		{"slow", osqueryStartupTimeout / 2},
-		// longer than we used to wait for the socket alone, so this only passes
-		// if the extension client is allowed the full startup budget
-		{"slower", osqueryStartupTimeout + socketOpenTimeout/2},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			runner, logBytes, osqHistory := newTestRunner(t, delayOsqueryd(t, tt.delay))
-			ensureShutdownOnCleanup(t, runner, logBytes)
-			go runner.Run()
-
-			// nothing can be healthy before the delay elapses, and waiting here keeps
-			// waitHealthy's deadline from overlapping the instance's own startup budget
-			time.Sleep(tt.delay)
-			waitHealthy(t, runner, logBytes, osqHistory)
-
-			waitShutdown(t, runner, logBytes)
-		})
-	}
-}
-
 // TestExtensionSocketPath tests that the launcher can start osqueryd with a custom extension socket path.
 // This is only run on non-windows platforms because the extension socket path is semi random on windows.
 func TestExtensionSocketPath(t *testing.T) {

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -1157,8 +1157,8 @@ func TestRestart(t *testing.T) {
 	waitShutdown(t, runner, logBytes)
 }
 
-// sets up an osquery instance with a running extension to be used in tests.
-func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, osqHistory *history.History) {
+// sets up an osquery instance and returns it.
+func newTestRunner(t *testing.T, opts ...OsqueryInstanceOption) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, osqHistory *history.History) {
 	rootDirectory := testRootDirectory(t)
 
 	logBytes, slogger := setUpTestSlogger()
@@ -1209,7 +1209,12 @@ func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threa
 	s.On("WriteSettings").Return(nil).Maybe()
 	lpc := makeTestOsqLogPublisher(t, k)
 
-	runner = New(k, lpc, s)
+	return New(k, lpc, s, opts...), logBytes, osqHistory
+}
+
+// sets up an osquery instance with a running extension to be used in tests.
+func setupOsqueryInstanceForTests(t *testing.T) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, osqHistory *history.History) {
+	runner, logBytes, osqHistory = newTestRunner(t)
 	go runner.Run()
 	waitHealthy(t, runner, logBytes, osqHistory)
 

--- a/pkg/osquery/runtime/runtime_test.go
+++ b/pkg/osquery/runtime/runtime_test.go
@@ -1157,6 +1157,43 @@ func TestRestart(t *testing.T) {
 	waitShutdown(t, runner, logBytes)
 }
 
+// runner should wait out a slow-starting osqueryd.
+func TestOsquerySlowStart(t *testing.T) {
+	t.Parallel()
+	requirePermissions(t)
+	downloadOnceFunc()
+	require.NoError(t, osqueryBinaryDownloadErr, "could not download osquery, cannot proceed with tests")
+	setupOnceFunc()
+
+	for _, tt := range []struct {
+		name  string
+		delay time.Duration
+	}{
+		{"slow", osqueryStartupTimeout / 2},
+		// longer than we used to wait for the socket alone, so this only passes
+		// if the extension client is allowed the full startup budget
+		{"slower", osqueryStartupTimeout + socketOpenTimeout/2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner, logBytes, osqHistory := newTestRunner(t, delayOsqueryd(t, tt.delay))
+			ensureShutdownOnCleanup(t, runner, logBytes)
+			go runner.Run()
+
+			// nothing can be healthy before the delay elapses, and waiting here keeps
+			// waitHealthy's deadline from overlapping the instance's own startup budget
+			time.Sleep(tt.delay - 1*time.Second)
+			require.Error(t, runner.Healthy(), "healthy before delayed osqueryd could have started")
+			time.Sleep(1 * time.Second)
+
+			waitHealthy(t, runner, logBytes, osqHistory)
+
+			waitShutdown(t, runner, logBytes)
+		})
+	}
+}
+
 // sets up an osquery instance and returns it.
 func newTestRunner(t *testing.T, opts ...OsqueryInstanceOption) (runner *Runner, logBytes *threadsafebuffer.ThreadSafeBuffer, osqHistory *history.History) {
 	rootDirectory := testRootDirectory(t)

--- a/pkg/osquery/runtime/runtime_windows_test.go
+++ b/pkg/osquery/runtime/runtime_windows_test.go
@@ -3,8 +3,13 @@
 package runtime
 
 import (
+	"os"
+	"os/exec"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
 
@@ -14,4 +19,32 @@ func requirePgidMatch(_ *testing.T, _ int) {}
 // this is required to run tests on windows
 func hasPermissionsToRunTest() bool {
 	return windows.GetCurrentProcessToken().IsElevated()
+}
+
+// delayOsqueryd wraps the configured osqueryd invocation in a sleep script.
+func delayOsqueryd(t *testing.T, delay time.Duration) OsqueryInstanceOption {
+	script, err := os.CreateTemp(t.TempDir(), "*_osquery-wrapper.ps1")
+	require.NoError(t, err, "failed to make temp file")
+	// script file is simpler than escaping or encoding
+	// powershell does not propagate a native exit code on its own
+	_, err = script.WriteString("$delay, $exe, $rest = $args\nStart-Sleep -Seconds ([int]$delay)\n& $exe @rest\nexit $LASTEXITCODE\n")
+	require.NoError(t, err)
+	require.NoError(t, script.Close())
+
+	t.Cleanup(func() {
+		os.Remove(script.Name())
+	})
+
+	return WithStartFunc(func(cmd *exec.Cmd) error {
+		powershell, err := exec.LookPath("powershell.exe")
+		require.NoError(t, err)
+
+		cmd.Args = append([]string{
+			"powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script.Name(),
+			strconv.Itoa(int(delay.Seconds())), cmd.Path,
+		}, cmd.Args[1:]...)
+		cmd.Path = powershell
+
+		return cmd.Start()
+	})
 }


### PR DESCRIPTION
## Summary
This PR:
  - Uses osquery client as a health check instead over `os.Stat`, simplifying the flow and fixing a Windows bug as a side effect.
  - Reworks `TestOsquerySlowStart` which previously always passed. This changeset broke its assumption.
     - Adds Windows support.

Note: A new side effect is that we can more easily wait up to 20 seconds when osqueryd started and died, where before it was more likely we'd wait up to 10 seconds depending on which backoff was hit. I do not have the context on tuning these timeouts, so I kept it as a broader verion of what it was.

## Background
I'm neck deep in osqueryinstance test flakes after #2800 had several consecutive flakes and a subsequent commit hit more again.

A separate PR is coming that improves the other osquery-related flakes enough to make this bug stand out.

### Testing
I ran the whole test suite with count 1000 for several hours (~5k test runs). The flake count is lower, especially on Windows, and the bug I targeted is gone.

Linux unit test results:  [20260904-osquerystatfix-linux.log](https://github.com/user-attachments/files/31965818/20260904-osquerystatfix-linux.log)
Windows unit test results: 
[20260905-osquery-runtime-tests-5c57cd51-windows.log](https://github.com/user-attachments/files/31965822/20260905-osquery-runtime-tests-5c57cd51-windows.log)
MacOS unit tests results: 
[20260908-osquery-runtime-tests-windows-pipe-fix-macos.log](https://github.com/user-attachments/files/31969578/20260908-osquery-runtime-tests-windows-pipe-fix-macos.log)


### Breakdown
I'm pretty sure the bug is from a Windows quirk, but I didn't dive into osqueryd to confirm:
1. In `osqueryinstance.startOsquerydProcess`, we check if the extension pipe is present with `os.Stat`.
2. `os.Stat` gets file attributes. It fails successfully with `ERROR_INVALID_PARAMETER` because a pipe is not a file.
3. `os.Stat` then connects to the pipe [here](https://github.com/golang/go/blob/4756f33d43d84aa3b38e68cad67d24d0720c5a0d/src/os/stat_windows.go#L77-L92), which consumes it on close.
4. `os.Stat` pulls info from the pipe's handle and returns.
5. If it didn't error, `startOsquerydProcess` returns to `Launch`.

Then in parallel:
 * `Launch` attempts to connect via `StartOsqueryClient` over the pipe.
 * osqueryd's thrift server detects the now-closed client pipe and creates another.

Test flakes occur when `Launch` tries the pipe before it's recreated, which triggers a backoff. I'd guess with many parallel tests it takes a while to recreate the socket. In production, this could happen but it would self-heal eventually.

### Example Failures

<details>
<summary> From my testing, it causes ~1% of all Windows osquery tests to fail in this shape.</summary>

```
    osqueryinstance_test.go:446:
                Error Trace:    /home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance_test.go:446
                Error:          Received unexpected error:
                                timeout after 30s (32 attempts): instance not healthy: instance not started
                Test:           TestLaunch
                Messages:       instance not healthy by 2026-09-02 11:23:36.1673219 -0700 PDT m=+826.509371901: instance logs:
```


Printed logs show:
> [...] "osquery instance exited, will restart after delay" [...] err="could not create an extension client: could not create an extension client: timeout after 10s (51 attempts): dialing pipe '\\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ': open \\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ: The system cannot find the file specified."                                                                                                                                                                               )

Example:
```
--- FAIL: TestLaunch (30.40s)
=== NAME  TestOsqueryDies
    helpers_test.go:90:
                Error Trace:    /home/billy/work/launcher/pkg/osquery/runtime/helpers_test.go:90
                                                        /home/billy/work/launcher/pkg/osquery/runtime/runtime_test.go:859
                Error:          Received unexpected error:
                                timeout after 30s (602 attempts): healthchecking all instances: [healthcheck error for default: instance not started]
                Test:           TestOsqueryDies
                Messages:       instance not replaced and healthy before timeout: runner logs:

                                %!(EXTRA string=time=2026-09-02T11:23:06.190-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/extension.go:188 msg="got host identifier" component=osquery_extension enrollment_id=default host_identifier=d791f096-d521-4738-baf2-2e85c4390bc2
                                time=2026-09-02T11:23:06.190-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/extension.go:333 msg="checking enrollment" component=osquery_extension enrollment_id=default
                                time=2026-09-02T11:23:06.190-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=saas_extension_execute
                                time=2026-09-02T11:23:06.191-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/extension.go:340 msg="node key exists, skipping enrollment" component=osquery_extension enrollment_id=default
                                time=2026-09-02T11:23:06.259-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:549 msg="launching osqueryd" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 path=C:\Users\billy\AppData\Local\Temp\launcher-test-osquery\osqueryd-stable-windows-amd64.exe args="C:\\Users\\billy\\AppData\\Local\\Temp\\launcher-test-osquery\\osqueryd-stable-windows-amd64.exe --logger_plugin=kolide_grpc --distributed_plugin=kolide_grpc --disable_distributed=false --distributed_interval=5 --pack_delimiter=: --host_identifier=uuid --force=true --utc --tls_server_certs=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\ca-certs-system-3f88b94771f5aa9a3feece1a3d2bdedd2b061045238d550c86ea0ac43cf11858.crt --disable_watchdog --distributed_denylist_duration=0 --verbose --config_refresh=300 --config_accelerated_refresh=30 --allow_unsafe --pidfile=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery-01M1HNRGYAX6067S4TR4J0ABZ5.pid --database_path=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery.db --extensions_socket=\\\\.\\pipe\\kolide-osquery-01M1HNRGYAX6067S4TR4J0ABZ5 --disable_extensions=false --extensions_timeout=20 --config_plugin=kolide_grpc --extensions_require=kolide_grpc"
                                time=2026-09-02T11:23:06.289-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:616 msg="osquery extension socket not created yet ... will retry" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 path=\\.\pipe\kolide-osquery-01M1HNRGYAX6067S4TR4J0ABZ5
                                time=2026-09-02T11:23:06.289-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:616 msg="osquery extension socket not created yet ... will retry" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 path=\\.\pipe\kolide-osquery-01M1HNRGYAX6067S4TR4J0ABZ5
                                time=2026-09-02T11:23:06.292-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=osqueryd_execute
                                time=2026-09-02T11:23:06.292-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:577 msg="launched osquery process" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 osqueryd_pid=756
                                time=2026-09-02T11:23:06.382-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:06.377830 14656 init.cpp:413] osquery initialized [version=5.22.1]" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=init.cpp:413
                                time=2026-09-02T11:23:06.387-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:06.386075 14656 dispatcher.cpp:78] Adding new service: UsersService (0000014D92D0D980) to thread: 17500 (0000014D92D4E040) in process 756" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:06.388-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:06.386075 14656 dispatcher.cpp:78] Adding new service: GroupsService (0000014D92D0DA90) to thread: 20892 (0000014D92D4E440) in process 756\r\nI0902 11:23:06.386075 14656 extensions.cpp:453] Could not autoload extensions: Cannot open file for reading: \\Program Files\\osquery\\extensions.load\r\nI0902 11:23:06.386601 14656 rocksdb.cpp:90] Opening RocksDB handle: C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery.db" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:06.494-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:06.492558 20892 groups_service.cpp:55] Groups cache initialized" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=groups_service.cpp:55
                                time=2026-09-02T11:23:06.553-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:06.526602 17500 users_service.cpp:149] Users cache initialized" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=users_service.cpp:149
                                time=2026-09-02T11:23:07.183-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.183017 14656 database.cpp:655] Failed to obtain database version. Assume version '0' and migrate." component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=database.cpp:655
                                time=2026-09-02T11:23:07.187-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.187069 14656 dispatcher.cpp:78] Adding new service: ExtensionWatcher (0000014D92C787A0) to thread: 20624 (0000014D938B7930) in process 756" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:07.187-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.187196 14656 dispatcher.cpp:78] Adding new service: ExtensionRunnerCore (0000014D93A61830) to thread: 3608 (0000014D938B7C50) in process 756" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:07.187-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.187266  3608 interface.cpp:299] Extension manager service starting: \\\\.\\pipe\\kolide-osquery-01M1HNRGYAX6067S4TR4J0ABZ5" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=interface.cpp:299
                                time=2026-09-02T11:23:07.290-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:628 msg="osquery socket created" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5
                                time=2026-09-02T11:23:07.337-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=kolide_grpc
                                time=2026-09-02T11:23:07.435-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=healthcheck
                                time=2026-09-02T11:23:07.555-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.555230 22440 interface.cpp:137] Registering extension (kolide_grpc, 14231, version=, sdk=)" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=interface.cpp:137
                                time=2026-09-02T11:23:07.556-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.555859 22440 registry_factory.cpp:116] Extension 14231 registered config plugin kolide_grpc\r\nI0902 11:23:07.555859 22440 registry_factory.cpp:116] Extension 14231 registered distributed plugin kolide_grpc\r\nI0902 11:23:07.555859 22440 registry_factory.cpp:116] Extension 14231 registered logger plugin kolide_grpc" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=registry_factory.cpp:116
                                time=2026-09-02T11:23:07.571-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_chrome_user_profiles" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=registry_factory.cpp:116
                                time=2026-09-02T11:23:07.572-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_control_flags\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_cryptinfo\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_deadly_sleeper\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_desktop_procs\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_dev_table_tooling\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_dsim_default_associations\r\nI0902 11:23:07.571249 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_dsregcmd\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_filewalk\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_firefox_preferences\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_ini\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_json\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_jsonc\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_jsonl\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_jwt\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_keyinfo\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_launcher_autoupdate_config\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_launcher_config\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_launcher_db_info\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_launcher_info\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_launcher_osquery_instance_history\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_onepassword_accounts\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_plist\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_program_icon_checksums\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_program_icons\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_protobuf" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=registry_factory.cpp:116
                                time=2026-09-02T11:23:07.575-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_secedit\r\nI0902 11:23:07.571822 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_secret_scan\r\nI0902 11:23:07.572398 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_server_data\r\nI0902 11:23:07.572398 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_slack_config\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_sourced_data\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_ssh_keys\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_toml\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_tuf_release_version\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_wifi_networks\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_windows_update_history\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_windows_updates\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_windows_updates_cached\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_wmi\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_xml\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_yaml\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_zerotier_info\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_zerotier_networks\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_zerotier_peers\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin kolide_zscaler\r\nI0902 11:23:07.572472 22440 registry_factory.cpp:116] Extension 14231 registered table plugin launcher_gc_info" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=registry_factory.cpp:116
                                time=2026-09-02T11:23:07.589-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.589982 14656 auto_constructed_tables.cpp:107] Removing stale ATC entries" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=auto_constructed_tables.cpp:107
                                time=2026-09-02T11:23:07.591-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.591796 14656 dispatcher.cpp:78] Adding new service: ConfigRefreshRunner (0000014D92D04590) to thread: 6972 (0000014D93B20260) in process 756" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:07.598-07:00 level=WARN source=/home/billy/work/launcher/pkg/service/request_config.go:103 msg="failure requesting config" method=RequestConfig uuid=e6d3447e-94d3-4e4a-ae1a-0d1e1812e75b config_size=0 reauth=false err=EOF took=4.3244ms
                                time=2026-09-02T11:23:07.598-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/extension.go:558 msg="generating configs with reenroll failed" component=osquery_extension enrollment_id=default err="transport error getting queries: EOF"
                                time=2026-09-02T11:23:07.599-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.599372 14656 config.cpp:543] Using accelerated configuration delay" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=config.cpp:543
                                time=2026-09-02T11:23:07.600-07:00 level=WARN source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="W0902 11:23:07.599372 14656 init.cpp:760] Error reading config: error getting config: loading config failed, no cached config: transport error getting queries: EOF" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=init.cpp:760
                                time=2026-09-02T11:23:07.619-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.619663 14656 system.cpp:241] Using host identifier: 0E108654-B696-4A1A-93BE-0E9942480F97" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=system.cpp:241
                                time=2026-09-02T11:23:07.652-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.650463 14656 eventfactory.cpp:156] Event publisher not enabled: etw_dns_publisher: etw_dns_publisher publisher disabled via configuration." component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=eventfactory.cpp:156
                                time=2026-09-02T11:23:07.652-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:07.650463 14656 eventfactory.cpp:156] Event publisher not enabled: etw_process_publisher: etw_process_publisher publisher disabled via configuration.\r\nI0902 11:23:07.650463 14656 eventfactory.cpp:156] Event publisher not enabled: ntfs_event_publisher: NTFS event publisher disabled via configuration\r\nI0902 11:23:07.650983 14656 events.cpp:70] Skipping subscriber: dns_lookup_events: subscriber disabled via configuration.\r\nI0902 11:23:07.651105 14656 events.cpp:70] Skipping subscriber: powershell_events: Required publisher is disabled by configuration\r\nI0902 11:23:07.651105 14656 events.cpp:70] Skipping subscriber: process_etw_events: subscriber disabled via configuration.\r\nI0902 11:23:07.651105 14656 events.cpp:70] Skipping subscriber: windows_events: Required publisher is disabled by configuration\r\nI0902 11:23:07.651105 14656 loader.cpp:45] No experiments selected\r\nI0902 11:23:07.651625 14656 dispatcher.cpp:78] Adding new service: DistributedRunner (0000014D92D03870) to thread: 16108 (0000014D93B1FD60) in process 756\r\nI0902 11:23:07.651625 14656 dispatcher.cpp:78] Adding new service: SchedulerRunner (0000014D93B0BBA0) to thread: 596 (0000014D93B1FDA0) in process 756\r\nI0902 11:23:07.651625  6476 eventfactory.cpp:390] Starting event publisher run loop: WindowsEventLogPublisher\r\nI0902 11:23:07.651625  6476 eventfactory.cpp:410] Event publisher WindowsEventLogPublisher run loop terminated for reason: Publisher disabled by configuration" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 caller=eventfactory.cpp:156
                                time=2026-09-02T11:23:07.659-07:00 level=WARN source=/home/billy/work/launcher/pkg/service/request_queries.go:123 msg="failure requesting queries" method=RequestQueries uuid=4f59a9eb-1803-4a0f-8eb1-64d37cc037dd res=null reauth=false err=EOF took=3.6253ms
                                time=2026-09-02T11:23:08.096-07:00 level=WARN source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:595 msg="error running osquery command" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 path=C:\Users\billy\AppData\Local\Temp\launcher-test-osquery\osqueryd-stable-windows-amd64.exe sizeBytes=25964576 mode=-rw-rw-rw- sha256=3de2593efa9d698542a139dd0f35d2e6dd91af6f7e9a0b609cbdfa2243c8eb24 err="exit status 1"
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:68 msg="exiting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=osqueryd_execute goroutine_err="running osqueryd command: exit status 1"
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=remove_socket_file
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:68 msg="exiting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=healthcheck goroutine_err=<nil>
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=kolide_grpc_cleanup
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=remove_pid_file
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=saas_extension_cleanup
                                time=2026-09-02T11:23:08.096-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=remove_socket_file goroutine_run_time=0s goroutine_err=<nil>
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=remove_pid_file goroutine_run_time=584┬╡s goroutine_err=<nil>
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:968 msg="got error while shutting down extension server" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 err="The pipe is being closed.\nderegistering extension\ngithub.com/osquery/osquery-go.(*ExtensionManagerServer).Shutdown\n\t/home/billy/go/pkg/mod/github.com/osquery/osquery-go@v0.0.0-20260630173615-eb39ad3443df/server.go:356\ngithub.com/kolide/launcher/v2/pkg/osquery/runtime.(*OsqueryInstance).StartOsqueryExtensionManagerServer.func3\n\t/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:966\ngithub.com/kolide/launcher/v2/pkg/osquery/runtime.(*OsqueryInstance).StartOsqueryExtensionManagerServer.(*LoggedErrgroup).AddShutdownGoroutine.func5\n\t/home/billy/work/launcher/ee/errgroup/errgroup.go:157\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/home/billy/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93\nruntime.goexit\n\t/nix/store/i77g9dmcd399rmxk8688qfr4g2wzgk37-go-1.26.7/share/go/src/runtime/asm_amd64.s:1771" extension_name=kolide_grpc
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=saas_extension_cleanup goroutine_run_time=584┬╡s goroutine_err=<nil>
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=kolide_grpc_cleanup goroutine_run_time=584┬╡s goroutine_err=<nil>
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:68 msg="exiting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=kolide_grpc goroutine_err="extension manager server exited"
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/extension.go:218 msg="osquery extension received shutdown request" component=osquery_extension enrollment_id=default
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:68 msg="exiting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRGYAX6067S4TR4J0ABZ5 goroutine_name=saas_extension_execute goroutine_err=<nil>
                                time=2026-09-02T11:23:08.097-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/runner.go:136 msg="osquery instance exited, will restart after delay" component=osquery_runner enrollment_id=default err="running osqueryd command: exit status 1"
                                time=2026-09-02T11:23:18.102-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/extension.go:188 msg="got host identifier" component=osquery_extension enrollment_id=default host_identifier=d791f096-d521-4738-baf2-2e85c4390bc2
                                time=2026-09-02T11:23:18.102-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/extension.go:333 msg="checking enrollment" component=osquery_extension enrollment_id=default
                                time=2026-09-02T11:23:18.102-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=saas_extension_execute
                                time=2026-09-02T11:23:18.103-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/extension.go:340 msg="node key exists, skipping enrollment" component=osquery_extension enrollment_id=default
                                time=2026-09-02T11:23:18.121-07:00 level=WARN source=/home/billy/work/launcher/pkg/service/publish_logs.go:115 msg="failure publishing logs" method=PublishLogs uuid=dcda4c24-5ef8-403b-86b0-d33bb8fbcfd7 log_type=status log_count=66 errcode="" reauth=false err=EOF took=14.6137ms publication_state="map[current_batch_limit_bytes:3145728 options_batch_limit_bytes:3145728]"
                                time=2026-09-02T11:23:18.121-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/extension.go:771 msg="sending logs" component=osquery_extension enrollment_id=default type=status attempted_publication_state="map[current_batch_limit_bytes:3145728 options_batch_limit_bytes:3145728]" err="writing logs: transport error sending logs: EOF"
                                time=2026-09-02T11:23:18.135-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:549 msg="launching osqueryd" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ path=C:\Users\billy\AppData\Local\Temp\launcher-test-osquery\osqueryd-stable-windows-amd64.exe args="C:\\Users\\billy\\AppData\\Local\\Temp\\launcher-test-osquery\\osqueryd-stable-windows-amd64.exe --logger_plugin=kolide_grpc --distributed_plugin=kolide_grpc --disable_distributed=false --distributed_interval=5 --pack_delimiter=: --host_identifier=uuid --force=true --utc --tls_server_certs=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\ca-certs-system-3f88b94771f5aa9a3feece1a3d2bdedd2b061045238d550c86ea0ac43cf11858.crt --disable_watchdog --distributed_denylist_duration=0 --verbose --config_refresh=300 --config_accelerated_refresh=30 --allow_unsafe --pidfile=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ.pid --database_path=C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery.db --extensions_socket=\\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ --disable_extensions=false --extensions_timeout=20 --config_plugin=kolide_grpc --extensions_require=kolide_grpc"
                                time=2026-09-02T11:23:18.162-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:616 msg="osquery extension socket not created yet ... will retry" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ path=\\.\pipe\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ
                                time=2026-09-02T11:23:18.162-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:62 msg="starting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=osqueryd_execute
                                time=2026-09-02T11:23:18.163-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:616 msg="osquery extension socket not created yet ... will retry" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ path=\\.\pipe\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ
                                time=2026-09-02T11:23:18.163-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:577 msg="launched osquery process" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ osqueryd_pid=17724
                                time=2026-09-02T11:23:18.221-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.215786  1624 init.cpp:413] osquery initialized [version=5.22.1]" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=init.cpp:413
                                time=2026-09-02T11:23:18.226-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.225704  1624 dispatcher.cpp:78] Adding new service: UsersService (000002435D58A740) to thread: 6504 (000002435D5CE320) in process 17724" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:18.226-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.226368  1624 dispatcher.cpp:78] Adding new service: GroupsService (000002435D589200) to thread: 22136 (000002435D5CE4A0) in process 17724\r\nI0902 11:23:18.226444  1624 extensions.cpp:453] Could not autoload extensions: Cannot open file for reading: \\Program Files\\osquery\\extensions.load" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:18.229-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.229657  1624 rocksdb.cpp:90] Opening RocksDB handle: C:\\Users\\billy\\AppData\\Local\\Temp\\TestOsqueryDies751080823\\001\\osquery.db" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=rocksdb.cpp:90
                                time=2026-09-02T11:23:18.274-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.270246 22136 groups_service.cpp:55] Groups cache initialized" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=groups_service.cpp:55
                                time=2026-09-02T11:23:18.286-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.285835  6504 users_service.cpp:149] Users cache initialized" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=users_service.cpp:149
                                time=2026-09-02T11:23:18.504-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.497220  1624 dispatcher.cpp:78] Adding new service: ExtensionWatcher (000002435D4FA6C0) to thread: 15588 (000002435DFC7B80) in process 17724" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:18.504-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.497220  1624 dispatcher.cpp:78] Adding new service: ExtensionRunnerCore (000002435E0A3E00) to thread: 12296 (000002435DFC7B20) in process 17724" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=dispatcher.cpp:78
                                time=2026-09-02T11:23:18.504-07:00 level=INFO source=/home/billy/work/launcher/ee/log/osquerylogs/log.go:82 msg="I0902 11:23:18.504177 12296 interface.cpp:299] Extension manager service starting: \\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ" component=osquery osqlevel=stderr enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ caller=interface.cpp:299
                                time=2026-09-02T11:23:19.163-07:00 level=DEBUG source=/home/billy/work/launcher/pkg/osquery/runtime/osqueryinstance.go:628 msg="osquery socket created" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ
                                time=2026-09-02T11:23:28.966-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=remove_socket_file
                                time=2026-09-02T11:23:28.966-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=saas_extension_cleanup
                                time=2026-09-02T11:23:28.966-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:152 msg="starting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=remove_pid_file
                                time=2026-09-02T11:23:28.966-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=remove_socket_file goroutine_run_time=0s goroutine_err=<nil>
                                time=2026-09-02T11:23:28.967-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:164 msg="exiting shutdown goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=saas_extension_cleanup goroutine_run_time=611.2┬╡s gorouti                                time=2026-09-02T11:23:29.532-07:00 level=INFO source=/home/billy/work/launcher/ee/errgroup/errgroup.go:68 msg="exiting goroutine in errgroup" component=osquery_instance enrollment_id=default instance_run_id=01M1HNRWJKNAYKZZDPDMBA67ZZ goroutine_name=osqueryd_execute goroutine_err="running osqueryd command: exit status 1"
                                time=2026-09-02T11:23:29.532-07:00 level=INFO source=/home/billy/work/launcher/pkg/osquery/runtime/runner.go:136 msg="osquery instance exited, will restart after delay" component=osquery_runner enrollment_id=default err="could not create an extension client: could not create an extension client: timeout after 10s (51 attempts): dialing pipe '\\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ': open \\\\.\\pipe\\kolide-osquery-01M1HNRWJKNAYKZZDPDMBA67ZZ: The system cannot find the file specified.\ncontext canceled"                                                                                                                                                                               )
--- FAIL: TestOsqueryDies (32.01s)
```
</details>